### PR TITLE
docs: record the single-repository cutover and the project's origin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,10 @@ the machine that will merge, say so in the pull request.
 ## Records that do not change
 
 `docs/reviews/`, `docs/merge-notes/`, `docs/briefs/` and `docs/plans/archive/`
-are dated records of finished work: append-only, and never current authority. A
-plan whose batch ships moves into `docs/plans/archive/`.
+are dated records of finished work: append-only, and never current authority.
+They are not kept here. They live in this project's private operator
+repository, and nothing in this repository is meant to be read against them.
+
 `scripts/check-frozen-docs.sh` runs in the gate and enforces exactly three
 things, no more: a file merged into one of those four directories is neither
 modified nor deleted; a file added to one is named `YYYY-MM-DD-…`; and any line in a tracked `*.md` file that begins
@@ -50,7 +52,9 @@ modified nor deleted; a file added to one is named `YYYY-MM-DD-…`; and any lin
 `> Superseded by <repository-root-relative path> (YYYY-MM-DD)`, appears once,
 and names a path the commit tracks. A record merged under a wrong name can be
 corrected only by a byte-identical rename inside its own directory to a dated
-name — nothing else about a merged record may change.
+name — nothing else about a merged record may change. The first two rules have
+nothing to act on while those directories are absent from this repository; the
+third applies to every tracked `*.md`, and is why the check stays in the gate.
 
 What the gate cannot decide is whether a document that *should* carry a
 supersession marker does: no diff says "this stopped being authority". That half

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,10 +80,12 @@ snapshot:scan` checks this, and it requires a clean worktree matching `HEAD`.
 ### Records that do not change
 
 `docs/reviews/`, `docs/merge-notes/`, `docs/briefs/` and `docs/plans/archive/`
-are dated records of finished work: append-only, and never current authority. A
-file merged into one of them is neither modified nor deleted, and a file added to
-one is named `YYYY-MM-DD-…`. `scripts/check-frozen-docs.sh` enforces that in the
-gate.
+are dated records of finished work: append-only, and never current authority.
+They are not kept here — they live in this project's private operator
+repository — so nothing you contribute needs to read them.
+`scripts/check-frozen-docs.sh` still runs in the gate: it would enforce those
+directories if they appeared, and it enforces the `> Superseded by ` marker
+shape on every tracked `*.md`.
 
 ### Style
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ AgentOS orchestrates the official Codex CLI and Claude Code installed and
 authenticated on the user's Mac, bundles or resells no subscription, and
 provider terms and plan limits apply.
 
+An independent build inspired by Danny Postma's video 'How I Built My Own
+AgentOS on Claude's Agent SDK (So You Can Too)' (2026) — built from scratch
+from the ideas in the video.
+
 ## Release-candidate evidence status
 
 The labels below describe the evidence recorded in this repository; they are

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,9 @@ AgentOS 是面向单一操作者的本地控制平面，用于把有明确权限
 AgentOS 编排安装在用户 Mac 上且已完成认证的官方 Codex CLI 和 Claude Code；
 AgentOS 不捆绑或转售任何订阅，provider 条款和套餐限制仍然适用。
 
+本项目是受 Danny Postma 的视频 'How I Built My Own AgentOS on Claude's Agent
+SDK (So You Can Too)'（2026）启发的独立实现，从视频中的想法出发从零构建。
+
 ## 发布候选证据状态
 
 以下标签描述本仓库内记录的证据，不是 CLI provider 作出的兼容性承诺。


### PR DESCRIPTION
This repository is now the only place AgentOS is developed. The dated
append-only records (`docs/reviews/`, `docs/merge-notes/`, `docs/briefs/`,
`docs/plans/archive/`) moved to a private operator repository, and they were
never in this one, so `AGENTS.md` and `CONTRIBUTING.md` stop describing four
directories that are not here. `scripts/check-frozen-docs.sh` stays in the gate
for the supersession-marker rule it still enforces on every tracked `*.md`.

Both READMEs state what the project was built from.

## Gate

```
MERGE GATE: PASS 2f1741296ab06e6d3301bdcf619cb4392fe5d6cd
```

Run as `bash scripts/merge-gate.sh --expect-head 2f1741296ab06e6d3301bdcf619cb4392fe5d6cd`,
in a fresh clone of this branch rather than in the operator's checkout — that
checkout still holds the objects of the pre-cutover private lineage, which the
attestation's object-id binding takes a stricter path on. Rebased onto #3.