### PR TITLE
fix(api): tolerate device drift across restarts

### DIFF
--- a/packages/api/src/control-plane-ownership.test.ts
+++ b/packages/api/src/control-plane-ownership.test.ts
@@ -106,6 +106,27 @@ test("UT-OWN-STATE-MATRIX preserves stable identity across clean release and rea
   await second.ownership.release();
 });
 
+test("UT-OWN-STATE-MATRIX upgrades a released v1 record after device numbers drift across reboot", async (t) => {
+  const paths = await fixture();
+  t.after(() => rm(paths.container, { recursive: true, force: true }));
+  const first = await acquire(paths);
+  await first.ownership.release();
+  const ownerPath = join(first.ownership.controlStateEntryPath, controlPlaneOwnerFilename);
+  const released = JSON.parse(await readFile(ownerPath, "utf8")) as Record<string, unknown>;
+  released.formatVersion = 1;
+  released.workspaceRootDevice = (first.ownership.workspaceRootDevice + 3n).toString();
+  released.lockDevice = (first.ownership.lockDevice + 3n).toString();
+  await writeFile(ownerPath, `${JSON.stringify(released)}\n`, { mode: 0o600 });
+
+  const second = await acquire(paths);
+  assert.equal(second.ownership.controlPlaneId, first.ownership.controlPlaneId);
+  const upgraded = JSON.parse(await readFile(ownerPath, "utf8")) as Record<string, unknown>;
+  assert.equal(upgraded.formatVersion, 2);
+  assert.equal("workspaceRootDevice" in upgraded, false);
+  assert.equal("lockDevice" in upgraded, false);
+  await second.ownership.release();
+});
+
 test("UT-OWN-STATE-MATRIX advances valid stable-without-owner and removes only bounded temp debris", async (t) => {
   const paths = await fixture();
   t.after(() => rm(paths.container, { recursive: true, force: true }));

--- a/packages/api/src/control-plane-ownership.ts
+++ b/packages/api/src/control-plane-ownership.ts
@@ -41,8 +41,7 @@ const stableRecordSchema = z.object({
   controlStateDigest: z.string().regex(/^[0-9a-f]{64}$/u),
 }).strict();
 
-const ownerRecordSchema = z.object({
-  formatVersion: z.literal(1),
+const ownerRecordFields = {
   state: z.enum(["owned", "released"]),
   controlPlaneId: z.string().uuid(),
   incarnationId: z.string().uuid(),
@@ -50,16 +49,36 @@ const ownerRecordSchema = z.object({
   hostname: z.string().min(1),
   canonicalWorkspaceRoot: z.string().min(1),
   controlStateDigest: z.string().regex(/^[0-9a-f]{64}$/u),
-  workspaceRootDevice: z.string().regex(/^\d+$/u),
   workspaceRootInode: z.string().regex(/^\d+$/u),
-  lockDevice: z.string().regex(/^\d+$/u),
   lockInode: z.string().regex(/^\d+$/u),
   acquiredAt: z.string().datetime(),
   releasedAt: z.string().datetime().optional(),
-}).strict().superRefine((record, context) => {
+} as const;
+
+const refineOwnerRecord = (
+  record: { state: "owned" | "released"; releasedAt?: string | undefined },
+  context: z.RefinementCtx,
+) => {
   if (record.state === "released" && !record.releasedAt) context.addIssue({ code: "custom", message: "releasedAt required" });
   if (record.state === "owned" && record.releasedAt) context.addIssue({ code: "custom", message: "releasedAt forbidden" });
-});
+};
+
+// v1 persisted device numbers. A mount can receive a different device number
+// after reboot, so v1 remains readable for one safe upgrade but those fields
+// are deliberately excluded from cross-incarnation identity checks.
+const legacyOwnerRecordSchema = z.object({
+  formatVersion: z.literal(1),
+  ...ownerRecordFields,
+  workspaceRootDevice: z.string().regex(/^\d+$/u),
+  lockDevice: z.string().regex(/^\d+$/u),
+}).strict().superRefine(refineOwnerRecord);
+
+const currentOwnerRecordSchema = z.object({
+  formatVersion: z.literal(2),
+  ...ownerRecordFields,
+}).strict().superRefine(refineOwnerRecord);
+
+const ownerRecordSchema = z.union([legacyOwnerRecordSchema, currentOwnerRecordSchema]);
 
 export type StableControlPlaneRecord = z.infer<typeof stableRecordSchema>;
 export type ControlPlaneOwnerRecord = z.infer<typeof ownerRecordSchema>;
@@ -148,15 +167,13 @@ const recordsMatch = (
   owner: ControlPlaneOwnerRecord,
   workspace: CanonicalWorkspaceRoot,
   digest: string,
-  lockIdentity: { device: bigint; inode: bigint },
+  lockIdentity: { inode: bigint },
 ): boolean => stable.controlPlaneId === owner.controlPlaneId
   && stable.canonicalWorkspaceRoot === workspace.canonicalPath
   && owner.canonicalWorkspaceRoot === workspace.canonicalPath
   && stable.controlStateDigest === digest
   && owner.controlStateDigest === digest
-  && owner.workspaceRootDevice === workspace.device.toString()
   && owner.workspaceRootInode === workspace.inode.toString()
-  && owner.lockDevice === lockIdentity.device.toString()
   && owner.lockInode === lockIdentity.inode.toString();
 
 export interface AcquireControlPlaneOwnershipOptions {
@@ -287,7 +304,7 @@ export const acquireControlPlaneOwnership = async (
     if (stable.absent) await atomicWriteJson(state.entryPath, controlPlaneIdFilename, incarnationId, stableValue);
     const acquiredAt = (options.now ?? (() => new Date()))().toISOString();
     const ownerValue: ControlPlaneOwnerRecord = {
-      formatVersion: 1,
+      formatVersion: 2,
       state: "owned",
       controlPlaneId: stableValue.controlPlaneId,
       incarnationId,
@@ -295,9 +312,7 @@ export const acquireControlPlaneOwnership = async (
       hostname: options.hostname ?? hostname(),
       canonicalWorkspaceRoot: workspace.canonicalPath,
       controlStateDigest: state.digest,
-      workspaceRootDevice: workspace.device.toString(),
       workspaceRootInode: workspace.inode.toString(),
-      lockDevice: lock.device.toString(),
       lockInode: lock.inode.toString(),
       acquiredAt,
     };


### PR DESCRIPTION
## Summary

- read legacy v1 owner records without using persisted device numbers as cross-incarnation identity
- write v2 owner records containing canonical path, digest, and inode identity only
- retain device checks inside the live capability assertHeld path
- cover a released owner record whose workspace and lock device numbers drift after reboot

## Verification

- `node --import tsx --test packages/api/src/control-plane-ownership.test.ts` (21/21)
- `npm run typecheck -w @agentos/api`
- `git diff --check`