### PR TITLE
fix(db): validate backup quiescence attestation

### DIFF
--- a/packages/db/src/backup-bundle.test.ts
+++ b/packages/db/src/backup-bundle.test.ts
@@ -15,6 +15,7 @@ import {
   ATTESTATION_MAX_AGE_MS,
   ATTESTATION_MAX_SKEW_MS,
   parseAttestation,
+  QUIESCENCE_TOKEN_V1,
   validateBackupBundle,
   type BundleFacts,
 } from "./backup-bundle.js";
@@ -30,7 +31,7 @@ const attestation = (overrides: Record<string, unknown> = {}): string => JSON.st
   archive: { bytes: 1024, sha256: SHA },
   targetFingerprint: TARGET,
   walFingerprint: WAL,
-  quiescence: "exclusive-maintenance-lock-held-for-the-whole-dump",
+  quiescence: QUIESCENCE_TOKEN_V1,
   ...overrides,
 });
 
@@ -119,13 +120,23 @@ describe("parseAttestation", () => {
       [{ archive: { bytes: 1024, sha256: SHA.slice(0, 63) } }, "attestation-is-malformed"],
       [{ targetFingerprint: "0123" }, "attestation-is-malformed"],
       [{ walFingerprint: 42 }, "attestation-is-malformed"],
-      [{ quiescence: "" }, "attestation-is-malformed"],
+      [{ quiescence: "" }, "attestation-quiescence-is-unsupported"],
     ];
     for (const [overrides, reason] of cases) {
       const result = parseAttestation(attestation(overrides));
       assert.equal(result.ok, false, JSON.stringify(overrides));
       assert.equal(result.ok === false && result.reason, reason, JSON.stringify(overrides));
     }
+  });
+
+  it("accepts only the versioned quiescence authority token", () => {
+    for (const value of ["not-locked", "locked", "exclusive-maintenance-lock-held", 1, null]) {
+      const result = parseAttestation(attestation({ quiescence: value }));
+      assert.deepEqual(result, { ok: false, reason: "attestation-quiescence-is-unsupported" });
+    }
+    const accepted = parseAttestation(attestation({ quiescence: QUIESCENCE_TOKEN_V1 }));
+    assert.equal(accepted.ok, true);
+    assert.equal(accepted.ok && accepted.attestation.quiescence, QUIESCENCE_TOKEN_V1);
   });
 
   it("refuses text that is not a JSON object at all", () => {

--- a/packages/db/src/backup-bundle.ts
+++ b/packages/db/src/backup-bundle.ts
@@ -48,6 +48,8 @@ export const ATTESTATION_MEMBER = "attestation.json";
 /** The first five bytes of every PostgreSQL custom-format dump. */
 export const CUSTOM_FORMAT_MAGIC = "PGDMP";
 export const ATTESTATION_VERSION = 1;
+/** Version-1 proof that the exclusive maintenance lock covered the whole dump. */
+export const QUIESCENCE_TOKEN_V1 = "exclusive-maintenance-lock-held-for-the-whole-dump";
 
 export type BundleEntryKind = "file" | "directory" | "symlink" | "other";
 
@@ -80,7 +82,7 @@ export interface BackupAttestation {
   archiveSha256: string;
   targetFingerprint: string;
   walFingerprint: string;
-  quiescence: string;
+  quiescence: typeof QUIESCENCE_TOKEN_V1;
 }
 
 export type BundleResolution =
@@ -133,7 +135,7 @@ export const parseAttestation = (text: string): { ok: true; attestation: BackupA
   if (typeof walFingerprint !== "string" || !HEX_32.test(walFingerprint)) {
     return { ok: false, reason: "attestation-is-malformed" };
   }
-  if (typeof quiescence !== "string" || quiescence === "") return { ok: false, reason: "attestation-is-malformed" };
+  if (quiescence !== QUIESCENCE_TOKEN_V1) return { ok: false, reason: "attestation-quiescence-is-unsupported" };
 
   return {
     ok: true,
@@ -144,7 +146,7 @@ export const parseAttestation = (text: string): { ok: true; attestation: BackupA
       archiveSha256: sha256,
       targetFingerprint,
       walFingerprint,
-      quiescence,
+      quiescence: QUIESCENCE_TOKEN_V1,
     },
   };
 };

--- a/packages/db/src/release-migrate.test.ts
+++ b/packages/db/src/release-migrate.test.ts
@@ -28,7 +28,7 @@ import {
   type PlanInputs,
   type ServerIdentity,
 } from "./local-release-target.js";
-import { ARCHIVE_MEMBER, ATTESTATION_MEMBER, type BundleFacts } from "./backup-bundle.js";
+import { ARCHIVE_MEMBER, ATTESTATION_MEMBER, QUIESCENCE_TOKEN_V1, type BundleFacts } from "./backup-bundle.js";
 import {
   DRIFT_CHECK_COMMAND,
   FILES_PRECHECK_COMMAND,
@@ -121,7 +121,7 @@ const attestationText = (overrides: Record<string, unknown> = {}): string => JSO
   archive: { bytes: ARCHIVE_BYTES, sha256: ARCHIVE_SHA256 },
   targetFingerprint: TARGET_FINGERPRINT,
   walFingerprint: WAL_FINGERPRINT,
-  quiescence: "exclusive-maintenance-lock-held-for-the-whole-dump",
+  quiescence: QUIESCENCE_TOKEN_V1,
   ...overrides,
 });
 
@@ -895,6 +895,8 @@ describe("releaseMigrate --existing", () => {
         "archive-digest-disagrees-with-the-attestation"],
       [{ attestationText: "{" }, "attestation-is-not-json"],
       [{ attestationText: attestationText({ version: 2 }) }, "attestation-version-is-unsupported"],
+      [{ attestationText: attestationText({ quiescence: "attacker-controlled-lock-claim" }) },
+        "attestation-quiescence-is-unsupported"],
       [{ attestationText: attestationText({ walFingerprint: "short" }) }, "attestation-is-malformed"],
       [{ attestationText: attestationText({ createdAt: "yesterday" }) }, "attestation-created-at-is-unparsable"],
       [{ attestationText: attestationText({ createdAt: new Date(NOW_MS - 16 * 60_000).toISOString() }) },


### PR DESCRIPTION
## Summary

- accept only the version-1 stable quiescence token
- export one token authority for consumer and contract fixtures
- refuse arbitrary prose before maintenance-lock inspection or migration mutation

Covers DEBT1-OSSD-1 / OSS-D-3.

## Blocked by v0.1.1 attestation

- DEBT1-OSSD-2 / OSS-D-5 and OSS-D-7: requires both attested release-migrate paths
- DEBT1-OSSD-3 / OSS-D-8: requires attested target-fingerprint producer/consumer semantics
- DEBT1-OSSD-4 / OSS-D-9: requires attested write-since-backup orchestration

No attested file was modified or bypassed.

## Tests

- npm run typecheck -w @agentos/db
- node --import tsx --test packages/db/src/backup-bundle.test.ts packages/db/src/release-migrate.test.ts
- npm run lint

Local result: 85 passed.