### PR TITLE
fix: harden public snapshot scanning

### DIFF
--- a/scripts/public-snapshot-scan.mjs
+++ b/scripts/public-snapshot-scan.mjs
@@ -2,8 +2,17 @@
 
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
+import { dirname, isAbsolute, posix, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const DISPOSITIONS = new Set([
@@ -56,6 +65,31 @@ function matches(glob, path) {
   return globToRegExp(glob).test(path);
 }
 
+function validateRepositoryPath(path, label) {
+  if (typeof path !== "string" || path.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (path.includes("\0")) throw new Error(`${label} must not contain NUL`);
+  if (isAbsolute(path) || path.startsWith("/")) {
+    throw new Error(`${label} must be repository-relative`);
+  }
+  if (path.includes("\\")) throw new Error(`${label} must use slash separators`);
+  if (posix.normalize(path) !== path || path === "." || path.startsWith("../")) {
+    throw new Error(`${label} must be normalized and repository-relative`);
+  }
+  return path;
+}
+
+function validatePathList(paths, label) {
+  const normalized = new Set();
+  for (const path of paths) {
+    const checked = validateRepositoryPath(path, label);
+    const key = posix.normalize(checked);
+    if (normalized.has(key)) throw new Error(`${label} contains a duplicate normalized path`);
+    normalized.add(key);
+  }
+}
+
 function validateManifest(manifest) {
   if (manifest.schemaVersion !== 2) throw new Error("unsupported manifest schema");
   if (manifest.source !== "git-tracked-files+minted-artifacts") {
@@ -65,16 +99,30 @@ function validateManifest(manifest) {
   for (const key of ["include", "deny", "exclude", "approvedFindings", "generatedRuntimePatterns", "mintedArtifacts"]) {
     if (!Array.isArray(manifest[key])) throw new Error(`manifest ${key} must be an array`);
   }
+  validatePathList(manifest.include.map((rule) => rule.glob), "manifest include glob");
+  validatePathList(manifest.deny.map((rule) => rule.glob), "manifest deny glob");
+  validatePathList(manifest.exclude.map((rule) => rule.glob), "manifest exclude glob");
   for (const rule of manifest.deny) {
+    validateRepositoryPath(rule.glob, "manifest deny glob");
     if (!new Set(["internal-only-artifact", "generated-runtime-data"]).has(rule.category)) {
       throw new Error(`invalid deny category for ${rule.glob}`);
     }
   }
   for (const rule of manifest.exclude) {
+    validateRepositoryPath(rule.glob, "manifest exclude glob");
     if (!DISPOSITIONS.has(rule.disposition) || rule.disposition === "approved-public-material") {
       throw new Error(`invalid exclusion disposition for ${rule.glob}`);
     }
   }
+  const approvalKeys = new Set();
+  for (const rule of manifest.approvedFindings) {
+    validateRepositoryPath(rule.glob, "manifest approved finding glob");
+    const key = `${rule.category}\0${rule.glob}`;
+    if (approvalKeys.has(key)) throw new Error("manifest approved finding contains a duplicate rule");
+    approvalKeys.add(key);
+  }
+  validatePathList(manifest.mintedArtifacts, "manifest minted artifact");
+  validatePathList(manifest.generatedRuntimePatterns, "manifest generated runtime pattern");
 }
 
 export function scopeFor(path, manifest) {
@@ -96,14 +144,13 @@ export function scopeFor(path, manifest) {
 }
 
 function isProbablyBinary(buffer) {
-  const sample = buffer.subarray(0, Math.min(buffer.length, 8192));
-  if (sample.includes(0)) return true;
-  if (sample.length === 0) return false;
+  if (buffer.includes(0)) return true;
+  if (buffer.length === 0) return false;
   let suspicious = 0;
-  for (const byte of sample) {
+  for (const byte of buffer) {
     if (byte < 7 || (byte > 14 && byte < 32)) suspicious += 1;
   }
-  return suspicious / sample.length > 0.1;
+  return suspicious / buffer.length > 0.1;
 }
 
 function countMatches(text, expression, predicate = () => true) {
@@ -231,6 +278,12 @@ function dispositionFor(category, path, scope, manifest) {
       reason: scope.denies[0].reason,
     };
   }
+  if (category === "credential" && scope.included) {
+    return {
+      disposition: "blocker",
+      reason: "real credentials cannot be approved on the public surface",
+    };
+  }
   const approval = manifest.approvedFindings.find(
     (rule) => rule.category === category && matches(rule.glob, path),
   );
@@ -272,33 +325,109 @@ function assertCleanTrackedWorktree(root) {
   }
 }
 
+function readGitTree(root, commit) {
+  const output = execFileSync("git", ["ls-tree", "-rz", "--full-tree", "-r", commit], {
+    cwd: root,
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  const entries = [];
+  for (const record of output.toString("utf8").split("\0").filter(Boolean)) {
+    const match = /^(\d{6}) ([a-z]+) ([0-9a-f]{40})\t([\s\S]+)$/.exec(record);
+    if (!match) throw new Error("git tree contains an unsupported entry record");
+    const [, mode, type, oid, path] = match;
+    validateRepositoryPath(path, "tracked path");
+    entries.push({ mode, type, oid, path });
+  }
+  entries.sort((left, right) => left.path.localeCompare(right.path));
+  return entries;
+}
+
+function readGitBlobs(root, entries) {
+  const oids = [...new Set(entries.filter((entry) => entry.type === "blob").map((entry) => entry.oid))];
+  if (oids.length === 0) return new Map();
+  const output = execFileSync("git", ["cat-file", "--batch"], {
+    cwd: root,
+    input: `${oids.join("\n")}\n`,
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  const blobs = new Map();
+  let offset = 0;
+  for (const expectedOid of oids) {
+    const newline = output.indexOf(10, offset);
+    if (newline === -1) throw new Error("git cat-file returned a truncated header");
+    const header = output.subarray(offset, newline).toString("ascii");
+    const match = /^([0-9a-f]{40}) blob (\d+)$/.exec(header);
+    if (!match || match[1] !== expectedOid) throw new Error("git cat-file returned an unexpected object");
+    const size = Number(match[2]);
+    const start = newline + 1;
+    const end = start + size;
+    if (!Number.isSafeInteger(size) || end >= output.length || output[end] !== 10) {
+      throw new Error("git cat-file returned truncated blob bytes");
+    }
+    blobs.set(expectedOid, output.subarray(start, end));
+    offset = end + 1;
+  }
+  if (offset !== output.length) throw new Error("git cat-file returned trailing output");
+  return blobs;
+}
+
+function isWithinRoot(root, path) {
+  const pathFromRoot = relative(root, path);
+  return pathFromRoot === "" || (!pathFromRoot.startsWith(`..${posix.sep}`) && pathFromRoot !== "..");
+}
+
+function readMintedFile(root, path) {
+  const candidate = resolve(root, path);
+  if (!isWithinRoot(root, candidate)) throw new Error("minted artifact escapes repository root");
+  const lexical = lstatSync(candidate);
+  if (!lexical.isFile() || lexical.isSymbolicLink()) {
+    throw new Error("minted artifact must be a regular file, not a symlink or special file");
+  }
+  const canonical = realpathSync(candidate);
+  if (!isWithinRoot(root, canonical)) throw new Error("minted artifact resolves outside repository root");
+  const descriptor = openSync(candidate, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = fstatSync(descriptor);
+    if (!opened.isFile() || opened.dev !== lexical.dev || opened.ino !== lexical.ino) {
+      throw new Error("minted artifact identity changed while opening");
+    }
+    return readFileSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
 export function scanRepository(
   root = resolve(dirname(fileURLToPath(import.meta.url)), ".."),
   { requireClean = true } = {},
 ) {
+  root = realpathSync(root);
   if (requireClean) assertCleanTrackedWorktree(root);
-  const manifestPath = resolve(root, "public-snapshot.json");
-  const manifestBytes = readFileSync(manifestPath);
+  const commit = execFileSync("git", ["rev-parse", "HEAD^{commit}"], { cwd: root })
+    .toString("utf8")
+    .trim();
+  const trackedEntries = readGitTree(root, commit);
+  const trackedByPath = new Map(trackedEntries.map((entry) => [entry.path, entry]));
+  const blobs = readGitBlobs(root, trackedEntries);
+  const manifestEntry = trackedByPath.get("public-snapshot.json");
+  if (!manifestEntry || manifestEntry.type !== "blob" || !["100644", "100755"].includes(manifestEntry.mode)) {
+    throw new Error("public-snapshot.json must be a tracked regular file");
+  }
+  const manifestBytes = blobs.get(manifestEntry.oid);
+  if (!manifestBytes) throw new Error("public-snapshot.json blob is unavailable");
   const manifest = JSON.parse(manifestBytes.toString("utf8"));
   validateManifest(manifest);
 
-  const trackedPaths = execFileSync("git", ["ls-files", "-z"], { cwd: root })
-    .toString("utf8")
-    .split("\0")
-    .filter(Boolean)
-    .sort();
+  const trackedPaths = trackedEntries.map((entry) => entry.path);
   // Files the snapshot procedure mints rather than tracks — today, the release
   // authority attestation. They are `.gitignore`d by design, so `git ls-files`
   // cannot see them, and a snapshot input that no scan reads is a snapshot
   // input nobody has checked. They are classified and read exactly like a
   // tracked path; the only difference is where the list comes from.
   const mintedPaths = manifest.mintedArtifacts
-    .filter((path) => !trackedPaths.includes(path) && existsSync(resolve(root, path)))
+    .filter((path) => !trackedByPath.has(path) && existsSync(resolve(root, path)))
     .sort();
   const paths = [...trackedPaths, ...mintedPaths].sort();
-  const commit = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root })
-    .toString("utf8")
-    .trim();
 
   const findings = [];
   const includedPaths = [];
@@ -314,6 +443,15 @@ export function scanRepository(
     else if (scope.classification === "excluded") excludedPaths.push(path);
     else if (scope.classification === "unclassified") unclassifiedPaths.push(path);
     else overlappingPaths.push(path);
+
+    const tracked = trackedByPath.get(path);
+    if (
+      scope.included &&
+      tracked &&
+      (tracked.type !== "blob" || !["100644", "100755"].includes(tracked.mode))
+    ) {
+      throw new Error("included tracked path must be a regular Git file");
+    }
 
     if (scope.classification === "overlapping") {
       addFinding(findings, {
@@ -382,8 +520,13 @@ export function scanRepository(
   }
 
   for (const path of paths) {
-    const bytes = readFileSync(resolve(root, path));
     const scope = scopeByPath.get(path);
+    const tracked = trackedByPath.get(path);
+    if (tracked && (tracked.type !== "blob" || !["100644", "100755"].includes(tracked.mode))) {
+      continue;
+    }
+    const bytes = tracked ? blobs.get(tracked.oid) : readMintedFile(root, path);
+    if (!bytes) throw new Error("snapshot input bytes are unavailable");
     if (isProbablyBinary(bytes)) {
       const decision = dispositionFor("binary-material", path, scope, manifest);
       addFinding(findings, {
@@ -429,7 +572,7 @@ export function scanRepository(
     report: {
       schemaVersion: 2,
       commit,
-      source: mintedPaths.length > 0 ? "clean-tracked-worktree+minted-artifacts" : "clean-tracked-worktree",
+      source: mintedPaths.length > 0 ? "git-objects+minted-artifacts" : "git-objects",
       manifestSha256: createHash("sha256").update(manifestBytes).digest("hex"),
       scope: {
         trackedFiles: trackedPaths.length,

--- a/scripts/public-snapshot-scan.test.mjs
+++ b/scripts/public-snapshot-scan.test.mjs
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { readFileSync, statSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -11,6 +21,60 @@ import {
   scanTextFindings,
   scopeFor,
 } from "./public-snapshot-scan.mjs";
+
+function baseManifest({ include = [], exclude = [], approvedFindings = [], mintedArtifacts = [] } = {}) {
+  return {
+    schemaVersion: 2,
+    source: "git-tracked-files+minted-artifacts",
+    defaultDisposition: "blocker",
+    include: include.map((glob) => ({ glob, reason: "test public input" })),
+    deny: [],
+    exclude: exclude.map((glob) => ({
+      glob,
+      disposition: "later-release-follow-up",
+      reason: "test excluded input",
+    })),
+    approvedFindings,
+    mintedArtifacts,
+    generatedRuntimePatterns: [],
+  };
+}
+
+function createRepositoryFixture({ files = {}, manifest, symlinks = {}, copyScanner = false }) {
+  const root = mkdtempSync(join(tmpdir(), "agentos-snapshot-scan-"));
+  for (const [path, bytes] of Object.entries(files)) {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    writeFileSync(join(root, path), bytes);
+  }
+  for (const [path, target] of Object.entries(symlinks)) {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    symlinkSync(target, join(root, path));
+  }
+  if (copyScanner) {
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    copyFileSync(fileURLToPath(new URL("./public-snapshot-scan.mjs", import.meta.url)), join(root, "scripts/public-snapshot-scan.mjs"));
+  }
+  writeFileSync(join(root, "public-snapshot.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  execFileSync("git", ["init", "-b", "main"], { cwd: root });
+  const trackedPaths = [
+    ...Object.keys(files),
+    ...Object.keys(symlinks),
+    ...(copyScanner ? ["scripts/public-snapshot-scan.mjs"] : []),
+    "public-snapshot.json",
+  ];
+  execFileSync("git", ["add", "--", ...trackedPaths], { cwd: root });
+  execFileSync("git", ["commit", "-m", "test: create snapshot fixture"], { cwd: root });
+  return root;
+}
+
+function withRepositoryFixture(options, callback) {
+  const root = createRepositoryFixture(options);
+  try {
+    return callback(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
 
 test("glob matching keeps the allowlist bounded", () => {
   assert.equal(globToRegExp("apps/**").test("apps/web/src/App.tsx"), true);
@@ -131,47 +195,115 @@ test("the checked-out tree is fully classified", () => {
   assert.equal(includedPaths.includes("public-snapshot.json"), true);
 });
 
-test("a credential on the published surface is red whatever disposition it carries", () => {
-  // The published half of the scoped check, proven on real bytes rather than a
-  // fabricated report: `release-authority.json` is on the published surface, so
-  // a token planted in it is a credential the export would carry. It is a
-  // tracked file, so this test puts its bytes back rather than deleting it.
-  const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const artifact = resolve(root, "release-authority.json");
-  const original = readFileSync(artifact);
+test("an approved credential on the published surface is always a blocker", () => {
+  const credential = `ghp_${"A".repeat(24)}`;
+  withRepositoryFixture({
+    files: { "published.txt": `token=${credential}\n` },
+    manifest: baseManifest({
+      include: ["published.txt"],
+      exclude: ["public-snapshot.json", "scripts/**"],
+      approvedFindings: [{
+        category: "credential",
+        glob: "published.txt",
+        reason: "an approval must not make this safe",
+      }],
+    }),
+    copyScanner: true,
+  }, (root) => {
+    const { report } = scanRepository(root, { requireClean: true });
+    const flagged = report.findings.filter((finding) => finding.category === "credential");
+    assert.equal(report.summary.countsByDisposition.blocker, 1);
+    assert.deepEqual(flagged.map((finding) => finding.disposition), ["blocker"]);
+    assert.equal(JSON.stringify(report).includes(credential), false, "no matched value may be emitted");
 
-  try {
-    writeFileSync(artifact, JSON.stringify({ token: `ghp_${"A".repeat(24)}` }, null, 2));
-    const { report, includedPaths } = scanRepository(undefined, { requireClean: false });
-    assert.equal(includedPaths.includes("release-authority.json"), true, "the plant must be on the published surface");
-    const flagged = report.findings.filter(
-      (finding) => finding.category === "credential" && includedPaths.includes(finding.path),
-    );
-    assert.deepEqual(
-      flagged.map((finding) => finding.path),
-      ["release-authority.json"],
-      "a credential on a published path must be reported out of scope",
-    );
-    assert.equal(JSON.stringify(flagged).includes("ghp_"), false, "no matched value may be emitted");
+    const cli = spawnSync(process.execPath, ["scripts/public-snapshot-scan.mjs"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    assert.equal(cli.status, 1, cli.stderr);
+    assert.equal(cli.stdout.includes(credential), false);
+    assert.equal(cli.stderr.includes(credential), false);
+  });
+});
 
-    // And the published clause does not consult the disposition: relabelling
-    // the same finding the way an `approvedFindings` entry would still fails.
-    const approved = {
-      ...report,
-      findings: report.findings.map((finding) =>
-        finding.category === "credential" ? { ...finding, disposition: "approved-public-material" } : finding,
-      ),
-    };
-    assert.equal(
-      approved.findings.filter(
-        (finding) => finding.category === "credential" && includedPaths.includes(finding.path),
-      ).length,
-      1,
-      "approving a credential into the snapshot must not clear it",
-    );
-  } finally {
-    writeFileSync(artifact, original);
+test("manifest paths reject traversal, absolute, non-normalized, NUL, and duplicate entries", () => {
+  const cases = [
+    ["../outside.txt"],
+    ["/absolute.txt"],
+    ["nested/../outside.txt"],
+    ["bad\0path"],
+    ["same.txt", "same.txt"],
+  ];
+  for (const mintedArtifacts of cases) {
+    withRepositoryFixture({
+      manifest: baseManifest({ exclude: ["public-snapshot.json"], mintedArtifacts }),
+    }, (root) => {
+      assert.throws(() => scanRepository(root, { requireClean: true }), /manifest minted artifact/);
+    });
   }
+});
+
+test("tracked and minted paths cannot escape or resolve through symlinks", () => {
+  withRepositoryFixture({
+    symlinks: { "published-link": "public-snapshot.json" },
+    manifest: baseManifest({ include: ["published-link"], exclude: ["public-snapshot.json"] }),
+  }, (root) => {
+    assert.throws(
+      () => scanRepository(root, { requireClean: true }),
+      /included tracked path must be a regular Git file/,
+    );
+  });
+
+  const outside = mkdtempSync(join(tmpdir(), "agentos-snapshot-outside-"));
+  const secret = `ghp_${"B".repeat(24)}`;
+  writeFileSync(join(outside, "secret.txt"), secret);
+  try {
+    withRepositoryFixture({
+      manifest: baseManifest({
+        exclude: ["public-snapshot.json"],
+        mintedArtifacts: ["minted/secret.txt"],
+      }),
+    }, (root) => {
+      mkdirSync(join(root, "minted"));
+      symlinkSync(join(outside, "secret.txt"), join(root, "minted/secret.txt"));
+      assert.throws(() => scanRepository(root, { requireClean: true }), /regular file/);
+      const cliScanner = fileURLToPath(new URL("./public-snapshot-scan.mjs", import.meta.url));
+      const cli = spawnSync(process.execPath, ["-e", [
+        `import(${JSON.stringify(new URL(`file://${cliScanner}`).href)})`,
+        `.then(({scanRepository}) => scanRepository(${JSON.stringify(root)}, {requireClean:true}))`,
+      ].join("")], { encoding: "utf8" });
+      assert.notEqual(cli.status, 0);
+      assert.equal(`${cli.stdout}${cli.stderr}`.includes(secret), false, "outside bytes must not be emitted");
+    });
+  } finally {
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test("tracked bytes come from the reported commit even when the worktree changes", () => {
+  withRepositoryFixture({
+    files: { "published.txt": "safe text\n" },
+    manifest: baseManifest({ include: ["published.txt"], exclude: ["public-snapshot.json"] }),
+  }, (root) => {
+    const commit = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    writeFileSync(join(root, "published.txt"), `ghp_${"C".repeat(24)}\n`);
+    const { report } = scanRepository(root, { requireClean: false });
+    assert.equal(report.commit, commit);
+    assert.equal(report.source, "git-objects");
+    assert.equal(report.summary.countsByCategory.credential, 0);
+    assert.throws(() => scanRepository(root, { requireClean: true }), /tracked worktree must match HEAD/);
+  });
+});
+
+test("binary detection examines bytes after the first 8192", () => {
+  withRepositoryFixture({
+    files: { "late-binary.dat": Buffer.concat([Buffer.alloc(8192, 65), Buffer.from([0, 1, 2])]) },
+    manifest: baseManifest({ include: ["late-binary.dat"], exclude: ["public-snapshot.json"] }),
+  }, (root) => {
+    const { report } = scanRepository(root, { requireClean: true });
+    assert.equal(report.summary.countsByCategory["binary-material"], 1);
+    assert.equal(report.summary.countsByDisposition.blocker, 1);
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

- validate manifest paths and tracked entry types before scanning
- read tracked bytes from the pinned Git commit and harden minted-artifact containment
- make credentials unconditional blockers and scan complete blobs for binary data

## Verification

MERGE GATE: PASS 4d0ab90fed2519c0d9e117bc37899f5a4c005608