### PR TITLE
docs: correct existing migration contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,13 @@ release path above runs `npm run db:migrate:release -- --fresh`, which takes an
 exclusive maintenance lock before it inspects schema state and holds it through
 the guarded migration. An export without a valid `release-authority.json`
 attestation stops rather than defaulting to trusted. `--existing` separately
-stops at `oss-d-interface-unavailable`, so migrating an installation that already
-holds data is unsupported. The full sequence and refusal conditions are in the
-release quickstart and migration guide. Packaging, notarization and auto-update
-are not in this release candidate.
+implements the verified-bundle consumer, but this repository does not ship the
+backup producer needed to create a conforming bundle. The supported release
+workflow therefore remains fresh-only; `--existing` does not emit a synthetic
+"interface unavailable" refusal and must not be treated as an end-to-end
+supported migration path. The exact implemented sequence and refusal conditions
+are in the release quickstart and migration guide. Packaging, notarization and
+auto-update are not in this release candidate.
 
 `npm run setup:local` writes `.env` once, at mode 0600, with distinct random
 operator and runner tokens, a session-cookie secret, a base64 32-byte encryption

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -114,9 +114,11 @@ Prisma client——因此**不支持 `--ignore-scripts`**。Inbox 服务可选�
 `CONTRIBUTING.md` 中作为开发命令说明，不是安装命令。上面的有闸发布路径运行
 `npm run db:migrate:release -- --fresh`。该命令在读取 schema 状态前取得排他维护锁，
 并在有闸迁移全程持有它。没有有效 `release-authority.json` attestation 的导出会停下，
-不会默认为可信。`--existing` 另行停在 `oss-d-interface-unavailable`，因此本版本不支持
-迁移已有数据的安装。完整流程与拒绝条件见发布 quickstart 和迁移指南。打包、公证与自动
-更新同样不属于本发布候选范围。
+不会默认为可信。`--existing` 已实现 verified-bundle consumer，但本仓库不交付用于生成
+合规 bundle 的 backup producer。因此受支持的发布流程仍只有 fresh；`--existing` 不会
+发出虚构的 “interface unavailable” refusal，也不能被视为受支持的端到端迁移路径。实际
+实现的完整流程与拒绝条件见发布 quickstart 和迁移指南。打包、公证与自动更新同样不属于
+本发布候选范围。
 
 `npm run setup:local` 会一次性生成权限 0600 的 `.env`：互不相同的 operator 与 runner
 token、session cookie secret、base64 编码的 32 字节加密密钥，以及同时写入

--- a/docs/release/v0.1.0-migration-and-recovery.md
+++ b/docs/release/v0.1.0-migration-and-recovery.md
@@ -16,9 +16,11 @@ has already gone wrong.
 miss. It is not a faster release path; it is a different thing that happens to
 end with a schema.
 
-**One command is supported on the release path: `npm run db:migrate:release`.**
-It is the only entry point this release covers, and it never reaches Prisma
-directly — it composes `npm run db:migrate-goal-execution`, which is exactly
+**One mode is supported on the release path: `npm run db:migrate:release --
+--fresh`.** The wrapper also contains an executable `--existing` consumer, but
+this repository does not ship the backup producer required to create its input,
+so that mode is not an end-to-end supported workflow. The wrapper never reaches
+Prisma directly — it composes `npm run db:migrate-goal-execution`, which is exactly
 `npm run db:preflight-goal-execution && prisma migrate deploy`. That composed
 command is the floor: every migration on a release path runs through the
 preflight, and `db:migrate-goal-execution` is itself supported for the case where
@@ -64,10 +66,14 @@ npm run db:migrate:release -- --existing --backup-bundle /ABSOLUTE/PATH/TO/BUNDL
 The path must be absolute; a relative one is refused before anything else
 happens.
 
-> **Status.** `--existing` stops immediately at `oss-d-interface-unavailable`:
-> the verified-backup attestation producer its safety story rests on has not
-> merged, and a command that validated a bundle no producer creates would *look*
-> guarded without being it.
+> **Status.** The `--existing` consumer is implemented: after target identity it
+> validates the bundle, attested target, maintenance lock, WAL fingerprint and
+> migration history before it can deploy. The repository does not ship the
+> backup producer or a supported runbook that creates such a bundle. Therefore
+> no end-to-end existing-install migration is supported in v0.1.0, even though
+> the consumer is executable. It does not emit an `interface unavailable`
+> condition; supplying an absent, malformed or mismatched bundle reaches the
+> corresponding refusal below.
 >
 > `--fresh` is the supported path. It acquires the exclusive maintenance lock
 > before it inspects any schema state and holds it across the emptiness census,
@@ -97,11 +103,25 @@ STOP preflight <condition>: <detail>
 | `env-file`, `compose-file`, `compose-service`, `compose-port` | The checkout's `.env` or `docker-compose.yml` does not describe one PostgreSQL service published on one loopback port. |
 | `target-url`, `env-conflict` | `DATABASE_URL` is absent, unparsable, not PostgreSQL, or an inherited value disagrees with the one in `.env`. The command will not migrate a target it cannot prove is the one in this checkout. |
 | `compose-identity`, `server-identity` | The database answering is not the Compose database this checkout defines. |
+| `backup-bundle`, `backup-target`, `backup-wal` | Existing mode, and the bundle is unreadable/invalid, names another target, or no longer matches the target's WAL fingerprint. These are real consumer checks; this release does not ship the producer needed to create a supported bundle. |
 | `target-not-empty` | Fresh mode, and the schema already holds migration history or user objects. The line above it reports the census. |
 | `migration-tail` | This checkout's migration set is not the recorded release candidate — shorter or longer. Authority evidence describes a specific set; a different one is not covered by it. |
+| `migration-state`, `files-precheck` | Existing mode, and migration history cannot be proven compatible or the owned-files precheck fails. |
 | `maintenance-lock-unavailable` | The exclusive maintenance lock could not be taken, was already held by another session or an active service, or was lost while the migration ran. |
-| `oss-d-interface-unavailable` | Existing mode, and the verified-backup attestation interface has not merged. |
 | `migrate-goal-execution`, `migrate-status`, `drift-check` | The composed migration, the status check, or the drift check exited non-zero. |
+
+The argument boundary can be checked without a database or a bundle. This
+literal command:
+
+```sh
+npm run db:migrate:release -- --existing
+```
+
+terminates before environment or target inspection with:
+
+```text
+STOP release-migrate arguments: existing-mode-requires---backup-bundle
+```
 
 ### Preflight conditions
 

--- a/docs/release/v0.1.0-support-matrix.md
+++ b/docs/release/v0.1.0-support-matrix.md
@@ -100,7 +100,7 @@ the CLI vendor.
 | Operation | Status | Evidence boundary |
 | --- | --- | --- |
 | Fresh install migration | **Implementation verified; clean install Pending** | `npm run db:migrate:release -- --fresh` proves its target, emptiness and migration set, then runs behind its preflight. A complete clean-machine install has not been recorded. |
-| Migrating an existing installation | **Pending** | `--existing` stops at `oss-d-interface-unavailable`: the verified-backup attestation producer its safety story rests on has not merged. |
+| Migrating an existing installation | **Unsupported end to end; consumer implemented** | `--existing` validates a verified bundle and can continue through the guarded migration sequence, but this repository ships no backup producer or supported runbook that creates that bundle. The mode does not emit an `interface unavailable` condition; executable consumer code alone is not release evidence. |
 | Upgrading between preview builds | **Unsupported** | There is no upgrade path other than a fresh install. Nothing is packaged, notarized or self-updating. |
 | Down migration | **Does not exist** | No command in this repository reverses an applied migration. Rolling back code does not roll back the database. |
 | Restore | **Unsupported** | Restoring over a database something is still using is not a supported operation of this release. |

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "snapshot:authority-keygen": "npm run snapshot:authority-keygen -w @agentos/db --",
     "snapshot:scan": "node scripts/public-snapshot-scan.mjs",
     "test:snapshot-scan": "node --test scripts/public-snapshot-scan.test.mjs",
+    "test:release-docs": "node --test scripts/release-docs.test.mjs",
     "test:dependency-gate": "node --test scripts/goal-5a0-dependency-gate.test.mjs scripts/goal-5a0-handoff-preimage.test.mjs",
     "test:db": "npm run test:db -w @agentos/api",
     "merge-gate": "bash scripts/merge-gate.sh",

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -101,6 +101,7 @@
     { "glob": "scripts/os-isolation/verify.sh", "purpose": "OS isolation: read-only posture check and containment probe" },
     { "glob": "scripts/public-snapshot-scan.mjs", "purpose": "redacted safety scan" },
     { "glob": "scripts/public-snapshot-scan.test.mjs", "purpose": "scanner regression tests" },
+    { "glob": "scripts/release-docs.test.mjs", "purpose": "executable release documentation contract tests" },
     { "glob": "scripts/setup-local.mjs", "purpose": "atomic local configuration generator" },
     { "glob": "scripts/setup-local.test.mjs", "purpose": "local configuration generator regression tests" },
     { "glob": "scripts/verify-secret-hygiene.mjs", "purpose": "bundle and tracked-file secret hygiene scan" },

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -406,6 +406,7 @@ step "frozen records append-only" bash scripts/check-frozen-docs.sh --master "${
 # The checker is a gate rule, so it is gated too: PR #156 shipped one whose
 # date-prefix rule was unreachable by construction, and nothing ran to say so.
 step "frozen-record checker fixtures" node --test scripts/check-frozen-docs.test.mjs
+step "release documentation executable contract" npm run test:release-docs
 
 # --- docker ----------------------------------------------------------------
 

--- a/scripts/release-docs.test.mjs
+++ b/scripts/release-docs.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const PUBLIC_EXISTING_MODE_DOCS = [
+  "README.md",
+  "README.zh-CN.md",
+  "docs/release/v0.1.0-migration-and-recovery.md",
+  "docs/release/v0.1.0-support-matrix.md",
+];
+
+test("published docs describe the executable existing-mode consumer truthfully", () => {
+  const docs = PUBLIC_EXISTING_MODE_DOCS.map((path) => [path, readFileSync(path, "utf8")]);
+  for (const [path, text] of docs) {
+    assert.equal(
+      text.includes("oss-d-interface-unavailable"),
+      false,
+      `${path} must not document a condition the release migrator cannot emit`,
+    );
+    assert.match(text, /--existing/u, `${path} must state the existing-mode boundary`);
+  }
+
+  const migrationGuide = docs.find(([path]) => path.endsWith("migration-and-recovery.md"))?.[1];
+  assert.ok(migrationGuide);
+  assert.match(migrationGuide, /npm run db:migrate:release -- --existing\n/u);
+  assert.match(
+    migrationGuide,
+    /STOP release-migrate arguments: existing-mode-requires---backup-bundle/u,
+  );
+  assert.match(migrationGuide, /does not ship the\n> backup producer/u);
+});
+
+test("the documented no-bundle invocation stops at the argument boundary", () => {
+  const result = spawnSync("npm", ["run", "db:migrate:release", "--", "--existing"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      PATH: process.env.PATH,
+      RUNNER_WORKSPACE_ROOT: process.env.RUNNER_WORKSPACE_ROOT,
+    },
+  });
+  assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+  assert.match(
+    result.stderr,
+    /^STOP release-migrate arguments: existing-mode-requires---backup-bundle$/mu,
+  );
+  assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /step=target|DATABASE_URL|postgres/iu);
+});


### PR DESCRIPTION
## Summary

- describe `--existing` as an implemented backup-bundle consumer, not a complete backup workflow
- mark the current release path fresh-install only until a producer and runbook exist
- add an executable no-DB documentation contract and include it in the merge gate

## Verification

MERGE GATE: PASS 3eabe733932221adee93b078721ff81507e2fb86