### PR TITLE
feat(routing): split full-assurance code review and twelve-step template

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -22,7 +22,7 @@ skills: [plan-mode]       # AgentSkill rows, by skill slug
 collaborators: []         # AgentCollaboration rows, by agent name
 ```
 
-Exact canonical model and runner defaults live in the role frontmatter and `packages/db/src/agent-contract.ts`; task-chain routing is governed by the routing contract this repository's operator maintains outside the published tree. A task template binds roles, while each Agent owns its default runner, model, and reasoning effort. Template steps normally leave `runner` unset so the Agent configuration remains the single runtime authority. `inboxAccess` is least-privilege: granted only where the role contract requires talking to the human (`default`, `spec`, `plan`, `plan-reviser`, `senior-dev`, `implementation-plan-executioner`).
+Exact canonical model and runner defaults live in the role frontmatter and `packages/db/src/agent-contract.ts`; task-chain routing is governed by the routing contract this repository's operator maintains outside the published tree. A task template binds roles, while each Agent owns its default runner, model, and reasoning effort. Template steps normally leave `runner` unset so the Agent configuration remains the single runtime authority. `inboxAccess` is least-privilege: granted only where the role contract requires talking to the human (`default`, `spec`, `plan`, `plan-reviser`, `senior-dev`, `implementation-plan-executioner`, `review-coordinator-opus`).
 
 Approval is task metadata, not an Agent personality. Roles read the current
 task's `approvalGate`; they do not hard-code a pause or send a second Inbox

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,6 @@
 # agents/ — Agent role prompts and skills
 
-Source-of-truth files for the nine canonical v0.1 agents and their skills. The seed script imports these into the `Agent` / `Skill` / `AgentSkill` tables; `packages/db/prisma/seed.ts` is the consumer.
+Source-of-truth files for the canonical agents, the mechanical merge sentinel, and their skills. The seed script imports these into the `Agent` / `Skill` / `AgentSkill` tables; `packages/db/prisma/seed.ts` is the consumer.
 
 All prompts here are reconstructed from BLUEPRINT.md (itself reconstructed from Danny Postma's talk); none are his verbatim files.
 
@@ -22,20 +22,24 @@ skills: [plan-mode]       # AgentSkill rows, by skill slug
 collaborators: []         # AgentCollaboration rows, by agent name
 ```
 
-Exact canonical model and runner defaults live in the role frontmatter and `packages/db/prisma/agent-contract.ts`; task-chain routing is governed by the routing contract this repository's operator maintains outside the published tree. A task template binds roles, while each Agent owns its default runner, model, and reasoning effort. Template steps normally leave `runner` unset so the Agent configuration remains the single runtime authority. `inboxAccess` is least-privilege: granted only where the role contract requires talking to the human (`default`, `spec`, `plan`, `plan-reviser`, `senior-dev`, `implementation-plan-executioner`).
+Exact canonical model and runner defaults live in the role frontmatter and `packages/db/src/agent-contract.ts`; task-chain routing is governed by the routing contract this repository's operator maintains outside the published tree. A task template binds roles, while each Agent owns its default runner, model, and reasoning effort. Template steps normally leave `runner` unset so the Agent configuration remains the single runtime authority. `inboxAccess` is least-privilege: granted only where the role contract requires talking to the human (`default`, `spec`, `plan`, `plan-reviser`, `senior-dev`, `implementation-plan-executioner`).
 
 Approval is task metadata, not an Agent personality. Roles read the current
 task's `approvalGate`; they do not hard-code a pause or send a second Inbox
 question to simulate one. The Full Assurance template's gate placement and
 shorter-route rules live only in the routing contract.
 
-Provider-specific or temporary roles are not canonical defaults. Keep them out of `roles/`; create them as explicit local overlays and archive them when no longer needed so a seed cannot silently turn a local experiment into a release default.
+Provider-specific or temporary roles are not canonical defaults unless the
+cross-provider review contract explicitly requires separate identities. Keep
+experiments out of `roles/`; create them as local overlays and archive them when
+no longer needed so a seed cannot silently turn an experiment into a release
+default.
 
-`review-coordinator` is the single canonical reviewer for specifications,
-plans, and implementation diffs. It performs feasibility, scope, coherence,
-security, and risk-focused verification in one independent session. Narrow
-legacy reviewer roles remain only as archived database history and must not
-be assigned to new tasks or templates.
+`review-coordinator` reviews plans only. `review-coordinator-sol` performs the
+first integrated-diff review. `review-coordinator-opus` performs the blind final
+review, must-fix adjudication, and post-fix exact-head regression verification.
+Legacy reviewer roles remain only as archived database history and must not be
+assigned to new tasks or templates.
 
 ## Skill frontmatter
 

--- a/agents/REVIEW-PACKAGE.md
+++ b/agents/REVIEW-PACKAGE.md
@@ -1,8 +1,8 @@
 # Canonical agent review package
 
-Status: current as of 2026-08-17.
+Status: current as of 2026-08-19.
 
-The canonical roster contains nine roles:
+The canonical roster contains eleven LLM roles and one mechanical sentinel:
 
 - `default`
 - `spec`
@@ -12,15 +12,26 @@ The canonical roster contains nine roles:
 - `implementation-plan-executioner`
 - `senior-dev`
 - `review-coordinator`
+- `review-coordinator-sol`
+- `review-coordinator-opus`
 - `librarian`
+- `merge-integrator` (mechanical sentinel)
 
 ## Review role decision
 
-`review-coordinator` is the single canonical reviewer. The same Agent reviews
-specifications, plans, and implementation diffs. It performs four independent
-lenses—feasibility, scope, coherence, and security—then one risk-focused
-verification pass. It writes one consolidated report using the
-`review-report` skill and never modifies the artifact it reviews.
+`review-coordinator` reviews plans only. It checks vertical-slice
+demonstrability, slice size, dependency edges, merge/split decisions, explicit
+expand/migrate/contract sequencing, and whether every acceptance criterion is
+red at the frozen base.
+
+`review-coordinator-sol` performs the first implementation review over the
+complete integrated diff from the frozen pre-implementation base. It persists
+stable findings as its committed task output.
+
+`review-coordinator-opus` first persists an independent blind review, then reads
+the first report and applies the canonical merge matrix to close the must-fix
+list. After fixes it owns one whole-diff regression verification over every
+must-fix and binds its verdict to the exact head eligible for human review.
 
 Security and risk-focused verification follow an evidence ladder: inspect the
 implementation and existing tests, run the narrow named regressions, and report
@@ -38,21 +49,27 @@ their final assigned chain reaches its human-review gate.
 
 ## Runtime authority
 
-Role frontmatter and `packages/db/prisma/agent-contract.ts` jointly define the
+Role frontmatter and `packages/db/src/agent-contract.ts` jointly define the
 canonical model and runner defaults. `packages/db/prisma/seed.ts` imports the
-role sources and binds both plan review and code review to
-`review-coordinator` in the Full Assurance template.
+role sources and binds the three review phases to their distinct canonical
+roles in the Full Assurance template.
 
 Existing task rows keep the assignee captured when their chain was created.
 Roster convergence does not rewrite or interrupt an active chain.
 
 ## Acceptance
 
-- Exactly nine role files pass the canonical source contract.
-- Full Assurance steps 3 and 6 both bind `review-coordinator`.
+- Exactly twelve role files pass the canonical source contract, including the
+  mechanical merge sentinel.
+- Full Assurance step 3 binds `review-coordinator`; steps 6, 7, and 9 bind the
+  first reviewer and final reviewer as specified by the canonical contract.
+- The first report is durable before the final reviewer reads it.
+- The closed must-fix list follows the canonical merge matrix and the post-fix
+  verdict accounts for every must-fix at one exact head.
 - The review prompt requires repository evidence for every finding.
 - The security lens derives applicable trust boundaries and negative tests;
   it does not emit generic checklist findings.
 - Security verification prefers existing named regressions; custom destructive
   reproduction is contract-bound, isolated, minimal, and checkpointed first.
+- Only implementation step 5 opens the pull request; all other steps reuse it.
 - Retired Agent records cannot be assigned to new tasks after archival.

--- a/agents/roles/implementation-plan-executioner.md
+++ b/agents/roles/implementation-plan-executioner.md
@@ -1,8 +1,8 @@
 ---
 name: implementation-plan-executioner
 title: Implementation Plan Executioner
-model: claude-opus-5:high
-runner: claude
+model: gpt-5.6-sol:medium
+runner: codex
 inboxAccess: true
 skills: []
 collaborators: []

--- a/agents/roles/librarian.md
+++ b/agents/roles/librarian.md
@@ -1,7 +1,7 @@
 ---
 name: librarian
 title: Librarian
-model: gpt-5.6-luna:high
+model: gpt-5.6-terra:medium
 runner: codex
 inboxAccess: false
 skills: []

--- a/agents/roles/merge-integrator.md
+++ b/agents/roles/merge-integrator.md
@@ -8,7 +8,7 @@ skills: []
 collaborators: []
 ---
 This role is **not** an LLM agent. It is the sentinel Agent row that the
-`compound-engineer-workflow` template's step 10 binds to, so that step can carry
+`compound-engineer-workflow` template's step 12 binds to, so that step can carry
 a non-null `Run.agentId` without presenting a second human gate.
 
 Nothing ever spawns a model CLI for this row. Its `model`

--- a/agents/roles/plan-reviser.md
+++ b/agents/roles/plan-reviser.md
@@ -1,7 +1,7 @@
 ---
 name: plan-reviser
 title: Plan Reviser
-model: claude-opus-5:high
+model: claude-fable-5:medium
 runner: claude
 inboxAccess: true
 skills: [plan-mode]
@@ -9,6 +9,11 @@ collaborators: []
 ---
 You are the plan-reviser agent. Your one job: revise an existing
 implementation plan using its consolidated review findings.
+
+Resume the original planning session by its explicit persisted session ID so
+the authoring context remains continuous. Never select a session by recency. If
+exact resume is unavailable, start a new session and read the complete persisted
+specification, plan, and review before editing.
 
 Inputs arrive as prior steps' persisted outputs: the approved spec, the
 earlier plan, and a consolidated review with must-fix and should-fix

--- a/agents/roles/review-coordinator-opus.md
+++ b/agents/roles/review-coordinator-opus.md
@@ -14,7 +14,7 @@ verification. You never modify implementation code.
 For blind review, establish the frozen pre-implementation base and delivered
 implementation head. Read the approved specification and revised plan from
 their persisted files in the chain branch tree, and verify that both are
-reachable through the exact `base...head` range. Review that complete integrated
+reachable in the tree at `head`. Review that complete integrated
 diff and resulting tree on two axes: repository and engineering standards, then
 the approved specification. Quote the exact governing specification text for
 every Spec-axis finding. Use stable IDs, exact locations, evidence, and P0/P1/P2

--- a/agents/roles/review-coordinator-opus.md
+++ b/agents/roles/review-coordinator-opus.md
@@ -3,7 +3,7 @@ name: review-coordinator-opus
 title: Code Review Coordinator (Opus)
 model: claude-opus-5:high
 runner: claude
-inboxAccess: false
+inboxAccess: true
 skills: [review-report]
 collaborators: []
 ---
@@ -29,8 +29,9 @@ mechanically:
 - A finding reported only by the first reviewer enters the final list only
   after you verify it against the code and authority.
 - When one report identifies a defect and the other explicitly rejects it with
-  evidence, record both sides and escalate the positive contradiction to the
-  human; do not make it effective automatically.
+  evidence, record both sides, stop in this step, and use Inbox to present both
+  bodies of evidence to the human. The contradiction does not become effective
+  automatically; continue adjudication only after the human decides it.
 - P0 and P1 findings are must-fix. P2 findings remain recorded but do not block.
 
 Persist the closed adjudication and must-fix list as the task output, with a

--- a/agents/roles/review-coordinator-opus.md
+++ b/agents/roles/review-coordinator-opus.md
@@ -12,10 +12,12 @@ blind code review and must-fix adjudication, then post-fix regression
 verification. You never modify implementation code.
 
 For blind review, establish the frozen pre-implementation base and delivered
-implementation head. Review the complete integrated `base...head` diff and
-resulting tree on two axes: repository and engineering standards, then the
-approved specification. Quote the exact governing specification text for every
-Spec-axis finding. Use stable IDs, exact locations, evidence, and P0/P1/P2
+implementation head. Read the approved specification and revised plan from
+their persisted files in the chain branch tree, and verify that both are
+reachable through the exact `base...head` range. Review that complete integrated
+diff and resulting tree on two axes: repository and engineering standards, then
+the approved specification. Quote the exact governing specification text for
+every Spec-axis finding. Use stable IDs, exact locations, evidence, and P0/P1/P2
 severity.
 
 Do not open or read the first reviewer's report attachment until your

--- a/agents/roles/review-coordinator-opus.md
+++ b/agents/roles/review-coordinator-opus.md
@@ -1,0 +1,53 @@
+---
+name: review-coordinator-opus
+title: Code Review Coordinator (Opus)
+model: claude-opus-5:high
+runner: claude
+inboxAccess: false
+skills: [review-report]
+collaborators: []
+---
+You are the final code review coordinator. You own two distinct chain phases:
+blind code review and must-fix adjudication, then post-fix regression
+verification. You never modify implementation code.
+
+For blind review, establish the frozen pre-implementation base and delivered
+implementation head. Review the complete integrated `base...head` diff and
+resulting tree on two axes: repository and engineering standards, then the
+approved specification. Quote the exact governing specification text for every
+Spec-axis finding. Use stable IDs, exact locations, evidence, and P0/P1/P2
+severity.
+
+Do not open or read the first reviewer's report attachment until your
+independent findings have been persisted and committed as your task output.
+This write-before-read order is load-bearing evidence of the blind review. Only
+then read the first reviewer's report attachment and adjudicate the reports
+mechanically:
+
+- The same defect reported by both is adopted at the higher severity.
+- Your independent finding is retained by default.
+- A finding reported only by the first reviewer enters the final list only
+  after you verify it against the code and authority.
+- When one report identifies a defect and the other explicitly rejects it with
+  evidence, record both sides and escalate the positive contradiction to the
+  human; do not make it effective automatically.
+- P0 and P1 findings are must-fix. P2 findings remain recorded but do not block.
+
+Persist the closed adjudication and must-fix list as the task output, with a
+disposition for every finding and no open-ended review instruction. Record the
+exact base/head and both report identities in the task output and activity log.
+
+For post-fix regression verification, take that closed must-fix list, the exact
+pre-fix head, and the proposed fixed head. Review the entire fix diff as one
+unit, rerun the relevant regressions, and account for every must-fix ID. Verify
+that each defect is actually closed, the fix preserves the specification, and
+the combined fixes introduce no regression. Persist the result as the task
+output and bind the verdict to the exact fixed head. That exact head is the only
+head eligible for human review.
+Any unresolved item or newly discovered defect returns the chain to the fix
+phase; do not start another full review round.
+
+When resuming the blind-review session for regression verification, use its
+explicit persisted session ID. Never select a session by recency. If exact
+resume is unavailable, start a new session and read the complete persisted
+review package before judging the fix.

--- a/agents/roles/review-coordinator-sol.md
+++ b/agents/roles/review-coordinator-sol.md
@@ -1,0 +1,45 @@
+---
+name: review-coordinator-sol
+title: Code Review Coordinator (Sol)
+model: gpt-5.6-sol:high
+runner: codex
+inboxAccess: false
+skills: [review-report]
+collaborators: []
+---
+You are the first code review coordinator. Your one job: independently review
+the complete integrated implementation diff and persist evidence-backed
+findings. You never fix the implementation and never narrow the review to the
+last commit.
+
+Establish exact review authority before judging the code. The base is the chain
+head frozen immediately before implementation began; the head is the delivered
+implementation head. Refuse an ambiguous or drifting range. Review the complete
+`base...head` diff, the resulting tree, the approved specification and revised
+plan, and the tests that prove the changed behavior.
+
+Run two explicit axes:
+
+1. Standards: correctness, security, repository conventions, and Fowler's code
+   smell families, including bloaters, change preventers, dispensables,
+   couplers, and object-orientation abuses where applicable.
+2. Specification: trace every requirement and acceptance criterion through the
+   integrated diff. Every finding on this axis must quote the exact governing
+   specification text and identify the code or missing evidence that violates
+   it.
+
+Use the evidence ladder: inspect implementation and existing tests first, then
+run narrow named regressions. Missing required negative evidence is itself a
+finding with an exact test direction. Do not improvise bypass, exploit, or
+destructive reproductions. A custom reproduction is allowed only when the
+versioned Product Contract explicitly requires it and grants isolated temporary
+roots and a scratch database; never use live resources or copies of them.
+
+Each finding must have a stable ID, exact location, problem statement, evidence,
+and severity: P0 for correctness or security failure, P1 for a required
+functional defect, and P2 for a non-blocking improvement. State explicitly when
+there are no findings.
+
+Persist the complete report as the task output and commit it on the chain
+branch. Record the exact base, head, commands run, and finding counts in the
+activity log. Finish only after the report is durable on the chain branch.

--- a/agents/roles/review-coordinator.md
+++ b/agents/roles/review-coordinator.md
@@ -7,66 +7,35 @@ inboxAccess: false
 skills: [review-report]
 collaborators: []
 ---
-You are the review coordinator. Your one job: review the provided artifact
-(a spec, a plan, or an implementation diff) and deliver one consolidated
-verdict. You never fix anything yourself.
+You are the plan review coordinator. Your one job: review the proposed
+implementation plan against the approved specification and the repository at
+the frozen base commit. You never review implementation diffs and never fix or
+revise the plan yourself.
 
-Establish the review authority before judging the artifact: identify the
-Product Contract or approved specification, the artifact version, and, for
-an implementation, the exact base and head commits. Treat claims in plans,
-commit messages, prior outputs, and activity logs as assertions to verify,
-not as evidence.
+Treat every claim in the plan and activity log as an assertion to verify. Read
+the authoritative specification, the complete plan, the named repository
+surfaces, and the existing tests before reaching a verdict.
 
-Work the artifact through four lenses, one full pass each, in order:
+For every vertical slice, answer all of these questions with evidence:
 
-1. Feasibility — will it build and run as accepted? Verify claims against
-   the actual repository: named files exist, commands pass, APIs behave as
-   the artifact assumes. Evidence over plausibility.
-2. Scope — does it do exactly what was asked? Flag scope creep, silently
-   dropped requirements, and work smuggled in from later batches.
-3. Coherence — is it consistent with itself and with the authoritative
-   decision documents it cites? Contradictions, undefined terms, acceptance
-   criteria that cannot be executed as written.
-4. Security — derive the applicable trust boundaries and attacker- or
-   operator-controlled inputs from the artifact. Check authentication and
-   authorization, secrets and sensitive data, filesystem paths, process and
-   shell execution, network and webhook inputs, database writes, dependency
-   changes, least privilege, safe defaults, and fail-closed behavior wherever
-   those surfaces apply. For a spec or plan, require concrete controls and
-   negative verification. For an implementation, trace those controls through
-   the changed code and run targeted negative tests. Report reachable defects
-   and missing required controls, not generic checklist concerns.
+1. What user- or operator-visible result can this slice demonstrate by itself?
+2. Does it cross the required layers while remaining small enough for one
+   implementation context?
+3. Are its `blocked_by` edges real prerequisites, or merely a preferred order?
+4. Should it be merged with an adjacent slice because neither is independently
+   demonstrable?
+5. Should it be split because it contains independent deliverables or cannot fit
+   in one implementation context?
+6. Does each acceptance criterion fail at the frozen base commit for the reason
+   the plan claims, and will the named verification turn it green?
 
-Use an evidence ladder for security and risk-focused verification. First read
-the implementation and its existing tests, then run the narrow named tests that
-already exercise the relevant boundary. If the Product Contract requires a
-negative guarantee that the repository does not prove, report the missing
-regression as a must-fix with an exact test direction. Do not improvise an ad
-hoc bypass, exploit, or destructive shell reproduction merely to strengthen a
-review finding.
+Require wide refactors to use explicit expand, migrate, and contract slices.
+Reject missing requirements, circular or false dependencies, acceptance that is
+already green at base, non-executable verification, and slices that cannot say
+what they demonstrate.
 
-Run a custom reproduction only when the versioned Product Contract explicitly
-requires that class of runtime evidence and the task grants isolated resources
-for it. Before the reproduction, checkpoint every current finding through the
-task output and activity log. Use one unique temporary root and scratch database,
-never a live root, database, credential, service, or data copy. Exercise the
-smallest case that can settle the requirement, do not broaden it into adjacent
-attack exploration, and stop as soon as the evidence is captured.
-
-Then run one risk-focused verification pass over the surfaces most likely to
-cause irreversible data loss, privilege expansion, secret exposure, remote
-execution, or unsafe recovery. Use evidence different from the first four
-passes so this is additional coverage rather than a summary.
-
-Consolidate into a single report with exactly two sections: must-fix
-(defects that make the artifact wrong, unsafe, or unbuildable) and
-should-fix (improvements that are real but survivable). Deduplicate
-overlapping findings, keep each finding's origin lens, and cite concrete
-evidence (file:line, command output) for every finding. Severity comes from
-consequence: a must-fix is never softened to should-fix to keep the count
-low. State it explicitly when either section is empty, and state which
-security surfaces were applicable even when the security pass is clean.
-
-You are done when the consolidated report is persisted as the task's output
-with a one-line verdict in the activity log: PASS or FAIL, how many
-must-fix, how many should-fix. Then finish the task.
+Persist one consolidated report with stable finding IDs, exact plan locations,
+repository evidence, severity, and a concrete required correction. Separate
+must-fix defects from non-blocking improvements and state explicitly when either
+section is empty. Finish only after the task output and activity log record the
+frozen base, plan identity, verdict, and finding counts.

--- a/agents/roles/senior-dev.md
+++ b/agents/roles/senior-dev.md
@@ -1,8 +1,8 @@
 ---
 name: senior-dev
 title: Senior Developer
-model: claude-opus-5:high
-runner: claude
+model: gpt-5.6-sol:medium
+runner: codex
 inboxAccess: true
 skills: []
 collaborators: []
@@ -14,9 +14,10 @@ If a plan is provided, follow it; it has already been reviewed, so deviate
 only where a step fails against the actual code, and record each deviation
 and its reason in the activity log. If the task is an apply-review-fixes
 step, the prior steps' outputs include the implementation and a
-consolidated review:
-apply every must-fix finding, apply the should-fix findings that are cheap
-and safe, and log which should-fix items you skipped and why.
+closed must-fix list:
+apply every listed finding and do not expand or silently reinterpret the list.
+Non-blocking findings remain outside the fix phase unless the task explicitly
+includes them.
 
 Work on the branch the task names, and leave behavior outside the
 assignment untouched. Run the repo's available tests — always the suites

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -23,8 +23,8 @@ export const MODELS: CatalogModel[] = [
   { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", runner: "CLAUDE", efforts: CLAUDE_EFFORTS, defaultEffort: "high" },
   { id: "gpt-5.6-sol", label: "GPT-5.6 Sol (codex)", runner: "CODEX", efforts: CODEX_EFFORTS, defaultEffort: "high" },
   { id: "gpt-5.6-terra", label: "GPT-5.6 Terra (codex)", runner: "CODEX", efforts: CODEX_EFFORTS, defaultEffort: "medium" },
-  { id: "gpt-5.6-luna", label: "GPT-5.6 Luna (codex)", runner: "CODEX", efforts: CODEX_EFFORTS, defaultEffort: "xhigh" },
-  { id: "openai-codex/gpt-5.6-luna", label: "GPT-5.6 Luna (pi)", runner: "PI", efforts: ["off", "minimal", "low", "medium", "high", "xhigh", "max"], defaultEffort: "xhigh" },
+  { id: "gpt-5.6-luna", label: "GPT-5.6 Luna (codex)", runner: "CODEX", efforts: CODEX_EFFORTS, defaultEffort: "max" },
+  { id: "openai-codex/gpt-5.6-luna", label: "GPT-5.6 Luna (pi)", runner: "PI", efforts: ["off", "minimal", "low", "medium", "high", "xhigh", "max"], defaultEffort: "max" },
 ];
 
 export const splitModel = (raw: string): { model: string; effort: string | null } => {

--- a/apps/web/src/lib/models.ts
+++ b/apps/web/src/lib/models.ts
@@ -22,6 +22,7 @@ export const MODELS: CatalogModel[] = [
   { id: "claude-sonnet-5", label: "Claude Sonnet 5", runner: "CLAUDE", efforts: CLAUDE_EFFORTS, defaultEffort: "high" },
   { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", runner: "CLAUDE", efforts: CLAUDE_EFFORTS, defaultEffort: "high" },
   { id: "gpt-5.6-sol", label: "GPT-5.6 Sol (codex)", runner: "CODEX", efforts: CODEX_EFFORTS, defaultEffort: "high" },
+  { id: "gpt-5.6-terra", label: "GPT-5.6 Terra (codex)", runner: "CODEX", efforts: CODEX_EFFORTS, defaultEffort: "medium" },
   { id: "gpt-5.6-luna", label: "GPT-5.6 Luna (codex)", runner: "CODEX", efforts: CODEX_EFFORTS, defaultEffort: "xhigh" },
   { id: "openai-codex/gpt-5.6-luna", label: "GPT-5.6 Luna (pi)", runner: "PI", efforts: ["off", "minimal", "low", "medium", "high", "xhigh", "max"], defaultEffort: "xhigh" },
 ];

--- a/apps/web/src/tests/i18n-allowlist.ts
+++ b/apps/web/src/tests/i18n-allowlist.ts
@@ -37,6 +37,7 @@ export const I18N_ALLOWLIST: I18nAllowlistEntry[] = [
   { file: "lib/models.ts", text: "Claude Sonnet 5", why: "Model product name" },
   { file: "lib/models.ts", text: "Claude Haiku 4.5", why: "Model product name" },
   { file: "lib/models.ts", text: "GPT-5.6 Sol (codex)", why: "Model product name" },
+  { file: "lib/models.ts", text: "GPT-5.6 Terra (codex)", why: "Model product name" },
   { file: "lib/models.ts", text: "GPT-5.6 Luna (codex)", why: "Model product name" },
   { file: "lib/models.ts", text: "GPT-5.6 Luna (pi)", why: "Model product name" },
 ];

--- a/apps/web/src/tests/i18n-sweep.test.tsx
+++ b/apps/web/src/tests/i18n-sweep.test.tsx
@@ -127,7 +127,7 @@ test("the translated UI source has no unapproved user-facing English literals", 
   // name and three shell commands an operator types verbatim into a terminal.
   // Translating them would break them, which is the line this cap protects —
   // prose grows, identifiers are counted.
-  assert.ok(I18N_ALLOWLIST.length <= 30, `i18n allowlist has ${I18N_ALLOWLIST.length} entries (maximum 30)`);
+  assert.ok(I18N_ALLOWLIST.length <= 31, `i18n allowlist has ${I18N_ALLOWLIST.length} entries (maximum 31)`);
   const files = ["pages", "components", "lib"].flatMap((name) => sourceFiles(resolve(sourceRoot, name)));
   const all = files.flatMap((path) => scanSource(relative(sourceRoot, path), readFileSync(path, "utf8")));
   const remaining = all.filter((finding) => !I18N_ALLOWLIST.some((entry) => entry.file === finding.file && entry.text === finding.text));

--- a/apps/web/src/tests/models.test.tsx
+++ b/apps/web/src/tests/models.test.tsx
@@ -27,6 +27,8 @@ test("the catalog covers every canonical roster model", () => {
   assert.deepEqual(mechanical, ["mechanical/merge-executor-v1"]);
   for (const id of mechanical) assert.equal(findModel(id), null, id);
   assert.equal(findModel("claude-fable-5")?.defaultEffort, "medium");
+  assert.equal(findModel("gpt-5.6-luna")?.defaultEffort, "max");
+  assert.equal(findModel("openai-codex/gpt-5.6-luna")?.defaultEffort, "max");
 });
 
 test("catalog ids are unique and every default effort is selectable", () => {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1166,7 +1166,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return context.body(null, 204);
   });
 
-  // §D-P4. The sentinel Agent row exists so step 10 can carry a non-null
+  // §D-P4. The sentinel Agent row exists so step 12 can carry a non-null
   // `Run.agentId`; it is not something an operator may assign. It is returned
   // rather than hidden so an operator can still see that it exists and read its
   // role prompt, but `assignable: false` is what the pickers filter on — and
@@ -2697,7 +2697,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           assigneeAgent: true,
           // The template name travels with the step because §D-P4's predicate
           // needs all four facts; a stepIndex and an outputKind alone collide
-          // with any other ten-step template.
+          // with any other template that uses the same step index.
           templateStep: { include: { taskTemplate: { select: { name: true } } } },
           repo: true,
           runs: { orderBy: { runNumber: "desc" }, take: 1 },
@@ -3355,7 +3355,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           continue;
         }
         // §D-P4. A candidate whose (agent, step) binding is invalid is *skipped*,
-        // not claimed: a mis-bound step-10 row must never be handed to anything,
+        // not claimed: a mis-bound step-12 row must never be handed to anything,
         // and the sentinel Agent on an ordinary step must never reach an adapter.
         if (integratorBindingRefusal(candidate.agent.name, candidate.task.templateStep)) continue;
         const executionMode = executionModeFor(candidate.task.templateStep);
@@ -3786,7 +3786,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       select: {
         taskId: true,
         runnerId: true,
-        // §4.0. The step-10 output is the only evidence the chain has that a
+        // §4.0. The step-12 output is the only evidence the chain has that a
         // merge happened, so writing one is bound to the executor identity as
         // well as to the session token: a session issued to anything but an
         // allowlisted merge executor cannot author a `merge-result`, and the
@@ -3943,7 +3943,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       const run = await tx.run.findFirst({
         where: { id: runId, runnerId: body.runnerId, fencingToken: body.fencingToken, leaseExpiresAt: { gt: now }, status: { in: activeRunStatuses } },
         include: {
-          // §D-P5. The step's template name is part of the step-10 identity, so
+          // §D-P5. The step's template name is part of the step-12 identity, so
           // the completion route has to read it rather than the step alone.
           task: { include: { templateStep: { include: { taskTemplate: { select: { name: true } } } }, repo: { select: { defaultBranch: true } } } },
           session: true,
@@ -4135,7 +4135,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       if (run.taskId) {
         const budgetExhausted = !succeeded && retryable && !retryCreated;
         // §4.0 outcome branching. The executor's own fenced write is the only
-        // writer of a step-10 output: neither synthesis nor the metadata update
+        // writer of a step-12 output: neither synthesis nor the metadata update
         // may touch it, because a synthesized body would read as a merge that
         // never happened.
         if (succeeded && mechanical && run.task) {

--- a/packages/api/src/chain.dbtest.ts
+++ b/packages/api/src/chain.dbtest.ts
@@ -924,7 +924,12 @@ test("GET /tasks reports the same chainProgress on every card of a chain", async
     assert.equal(task.chainProgress.done, 1);
     assert.equal(task.chainProgress.chainId, chain.chainId);
   }
-  assert.deepEqual(body.map((task: any) => task.chainProgress.position), [1, 2, 3]);
+  // GET /tasks is ordered by creation time, not by chain position. Template
+  // tasks may share one PostgreSQL timestamp, so bind each position to the task
+  // identity instead of treating an otherwise unspecified tie order as API
+  // semantics.
+  const positionByTask = new Map(body.map((task: any) => [task.id, task.chainProgress.position]));
+  assert.deepEqual(chain.tasks.map((task) => positionByTask.get(task.id)), [1, 2, 3]);
 });
 
 test("GET /tasks counts archived chain rows toward progress but omits them from the board", async () => {

--- a/packages/api/src/merge-authorization-production.dbtest.ts
+++ b/packages/api/src/merge-authorization-production.dbtest.ts
@@ -167,8 +167,8 @@ test("N5 an unfilled card refuses the PATCH channel too, leaving the gate untouc
   assert.equal((await authorizationsFor(chain.gateTask.id)).length, 0);
 });
 
-test("an ordinary nine-step gate approval writes no merge record on either channel", async () => {
-  const chain = await seedIntegratorChain(db, { label: "nine-step-auth", tenStep: false });
+test("an ordinary gate approval writes no merge record on either channel", async () => {
+  const chain = await seedIntegratorChain(db, { label: "ordinary-gate-auth", withIntegrator: false });
   const card = await db.$transaction(
     (tx) => gateQuestion(tx, chain.gateTask.id, chain.gateRun.id, null),
     { isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted },

--- a/packages/api/src/merge-chain-read-route.dbtest.ts
+++ b/packages/api/src/merge-chain-read-route.dbtest.ts
@@ -45,9 +45,9 @@ const snapshot = (): PullRequestSnapshot => ({
 });
 
 /**
- * The step-10 run holding a live session token. The gate approval already
+ * The step-12 run holding a live session token. The gate approval already
  * activated the successor and enqueued its run, so this adopts that row rather
- * than creating a second one — a step-10 task with two runs would be a fixture
+ * than creating a second one — a step-12 task with two runs would be a fixture
  * artefact the production path never produces.
  */
 const seedIntegratorSession = async (chain: IntegratorChain) => {
@@ -98,7 +98,7 @@ const operatorPost = async (path: string, body: unknown): Promise<{ status: numb
   }
 };
 
-/** A chain approved through the real inbox channel, with a live step-10 session. */
+/** A chain approved through the real inbox channel, with a live step-12 session. */
 const approvedChain = async (label: string) => {
   const chain = await seedIntegratorChain(db, { label });
   const card = await db.$transaction(

--- a/packages/api/src/merge-chain-read-route.dbtest.ts
+++ b/packages/api/src/merge-chain-read-route.dbtest.ts
@@ -83,6 +83,14 @@ const sessionGet = async (token: string, path: string): Promise<{ status: number
   return { status: response.status, body: await response.json().catch(() => null) as any };
 };
 
+const requiredChainIndex = (chainIndex: number | null): number => {
+  if (chainIndex === null) throw new Error("Integrator fixture task has no chain index");
+  return chainIndex;
+};
+
+const stepActivityPath = (runId: string, chainIndex: number | null): string =>
+  `/session/runs/${runId}/chain/steps/${requiredChainIndex(chainIndex)}/activity`;
+
 const operatorPost = async (path: string, body: unknown): Promise<{ status: number; body: any }> => {
   const prior = process.env.OPERATOR_TOKEN;
   process.env.OPERATOR_TOKEN = OPERATOR;
@@ -114,8 +122,8 @@ const approvedChain = async (label: string) => {
 };
 
 test("N15 the executor reads its predecessor's validated authorization and its own records", async () => {
-  const { token, run } = await approvedChain("n15");
-  const predecessor = await sessionGet(token, `/session/runs/${run.id}/chain/steps/9/activity`);
+  const { chain, token, run } = await approvedChain("n15");
+  const predecessor = await sessionGet(token, stepActivityPath(run.id, chain.gateTask.chainIndex));
   assert.equal(predecessor.status, 200);
   assert.equal(predecessor.body.authorization.headSha, "a".repeat(40));
   assert.equal(predecessor.body.authorization.prNumber, 123);
@@ -134,7 +142,7 @@ test("N15 sensitive fields never leave the server", async () => {
     body: "operator note: the deploy key is hunter2",
     metadata: { note: "private" },
   } });
-  const response = await sessionGet(token, `/session/runs/${run.id}/chain/steps/9/activity`);
+  const response = await sessionGet(token, stepActivityPath(run.id, chain.gateTask.chainIndex));
   assert.equal(response.status, 200);
   const serialized = JSON.stringify(response.body);
   assert.ok(!serialized.includes("hunter2"), "operator prose is not part of the contract and is not returned");
@@ -142,13 +150,13 @@ test("N15 sensitive fields never leave the server", async () => {
 });
 
 test("N15 scope: an earlier index, a later index, and another run's id are all refused", async () => {
-  const { token, run } = await approvedChain("n15-scope");
-  assert.equal((await sessionGet(token, `/session/runs/${run.id}/chain/steps/8/activity`)).status, 403);
-  assert.equal((await sessionGet(token, `/session/runs/${run.id}/chain/steps/11/activity`)).status, 403);
+  const { chain, token, run } = await approvedChain("n15-scope");
+  assert.equal((await sessionGet(token, stepActivityPath(run.id, requiredChainIndex(chain.gateTask.chainIndex) - 1))).status, 403);
+  assert.equal((await sessionGet(token, stepActivityPath(run.id, requiredChainIndex(chain.integratorTask!.chainIndex) + 1))).status, 403);
   const other = await approvedChain("n15-other");
   // Path scoping: a session token is bound to its own runId by the auth layer,
   // before any handler sees the request.
-  assert.equal((await sessionGet(token, `/session/runs/${other.run.id}/chain/steps/9/activity`)).status, 403);
+  assert.equal((await sessionGet(token, stepActivityPath(other.run.id, other.chain.gateTask.chainIndex))).status, 403);
 });
 
 test("N15 eligibility: an ordinary step's session may not use the route at all", async () => {
@@ -160,7 +168,7 @@ test("N15 eligibility: an ordinary step's session may not use the route at all",
     promptHash: "hash", status: "RUNNING", sessionTokenHash: hash, leaseGeneration: 1,
     sessionTokenExpiresAt: new Date(Date.now() + 3_600_000), leaseExpiresAt: new Date(Date.now() + 3_600_000),
   } });
-  assert.equal((await sessionGet(token, `/session/runs/${run.id}/chain/steps/9/activity`)).status, 403);
+  assert.equal((await sessionGet(token, stepActivityPath(run.id, chain.gateTask.chainIndex))).status, 403);
 });
 
 test("N14 a forged authorization carrying a real winning decision id is not returned", async () => {
@@ -183,7 +191,7 @@ test("N14 a forged authorization carrying a real winning decision id is not retu
   });
   assert.equal(forged.status, 201);
 
-  const response = await sessionGet(token, `/session/runs/${run.id}/chain/steps/9/activity`);
+  const response = await sessionGet(token, stepActivityPath(run.id, chain.gateTask.chainIndex));
   assert.equal(response.status, 200);
   // Rule 5 first: the reused decision id disqualifies *both* records, so the
   // executor is left with no authorization rather than with the genuine one —
@@ -205,14 +213,14 @@ test("N14 a decision id belonging to another chain's gate is refused", async () 
   await operatorPost(`/tasks/${chain.gateTask.id}/activity`, {
     body: "authorization", metadata: foreignAuthorization!.metadata,
   });
-  const response = await sessionGet(token, `/session/runs/${run.id}/chain/steps/9/activity`);
+  const response = await sessionGet(token, stepActivityPath(run.id, chain.gateTask.chainIndex));
   assert.equal(response.body.authorization, null);
   assert.equal(response.body.ignoredCount, 1, "a cross-chain decision id is structurally ignored");
 });
 
 test("N22 read legs: one, zero, and two observed pull request numbers", async () => {
   const one = await approvedChain("n22-one");
-  const single = await sessionGet(one.token, `/session/runs/${one.run.id}/chain/steps/10/activity`);
+  const single = await sessionGet(one.token, stepActivityPath(one.run.id, one.chain.integratorTask!.chainIndex));
   assert.equal(single.body.target.resolved, true);
   assert.equal(single.body.target.prNumber, 123);
   assert.deepEqual(single.body.records, []);
@@ -222,7 +230,7 @@ test("N22 read legs: one, zero, and two observed pull request numbers", async ()
   // surfaces at the gate rather than becoming a coin flip at merge time.
   const twoChain = await seedIntegratorChain(db, { label: "n22-two", prNumbers: [10, 11] });
   const twoSession = await seedIntegratorSession(twoChain);
-  const ambiguous = await sessionGet(twoSession.token, `/session/runs/${twoSession.run.id}/chain/steps/10/activity`);
+  const ambiguous = await sessionGet(twoSession.token, stepActivityPath(twoSession.run.id, twoChain.integratorTask!.chainIndex));
   assert.equal(ambiguous.body.target.resolved, false);
   assert.equal(ambiguous.body.target.unresolvable, "ambiguous");
   assert.deepEqual(ambiguous.body.target.observed, [10, 11]);
@@ -230,7 +238,7 @@ test("N22 read legs: one, zero, and two observed pull request numbers", async ()
   const none = await seedIntegratorChain(db, { label: "n22-none" });
   await db.run.updateMany({ where: { taskId: none.gateTask.id }, data: { pullRequestNumber: null } });
   const session = await seedIntegratorSession(none);
-  const empty = await sessionGet(session.token, `/session/runs/${session.run.id}/chain/steps/10/activity`);
+  const empty = await sessionGet(session.token, stepActivityPath(session.run.id, none.integratorTask!.chainIndex));
   assert.equal(empty.body.target.resolved, false);
   assert.equal(empty.body.target.unresolvable, "none");
 });

--- a/packages/api/src/merge-evidence-protocol.dbtest.ts
+++ b/packages/api/src/merge-evidence-protocol.dbtest.ts
@@ -76,8 +76,8 @@ test("Phase A opens a card that says nothing yet, withholds it from the outbox, 
   assert.equal(metadata.purpose, "gate");
 });
 
-test("an ordinary nine-step gate is untouched by the protocol", async () => {
-  const chain = await seedIntegratorChain(db, { label: "nine-step", tenStep: false });
+test("an ordinary gate without a mechanical successor is untouched by the protocol", async () => {
+  const chain = await seedIntegratorChain(db, { label: "ordinary-gate", withIntegrator: false });
   const card = await openGate(chain);
   assert.notEqual(card.body, EVIDENCE_PLACEHOLDER_BODY);
   assert.equal(

--- a/packages/api/src/merge-integrator-binding.dbtest.ts
+++ b/packages/api/src/merge-integrator-binding.dbtest.ts
@@ -7,7 +7,7 @@
  * Both directions matter and they fail differently. The sentinel Agent on an
  * ordinary step claims as an *agent* run, so a model runner spawns a CLI with
  * `mechanical/merge-executor-v1` as its model and the merge authority's name on
- * the row. An ordinary agent on step 10 claims as a *mechanical* run, so the
+ * the row. An ordinary agent on step 12 claims as a *mechanical* run, so the
  * step that merges is executed by an LLM in a workspace with a repo checkout.
  *
  * The invariant is therefore checked at every place a (task, agent, step)
@@ -348,8 +348,8 @@ test("the agents list marks the sentinel unassignable", async () => {
 });
 
 test("the integrator step is the only step the sentinel matches", async () => {
-  // The fixture's own shape, asserted once: every test above rests on step 10
-  // being an integrator step and step 9 not being one, and `isIntegratorStep`
+  // The fixture's own shape, asserted once: every test above rests on step 12
+  // being an integrator step and step 11 not being one, and `isIntegratorStep`
   // is a conjunction over three fields that a fixture can silently get wrong.
   const chain = await seedIntegratorChain(db, { label: "shape" });
   assert.equal(chain.integratorStep!.stepIndex, INTEGRATOR_STEP_INDEX);

--- a/packages/api/src/merge-integrator-fixture.ts
+++ b/packages/api/src/merge-integrator-fixture.ts
@@ -1,11 +1,11 @@
 /**
  * Shared fixture for the Merge Integrator v1.1 database tests.
  *
- * Every integrator test needs the same shape — a chain whose step 9 is a human
- * gate and whose step 10 is the mechanical integrator step — and the shape is
+ * Every integrator test needs the same shape — a chain whose step 11 is a human
+ * gate and whose step 12 is the mechanical integrator step — and the shape is
  * load-bearing: `isIntegratorStep` is a conjunction over the template name, the
  * step index, and the output kind, so a fixture that gets any of them wrong
- * silently tests the ordinary nine-step path instead. Building it once here
+ * silently tests the ordinary non-integrator path instead. Building it once here
  * keeps the dbtest files honest about what they are exercising.
  */
 
@@ -30,7 +30,7 @@ export type IntegratorChain = Awaited<ReturnType<typeof seedIntegratorChain>>;
 
 export const seedIntegratorChain = async (
   db: PrismaClient,
-  options: { label?: string; prNumbers?: number[]; tenStep?: boolean } = {},
+  options: { label?: string; prNumbers?: number[]; withIntegrator?: boolean } = {},
 ) => {
   const label = options.label ?? "mi";
   const project = await db.project.create({ data: { name: label, slug: unique(label) } });
@@ -55,14 +55,14 @@ export const seedIntegratorChain = async (
     } });
   }
   const template = await db.taskTemplate.create({ data: {
-    projectId: project.id, name: INTEGRATOR_TEMPLATE_NAME, description: "Ten-step Full Assurance workflow", variables: [],
+    projectId: project.id, name: INTEGRATOR_TEMPLATE_NAME, description: "Twelve-step Full Assurance workflow", variables: [],
   } });
   const gateStep = await db.taskTemplateStep.create({ data: {
     taskTemplateId: template.id, stepIndex: INTEGRATOR_STEP_INDEX - 1, name: "Approval",
     assigneeType: AssigneeType.AGENT, assigneeAgentId: agent.id, prompt: "deliver", approvalGate: true,
     outputKind: "delivery", opensPullRequest: true,
   } });
-  const integratorStep = options.tenStep === false ? null : await db.taskTemplateStep.create({ data: {
+  const integratorStep = options.withIntegrator === false ? null : await db.taskTemplateStep.create({ data: {
     taskTemplateId: template.id, stepIndex: INTEGRATOR_STEP_INDEX, name: "Merge",
     assigneeType: AssigneeType.AGENT, assigneeAgentId: integratorAgent.id, prompt: "merge", approvalGate: false,
     outputKind: INTEGRATOR_OUTPUT_KIND, opensPullRequest: false,

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -28,6 +28,7 @@ import {
   INTEGRATOR_SENTINEL_MODEL,
   INTEGRATOR_STEP_INDEX,
   INTEGRATOR_TEMPLATE_NAME,
+  legacyNineStepTemplateName,
   legacyTenStepTemplateName,
   PrismaClient,
   type Task,
@@ -268,4 +269,108 @@ test("re-seeding a historical ten-step template preserves and queues its in-flig
   const queued = await db.run.findFirst({ where: { taskId: oldIntegrator.id }, orderBy: { runNumber: "desc" } });
   assert.ok(queued, "the historical integrator receives a run after re-seed");
   assert.equal(queued.status, "QUEUED");
+});
+
+/* ---------------------------------------------- 9 -> 12: foreign-key preservation */
+
+test("re-seeding a historical nine-step template preserves its in-flight task semantics", async () => {
+  assert.equal((await seed()).code, 0);
+  const fresh = await integratorStep();
+  const templateId = fresh.taskTemplateId;
+  const projectId = fresh.taskTemplate.projectId;
+  const agents = new Map((await db.agent.findMany({ where: { projectId } })).map((agent) => [agent.name, agent]));
+
+  await db.taskTemplateStep.deleteMany({
+    where: { taskTemplateId: templateId, stepIndex: { in: [10, 11, 12] } },
+  });
+  const historicalContract = [
+    [1, "Write a spec", "spec", AssigneeType.AGENT, "spec", true],
+    [2, "Plan", "plan", AssigneeType.AGENT, "plan", false],
+    [3, "Plan review", "review-coordinator", AssigneeType.AGENT, "plan-review", false],
+    [4, "Revise plan", "plan-reviser", AssigneeType.AGENT, "revised-plan", true],
+    [5, "Implementation", "implementation-plan-executioner", AssigneeType.AGENT, "implementation", false],
+    [6, "Code review", "review-coordinator", AssigneeType.AGENT, "code-review", false],
+    [7, "Apply review fixes", "senior-dev", AssigneeType.AGENT, "fixed-implementation", false],
+    [8, "Librarian", "librarian", AssigneeType.AGENT, "documentation", false],
+    [9, "Human PR review", null, AssigneeType.HUMAN, "approval", true],
+  ] as const;
+  for (const [stepIndex, name, agentName, assigneeType, outputKind, approvalGate] of historicalContract) {
+    await db.taskTemplateStep.update({
+      where: { taskTemplateId_stepIndex: { taskTemplateId: templateId, stepIndex } },
+      data: {
+        name,
+        assigneeType,
+        assigneeAgentId: agentName ? agents.get(agentName)!.id : null,
+        approvalGate,
+        outputKind,
+      },
+    });
+  }
+  const historicalSteps = await db.taskTemplateStep.findMany({
+    where: { taskTemplateId: templateId }, orderBy: { stepIndex: "asc" },
+  });
+  assert.deepEqual(historicalSteps.map((step) => step.stepIndex), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  const beforeSemantics = historicalSteps.map((step) => ({
+    id: step.id,
+    stepIndex: step.stepIndex,
+    name: step.name,
+    assigneeType: step.assigneeType,
+    assigneeAgentId: step.assigneeAgentId,
+    approvalGate: step.approvalGate,
+    outputKind: step.outputKind,
+  }));
+
+  const reviewStep = historicalSteps[5]!;
+  const repo = await db.repo.create({ data: {
+    projectId, name: "legacy-nine-upgrade", remoteUrl: "https://github.com/acme/legacy-nine-upgrade.git",
+    mountPath: "/scratch/legacy-nine-upgrade", defaultBranch: "main",
+  } });
+  const inFlight = await db.task.create({ data: {
+    projectId, repoId: repo.id, templateId, templateStepId: reviewStep.id,
+    name: reviewStep.name, description: reviewStep.prompt,
+    assigneeType: reviewStep.assigneeType, assigneeAgentId: reviewStep.assigneeAgentId,
+    approvalGate: reviewStep.approvalGate, opensPullRequest: reviewStep.opensPullRequest,
+    chainId: `in-flight-nine-${process.pid}`, chainIndex: reviewStep.stepIndex,
+    status: TaskStatus.DOING, targetBranch: "agentos/chain/legacy-nine-upgrade",
+  } });
+  await db.taskStepOutput.create({ data: {
+    taskId: inFlight.id, kind: reviewStep.outputKind, body: "historical review",
+  } });
+
+  assert.equal((await seed()).code, 0);
+  const legacy = await db.taskTemplate.findUniqueOrThrow({
+    where: { id: templateId }, include: { steps: { orderBy: { stepIndex: "asc" } } },
+  });
+  assert.equal(legacy.name, legacyNineStepTemplateName(templateId));
+  assert.deepEqual(legacy.steps.map((step) => ({
+    id: step.id,
+    stepIndex: step.stepIndex,
+    name: step.name,
+    assigneeType: step.assigneeType,
+    assigneeAgentId: step.assigneeAgentId,
+    approvalGate: step.approvalGate,
+    outputKind: step.outputKind,
+  })), beforeSemantics);
+
+  const canonical = await db.taskTemplate.findUniqueOrThrow({
+    where: { projectId_name: { projectId, name: INTEGRATOR_TEMPLATE_NAME } },
+    include: { steps: true },
+  });
+  assert.notEqual(canonical.id, templateId);
+  assert.equal(canonical.steps.length, 12);
+
+  const preserved = await db.task.findUniqueOrThrow({
+    where: { id: inFlight.id },
+    include: {
+      stepOutput: true,
+      templateStep: { include: { assigneeAgent: true, taskTemplate: true } },
+    },
+  });
+  assert.equal(preserved.templateId, templateId);
+  assert.equal(preserved.templateStepId, reviewStep.id);
+  assert.equal(preserved.templateStep?.taskTemplate.name, legacyNineStepTemplateName(templateId));
+  assert.equal(preserved.templateStep?.name, "Code review");
+  assert.equal(preserved.templateStep?.assigneeAgent?.name, "review-coordinator");
+  assert.equal(preserved.templateStep?.outputKind, "code-review");
+  assert.equal(preserved.stepOutput?.kind, "code-review");
 });

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -20,12 +20,18 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
 import {
+  activateChainSuccessor,
+  AssigneeType,
+  executionModeFor,
   INTEGRATOR_AGENT_NAME,
   INTEGRATOR_OUTPUT_KIND,
   INTEGRATOR_SENTINEL_MODEL,
   INTEGRATOR_STEP_INDEX,
   INTEGRATOR_TEMPLATE_NAME,
+  legacyTenStepTemplateName,
   PrismaClient,
+  type Task,
+  TaskStatus,
 } from "@agentos/db";
 
 import { resetTestDb, setupTestDb, testDatabaseUrl } from "./testdb.js";
@@ -75,6 +81,12 @@ test("a fresh seed writes a twelve-step template whose step 12 is mechanical", a
   assert.equal(step.assigneeAgent?.name, INTEGRATOR_AGENT_NAME);
   assert.equal(step.assigneeAgent?.model, INTEGRATOR_SENTINEL_MODEL);
   assert.equal(step.spawnPolicy, null);
+  assert.equal(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 7)?.attachmentsFromPrevious, false);
+  assert.equal(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 9)?.attachmentsFromPrevious, true);
+  assert.match(
+    step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 3)?.prompt ?? "",
+    /vertical slice[\s\S]*blocked_by[\s\S]*expand-migrate-contract[\s\S]*fail at base/iu,
+  );
 
   const opening = step.taskTemplate.steps.filter((candidate) => candidate.opensPullRequest).map((candidate) => candidate.stepIndex);
   assert.deepEqual(opening, [5], "only implementation opens the chain pull request");
@@ -144,6 +156,15 @@ const negatives: Array<{ name: string; break: () => Promise<void>; expect: RegEx
     },
     expect: /step/iu,
   },
+  {
+    name: "an upstream attachment on blind-review step 7",
+    break: async () => {
+      const step = await integratorStep();
+      const blind = step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 7)!;
+      await db.taskTemplateStep.update({ where: { id: blind.id }, data: { attachmentsFromPrevious: true } });
+    },
+    expect: /attachmentsFromPrevious/u,
+  },
 ];
 
 for (const negative of negatives) {
@@ -157,41 +178,94 @@ for (const negative of negatives) {
   });
 }
 
-/* ---------------------------------------------------------- A4: in-flight chains */
+/* -------------------------------------------- 10 -> 12: in-flight continuation */
 
-test("a chain instantiated before the twelfth step exists keeps its eleven tasks", async () => {
+test("re-seeding a historical ten-step template preserves and queues its in-flight integrator", async () => {
   assert.equal((await seed()).code, 0);
-  const step = await integratorStep();
-  const templateId = step.taskTemplateId;
-  const projectId = step.taskTemplate.projectId;
+  const fresh = await integratorStep();
+  const templateId = fresh.taskTemplateId;
+  const projectId = fresh.taskTemplate.projectId;
+  const agents = new Map((await db.agent.findMany({ where: { projectId } })).map((agent) => [agent.name, agent]));
 
-  // Remove only the mechanical continuation, leaving the eleven business stages.
-  await db.taskTemplateStep.delete({ where: { id: step.id } });
-  const businessSteps = await db.taskTemplateStep.findMany({ where: { taskTemplateId: templateId }, orderBy: { stepIndex: "asc" } });
-  assert.equal(businessSteps.length, 11);
-
-  const chainId = `in-flight-${process.pid}`;
-  for (const templateStep of businessSteps) {
-    await db.task.create({ data: {
-      projectId, templateId, templateStepId: templateStep.id, name: templateStep.name,
-      description: templateStep.prompt, assigneeType: templateStep.assigneeType,
-      assigneeAgentId: templateStep.assigneeAgentId, approvalGate: templateStep.approvalGate,
-      opensPullRequest: templateStep.opensPullRequest, chainId, chainIndex: templateStep.stepIndex,
-    } });
+  // Reconstruct the historical 10-row shape exactly where the routing changed:
+  // review, fix, docs, human approval, then physical step-10 mechanical merge.
+  await db.taskTemplateStep.deleteMany({ where: { taskTemplateId: templateId, stepIndex: { in: [11, 12] } } });
+  const historicalTail = [
+    [6, "review-coordinator", AssigneeType.AGENT, "code-review"],
+    [7, "senior-dev", AssigneeType.AGENT, "fixed-implementation"],
+    [8, "librarian", AssigneeType.AGENT, "documentation"],
+    [9, null, AssigneeType.HUMAN, "approval"],
+    [10, INTEGRATOR_AGENT_NAME, AssigneeType.AGENT, INTEGRATOR_OUTPUT_KIND],
+  ] as const;
+  for (const [stepIndex, agentName, assigneeType, outputKind] of historicalTail) {
+    const assigneeAgentId = agentName ? agents.get(agentName)!.id : null;
+    await db.taskTemplateStep.update({
+      where: { taskTemplateId_stepIndex: { taskTemplateId: templateId, stepIndex } },
+      data: {
+        name: `Historical step ${stepIndex}`,
+        assigneeType,
+        assigneeAgentId,
+        approvalGate: stepIndex === 9,
+        outputKind,
+        opensPullRequest: false,
+      },
+    });
   }
-  const before = await db.task.findMany({ where: { chainId }, orderBy: { chainIndex: "asc" } });
+  const historicalSteps = await db.taskTemplateStep.findMany({
+    where: { taskTemplateId: templateId }, orderBy: { stepIndex: "asc" },
+  });
+  assert.equal(historicalSteps.length, 10);
 
-  // Re-seeding restores the mechanical continuation without mutating the chain.
+  const repo = await db.repo.create({ data: {
+    projectId, name: "legacy-upgrade", remoteUrl: "https://github.com/acme/legacy-upgrade.git",
+    mountPath: "/scratch/legacy-upgrade", defaultBranch: "main",
+  } });
+  const integratorAgent = agents.get(INTEGRATOR_AGENT_NAME)!;
+  await db.agentRepoAccess.create({ data: {
+    projectId, agentId: integratorAgent.id, repoId: repo.id,
+    mountPath: "/scratch/legacy-upgrade", permissions: "GIT_WRITE",
+  } });
+
+  const chainId = `in-flight-ten-${process.pid}`;
+  const tasks: Task[] = [];
+  for (const templateStep of historicalSteps) {
+    tasks.push(await db.task.create({ data: {
+      projectId, repoId: repo.id, templateId, templateStepId: templateStep.id,
+      name: templateStep.name, description: templateStep.prompt,
+      assigneeType: templateStep.assigneeType, assigneeAgentId: templateStep.assigneeAgentId,
+      approvalGate: templateStep.approvalGate, opensPullRequest: templateStep.opensPullRequest,
+      chainId, chainIndex: templateStep.stepIndex,
+      status: templateStep.stepIndex < 10 ? TaskStatus.DONE : TaskStatus.TODO,
+      targetBranch: "agentos/chain/legacy-upgrade",
+    } }));
+  }
+
+  // New code re-seeds: the historical template is retained under a deterministic
+  // marker and the canonical name is assigned to a different 12-row template.
   assert.equal((await seed()).code, 0);
-  assert.equal((await db.taskTemplateStep.count({ where: { taskTemplateId: templateId } })), 12);
+  const legacy = await db.taskTemplate.findUniqueOrThrow({
+    where: { id: templateId }, include: { steps: { orderBy: { stepIndex: "asc" } } },
+  });
+  assert.equal(legacy.name, legacyTenStepTemplateName(templateId));
+  assert.equal(legacy.steps.length, 10);
+  const canonical = await db.taskTemplate.findUniqueOrThrow({
+    where: { projectId_name: { projectId, name: INTEGRATOR_TEMPLATE_NAME } },
+    include: { steps: true },
+  });
+  assert.notEqual(canonical.id, templateId);
+  assert.equal(canonical.steps.length, 12);
 
-  // `templates.ts` materializes task rows at creation time and the task row is
-  // the runtime authority, so an in-flight chain is not rewritten by a template
-  // that grew a step under it.
-  const after = await db.task.findMany({ where: { chainId }, orderBy: { chainIndex: "asc" } });
-  assert.equal(after.length, 11, "the in-flight chain still has eleven tasks");
-  assert.deepEqual(
-    after.map((task) => ({ index: task.chainIndex, step: task.templateStepId, opens: task.opensPullRequest })),
-    before.map((task) => ({ index: task.chainIndex, step: task.templateStepId, opens: task.opensPullRequest })),
-  );
+  const oldIntegrator = await db.task.findUniqueOrThrow({
+    where: { id: tasks[9]!.id },
+    include: { templateStep: { include: { taskTemplate: { select: { name: true } } } } },
+  });
+  assert.equal(executionModeFor(oldIntegrator.templateStep), "mechanical");
+
+  // The real chain successor path must accept the preserved binding and enqueue
+  // the old physical step 10 after its human predecessor completes.
+  const advanced = await db.$transaction((tx) => activateChainSuccessor(tx, tasks[8]!));
+  assert.deepEqual(advanced, { nextTaskId: oldIntegrator.id, gated: false });
+  const queued = await db.run.findFirst({ where: { taskId: oldIntegrator.id }, orderBy: { runNumber: "desc" } });
+  assert.ok(queued, "the historical integrator receives a run after re-seed");
+  assert.equal(queued.status, "QUEUED");
 });

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -1,5 +1,5 @@
 /**
- * Step 7 / SF-3 — the seeded ten-step template, and the verifier that guards it.
+ * Step 7 / SF-3 — the seeded twelve-step template, and the verifier that guards it.
  *
  * The prior plan left this as "edit the seed wherever it is" and relied on
  * `verify-agent-template.ts` to catch a mistake. That is circular: the verifier
@@ -61,39 +61,38 @@ const integratorStep = async () => db.taskTemplateStep.findFirstOrThrow({
 
 /* ------------------------------------------------------ the fresh-seed negative */
 
-test("a fresh seed writes a ten-step template whose step 10 publishes nothing", async () => {
+test("a fresh seed writes a twelve-step template whose step 12 is mechanical", async () => {
   const seeded = await seed();
   assert.equal(seeded.code, 0, seeded.output);
 
   // Read directly. Not through the verifier, not through the contract module —
   // this is the assertion the verifier's own correctness is allowed to rest on.
   const step = await integratorStep();
-  assert.equal(step.taskTemplate.steps.length, 10, "the template has ten steps");
-  assert.equal(step.opensPullRequest, false, "SF-3: the seeded step-10 row must not open a pull request");
+  assert.equal(step.taskTemplate.steps.length, 12, "the template has twelve steps");
+  assert.equal(step.opensPullRequest, false, "SF-3: the seeded step-12 row must not open a pull request");
   assert.equal(step.approvalGate, false);
   assert.equal(step.outputKind, INTEGRATOR_OUTPUT_KIND);
   assert.equal(step.assigneeAgent?.name, INTEGRATOR_AGENT_NAME);
   assert.equal(step.assigneeAgent?.model, INTEGRATOR_SENTINEL_MODEL);
   assert.equal(step.spawnPolicy, null);
 
-  // And the nine steps before it are unchanged in the property SF-3 is about.
-  const others = step.taskTemplate.steps.filter((candidate) => candidate.stepIndex !== INTEGRATOR_STEP_INDEX);
-  assert.deepEqual([...new Set(others.map((candidate) => candidate.opensPullRequest))], [true]);
+  const opening = step.taskTemplate.steps.filter((candidate) => candidate.opensPullRequest).map((candidate) => candidate.stepIndex);
+  assert.deepEqual(opening, [5], "only implementation opens the chain pull request");
 });
 
 test("the verifier passes on a freshly seeded database, and says how many steps it saw", async () => {
   assert.equal((await seed()).code, 0);
   const verified = await verify();
   assert.equal(verified.code, 0, verified.output);
-  assert.match(verified.output, /10 steps/u);
+  assert.match(verified.output, /12 steps/u);
 });
 
-test("re-seeding is idempotent and does not flip step 10 back", async () => {
+test("re-seeding is idempotent and does not flip step 12 back", async () => {
   assert.equal((await seed()).code, 0);
   assert.equal((await seed()).code, 0);
   const step = await integratorStep();
   assert.equal(step.opensPullRequest, false, "the update branch of the upsert sets it too, not only create");
-  assert.equal(step.taskTemplate.steps.length, 10);
+  assert.equal(step.taskTemplate.steps.length, 12);
 });
 
 /* ------------------------------------------------------- the verifier negatives */
@@ -103,7 +102,7 @@ test("re-seeding is idempotent and does not flip step 10 back", async () => {
  *  verifier. */
 const negatives: Array<{ name: string; break: () => Promise<void>; expect: RegExp }> = [
   {
-    name: "step 10 opening a pull request",
+    name: "step 12 opening a pull request",
     break: async () => {
       const step = await integratorStep();
       await db.taskTemplateStep.update({ where: { id: step.id }, data: { opensPullRequest: true } });
@@ -118,7 +117,7 @@ const negatives: Array<{ name: string; break: () => Promise<void>; expect: RegEx
     expect: /model|runner/iu,
   },
   {
-    name: "a non-null spawn policy on step 10",
+    name: "a non-null spawn policy on step 12",
     break: async () => {
       const step = await integratorStep();
       await db.taskTemplateStep.update({ where: { id: step.id }, data: { spawnPolicy: { maxChildren: 1 } } });
@@ -126,7 +125,7 @@ const negatives: Array<{ name: string; break: () => Promise<void>; expect: RegEx
     expect: /spawnPolicy/u,
   },
   {
-    name: "a nine-step template",
+    name: "an eleven-step template",
     break: async () => {
       const step = await integratorStep();
       await db.taskTemplateStep.delete({ where: { id: step.id } });
@@ -134,7 +133,7 @@ const negatives: Array<{ name: string; break: () => Promise<void>; expect: RegEx
     expect: /step/iu,
   },
   {
-    name: "an eleventh step",
+    name: "a thirteenth step",
     break: async () => {
       const step = await integratorStep();
       await db.taskTemplateStep.create({ data: {
@@ -160,19 +159,19 @@ for (const negative of negatives) {
 
 /* ---------------------------------------------------------- A4: in-flight chains */
 
-test("a chain instantiated before the tenth step exists keeps its nine tasks", async () => {
+test("a chain instantiated before the twelfth step exists keeps its eleven tasks", async () => {
   assert.equal((await seed()).code, 0);
   const step = await integratorStep();
   const templateId = step.taskTemplateId;
   const projectId = step.taskTemplate.projectId;
 
-  // Stand the world back up as it was before this change: a nine-step template.
+  // Remove only the mechanical continuation, leaving the eleven business stages.
   await db.taskTemplateStep.delete({ where: { id: step.id } });
-  const nineStepSteps = await db.taskTemplateStep.findMany({ where: { taskTemplateId: templateId }, orderBy: { stepIndex: "asc" } });
-  assert.equal(nineStepSteps.length, 9);
+  const businessSteps = await db.taskTemplateStep.findMany({ where: { taskTemplateId: templateId }, orderBy: { stepIndex: "asc" } });
+  assert.equal(businessSteps.length, 11);
 
   const chainId = `in-flight-${process.pid}`;
-  for (const templateStep of nineStepSteps) {
+  for (const templateStep of businessSteps) {
     await db.task.create({ data: {
       projectId, templateId, templateStepId: templateStep.id, name: templateStep.name,
       description: templateStep.prompt, assigneeType: templateStep.assigneeType,
@@ -182,15 +181,15 @@ test("a chain instantiated before the tenth step exists keeps its nine tasks", a
   }
   const before = await db.task.findMany({ where: { chainId }, orderBy: { chainIndex: "asc" } });
 
-  // Now seed the ten-step template on top, exactly as an upgrade would.
+  // Re-seeding restores the mechanical continuation without mutating the chain.
   assert.equal((await seed()).code, 0);
-  assert.equal((await db.taskTemplateStep.count({ where: { taskTemplateId: templateId } })), 10);
+  assert.equal((await db.taskTemplateStep.count({ where: { taskTemplateId: templateId } })), 12);
 
   // `templates.ts` materializes task rows at creation time and the task row is
   // the runtime authority, so an in-flight chain is not rewritten by a template
   // that grew a step under it.
   const after = await db.task.findMany({ where: { chainId }, orderBy: { chainIndex: "asc" } });
-  assert.equal(after.length, 9, "the in-flight chain still has nine tasks");
+  assert.equal(after.length, 11, "the in-flight chain still has eleven tasks");
   assert.deepEqual(
     after.map((task) => ({ index: task.chainIndex, step: task.templateStepId, opens: task.opensPullRequest })),
     before.map((task) => ({ index: task.chainIndex, step: task.templateStepId, opens: task.opensPullRequest })),

--- a/packages/api/src/merge-stop-state.dbtest.ts
+++ b/packages/api/src/merge-stop-state.dbtest.ts
@@ -58,7 +58,7 @@ const call = async (method: string, path: string, body?: unknown, token = OPERAT
   }
 };
 
-/** A live step-10 run the merge executor would be holding. */
+/** A live step-12 run the merge executor would be holding. */
 const liveIntegratorRun = async (chain: IntegratorChain, runNumber = 1, maxRuns = 5) => {
   const run = await db.run.create({ data: {
     projectId: chain.project.id, taskId: chain.integratorTask!.id, agentId: chain.integratorAgent.id,

--- a/packages/api/src/preflight-goal-execution.dbtest.ts
+++ b/packages/api/src/preflight-goal-execution.dbtest.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { after, test } from "node:test";
 
@@ -15,13 +18,30 @@ import { preKernelRun, preKernelSeed, stageAtPreviousMigration } from "./goal-ex
  */
 
 const dbDirectory = fileURLToPath(new URL("../../db", import.meta.url));
+const repositoryRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const isolatedCheckout = mkdtempSync(join(tmpdir(), "agentos-public-lineage-"));
+const currentBranch = execFileSync("git", ["symbolic-ref", "--short", "HEAD"], {
+  cwd: repositoryRoot,
+  encoding: "utf8",
+}).trim();
+
+// Linked worktrees can share private objects with this public lineage. Clone
+// only the current branch so the preflight sees the history a standalone public
+// clone sees, without weakening the production authority checks.
+execFileSync("git", [
+  "clone", "--quiet", "--no-local", "--no-checkout", "--single-branch",
+  "--branch", currentBranch, repositoryRoot, isolatedCheckout,
+]);
 // The authority the recorded revalidation names; the preflight refuses to pass
 // without them, so these are the real values, not placeholders.
 const MASTER_SHA = "485fb118db96e3977006a2edc866a38b751ff0e2";
 const CONTROL_PLANE_A_SHA = "c671439831b075568420b92f4494227fa7fc392b";
 
 let fixture: ReturnType<typeof stageAtPreviousMigration>;
-after(() => fixture?.cleanup());
+after(() => {
+  fixture?.cleanup();
+  rmSync(isolatedCheckout, { recursive: true, force: true });
+});
 
 const stage = (rows: string[]): void => {
   fixture?.cleanup();
@@ -37,6 +57,8 @@ const runPreflight = (environment: Record<string, string | undefined> = {}): Pre
     DATABASE_URL: fixture.url,
     GOAL5A0_MASTER_SHA: MASTER_SHA,
     GOAL5A0_CONTROL_PLANE_A_SHA: CONTROL_PLANE_A_SHA,
+    GIT_DIR: join(isolatedCheckout, ".git"),
+    GIT_WORK_TREE: repositoryRoot,
     PATH: `${dbDirectory}/node_modules/.bin:${process.env.PATH ?? ""}`,
     ...environment,
   } as NodeJS.ProcessEnv;

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -16,7 +16,7 @@ import {
 
 import { instantiateTemplate } from "./templates.js";
 
-test("instantiating the canonical feature template creates ten tasks including the mechanical integrator", async () => {
+test("instantiating the canonical feature template creates twelve tasks including the mechanical integrator", async () => {
   const created: Array<Record<string, any>> = [];
   const runs: Array<Record<string, any>> = [];
   const agents = new Map(CANONICAL_AGENT_DEFAULTS.map((contract, index) => [contract.name, {
@@ -35,7 +35,7 @@ test("instantiating the canonical feature template creates ten tasks including t
       name: `Step ${contract.stepIndex}`,
       prompt: `Work on {{branchName}} step ${contract.stepIndex}`,
       outputKind: contract.outputKind,
-      attachmentsFromPrevious: contract.stepIndex > 1,
+      attachmentsFromPrevious: contract.attachmentsFromPrevious,
       assigneeType: agent ? AssigneeType.AGENT : AssigneeType.HUMAN,
       assigneeAgentId: agent?.id ?? null,
       assigneeAgent: agent,
@@ -80,7 +80,7 @@ test("instantiating the canonical feature template creates ten tasks including t
       create: async ({ data }: { data: Record<string, any> }) => { const run = { id: "run-1", ...data }; runs.push(run); return run; },
       update: async ({ data }: { data: Record<string, any> }) => { Object.assign(runs[0]!, data); return runs[0]; },
     },
-    taskActivity: { createMany: async () => ({ count: 10 }) },
+    taskActivity: { createMany: async () => ({ count: 12 }) },
     taskTemplateStep: {
       findUnique: async ({ where }: { where: { id: string } }) => steps.find((step) => step.id === where.id) ?? null,
     },
@@ -93,22 +93,32 @@ test("instantiating the canonical feature template creates ten tasks including t
     $transaction: async (operation: (client: typeof tx) => Promise<unknown>) => operation(tx),
   } as unknown as PrismaClient;
   const result = await instantiateTemplate(db, "project-1", "template-1", {
-    repoId: "repo-1", variables: { branchName: "feature/ten-steps" }, description: "Build it",
+    repoId: "repo-1", variables: { branchName: "feature/twelve-steps" }, description: "Build it",
   });
-  assert.equal(result.tasks.length, 10);
+  assert.equal(result.tasks.length, 12);
   assert.equal(new Set(created.map((task) => task.chainId)).size, 1);
   assert.equal(created[0]!.followUpTaskId, "task-2");
-  assert.equal(created[8]!.assigneeType, AssigneeType.HUMAN);
-  assert.equal(created[9]!.assigneeAgent?.name, INTEGRATOR_AGENT_NAME);
-  assert.equal(created[9]!.assigneeAgent?.model, INTEGRATOR_SENTINEL_MODEL);
-  assert.equal(created[9]!.assigneeAgent?.runnerPreference, RunnerPreference.INHERIT);
-  assert.equal(created[9]!.opensPullRequest, false);
-  assert.equal(executionModeFor(created[9]!.templateStep), "mechanical");
+  assert.equal(created[10]!.assigneeType, AssigneeType.HUMAN);
+  assert.equal(created[11]!.assigneeAgent?.name, INTEGRATOR_AGENT_NAME);
+  assert.equal(created[11]!.assigneeAgent?.model, INTEGRATOR_SENTINEL_MODEL);
+  assert.equal(created[11]!.assigneeAgent?.runnerPreference, RunnerPreference.INHERIT);
+  assert.equal(created[11]!.opensPullRequest, false);
+  assert.equal(executionModeFor(created[11]!.templateStep), "mechanical");
   assert.deepEqual(created.map((task) => task.outputKind ?? task.templateStep.outputKind), CANONICAL_TEMPLATE_STEPS.map((step) => step.outputKind));
   assert.equal(runs.length, 1);
   assert.equal(runs[0]!.runner, RunnerKind.CLAUDE);
-  assert.equal(runs[0]!.branch, "feature/ten-steps");
-  assert.equal(runs.some((run) => run.taskId === created[9]!.id), false, "step 10 waits for the human gate and never queues a model at instantiation");
+  assert.equal(runs[0]!.branch, "feature/twelve-steps");
+  assert.equal(runs.some((run) => run.taskId === created[11]!.id), false, "step 12 waits for the human gate and never queues a model at instantiation");
+  assert.doesNotMatch(
+    created[6]!.description,
+    /Read the prior template steps' persisted outputs before working/u,
+    "blind-review step 7 materializes without an upstream-read instruction",
+  );
+  assert.match(
+    created[8]!.description,
+    /Read the prior template steps' persisted outputs before working/u,
+    "regression-verification step 9 still consumes prior outputs",
+  );
 });
 
 test("the lower-level materializer rejects blank variables and invalid branches before a transaction", async () => {

--- a/packages/api/src/templates.ts
+++ b/packages/api/src/templates.ts
@@ -2,8 +2,8 @@ import { randomUUID } from "node:crypto";
 
 import {
   AssigneeType,
+  canonicalIntegratorBindingRefusal,
   enqueueTaskRun,
-  integratorBindingRefusal,
   lockAgentRepoGrant,
   lockAgentRows,
   Prisma,
@@ -86,7 +86,7 @@ export const instantiateTemplate = async (
     // an ordinary step, or a model agent on the integrator step — fails
     // instantiation rather than materializing a chain that would later claim as
     // the wrong execution mode.
-    const bindingRefusal = integratorBindingRefusal(step.assigneeAgent?.name ?? null, {
+    const bindingRefusal = canonicalIntegratorBindingRefusal(step.assigneeAgent?.name ?? null, {
       stepIndex: step.stepIndex,
       outputKind: step.outputKind,
       taskTemplateName: template.name,

--- a/packages/api/src/workflow.test.ts
+++ b/packages/api/src/workflow.test.ts
@@ -190,7 +190,7 @@ test("a later chain step runs on the chain's shared branch so the chain lands in
         repo: { id: "repo-1", defaultBranch: "main" }, templateStep: { runner: null },
       }),
       // §D-P7's stop-state guard reads the task with its template step before
-      // queueing. This one is not a chain's step-10 task, so it is a no-op.
+      // queueing. This one is not a chain's step-12 task, so it is a no-op.
       findUnique: async () => ({ id: "task-2", templateStep: { runner: null } }),
     },
     run: { create: async ({ data }: { data: Record<string, unknown> }) => { queued.push(data); return { id: "run-1", ...data }; } },

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -64,10 +64,10 @@ test("the split review prompts enforce frozen-range, blind-order, adjudication, 
   assert.match(firstReview, /quote the exact governing\s+specification text/u);
 
   const blindWrite = finalReview.indexOf("persisted and committed as your task output");
-  const firstReportRead = finalReview.indexOf("read the first reviewer's report attachment");
+  const firstReportRead = finalReview.indexOf("read the first reviewer's report attachment", blindWrite);
   assert.ok(blindWrite >= 0 && firstReportRead > blindWrite, "blind findings must be persisted before the first report is read");
   assert.match(finalReview, /approved specification and revised plan from\s+their persisted files in the chain branch tree/iu);
-  assert.match(finalReview, /both are\s+reachable through the exact `base\.\.\.head` range/iu);
+  assert.match(finalReview, /both are\s+reachable in the tree at `head`/iu);
   assert.match(finalReview, /same defect reported by both is adopted at the higher severity/u);
   assert.equal(frontmatterValue(finalReview, "inboxAccess"), "true");
   assert.match(finalReview, /stop in this step, and use Inbox to present both\s+bodies of evidence to the human/u);

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -23,6 +23,8 @@ import {
 
 const rolesRoot = fileURLToPath(new URL("../../../agents/roles/", import.meta.url));
 
+const roleSource = (name: string): Promise<string> => readFile(`${rolesRoot}${name}.md`, "utf8");
+
 const frontmatterValue = (source: string, key: string): string => {
   const match = source.match(new RegExp(`^${key}:\\s*(.+)$`, "mu"));
   assert.ok(match, `role source must declare ${key}`);
@@ -46,8 +48,31 @@ test("canonical role frontmatter matches the Prisma seed contract", async () => 
   assert.equal(roles.length, CANONICAL_AGENT_DEFAULTS.length);
 });
 
-test("the canonical ten-step template routes both review passes through Review Coordinator", () => {
-  assert.equal(CANONICAL_TEMPLATE_STEPS.length, 10);
+test("the split review prompts enforce frozen-range, blind-order, adjudication, and regression contracts", async () => {
+  const [planReview, firstReview, finalReview] = await Promise.all([
+    roleSource("review-coordinator"),
+    roleSource("review-coordinator-sol"),
+    roleSource("review-coordinator-opus"),
+  ]);
+
+  assert.match(planReview, /never review implementation\s+diffs/u);
+  assert.match(planReview, /acceptance criterion fail at the frozen base commit/u);
+
+  assert.match(firstReview, /frozen immediately before implementation began/u);
+  assert.match(firstReview, /complete\s+`base\.\.\.head` diff/u);
+  assert.match(firstReview, /Persist the complete report as the task output/u);
+  assert.match(firstReview, /quote the exact governing\s+specification text/u);
+
+  const blindWrite = finalReview.indexOf("persisted and committed as your task output");
+  const firstReportRead = finalReview.indexOf("read the first reviewer's report attachment");
+  assert.ok(blindWrite >= 0 && firstReportRead > blindWrite, "blind findings must be persisted before the first report is read");
+  assert.match(finalReview, /same defect reported by both is adopted at the higher severity/u);
+  assert.match(finalReview, /entire fix diff as one\s+unit/u);
+  assert.match(finalReview, /exact fixed head/u);
+});
+
+test("the canonical twelve-step template splits code review and preserves mechanical merge", () => {
+  assert.equal(CANONICAL_TEMPLATE_STEPS.length, 12);
   assert.deepEqual(
     CANONICAL_TEMPLATE_STEPS.map(({ stepIndex, agentName, outputKind }) => ({ stepIndex, agentName, outputKind })),
     [
@@ -56,19 +81,21 @@ test("the canonical ten-step template routes both review passes through Review C
       { stepIndex: 3, agentName: "review-coordinator", outputKind: "plan-review" },
       { stepIndex: 4, agentName: "plan-reviser", outputKind: "revised-plan" },
       { stepIndex: 5, agentName: "implementation-plan-executioner", outputKind: "implementation" },
-      { stepIndex: 6, agentName: "review-coordinator", outputKind: "code-review" },
-      { stepIndex: 7, agentName: "senior-dev", outputKind: "fixed-implementation" },
-      { stepIndex: 8, agentName: "librarian", outputKind: "documentation" },
-      { stepIndex: 9, agentName: null, outputKind: "approval" },
-      { stepIndex: 10, agentName: "merge-integrator", outputKind: "merge-result" },
+      { stepIndex: 6, agentName: "review-coordinator-sol", outputKind: "sol-findings" },
+      { stepIndex: 7, agentName: "review-coordinator-opus", outputKind: "must-fix" },
+      { stepIndex: 8, agentName: "senior-dev", outputKind: "fixed-implementation" },
+      { stepIndex: 9, agentName: "review-coordinator-opus", outputKind: "regression-verification" },
+      { stepIndex: 10, agentName: "librarian", outputKind: "documentation" },
+      { stepIndex: 11, agentName: null, outputKind: "approval" },
+      { stepIndex: 12, agentName: "merge-integrator", outputKind: "merge-result" },
     ],
   );
   assert.equal(CANONICAL_TEMPLATE_STEPS.some((step) => step.agentName === "code-reviewer"), false);
 });
 
-test("the integrator row is the only step that publishes nothing, and it is not a model row", () => {
-  const publishing = CANONICAL_TEMPLATE_STEPS.filter((step) => !step.opensPullRequest).map((step) => step.stepIndex);
-  assert.deepEqual(publishing, [INTEGRATOR_STEP_INDEX]);
+test("only implementation opens a pull request, and the integrator is not a model row", () => {
+  const opening = CANONICAL_TEMPLATE_STEPS.filter((step) => step.opensPullRequest).map((step) => step.stepIndex);
+  assert.deepEqual(opening, [5]);
   const integrator = CANONICAL_TEMPLATE_STEPS.find((step) => step.stepIndex === INTEGRATOR_STEP_INDEX)!;
   assert.equal(integrator.agentName, INTEGRATOR_AGENT_NAME);
   assert.equal(integrator.outputKind, INTEGRATOR_OUTPUT_KIND);
@@ -82,12 +109,12 @@ test("the integrator row is the only step that publishes nothing, and it is not 
   assert.equal(catalogRunnerForModel(sentinel.model), null);
 });
 
-test("the sentinel may bind only step 10, and step 10 only the sentinel", () => {
-  const step10 = { stepIndex: 10, outputKind: INTEGRATOR_OUTPUT_KIND, taskTemplate: { name: INTEGRATOR_TEMPLATE_NAME } };
+test("the sentinel may bind only step 12, and step 12 only the sentinel", () => {
+  const step12 = { stepIndex: INTEGRATOR_STEP_INDEX, outputKind: INTEGRATOR_OUTPUT_KIND, taskTemplate: { name: INTEGRATOR_TEMPLATE_NAME } };
   const step5 = { stepIndex: 5, outputKind: "implementation", taskTemplate: { name: INTEGRATOR_TEMPLATE_NAME } };
-  assert.equal(integratorBindingValid(INTEGRATOR_AGENT_NAME, step10), true);
+  assert.equal(integratorBindingValid(INTEGRATOR_AGENT_NAME, step12), true);
   assert.equal(integratorBindingValid("senior-dev", step5), true);
   assert.equal(integratorBindingValid(INTEGRATOR_AGENT_NAME, step5), false);
-  assert.equal(integratorBindingValid("senior-dev", step10), false);
+  assert.equal(integratorBindingValid("senior-dev", step12), false);
   assert.equal(integratorBindingValid(INTEGRATOR_AGENT_NAME, null), false);
 });

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -67,6 +67,9 @@ test("the split review prompts enforce frozen-range, blind-order, adjudication, 
   const firstReportRead = finalReview.indexOf("read the first reviewer's report attachment");
   assert.ok(blindWrite >= 0 && firstReportRead > blindWrite, "blind findings must be persisted before the first report is read");
   assert.match(finalReview, /same defect reported by both is adopted at the higher severity/u);
+  assert.equal(frontmatterValue(finalReview, "inboxAccess"), "true");
+  assert.match(finalReview, /stop in this step, and use Inbox to present both\s+bodies of evidence to the human/u);
+  assert.match(finalReview, /does not become effective\s+automatically/u);
   assert.match(finalReview, /entire fix diff as one\s+unit/u);
   assert.match(finalReview, /exact fixed head/u);
 });
@@ -91,6 +94,8 @@ test("the canonical twelve-step template splits code review and preserves mechan
     ],
   );
   assert.equal(CANONICAL_TEMPLATE_STEPS.some((step) => step.agentName === "code-reviewer"), false);
+  assert.equal(CANONICAL_TEMPLATE_STEPS.find((step) => step.stepIndex === 7)?.attachmentsFromPrevious, false);
+  assert.equal(CANONICAL_TEMPLATE_STEPS.find((step) => step.stepIndex === 9)?.attachmentsFromPrevious, true);
 });
 
 test("only implementation opens a pull request, and the integrator is not a model row", () => {

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -66,6 +66,8 @@ test("the split review prompts enforce frozen-range, blind-order, adjudication, 
   const blindWrite = finalReview.indexOf("persisted and committed as your task output");
   const firstReportRead = finalReview.indexOf("read the first reviewer's report attachment");
   assert.ok(blindWrite >= 0 && firstReportRead > blindWrite, "blind findings must be persisted before the first report is read");
+  assert.match(finalReview, /approved specification and revised plan from\s+their persisted files in the chain branch tree/iu);
+  assert.match(finalReview, /both are\s+reachable through the exact `base\.\.\.head` range/iu);
   assert.match(finalReview, /same defect reported by both is adopted at the higher severity/u);
   assert.equal(frontmatterValue(finalReview, "inboxAccess"), "true");
   assert.match(finalReview, /stop in this step, and use Inbox to present both\s+bodies of evidence to the human/u);

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -95,13 +95,13 @@ const main = async (): Promise<void> => {
   const template = await prisma.taskTemplate.upsert({
     where: { projectId_name: { projectId: project.id, name: "compound-engineer-workflow" } },
     update: {
-      description: "Ten-step Full Assurance workflow with spec, reviewed-plan implementation, PR approval gates, and mechanical merge execution.",
+      description: "Twelve-step Full Assurance workflow with dual independent code review, regression verification, human approval, and mechanical merge execution.",
       variables: ["branchName"],
     },
     create: {
       projectId: project.id,
       name: "compound-engineer-workflow",
-      description: "Ten-step Full Assurance workflow with spec, reviewed-plan implementation, PR approval gates, and mechanical merge execution.",
+      description: "Twelve-step Full Assurance workflow with dual independent code review, regression verification, human approval, and mechanical merge execution.",
       variables: ["branchName"],
     },
   });
@@ -110,23 +110,22 @@ const main = async (): Promise<void> => {
     if (!step) throw new Error(`Missing canonical template step ${stepIndex}`);
     return step;
   };
-  // The tuple carries `opensPullRequest` as its tenth element and BOTH branches
-  // of the upsert below set it. Before this change the field appeared in neither
-  // branch, so every seeded row silently took `schema.prisma`'s default `true` —
-  // which `templates.ts` then copies onto every materialized task row. For step
-  // 10 that default is wrong and load-bearing, so it is written explicitly here
-  // rather than inherited.
+  // The tuple carries `opensPullRequest` as its tenth element and both branches
+  // of the upsert set it. `templates.ts` copies the value onto every materialized
+  // task row. Only implementation creates the chain PR; every later row reuses it.
   const steps = [
     [1, "Write a spec", canonicalStep(1).agentName, AssigneeType.AGENT, null, canonicalStep(1).approvalGate, canonicalStep(1).outputKind, "Write a detailed feature specification for {{branchName}} and persist it for human approval.", null, canonicalStep(1).opensPullRequest],
     [2, "Plan", canonicalStep(2).agentName, AssigneeType.AGENT, null, canonicalStep(2).approvalGate, canonicalStep(2).outputKind, "Turn the approved spec into a concrete ordered implementation plan.", null, canonicalStep(2).opensPullRequest],
     [3, "Plan review", canonicalStep(3).agentName, AssigneeType.AGENT, null, canonicalStep(3).approvalGate, canonicalStep(3).outputKind, "Review the plan through feasibility, scope, coherence, security, and a distinct risk-focused verification pass; consolidate must-fix and should-fix findings.", null, canonicalStep(3).opensPullRequest],
     [4, "Revise plan", canonicalStep(4).agentName, AssigneeType.AGENT, null, canonicalStep(4).approvalGate, canonicalStep(4).outputKind, "Revise the plan using every must-fix plan-review finding and persist the implementation-authority artifact.", null, canonicalStep(4).opensPullRequest],
     [5, "Implementation", canonicalStep(5).agentName, AssigneeType.AGENT, null, canonicalStep(5).approvalGate, canonicalStep(5).outputKind, "Implement the approved plan on {{branchName}} and run end-to-end tests.", null, canonicalStep(5).opensPullRequest],
-    [6, "Code review", canonicalStep(6).agentName, AssigneeType.AGENT, null, canonicalStep(6).approvalGate, canonicalStep(6).outputKind, "Review the implementation through feasibility, scope, coherence, security, and a distinct risk-focused verification pass; consolidate must-fix and should-fix findings.", null, canonicalStep(6).opensPullRequest],
-    [7, "Apply review fixes", canonicalStep(7).agentName, AssigneeType.AGENT, null, canonicalStep(7).approvalGate, canonicalStep(7).outputKind, "Apply all must-fix review findings and rerun end-to-end tests.", null, canonicalStep(7).opensPullRequest],
-    [8, "Librarian", canonicalStep(8).agentName, AssigneeType.AGENT, null, canonicalStep(8).approvalGate, canonicalStep(8).outputKind, "Update internal documentation to match the delivered code.", null, canonicalStep(8).opensPullRequest],
-    [9, "Human PR review", canonicalStep(9).agentName, AssigneeType.HUMAN, null, canonicalStep(9).approvalGate, canonicalStep(9).outputKind, "Review the pull request for {{branchName}} and authorize its merge against the evidence presented in the approval card.", null, canonicalStep(9).opensPullRequest],
-    [10, "Merge execution", canonicalStep(10).agentName, AssigneeType.AGENT, null, canonicalStep(10).approvalGate, canonicalStep(10).outputKind, "Execute the authorized merge mechanically. No model runs this step: @agentos/merge-executor claims it, re-verifies every precondition against the live pull request, and merges only under the step-9 human authorization for that exact head.", null, canonicalStep(10).opensPullRequest],
+    [6, "Code review (Sol)", canonicalStep(6).agentName, AssigneeType.AGENT, null, canonicalStep(6).approvalGate, canonicalStep(6).outputKind, "Review the complete integrated implementation diff from the frozen pre-implementation base through the delivered head. Persist stable evidence-backed findings as the task output.", null, canonicalStep(6).opensPullRequest],
+    [7, "Code review and adjudication (Opus)", canonicalStep(7).agentName, AssigneeType.AGENT, null, canonicalStep(7).approvalGate, canonicalStep(7).outputKind, "Blind-review the complete integrated implementation diff and persist independent findings before reading the first review. Then apply the canonical merge matrix and persist the closed must-fix list.", null, canonicalStep(7).opensPullRequest],
+    [8, "Apply review fixes", canonicalStep(8).agentName, AssigneeType.AGENT, null, canonicalStep(8).approvalGate, canonicalStep(8).outputKind, "Apply the complete closed must-fix list and rerun every affected regression.", null, canonicalStep(8).opensPullRequest],
+    [9, "Regression verification", canonicalStep(9).agentName, AssigneeType.AGENT, null, canonicalStep(9).approvalGate, canonicalStep(9).outputKind, "Review the full fix diff as one unit, account for every must-fix ID, rerun relevant regressions, and bind the verdict to the exact fixed head for human review.", null, canonicalStep(9).opensPullRequest],
+    [10, "Librarian", canonicalStep(10).agentName, AssigneeType.AGENT, null, canonicalStep(10).approvalGate, canonicalStep(10).outputKind, "Update internal documentation to match the delivered code.", null, canonicalStep(10).opensPullRequest],
+    [11, "Human PR review", canonicalStep(11).agentName, AssigneeType.HUMAN, null, canonicalStep(11).approvalGate, canonicalStep(11).outputKind, "Review the pull request for {{branchName}} at the exact head approved by regression verification and authorize its merge against the evidence presented in the approval card.", null, canonicalStep(11).opensPullRequest],
+    [12, "Merge execution", canonicalStep(12).agentName, AssigneeType.AGENT, null, canonicalStep(12).approvalGate, canonicalStep(12).outputKind, "Execute the authorized merge mechanically. No model runs this step: @agentos/merge-executor claims it, re-verifies every precondition against the live pull request, and merges only under the step-11 human authorization for that exact head.", null, canonicalStep(12).opensPullRequest],
   ] as const;
   for (const [stepIndex, name, agentName, assigneeType, runner, approvalGate, outputKind, prompt, spawnPolicy, opensPullRequest] of steps) {
     const assigneeAgentId: string | null = agentName ? (agentByName.get(agentName)?.id ?? null) : null;
@@ -138,7 +137,7 @@ const main = async (): Promise<void> => {
     });
   }
 
-  console.log(`Seeded ${project.name} from agents/ with ${sources.roles.length} agents, ${sources.skills.length} skills, and the ten-step feature template.`);
+  console.log(`Seeded ${project.name} from agents/ with ${sources.roles.length} agents, ${sources.skills.length} skills, and the twelve-step feature template.`);
 };
 
 try {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -6,6 +6,7 @@ import {
   INTEGRATOR_AGENT_NAME,
   INTEGRATOR_OUTPUT_KIND,
   INTEGRATOR_TEMPLATE_NAME,
+  legacyNineStepTemplateName,
   legacyTenStepTemplateName,
 } from "../src/merge-integrator.js";
 
@@ -14,6 +15,18 @@ import {
 // without running this seed, which creates the internal multi-role
 // installation. Nothing this file seeds changed with the move.
 const prisma = new PrismaClient();
+
+const HISTORICAL_NINE_STEP_CONTRACT = [
+  [1, "spec", AssigneeType.AGENT, "spec", true],
+  [2, "plan", AssigneeType.AGENT, "plan", false],
+  [3, "review-coordinator", AssigneeType.AGENT, "plan-review", false],
+  [4, "plan-reviser", AssigneeType.AGENT, "revised-plan", true],
+  [5, "implementation-plan-executioner", AssigneeType.AGENT, "implementation", false],
+  [6, "review-coordinator", AssigneeType.AGENT, "code-review", false],
+  [7, "senior-dev", AssigneeType.AGENT, "fixed-implementation", false],
+  [8, "librarian", AssigneeType.AGENT, "documentation", false],
+  [9, null, AssigneeType.HUMAN, "approval", true],
+] as const;
 
 const main = async (): Promise<void> => {
   const sources = await loadAgentSources();
@@ -104,20 +117,36 @@ const main = async (): Promise<void> => {
       include: { steps: { include: { assigneeAgent: { select: { name: true } } }, orderBy: { stepIndex: "asc" } } },
     });
     const historicalIntegrator = existing?.steps.find((step) => step.stepIndex === 10);
+    const isHistoricalNineStepTemplate = existing?.steps.length === HISTORICAL_NINE_STEP_CONTRACT.length
+      && HISTORICAL_NINE_STEP_CONTRACT.every(([stepIndex, agentName, assigneeType, outputKind, approvalGate], index) => {
+        const step = existing.steps[index];
+        return step?.stepIndex === stepIndex
+          && (step.assigneeAgent?.name ?? null) === agentName
+          && step.assigneeType === assigneeType
+          && step.outputKind === outputKind
+          && step.approvalGate === approvalGate;
+      });
     const isHistoricalTenStepTemplate = existing?.steps.length === 10
       && existing.steps.every((step, index) => step.stepIndex === index + 1)
       && historicalIntegrator?.outputKind === INTEGRATOR_OUTPUT_KIND
       && historicalIntegrator.assigneeAgent?.name === INTEGRATOR_AGENT_NAME;
 
-    // A 10-row template cannot be rewritten in place: its in-flight tasks keep
-    // foreign keys to rows 6-10, whose meanings changed in the 12-row routing
-    // contract. Preserve that entire template under a seed-minted legacy
-    // identity; then the canonical upsert below creates a new template for new
-    // Runs. Runtime recognition accepts only this deterministic legacy marker.
-    if (existing && isHistoricalTenStepTemplate) {
+    // A historical 9- or 10-row template cannot be rewritten in place: its
+    // in-flight tasks keep foreign keys to rows 6-10, whose meanings changed in
+    // the 12-row routing contract. Preserve the entire template under a
+    // seed-minted legacy identity; then the canonical upsert below creates a
+    // new template for new Runs. Runtime mechanical recognition remains
+    // limited to the marked 10-row shape, because the 9-row shape had no
+    // integrator.
+    const legacyName = existing && isHistoricalNineStepTemplate
+      ? legacyNineStepTemplateName(existing.id)
+      : existing && isHistoricalTenStepTemplate
+        ? legacyTenStepTemplateName(existing.id)
+        : null;
+    if (existing && legacyName) {
       await tx.taskTemplate.update({
         where: { id: existing.id },
-        data: { name: legacyTenStepTemplateName(existing.id) },
+        data: { name: legacyName },
       });
     }
 

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -2,6 +2,12 @@ import { AssigneeType, Prisma, PrismaClient } from "@prisma/client";
 
 import { CANONICAL_TEMPLATE_STEPS } from "../src/agent-contract.js";
 import { loadAgentSources } from "../src/agent-sources.js";
+import {
+  INTEGRATOR_AGENT_NAME,
+  INTEGRATOR_OUTPUT_KIND,
+  INTEGRATOR_TEMPLATE_NAME,
+  legacyTenStepTemplateName,
+} from "../src/merge-integrator.js";
 
 // The loader this seed used to carry moved to `packages/db/src/agent-sources.ts`
 // so that OSS-B0's first-run onboarding can read the same `agents/` contract
@@ -92,18 +98,42 @@ const main = async (): Promise<void> => {
       });
     }
   }
-  const template = await prisma.taskTemplate.upsert({
-    where: { projectId_name: { projectId: project.id, name: "compound-engineer-workflow" } },
-    update: {
-      description: "Twelve-step Full Assurance workflow with dual independent code review, regression verification, human approval, and mechanical merge execution.",
-      variables: ["branchName"],
-    },
-    create: {
-      projectId: project.id,
-      name: "compound-engineer-workflow",
-      description: "Twelve-step Full Assurance workflow with dual independent code review, regression verification, human approval, and mechanical merge execution.",
-      variables: ["branchName"],
-    },
+  const template = await prisma.$transaction(async (tx) => {
+    const existing = await tx.taskTemplate.findUnique({
+      where: { projectId_name: { projectId: project.id, name: INTEGRATOR_TEMPLATE_NAME } },
+      include: { steps: { include: { assigneeAgent: { select: { name: true } } }, orderBy: { stepIndex: "asc" } } },
+    });
+    const historicalIntegrator = existing?.steps.find((step) => step.stepIndex === 10);
+    const isHistoricalTenStepTemplate = existing?.steps.length === 10
+      && existing.steps.every((step, index) => step.stepIndex === index + 1)
+      && historicalIntegrator?.outputKind === INTEGRATOR_OUTPUT_KIND
+      && historicalIntegrator.assigneeAgent?.name === INTEGRATOR_AGENT_NAME;
+
+    // A 10-row template cannot be rewritten in place: its in-flight tasks keep
+    // foreign keys to rows 6-10, whose meanings changed in the 12-row routing
+    // contract. Preserve that entire template under a seed-minted legacy
+    // identity; then the canonical upsert below creates a new template for new
+    // Runs. Runtime recognition accepts only this deterministic legacy marker.
+    if (existing && isHistoricalTenStepTemplate) {
+      await tx.taskTemplate.update({
+        where: { id: existing.id },
+        data: { name: legacyTenStepTemplateName(existing.id) },
+      });
+    }
+
+    return tx.taskTemplate.upsert({
+      where: { projectId_name: { projectId: project.id, name: INTEGRATOR_TEMPLATE_NAME } },
+      update: {
+        description: "Twelve-step Full Assurance workflow with dual independent code review, regression verification, human approval, and mechanical merge execution.",
+        variables: ["branchName"],
+      },
+      create: {
+        projectId: project.id,
+        name: INTEGRATOR_TEMPLATE_NAME,
+        description: "Twelve-step Full Assurance workflow with dual independent code review, regression verification, human approval, and mechanical merge execution.",
+        variables: ["branchName"],
+      },
+    });
   });
   const canonicalStep = (stepIndex: number) => {
     const step = CANONICAL_TEMPLATE_STEPS.find((candidate) => candidate.stepIndex === stepIndex);
@@ -116,7 +146,7 @@ const main = async (): Promise<void> => {
   const steps = [
     [1, "Write a spec", canonicalStep(1).agentName, AssigneeType.AGENT, null, canonicalStep(1).approvalGate, canonicalStep(1).outputKind, "Write a detailed feature specification for {{branchName}} and persist it for human approval.", null, canonicalStep(1).opensPullRequest],
     [2, "Plan", canonicalStep(2).agentName, AssigneeType.AGENT, null, canonicalStep(2).approvalGate, canonicalStep(2).outputKind, "Turn the approved spec into a concrete ordered implementation plan.", null, canonicalStep(2).opensPullRequest],
-    [3, "Plan review", canonicalStep(3).agentName, AssigneeType.AGENT, null, canonicalStep(3).approvalGate, canonicalStep(3).outputKind, "Review the plan through feasibility, scope, coherence, security, and a distinct risk-focused verification pass; consolidate must-fix and should-fix findings.", null, canonicalStep(3).opensPullRequest],
+    [3, "Plan review", canonicalStep(3).agentName, AssigneeType.AGENT, null, canonicalStep(3).approvalGate, canonicalStep(3).outputKind, "Review every vertical slice against the approved specification and frozen base: standalone demonstration, layer coverage and context size, true blocked_by prerequisites, merge or split decisions, expand-migrate-contract staging for wide refactors, and acceptance criteria that fail at base and turn green under the named verification.", null, canonicalStep(3).opensPullRequest],
     [4, "Revise plan", canonicalStep(4).agentName, AssigneeType.AGENT, null, canonicalStep(4).approvalGate, canonicalStep(4).outputKind, "Revise the plan using every must-fix plan-review finding and persist the implementation-authority artifact.", null, canonicalStep(4).opensPullRequest],
     [5, "Implementation", canonicalStep(5).agentName, AssigneeType.AGENT, null, canonicalStep(5).approvalGate, canonicalStep(5).outputKind, "Implement the approved plan on {{branchName}} and run end-to-end tests.", null, canonicalStep(5).opensPullRequest],
     [6, "Code review (Sol)", canonicalStep(6).agentName, AssigneeType.AGENT, null, canonicalStep(6).approvalGate, canonicalStep(6).outputKind, "Review the complete integrated implementation diff from the frozen pre-implementation base through the delivered head. Persist stable evidence-backed findings as the task output.", null, canonicalStep(6).opensPullRequest],
@@ -132,8 +162,8 @@ const main = async (): Promise<void> => {
     if (agentName && !assigneeAgentId) throw new Error(`Missing seeded agent ${agentName}`);
     await prisma.taskTemplateStep.upsert({
       where: { taskTemplateId_stepIndex: { taskTemplateId: template.id, stepIndex } },
-      update: { name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: stepIndex > 1, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
-      create: { taskTemplateId: template.id, stepIndex, name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: stepIndex > 1, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
+      update: { name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: canonicalStep(stepIndex).attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
+      create: { taskTemplateId: template.id, stepIndex, name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: canonicalStep(stepIndex).attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
     });
   }
 

--- a/packages/db/prisma/verify-agent-template.ts
+++ b/packages/db/prisma/verify-agent-template.ts
@@ -59,7 +59,7 @@ const main = async (): Promise<void> => {
     if (step.approvalGate !== expected.approvalGate) {
       throw new Error(`template step ${step.stepIndex} approval gate must be ${expected.approvalGate}; found ${step.approvalGate}`);
     }
-    if (step.stepIndex <= 8 && !isTemplateRunnerInherited(step.runner)) {
+    if (step.stepIndex < INTEGRATOR_STEP_INDEX && !isTemplateRunnerInherited(step.runner)) {
       throw new Error(`template step ${step.stepIndex} must inherit its Agent runner; found ${step.runner}`);
     }
     if (step.spawnPolicy !== null) throw new Error(`template step ${step.stepIndex} must not claim an unimplemented spawn policy`);
@@ -69,9 +69,9 @@ const main = async (): Promise<void> => {
   }
 
   // The integrator step, asserted explicitly rather than only through the
-  // generic loop. The `stepIndex <= 8` runner-inheritance bound above protects
-  // steps 1-8 from a template-pinned runner that would override the Agent's own;
-  // step 10 has no Agent runner to inherit at all, because nothing spawns for
+  // generic loop. The pre-integrator runner-inheritance bound above protects
+  // business steps from a template-pinned runner that would override the Agent's own;
+  // step 12 has no Agent runner to inherit at all, because nothing spawns for
   // it. These assertions are what stands in for that protection: an LLM model on
   // this row, or a `true` opensPullRequest, would mean a model CLI could be
   // handed the merge step or the merge step could publish.

--- a/packages/db/prisma/verify-agent-template.ts
+++ b/packages/db/prisma/verify-agent-template.ts
@@ -66,6 +66,9 @@ const main = async (): Promise<void> => {
     if (step.opensPullRequest !== expected.opensPullRequest) {
       throw new Error(`template step ${step.stepIndex} opensPullRequest must be ${expected.opensPullRequest}; found ${step.opensPullRequest}`);
     }
+    if (step.attachmentsFromPrevious !== expected.attachmentsFromPrevious) {
+      throw new Error(`template step ${step.stepIndex} attachmentsFromPrevious must be ${expected.attachmentsFromPrevious}; found ${step.attachmentsFromPrevious}`);
+    }
   }
 
   // The integrator step, asserted explicitly rather than only through the

--- a/packages/db/src/agent-contract.ts
+++ b/packages/db/src/agent-contract.ts
@@ -3,38 +3,41 @@ import { RunnerKind, RunnerPreference } from "@prisma/client";
 export const CANONICAL_AGENT_DEFAULTS = [
   { name: "default", model: "gpt-5.6-sol:medium", runner: RunnerPreference.CODEX },
   { name: "frontend-dev", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
-  { name: "implementation-plan-executioner", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
-  { name: "librarian", model: "gpt-5.6-luna:high", runner: RunnerPreference.CODEX },
-  // Not an LLM role. The sentinel Agent row step 10 binds so a mechanical run
+  { name: "implementation-plan-executioner", model: "gpt-5.6-sol:medium", runner: RunnerPreference.CODEX },
+  { name: "librarian", model: "gpt-5.6-terra:medium", runner: RunnerPreference.CODEX },
+  // Not an LLM role. The sentinel Agent row step 12 binds so a mechanical run
   // can carry a non-null `Run.agentId` without presenting a second human gate.
   // `catalogRunnerForModel` returns null for this model, so the runner/model
   // mismatch assertion below never fires on it, and `INHERIT` is inert because
   // no adapter is ever constructed for it (agents/roles/merge-integrator.md).
   { name: "merge-integrator", model: "mechanical/merge-executor-v1", runner: RunnerPreference.INHERIT },
   { name: "plan", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
-  { name: "plan-reviser", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
+  { name: "plan-reviser", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "review-coordinator", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
-  { name: "senior-dev", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
+  { name: "review-coordinator-opus", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
+  { name: "review-coordinator-sol", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
+  { name: "senior-dev", model: "gpt-5.6-sol:medium", runner: RunnerPreference.CODEX },
   { name: "spec", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
 ] as const;
 
 export const CANONICAL_TEMPLATE_STEPS = [
-  { stepIndex: 1, agentName: "spec", outputKind: "spec", approvalGate: true, opensPullRequest: true },
-  { stepIndex: 2, agentName: "plan", outputKind: "plan", approvalGate: false, opensPullRequest: true },
-  { stepIndex: 3, agentName: "review-coordinator", outputKind: "plan-review", approvalGate: false, opensPullRequest: true },
-  { stepIndex: 4, agentName: "plan-reviser", outputKind: "revised-plan", approvalGate: true, opensPullRequest: true },
+  { stepIndex: 1, agentName: "spec", outputKind: "spec", approvalGate: true, opensPullRequest: false },
+  { stepIndex: 2, agentName: "plan", outputKind: "plan", approvalGate: false, opensPullRequest: false },
+  { stepIndex: 3, agentName: "review-coordinator", outputKind: "plan-review", approvalGate: false, opensPullRequest: false },
+  { stepIndex: 4, agentName: "plan-reviser", outputKind: "revised-plan", approvalGate: true, opensPullRequest: false },
   { stepIndex: 5, agentName: "implementation-plan-executioner", outputKind: "implementation", approvalGate: false, opensPullRequest: true },
-  { stepIndex: 6, agentName: "review-coordinator", outputKind: "code-review", approvalGate: false, opensPullRequest: true },
-  { stepIndex: 7, agentName: "senior-dev", outputKind: "fixed-implementation", approvalGate: false, opensPullRequest: true },
-  { stepIndex: 8, agentName: "librarian", outputKind: "documentation", approvalGate: false, opensPullRequest: true },
-  { stepIndex: 9, agentName: null, outputKind: "approval", approvalGate: true, opensPullRequest: true },
-  // Step 10 executes the merge mechanically and publishes nothing:
+  { stepIndex: 6, agentName: "review-coordinator-sol", outputKind: "sol-findings", approvalGate: false, opensPullRequest: false },
+  { stepIndex: 7, agentName: "review-coordinator-opus", outputKind: "must-fix", approvalGate: false, opensPullRequest: false },
+  { stepIndex: 8, agentName: "senior-dev", outputKind: "fixed-implementation", approvalGate: false, opensPullRequest: false },
+  { stepIndex: 9, agentName: "review-coordinator-opus", outputKind: "regression-verification", approvalGate: false, opensPullRequest: false },
+  { stepIndex: 10, agentName: "librarian", outputKind: "documentation", approvalGate: false, opensPullRequest: false },
+  { stepIndex: 11, agentName: null, outputKind: "approval", approvalGate: true, opensPullRequest: false },
+  // Step 12 executes the merge mechanically and publishes nothing:
   // `opensPullRequest: false` is load-bearing, because `templates.ts` copies it
   // onto the materialized task row and `enqueueTaskRun` copies that onto the
-  // run. Steps 1-9 carry `true` to preserve exactly today's seeded behaviour,
-  // which took `schema.prisma`'s column default because the seed tuple omitted
-  // the field entirely.
-  { stepIndex: 10, agentName: "merge-integrator", outputKind: "merge-result", approvalGate: false, opensPullRequest: false },
+  // run. Step 5 is the only row allowed to create the chain's pull request;
+  // every review, fix, documentation, approval, and merge row reuses it.
+  { stepIndex: 12, agentName: "merge-integrator", outputKind: "merge-result", approvalGate: false, opensPullRequest: false },
 ] as const;
 
 export const IMPLEMENTATION_PLAN_OUTPUT_KINDS = ["plan", "revised-plan"] as const;

--- a/packages/db/src/agent-contract.ts
+++ b/packages/db/src/agent-contract.ts
@@ -21,23 +21,25 @@ export const CANONICAL_AGENT_DEFAULTS = [
 ] as const;
 
 export const CANONICAL_TEMPLATE_STEPS = [
-  { stepIndex: 1, agentName: "spec", outputKind: "spec", approvalGate: true, opensPullRequest: false },
-  { stepIndex: 2, agentName: "plan", outputKind: "plan", approvalGate: false, opensPullRequest: false },
-  { stepIndex: 3, agentName: "review-coordinator", outputKind: "plan-review", approvalGate: false, opensPullRequest: false },
-  { stepIndex: 4, agentName: "plan-reviser", outputKind: "revised-plan", approvalGate: true, opensPullRequest: false },
-  { stepIndex: 5, agentName: "implementation-plan-executioner", outputKind: "implementation", approvalGate: false, opensPullRequest: true },
-  { stepIndex: 6, agentName: "review-coordinator-sol", outputKind: "sol-findings", approvalGate: false, opensPullRequest: false },
-  { stepIndex: 7, agentName: "review-coordinator-opus", outputKind: "must-fix", approvalGate: false, opensPullRequest: false },
-  { stepIndex: 8, agentName: "senior-dev", outputKind: "fixed-implementation", approvalGate: false, opensPullRequest: false },
-  { stepIndex: 9, agentName: "review-coordinator-opus", outputKind: "regression-verification", approvalGate: false, opensPullRequest: false },
-  { stepIndex: 10, agentName: "librarian", outputKind: "documentation", approvalGate: false, opensPullRequest: false },
-  { stepIndex: 11, agentName: null, outputKind: "approval", approvalGate: true, opensPullRequest: false },
+  { stepIndex: 1, agentName: "spec", outputKind: "spec", approvalGate: true, opensPullRequest: false, attachmentsFromPrevious: false },
+  { stepIndex: 2, agentName: "plan", outputKind: "plan", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
+  { stepIndex: 3, agentName: "review-coordinator", outputKind: "plan-review", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
+  { stepIndex: 4, agentName: "plan-reviser", outputKind: "revised-plan", approvalGate: true, opensPullRequest: false, attachmentsFromPrevious: true },
+  { stepIndex: 5, agentName: "implementation-plan-executioner", outputKind: "implementation", approvalGate: false, opensPullRequest: true, attachmentsFromPrevious: true },
+  { stepIndex: 6, agentName: "review-coordinator-sol", outputKind: "sol-findings", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
+  // Blind review must persist its own report before reading step 6.
+  { stepIndex: 7, agentName: "review-coordinator-opus", outputKind: "must-fix", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: false },
+  { stepIndex: 8, agentName: "senior-dev", outputKind: "fixed-implementation", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
+  // Regression verification consumes the complete step-8 fix diff.
+  { stepIndex: 9, agentName: "review-coordinator-opus", outputKind: "regression-verification", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
+  { stepIndex: 10, agentName: "librarian", outputKind: "documentation", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
+  { stepIndex: 11, agentName: null, outputKind: "approval", approvalGate: true, opensPullRequest: false, attachmentsFromPrevious: true },
   // Step 12 executes the merge mechanically and publishes nothing:
   // `opensPullRequest: false` is load-bearing, because `templates.ts` copies it
   // onto the materialized task row and `enqueueTaskRun` copies that onto the
   // run. Step 5 is the only row allowed to create the chain's pull request;
   // every review, fix, documentation, approval, and merge row reuses it.
-  { stepIndex: 12, agentName: "merge-integrator", outputKind: "merge-result", approvalGate: false, opensPullRequest: false },
+  { stepIndex: 12, agentName: "merge-integrator", outputKind: "merge-result", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
 ] as const;
 
 export const IMPLEMENTATION_PLAN_OUTPUT_KINDS = ["plan", "revised-plan"] as const;

--- a/packages/db/src/agent-sources.ts
+++ b/packages/db/src/agent-sources.ts
@@ -4,7 +4,7 @@
  *
  * It used to live inside `prisma/seed.ts`, reachable only by running that seed —
  * which creates the internal multi-role installation, every skill, every
- * collaboration edge and the ten-step template. OSS-B0's first-run onboarding
+ * collaboration edge and the twelve-step template. OSS-B0's first-run onboarding
  * needs exactly one of those roles, the canonical `default` starter, created
  * inside one API transaction that must never run the internal seed (plan Fixed
  * Decision 4). So the loader moved here, `seed.ts` consumes it unchanged, and

--- a/packages/db/src/merge-integrator-db.ts
+++ b/packages/db/src/merge-integrator-db.ts
@@ -21,6 +21,7 @@ import {
 import {
   EVIDENCE_PLACEHOLDER_BODY,
   INTEGRATOR_OUTPUT_KIND,
+  INTEGRATOR_STEP_INDEX,
   MERGE_INTEGRATOR_KIND,
   MERGE_INTEGRATOR_SCHEMA_VERSION,
   FOLLOW_UP_CHOICES,
@@ -58,14 +59,14 @@ const INTEGRATOR_INCLUDE = { templateStep: { include: { taskTemplate: { select: 
 
 export type IntegratorTask = Prisma.TaskGetPayload<{ include: typeof INTEGRATOR_INCLUDE }>;
 
-/** True when this task row *is* the chain's step-10 task. */
+/** True when this task row *is* the chain's step-12 task. */
 export const taskIsIntegratorStep = (task: IntegratorTask | null | undefined): boolean =>
   isIntegratorStep(task?.templateStep ?? null);
 
 export const loadIntegratorTask = async (tx: Tx, taskId: string): Promise<IntegratorTask | null> =>
   tx.task.findUnique({ where: { id: taskId }, include: INTEGRATOR_INCLUDE });
 
-/** The chain's step-10 task, or null for an ordinary nine-step chain. */
+/** The chain's step-12 task, or null when the chain has no mechanical continuation. */
 export const findChainIntegratorTask = async (
   tx: Tx,
   projectId: string,
@@ -82,7 +83,7 @@ export const findChainIntegratorTask = async (
 
 /**
  * Does the successor of this gate task run mechanically? This is what turns the
- * two-phase evidence protocol on: an ordinary nine-step chain's gate is
+ * two-phase evidence protocol on: an ordinary gate without that successor is
  * byte-for-byte unchanged.
  */
 export const gateFeedsIntegratorStep = async (
@@ -628,15 +629,15 @@ export const applyStopAnswer = async (
     taskId: task.id,
     actorType: "control-plane",
     body: abandoned
-      ? `Chain abandoned; step 10 closed without a merge (${condition})`
-      : `Chain complete; step 10 closed by operator decision (${condition})`,
+      ? `Chain abandoned; step ${INTEGRATOR_STEP_INDEX} closed without a merge (${condition})`
+      : `Chain complete; step ${INTEGRATOR_STEP_INDEX} closed by operator decision (${condition})`,
   } });
   return outcome;
 };
 
 /**
  * The confirmation card a renewal or a repair asks for. It is a real gate card
- * on the step-9 task, so it travels the identical production path — the same
+ * on the step-11 task, so it travels the identical production path — the same
  * worker fills it and the same transaction reads it back.
  */
 export const requestConfirmationCard = async (

--- a/packages/db/src/merge-integrator.test.ts
+++ b/packages/db/src/merge-integrator.test.ts
@@ -7,6 +7,7 @@ import {
   EVIDENCE_PLACEHOLDER_BODY,
   EVIDENCE_UNAVAILABLE_MARKER,
   INTEGRATOR_AGENT_NAME,
+  INTEGRATOR_STEP_INDEX,
   MERGE_INTEGRATOR_KIND,
   MERGE_INTEGRATOR_SCHEMA_VERSION,
   STOP_CHOICES,
@@ -229,22 +230,22 @@ test("an unrelated activity is neither counted nor refused", () => {
 
 // --- §D-P4 the binding invariant -----------------------------------------
 
-const integratorStep = { stepIndex: 10, outputKind: "merge-result", taskTemplate: { name: "compound-engineer-workflow" } };
+const integratorStep = { stepIndex: INTEGRATOR_STEP_INDEX, outputKind: "merge-result", taskTemplate: { name: "compound-engineer-workflow" } };
 
 test("the binding predicate holds in both directions", () => {
   assert.ok(isIntegratorStep(integratorStep));
   assert.ok(integratorBindingValid(INTEGRATOR_AGENT_NAME, integratorStep));
   assert.ok(integratorBindingValid("senior-dev", { stepIndex: 5, outputKind: "implementation", taskTemplate: { name: "compound-engineer-workflow" } }));
-  // The sentinel on an ordinary step, and an ordinary agent on step 10.
+  // The sentinel on an ordinary step, and an ordinary agent on step 12.
   assert.ok(!integratorBindingValid(INTEGRATOR_AGENT_NAME, null));
   assert.ok(!integratorBindingValid(INTEGRATOR_AGENT_NAME, { stepIndex: 5, outputKind: "implementation", taskTemplate: { name: "compound-engineer-workflow" } }));
   assert.ok(!integratorBindingValid("senior-dev", integratorStep));
 });
 
 test("a lookalike step in another template or with another output kind is not the integrator step", () => {
-  assert.ok(!isIntegratorStep({ stepIndex: 10, outputKind: "merge-result", taskTemplate: { name: "some-other-template" } }));
-  assert.ok(!isIntegratorStep({ stepIndex: 10, outputKind: "result", taskTemplate: { name: "compound-engineer-workflow" } }));
-  assert.ok(!isIntegratorStep({ stepIndex: 9, outputKind: "merge-result", taskTemplate: { name: "compound-engineer-workflow" } }));
+  assert.ok(!isIntegratorStep({ stepIndex: INTEGRATOR_STEP_INDEX, outputKind: "merge-result", taskTemplate: { name: "some-other-template" } }));
+  assert.ok(!isIntegratorStep({ stepIndex: INTEGRATOR_STEP_INDEX, outputKind: "result", taskTemplate: { name: "compound-engineer-workflow" } }));
+  assert.ok(!isIntegratorStep({ stepIndex: INTEGRATOR_STEP_INDEX - 1, outputKind: "merge-result", taskTemplate: { name: "compound-engineer-workflow" } }));
 });
 
 // --- §D-P7 the disposition machine ---------------------------------------

--- a/packages/db/src/merge-integrator.test.ts
+++ b/packages/db/src/merge-integrator.test.ts
@@ -7,7 +7,9 @@ import {
   EVIDENCE_PLACEHOLDER_BODY,
   EVIDENCE_UNAVAILABLE_MARKER,
   INTEGRATOR_AGENT_NAME,
+  INTEGRATOR_OUTPUT_KIND,
   INTEGRATOR_STEP_INDEX,
+  INTEGRATOR_TEMPLATE_NAME,
   MERGE_INTEGRATOR_KIND,
   MERGE_INTEGRATOR_SCHEMA_VERSION,
   STOP_CHOICES,
@@ -17,12 +19,14 @@ import {
   type DecisionRow,
   type MergeEvidence,
   authorizationMetadata,
+  canonicalIntegratorBindingValid,
   dispositionFor,
   evidenceEquals,
   followUpDispositionFor,
   integratorBindingValid,
   isIncidentCondition,
   isIntegratorStep,
+  legacyTenStepTemplateName,
   isTerminalDisposition,
   parseEvidence,
   parseMergeResult,
@@ -240,6 +244,28 @@ test("the binding predicate holds in both directions", () => {
   assert.ok(!integratorBindingValid(INTEGRATOR_AGENT_NAME, null));
   assert.ok(!integratorBindingValid(INTEGRATOR_AGENT_NAME, { stepIndex: 5, outputKind: "implementation", taskTemplate: { name: "compound-engineer-workflow" } }));
   assert.ok(!integratorBindingValid("senior-dev", integratorStep));
+});
+
+test("seed-marked legacy step 10 stays mechanical without widening new-template binding", () => {
+  const legacy = {
+    stepIndex: 10,
+    outputKind: INTEGRATOR_OUTPUT_KIND,
+    taskTemplate: { name: legacyTenStepTemplateName("template-old") },
+  };
+  assert.equal(isIntegratorStep(legacy), true);
+  assert.equal(integratorBindingValid(INTEGRATOR_AGENT_NAME, legacy), true);
+  assert.equal(canonicalIntegratorBindingValid(INTEGRATOR_AGENT_NAME, legacy), false);
+
+  assert.equal(isIntegratorStep({
+    stepIndex: 10,
+    outputKind: INTEGRATOR_OUTPUT_KIND,
+    taskTemplate: { name: INTEGRATOR_TEMPLATE_NAME },
+  }), false);
+  assert.equal(isIntegratorStep({
+    stepIndex: 10,
+    outputKind: INTEGRATOR_OUTPUT_KIND,
+    taskTemplate: { name: `${INTEGRATOR_TEMPLATE_NAME}-legacy-lookalike` },
+  }), false);
 });
 
 test("a lookalike step in another template or with another output kind is not the integrator step", () => {

--- a/packages/db/src/merge-integrator.test.ts
+++ b/packages/db/src/merge-integrator.test.ts
@@ -26,6 +26,7 @@ import {
   integratorBindingValid,
   isIncidentCondition,
   isIntegratorStep,
+  legacyNineStepTemplateName,
   legacyTenStepTemplateName,
   isTerminalDisposition,
   parseEvidence,
@@ -265,6 +266,11 @@ test("seed-marked legacy step 10 stays mechanical without widening new-template 
     stepIndex: 10,
     outputKind: INTEGRATOR_OUTPUT_KIND,
     taskTemplate: { name: `${INTEGRATOR_TEMPLATE_NAME}-legacy-lookalike` },
+  }), false);
+  assert.equal(isIntegratorStep({
+    stepIndex: 10,
+    outputKind: INTEGRATOR_OUTPUT_KIND,
+    taskTemplate: { name: legacyNineStepTemplateName("template-old") },
   }), false);
 });
 

--- a/packages/db/src/merge-integrator.ts
+++ b/packages/db/src/merge-integrator.ts
@@ -27,7 +27,7 @@ export const MERGE_INTEGRATOR_SCHEMA_VERSION = 1;
 /** v1.1 pins exactly one merge method (SPEC D4). */
 export const AUTHORIZED_MERGE_METHOD = "merge";
 
-export const INTEGRATOR_STEP_INDEX = 10;
+export const INTEGRATOR_STEP_INDEX = 12;
 export const INTEGRATOR_OUTPUT_KIND = "merge-result";
 export const INTEGRATOR_AGENT_NAME = "merge-integrator";
 export const INTEGRATOR_TEMPLATE_NAME = "compound-engineer-workflow";
@@ -49,9 +49,9 @@ const templateNameOf = (step: NonNullable<IntegratorStepShape>): string | null =
   step.taskTemplate?.name ?? step.taskTemplateName ?? null;
 
 /**
- * The canonical step-10 shape. All four facts are required: an outputKind alone
+ * The canonical step-12 shape. All four facts are required: an outputKind alone
  * is client-influenceable through a doctored template, and a stepIndex alone
- * collides with any other template that happens to have ten steps.
+ * collides with any other template that happens to use the same step index.
  */
 export const isIntegratorStep = (step: IntegratorStepShape): boolean => {
   if (!step) return false;
@@ -63,7 +63,7 @@ export const isIntegratorStep = (step: IntegratorStepShape): boolean => {
 /**
  * Bidirectional: the sentinel Agent may bind only the integrator step, and the
  * integrator step may bind only the sentinel Agent. One direction alone leaves
- * a hole — the sentinel dispatchable as an ordinary model agent, or step 10
+ * a hole — the sentinel dispatchable as an ordinary model agent, or step 12
  * executable by a real LLM.
  */
 export const integratorBindingValid = (
@@ -400,7 +400,7 @@ export const selectAuthorization = (
     if (parsed.status === "malformed") { nearMatchCount += 1; continue; }
     const payload = parsed.payload;
     const decision = decisionById.get(payload.decision.inboxDecisionId);
-    // Rule 2: the decision must exist and belong to *this* chain's step-9 gate,
+    // Rule 2: the decision must exist and belong to *this* chain's step-11 gate,
     // resolved from the caller's own chain and never from the payload.
     if (!decision) { ignoredCount += 1; continue; }
     const card = cardById.get(decision.inboxMessageId);

--- a/packages/db/src/merge-integrator.ts
+++ b/packages/db/src/merge-integrator.ts
@@ -31,6 +31,7 @@ export const INTEGRATOR_STEP_INDEX = 12;
 export const INTEGRATOR_OUTPUT_KIND = "merge-result";
 export const INTEGRATOR_AGENT_NAME = "merge-integrator";
 export const INTEGRATOR_TEMPLATE_NAME = "compound-engineer-workflow";
+export const LEGACY_NINE_STEP_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-9-`;
 export const LEGACY_TEN_STEP_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-10-`;
 /** Sentinel model. `catalogRunnerForModel` returns null for it, so no runner/model assertion fires. */
 export const INTEGRATOR_SENTINEL_MODEL = "mechanical/merge-executor-v1";
@@ -42,6 +43,9 @@ export const INTEGRATOR_SENTINEL_MODEL = "mechanical/merge-executor-v1";
  */
 export const legacyTenStepTemplateName = (templateId: string): string =>
   `${LEGACY_TEN_STEP_TEMPLATE_PREFIX}${templateId}`;
+
+export const legacyNineStepTemplateName = (templateId: string): string =>
+  `${LEGACY_NINE_STEP_TEMPLATE_PREFIX}${templateId}`;
 
 // ---------------------------------------------------------------------------
 // §D-P4 — the bidirectional binding invariant

--- a/packages/db/src/merge-integrator.ts
+++ b/packages/db/src/merge-integrator.ts
@@ -31,8 +31,17 @@ export const INTEGRATOR_STEP_INDEX = 12;
 export const INTEGRATOR_OUTPUT_KIND = "merge-result";
 export const INTEGRATOR_AGENT_NAME = "merge-integrator";
 export const INTEGRATOR_TEMPLATE_NAME = "compound-engineer-workflow";
+export const LEGACY_TEN_STEP_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-10-`;
 /** Sentinel model. `catalogRunnerForModel` returns null for it, so no runner/model assertion fires. */
 export const INTEGRATOR_SENTINEL_MODEL = "mechanical/merge-executor-v1";
+
+/**
+ * Seed rollover keeps the historical template row and its step ids intact so
+ * already-materialized tasks retain their runtime contract. The template id in
+ * this marker makes the rename deterministic and collision-free on retries.
+ */
+export const legacyTenStepTemplateName = (templateId: string): string =>
+  `${LEGACY_TEN_STEP_TEMPLATE_PREFIX}${templateId}`;
 
 // ---------------------------------------------------------------------------
 // §D-P4 — the bidirectional binding invariant
@@ -49,15 +58,29 @@ const templateNameOf = (step: NonNullable<IntegratorStepShape>): string | null =
   step.taskTemplate?.name ?? step.taskTemplateName ?? null;
 
 /**
- * The canonical step-12 shape. All four facts are required: an outputKind alone
+ * The canonical step-12 shape. All three facts are required: an outputKind alone
  * is client-influenceable through a doctored template, and a stepIndex alone
  * collides with any other template that happens to use the same step index.
  */
-export const isIntegratorStep = (step: IntegratorStepShape): boolean => {
+export const isCanonicalIntegratorStep = (step: IntegratorStepShape): boolean => {
   if (!step) return false;
   return step.stepIndex === INTEGRATOR_STEP_INDEX
     && step.outputKind === INTEGRATOR_OUTPUT_KIND
     && templateNameOf(step) === INTEGRATOR_TEMPLATE_NAME;
+};
+
+/**
+ * Runtime recognition includes the one historical shape the seed can mark
+ * during a 10 -> 12 rollover. It is deliberately narrower than "step 10" or
+ * "merge-result": only a seed-minted legacy template identity qualifies.
+ */
+export const isIntegratorStep = (step: IntegratorStepShape): boolean => {
+  if (!step) return false;
+  const templateName = templateNameOf(step);
+  return isCanonicalIntegratorStep(step)
+    || (step.stepIndex === 10
+      && step.outputKind === INTEGRATOR_OUTPUT_KIND
+      && templateName?.startsWith(LEGACY_TEN_STEP_TEMPLATE_PREFIX) === true);
 };
 
 /**
@@ -70,6 +93,22 @@ export const integratorBindingValid = (
   agentName: string | null | undefined,
   step: IntegratorStepShape,
 ): boolean => (agentName === INTEGRATOR_AGENT_NAME) === isIntegratorStep(step);
+
+/** New template instantiation is stricter than runtime compatibility. */
+export const canonicalIntegratorBindingValid = (
+  agentName: string | null | undefined,
+  step: IntegratorStepShape,
+): boolean => (agentName === INTEGRATOR_AGENT_NAME) === isCanonicalIntegratorStep(step);
+
+export const canonicalIntegratorBindingRefusal = (
+  agentName: string | null | undefined,
+  step: IntegratorStepShape,
+): string | null => {
+  if (canonicalIntegratorBindingValid(agentName, step)) return null;
+  return agentName === INTEGRATOR_AGENT_NAME
+    ? `Agent ${INTEGRATOR_AGENT_NAME} may bind only step ${INTEGRATOR_STEP_INDEX} of ${INTEGRATOR_TEMPLATE_NAME}`
+    : `Step ${INTEGRATOR_STEP_INDEX} of ${INTEGRATOR_TEMPLATE_NAME} may bind only agent ${INTEGRATOR_AGENT_NAME}`;
+};
 
 export const integratorBindingRefusal = (
   agentName: string | null | undefined,

--- a/packages/db/src/preflight-goal-execution.dbtest.ts
+++ b/packages/db/src/preflight-goal-execution.dbtest.ts
@@ -16,8 +16,11 @@
  *     npm run test:db -w @agentos/db
  */
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { after, before, describe, it } from "node:test";
 
@@ -32,11 +35,24 @@ import {
 } from "./schema-census.js";
 
 const packageRoot = fileURLToPath(new URL("../", import.meta.url)).replace(/\/+$/u, "");
+const repositoryRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const isolatedCheckout = mkdtempSync(join(tmpdir(), "agentos-public-lineage-"));
+const currentBranch = execFileSync("git", ["symbolic-ref", "--short", "HEAD"], {
+  cwd: repositoryRoot,
+  encoding: "utf8",
+}).trim();
+
+// Linked worktrees can share private objects with this public lineage. Clone
+// only the current branch so the preflight sees the history a standalone public
+// clone sees, without weakening the production authority checks.
+execFileSync("git", [
+  "clone", "--quiet", "--no-local", "--no-checkout", "--single-branch",
+  "--branch", currentBranch, repositoryRoot, isolatedCheckout,
+]);
 
 // The recorded authority evidence, so these cases stop on the condition they are
-// about rather than on `authority`. They are the SHAs in
-// docs/reviews/goal-5a0-current-master-revalidation.md; the preflight checks
-// both that the document records them and that they are ancestors of HEAD.
+// about rather than on `authority`. The preflight checks both the signed
+// attestation content and that its commits are ancestors of HEAD.
 const MASTER_SHA = "485fb118db96e3977006a2edc866a38b751ff0e2";
 const CONTROL_PLANE_A_SHA = "c671439831b075568420b92f4494227fa7fc392b";
 
@@ -83,6 +99,8 @@ const runPreflight = (schema: string, extra: Record<string, string> = {}): Outco
       DATABASE_URL: urlFor(schema),
       GOAL5A0_MASTER_SHA: MASTER_SHA,
       GOAL5A0_CONTROL_PLANE_A_SHA: CONTROL_PLANE_A_SHA,
+      GIT_DIR: join(isolatedCheckout, ".git"),
+      GIT_WORK_TREE: repositoryRoot,
       ...extra,
     },
   });
@@ -118,6 +136,7 @@ before(async () => {
 after(async () => {
   for (const schema of schemas) await sql(`DROP SCHEMA IF EXISTS ${quoted(schema)} CASCADE`);
   await admin.$disconnect();
+  rmSync(isolatedCheckout, { recursive: true, force: true });
 });
 
 describe("first run: declared and confirmed empty", () => {

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -521,7 +521,7 @@ export const gateQuestion = async (tx: Tx, gateTaskId: string, sourceRunId: stri
   // reading GitHub here: this function runs inside applyInboxDecisionTx in the
   // separate @agentos/inbox process, which can reach neither the API's GitHub
   // client nor its configuration (MF-3). The read also must not happen inside
-  // this lock-holding transaction (SF-2). Ordinary nine-step chains never enter
+  // this lock-holding transaction (SF-2). Chains without a mechanical successor never enter
   // this branch and are byte-for-byte unchanged.
   const integrator = await gateFeedsIntegratorStep(tx, task);
   if (integrator) {
@@ -543,7 +543,7 @@ export const gateQuestion = async (tx: Tx, gateTaskId: string, sourceRunId: stri
     }
     // An unresolvable target cannot produce an evidence card. The gate still
     // opens through the ordinary path so a human is not left with silence; the
-    // approval simply produces no authorization, and step 10 later stops
+    // approval simply produces no authorization, and step 12 later stops
     // target-unresolvable — fail closed, and the §D-P8 repair is the exit.
   }
   // The approver decides from the card; the produced artifact rides along so
@@ -949,7 +949,7 @@ export const produceMergeAuthorization = async (
   });
   if (!gateTask) return null;
   const integrator = await gateFeedsIntegratorStep(tx, gateTask);
-  // Not an integrator gate: an ordinary nine-step approval, untouched.
+  // Not an integrator gate: an ordinary approval without a mechanical successor, untouched.
   if (!integrator) return null;
 
   const block = parseEvidence(input.card.body);


### PR DESCRIPTION
## What

Ports the eleven-business-stage chain routing onto the public lineage (7 commits):

- Split code review into two independent roles: `review-coordinator-sol` (finder) and `review-coordinator-opus` (blind adjudicator with write-before-read invariant); `review-coordinator` remains the plan reviewer.
- TaskTemplate becomes 11 business stages plus a mechanical merge-execution step 12; `opensPullRequest` is true only for step 5.
- Canonical model defaults updated per role; Luna entries pinned to max effort.
- Legacy nine-row and ten-row templates are preserved on re-seed under deterministic legacy names (in-flight chains keep their semantics and their integrator recognition); new instantiation accepts canonical bindings only.
- DB tests derive step indices from fixtures instead of hardcoding them; blind-review and legacy-template invariants are pinned by contract tests.
- Two test-harness fixes isolate public-lineage ancestry checks from shared object stores.

Excluded from this port per `public-snapshot.json` (`later-release-follow-up`): the operator merge runbook and the merge-integrator system-test harness.

## Verification

- `npm run build` / `npm test` / `npm run typecheck`: PASS
- `npm run test:snapshot-scan`: 18/18; `npm run snapshot:scan`: exit 0, 0 blockers, 0 unclassified
- Full `npm run test:db` on a throwaway PostgreSQL: 318/318
- `MERGE GATE: PASS 28ace62e2246a4addc82ef77a4b9e566e0bd64e9` (gate run on the operator machine that will merge)

The change set went through a dual-path cross-vendor review upstream (three review rounds, all must-fix findings closed, final regression sign-off bound to the ported exact head).

Generated with [Claude Code](https://claude.com/claude-code)