### PR TITLE
feat(db): load canonical workflow prompts from markdown

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -27,6 +27,12 @@ task's `approvalGate`; they do not hard-code a pause or send a second Inbox
 question to simulate one. The Full Assurance template's gate placement and
 shorter-route rules live only in the routing contract.
 
+The seed installs two templates over these roles: the twelve-step Full
+Assurance chain, and the six-step direct chain (`direct-engineer-workflow`) —
+implementation by `senior-dev` from the task brief, the same dual blind review
+spine, and a terminal human pull-request gate with no mechanical merge. Both
+step contracts live in `packages/db/src/agent-contract.ts`.
+
 Provider-specific or temporary roles are not canonical defaults unless the
 cross-provider review contract explicitly requires separate identities. Keep
 experiments out of `roles/`; create them as local overlays and archive them when

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,6 +1,6 @@
-# agents/ — Agent role prompts
+# agents/ — Canonical prompts
 
-Source-of-truth files for the canonical agents and the mechanical merge sentinel. The seed script imports these into the `Agent` table and its join tables; `packages/db/prisma/seed.ts` is the consumer. Skills remain an API-managed concept (`Skill` / `AgentSkill`), but no canonical skill is seeded from this directory.
+Source-of-truth files for canonical agents, the mechanical merge sentinel, and task-template step prompts. The seed script imports these into the `Agent`, join, and `TaskTemplateStep` tables; `packages/db/prisma/seed.ts` is the consumer. Skills remain an API-managed concept (`Skill` / `AgentSkill`), but no canonical skill is seeded from this directory.
 
 All prompts here are reconstructed from BLUEPRINT.md (itself reconstructed from Danny Postma's talk); none are his verbatim files.
 
@@ -8,6 +8,7 @@ All prompts here are reconstructed from BLUEPRINT.md (itself reconstructed from 
 
 - `foundational.md` — the shared foundational prompt. Body maps to `Agent.foundationalPrompt` for every agent.
 - `roles/<name>.md` — one file per agent. Frontmatter maps to `Agent` columns and join tables; markdown body maps to `Agent.rolePrompt`.
+- `templates/<template-name>/<NN>-<slug>.md` — one file per canonical workflow step. Frontmatter maps to structural `TaskTemplateStep` fields; markdown body maps to `TaskTemplateStep.prompt`.
 
 ## Role frontmatter
 
@@ -20,6 +21,20 @@ inboxAccess: true         # Agent.inboxAccess
 collaborators: []         # AgentCollaboration rows, by agent name
 ```
 
+## Template step frontmatter
+
+```yaml
+stepIndex: 5
+agent: implementation-plan-executioner # Agent.name, or null for a human step
+approvalGate: false
+outputKind: implementation
+attachmentsFromPrevious: true
+opensPullRequest: true
+spawnPolicy: null                      # null or an inline JSON object
+```
+
+The `compound-engineer-workflow` directory contains exactly twelve files and `direct-engineer-workflow` exactly six, each with contiguous indexes. The filename prefix must match `stepIndex`, and only these structural keys are accepted. Step display names remain seed-owned presentation metadata; all execution structure and prompt text live in the Markdown sources.
+
 Exact canonical model and runner defaults live in the role frontmatter and `packages/db/src/agent-contract.ts`; task-chain routing is governed by the routing contract this repository's operator maintains outside the published tree. A task template binds roles, while each Agent owns its default runner, model, and reasoning effort. Template steps normally leave `runner` unset so the Agent configuration remains the single runtime authority. `inboxAccess` is least-privilege: granted only where the role contract requires talking to the human (`default`, `spec`, `plan`, `plan-reviser`, `senior-dev`, `implementation-plan-executioner`, `review-coordinator-opus`).
 
 Approval is task metadata, not an Agent personality. Roles read the current
@@ -31,7 +46,7 @@ The seed installs two templates over these roles: the twelve-step Full
 Assurance chain, and the six-step direct chain (`direct-engineer-workflow`) —
 implementation by `senior-dev` from the task brief, the same dual blind review
 spine, and a terminal human pull-request gate with no mechanical merge. Both
-step contracts live in `packages/db/src/agent-contract.ts`.
+step contracts live in their Markdown directories under `templates/`.
 
 Provider-specific or temporary roles are not canonical defaults unless the
 cross-provider review contract explicitly requires separate identities. Keep

--- a/agents/roles/review-coordinator-opus.md
+++ b/agents/roles/review-coordinator-opus.md
@@ -11,7 +11,7 @@ blind code review and must-fix adjudication, then post-fix regression
 verification. You never modify implementation code.
 
 For blind review, establish the implementation base and delivered head from the labelled `implementation_range` entry in `.chain/<chain branch>/sessions.md`, verifying both resolve in the tree.
-Read the approved specification and revised slice set from `.chain/<chain branch>/` (`spec.md` and `slices/`), and verify that both are reachable in the tree at `head`.
+Read the approved specification from `.chain/<chain branch>/spec.md`, and the revised slice set from `.chain/<chain branch>/slices/` where the chain carries one — a direct chain has none. Verify that everything the chain carries is reachable in the tree at `head`.
 Review that complete integrated
 diff and resulting tree on two axes: repository and engineering standards, then
 the approved specification. On the standards axis, apply Fowler's code smell families — bloaters, change preventers, dispensables, couplers, and object-orientation abuses. A documented repository standard overrides the smell baseline, every smell finding is a labelled judgement call with a named fix direction, and skip duplicating a check a required tool has already run and passed while reporting any observed lint, type, or format failure by its consequence.

--- a/agents/roles/review-coordinator-sol.md
+++ b/agents/roles/review-coordinator-sol.md
@@ -13,8 +13,9 @@ last commit.
 
 Establish exact review authority before judging the code. Take the implementation base and head SHAs from the implementation step's persisted output and verify both resolve in the tree. Write them as a labelled `implementation_range` entry in `.chain/<chain branch>/sessions.md`, committed with your report, so the blind reviewer reads the range without opening your findings.
 Refuse an ambiguous or drifting range. Review the complete
-`base...head` diff, the resulting tree, the approved specification and revised
-plan, and the tests that prove the changed behavior.
+`base...head` diff, the resulting tree, the approved specification at
+`.chain/<chain branch>/spec.md`, the revised plan where the chain carries one —
+a direct chain has none — and the tests that prove the changed behavior.
 
 Run two explicit axes:
 

--- a/agents/templates/compound-engineer-workflow/01-write-a-spec.md
+++ b/agents/templates/compound-engineer-workflow/01-write-a-spec.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 1
+agent: spec
+approvalGate: true
+outputKind: spec
+attachmentsFromPrevious: false
+opensPullRequest: false
+spawnPolicy: null
+---
+Write a detailed feature specification for {{branchName}} and persist it for human approval.

--- a/agents/templates/compound-engineer-workflow/02-plan.md
+++ b/agents/templates/compound-engineer-workflow/02-plan.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 2
+agent: plan
+approvalGate: false
+outputKind: plan
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Turn the approved spec into a tracer-bullet slice set engineered for parallel execution: many slices with empty blocked_by, a shallow critical path. Write the chain artifacts under `.chain/{{branchName}}/` on {{branchName}} — the approved spec copied to `spec.md`, one file per slice at `slices/<NN>-<slug>.md`, and this run's id in `sessions.md` under the label `plan_authoring`. Each slice file carries YAML frontmatter — `id` (unique, matching its file's `<NN>-<slug>`), `title`, `blocked_by` (a list of existing slice ids, never its own), `files_hint` (a list of repo-relative paths), `risk` (boolean, true exactly when the slice touches persisted data or an irreversible external action) — and body sections Delivers and Acceptance. Each slice cuts one demonstrable path through every layer it needs and fits a single fresh context window. blocked_by carries only true prerequisites and stays acyclic; slice boundaries keep files_hint overlap between independent slices rare. Stage a wide refactor as expand-migrate-contract slices rather than one tracer bullet. Every acceptance criterion is red at the frozen base and names the verification that turns it green. The plan is complete when every spec requirement maps to exactly one slice's Delivers and every file above is committed to {{branchName}}.

--- a/agents/templates/compound-engineer-workflow/03-plan-review.md
+++ b/agents/templates/compound-engineer-workflow/03-plan-review.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 3
+agent: review-coordinator
+approvalGate: false
+outputKind: plan-review
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Review every vertical slice against the approved specification and frozen base: standalone demonstration, layer coverage and context size, true blocked_by prerequisites, merge or split decisions priced against frontier width, expand-migrate-contract staging for wide refactors, and acceptance criteria that fail at base and turn green under the named verification.

--- a/agents/templates/compound-engineer-workflow/04-revise-plan.md
+++ b/agents/templates/compound-engineer-workflow/04-revise-plan.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 4
+agent: plan-reviser
+approvalGate: true
+outputKind: revised-plan
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Attempt to resume the planning session with the run id labelled `plan_authoring` in `.chain/{{branchName}}/sessions.md`; if exact resume is unavailable, follow your role's new-session fallback. Revise the slice set against the plan-review findings by editing the slice files in place under `.chain/{{branchName}}/slices/`, preserving the planning invariants — tracer-bullet cut, acyclic true blocked_by, wide frontier and shallow critical path, rare files_hint overlap between independent slices, risk true exactly for persisted data or an irreversible external action, every acceptance criterion red at the frozen base. On a successful resume the `plan_authoring` id stands; in a new session add this session's id under `plan_revision`. Commit to {{branchName}}. The revised slice set is the implementation authority: complete when every must-fix finding has a resolving slice edit, every should-fix a recorded decision, and every spec requirement still maps to exactly one slice.

--- a/agents/templates/compound-engineer-workflow/05-implementation.md
+++ b/agents/templates/compound-engineer-workflow/05-implementation.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 5
+agent: implementation-plan-executioner
+approvalGate: false
+outputKind: implementation
+attachmentsFromPrevious: true
+opensPullRequest: true
+spawnPolicy: null
+---
+Implement the approved slice set on {{branchName}} by frontier waves. Read every slice under `.chain/{{branchName}}/slices/`; the frontier — every slice whose blocked_by is fully merged — forms the next wave. Run all slices of a wave in parallel, each as one background subprocess in its own git worktree at the subordinate tier fixed in your role configuration, escalating any slice whose frontmatter flags risk as that configuration directs. At the wave barrier, merge finished worktrees back serially in ascending slice id, resolve conflicts in that order, and rerun the affected tests before opening the next wave. After the final wave, run the end-to-end suite and record the implementation range — the base commit you started from and the final head — in your task output; leave publication of the branch to the runner. Complete when every slice's acceptance criteria are green at the recorded head.

--- a/agents/templates/compound-engineer-workflow/06-code-review-sol.md
+++ b/agents/templates/compound-engineer-workflow/06-code-review-sol.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 6
+agent: review-coordinator-sol
+approvalGate: false
+outputKind: sol-findings
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Review the complete integrated implementation diff from the frozen pre-implementation base through the delivered head. Persist stable evidence-backed findings as the task output.

--- a/agents/templates/compound-engineer-workflow/07-code-review-and-adjudication-opus.md
+++ b/agents/templates/compound-engineer-workflow/07-code-review-and-adjudication-opus.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 7
+agent: review-coordinator-opus
+approvalGate: false
+outputKind: must-fix
+attachmentsFromPrevious: false
+opensPullRequest: false
+spawnPolicy: null
+---
+Blind-review the complete integrated implementation diff and persist independent findings before reading the first review. Then apply the canonical merge matrix and persist the closed must-fix list.

--- a/agents/templates/compound-engineer-workflow/08-apply-review-fixes.md
+++ b/agents/templates/compound-engineer-workflow/08-apply-review-fixes.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 8
+agent: senior-dev
+approvalGate: false
+outputKind: fixed-implementation
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Apply the complete closed must-fix list and rerun every affected regression.

--- a/agents/templates/compound-engineer-workflow/09-regression-verification.md
+++ b/agents/templates/compound-engineer-workflow/09-regression-verification.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 9
+agent: review-coordinator-opus
+approvalGate: false
+outputKind: regression-verification
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Review the full fix diff as one unit, account for every must-fix ID, rerun relevant regressions, and bind the verdict to the exact fixed head for human review.

--- a/agents/templates/compound-engineer-workflow/10-librarian.md
+++ b/agents/templates/compound-engineer-workflow/10-librarian.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 10
+agent: librarian
+approvalGate: false
+outputKind: documentation
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Update internal documentation to match the delivered code.

--- a/agents/templates/compound-engineer-workflow/11-human-pr-review.md
+++ b/agents/templates/compound-engineer-workflow/11-human-pr-review.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 11
+agent: null
+approvalGate: true
+outputKind: approval
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Review the pull request for {{branchName}} at the exact head approved by regression verification and authorize its merge against the evidence presented in the approval card.

--- a/agents/templates/compound-engineer-workflow/12-merge-execution.md
+++ b/agents/templates/compound-engineer-workflow/12-merge-execution.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 12
+agent: merge-integrator
+approvalGate: false
+outputKind: merge-result
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Execute the authorized merge mechanically. No model runs this step: @agentos/merge-executor claims it, re-verifies every precondition against the live pull request, and merges only under the step-11 human authorization for that exact head.

--- a/agents/templates/direct-engineer-workflow/01-implementation.md
+++ b/agents/templates/direct-engineer-workflow/01-implementation.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 1
+agent: senior-dev
+approvalGate: false
+outputKind: implementation
+attachmentsFromPrevious: false
+opensPullRequest: true
+spawnPolicy: null
+---
+Implement this task on {{branchName}} directly from the feature brief below — a direct chain carries no spec or plan phase, so the brief is the specification of record. Copy the brief verbatim to `.chain/{{branchName}}/spec.md` on {{branchName}} before implementing, so every later reviewer reads the same authority. Run the suites touching your changes and the end-to-end tests, and record the implementation range — the base commit you started from and the final head — in your task output; leave publication of the branch to the runner. Complete when the brief's behavior is demonstrably delivered and tests are green at the recorded head.

--- a/agents/templates/direct-engineer-workflow/02-code-review-sol.md
+++ b/agents/templates/direct-engineer-workflow/02-code-review-sol.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 2
+agent: review-coordinator-sol
+approvalGate: false
+outputKind: sol-findings
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Review the complete integrated implementation diff from the frozen pre-implementation base through the delivered head. Persist stable evidence-backed findings as the task output.

--- a/agents/templates/direct-engineer-workflow/03-code-review-and-adjudication-opus.md
+++ b/agents/templates/direct-engineer-workflow/03-code-review-and-adjudication-opus.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 3
+agent: review-coordinator-opus
+approvalGate: false
+outputKind: must-fix
+attachmentsFromPrevious: false
+opensPullRequest: false
+spawnPolicy: null
+---
+Blind-review the complete integrated implementation diff and persist independent findings before reading the first review. Then apply the canonical merge matrix and persist the closed must-fix list.

--- a/agents/templates/direct-engineer-workflow/04-apply-review-fixes.md
+++ b/agents/templates/direct-engineer-workflow/04-apply-review-fixes.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 4
+agent: senior-dev
+approvalGate: false
+outputKind: fixed-implementation
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Apply the complete closed must-fix list and rerun every affected regression.

--- a/agents/templates/direct-engineer-workflow/05-regression-verification.md
+++ b/agents/templates/direct-engineer-workflow/05-regression-verification.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 5
+agent: review-coordinator-opus
+approvalGate: false
+outputKind: regression-verification
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Review the full fix diff as one unit, account for every must-fix ID, rerun relevant regressions, and bind the verdict to the exact fixed head for human review.

--- a/agents/templates/direct-engineer-workflow/06-human-pr-review.md
+++ b/agents/templates/direct-engineer-workflow/06-human-pr-review.md
@@ -1,0 +1,10 @@
+---
+stepIndex: 6
+agent: null
+approvalGate: true
+outputKind: approval
+attachmentsFromPrevious: true
+opensPullRequest: false
+spawnPolicy: null
+---
+Review the pull request for {{branchName}} at the exact head approved by regression verification. A direct chain has no mechanical merge step: approving this gate authorizes you to merge the pull request yourself.

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -22,6 +22,7 @@ import { promisify } from "node:util";
 import {
   activateChainSuccessor,
   AssigneeType,
+  DIRECT_TEMPLATE_NAME,
   executionModeFor,
   INTEGRATOR_AGENT_NAME,
   INTEGRATOR_OUTPUT_KIND,
@@ -66,9 +67,14 @@ const integratorStep = async () => db.taskTemplateStep.findFirstOrThrow({
   include: { assigneeAgent: true, taskTemplate: { include: { steps: true } } },
 });
 
+const directTemplate = async () => db.taskTemplate.findUniqueOrThrow({
+  where: { projectId_name: { projectId: (await db.project.findUniqueOrThrow({ where: { slug: "agentos-example" } })).id, name: DIRECT_TEMPLATE_NAME } },
+  include: { steps: { include: { assigneeAgent: true }, orderBy: { stepIndex: "asc" } } },
+});
+
 /* ------------------------------------------------------ the fresh-seed negative */
 
-test("a fresh seed writes a twelve-step template whose step 12 is mechanical", async () => {
+test("a fresh seed writes the twelve-step mechanical template and six-step direct template", async () => {
   const seeded = await seed();
   assert.equal(seeded.code, 0, seeded.output);
 
@@ -91,13 +97,24 @@ test("a fresh seed writes a twelve-step template whose step 12 is mechanical", a
 
   const opening = step.taskTemplate.steps.filter((candidate) => candidate.opensPullRequest).map((candidate) => candidate.stepIndex);
   assert.deepEqual(opening, [5], "only implementation opens the chain pull request");
+
+  const direct = await directTemplate();
+  assert.equal(direct.steps.length, 6);
+  assert.equal(direct.steps[0]?.assigneeAgent?.name, "senior-dev");
+  assert.equal(direct.steps[0]?.opensPullRequest, true);
+  assert.match(direct.steps[0]?.prompt ?? "", /brief is the specification of record/u);
+  assert.equal(direct.steps[2]?.attachmentsFromPrevious, false);
+  assert.equal(direct.steps[5]?.assigneeType, AssigneeType.HUMAN);
+  assert.equal(direct.steps[5]?.approvalGate, true);
+  assert.match(direct.steps[5]?.prompt ?? "", /no mechanical merge step/u);
+  assert.equal(direct.steps.some((candidate) => candidate.assigneeAgent?.name === INTEGRATOR_AGENT_NAME), false);
 });
 
 test("the verifier passes on a freshly seeded database, and says how many steps it saw", async () => {
   assert.equal((await seed()).code, 0);
   const verified = await verify();
   assert.equal(verified.code, 0, verified.output);
-  assert.match(verified.output, /12 steps/u);
+  assert.match(verified.output, /18 steps across 2 templates/u);
 });
 
 test("re-seeding is idempotent and does not flip step 12 back", async () => {

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -183,6 +183,45 @@ test("canonical sync rejects role structure drift without applying its prompts",
   assert.equal(persisted.rolePrompt, "role drift");
 });
 
+test("canonical sync ignores a customized same-name agent outside the canonical project", async () => {
+  assert.equal((await seed()).code, 0);
+  const canonical = await db.agent.findFirstOrThrow({
+    where: { name: "default", project: { slug: "agentos-example" } },
+  });
+  const customProject = await db.project.create({
+    data: { name: "Custom", slug: "custom", yamlDocument: "# custom\n" },
+  });
+  const customEnvironment = await db.environment.create({
+    data: { projectId: customProject.id, name: "local", networking: "OPEN", allowedHosts: [] },
+  });
+  const custom = await db.agent.create({
+    data: {
+      projectId: customProject.id,
+      environmentId: customEnvironment.id,
+      name: "default",
+      title: "Custom Default",
+      model: "custom-model",
+      runnerPreference: "CODEX",
+      inboxAccess: false,
+      foundationalPrompt: "custom foundation",
+      rolePrompt: "custom role",
+    },
+  });
+  await db.agent.update({ where: { id: canonical.id }, data: { rolePrompt: "canonical role drift" } });
+
+  const synced = await sync();
+  assert.equal(synced.code, 0, synced.output);
+  const expected = (await loadAgentSources()).roles.find(({ name }) => name === "default")!;
+  const [persistedCanonical, persistedCustom] = await Promise.all([
+    db.agent.findUniqueOrThrow({ where: { id: canonical.id } }),
+    db.agent.findUniqueOrThrow({ where: { id: custom.id } }),
+  ]);
+  assert.equal(persistedCanonical.rolePrompt, expected.rolePrompt);
+  assert.equal(persistedCustom.title, "Custom Default");
+  assert.equal(persistedCustom.foundationalPrompt, "custom foundation");
+  assert.equal(persistedCustom.rolePrompt, "custom role");
+});
+
 /* ------------------------------------------------------- the verifier negatives */
 
 /** Each of these is a way the contract could be violated in the database while

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -31,6 +31,8 @@ import {
   INTEGRATOR_TEMPLATE_NAME,
   legacyNineStepTemplateName,
   legacyTenStepTemplateName,
+  loadAgentSources,
+  loadTemplateStepSources,
   PrismaClient,
   type Task,
   TaskStatus,
@@ -60,6 +62,7 @@ const runScript = async (script: string): Promise<{ code: number; output: string
 };
 
 const seed = () => runScript("seed.ts");
+const sync = () => runScript("sync-canonical-prompts.ts");
 const verify = () => runScript("verify-agent-template.ts");
 
 const integratorStep = async () => db.taskTemplateStep.findFirstOrThrow({
@@ -125,6 +128,61 @@ test("re-seeding is idempotent and does not flip step 12 back", async () => {
   assert.equal(step.taskTemplate.steps.length, 12);
 });
 
+test("canonical sync restores step, role, and foundational prompts when structure matches", async () => {
+  assert.equal((await seed()).code, 0);
+  const direct = await directTemplate();
+  const step = direct.steps[0]!;
+  const agent = await db.agent.findFirstOrThrow({ where: { name: "default" } });
+  await Promise.all([
+    db.taskTemplateStep.update({ where: { id: step.id }, data: { prompt: "step prompt drift" } }),
+    db.agent.update({ where: { id: agent.id }, data: { foundationalPrompt: "foundation drift", rolePrompt: "role drift" } }),
+  ]);
+
+  const synced = await sync();
+  assert.equal(synced.code, 0, synced.output);
+  const expectedStep = (await loadTemplateStepSources(DIRECT_TEMPLATE_NAME))[0]!;
+  const sources = await loadAgentSources();
+  const expectedRole = sources.roles.find(({ name }) => name === "default")!;
+  const [persistedStep, persistedAgent] = await Promise.all([
+    db.taskTemplateStep.findUniqueOrThrow({ where: { id: step.id } }),
+    db.agent.findUniqueOrThrow({ where: { id: agent.id } }),
+  ]);
+  assert.equal(persistedStep.prompt, expectedStep.prompt);
+  assert.equal(persistedAgent.foundationalPrompt, sources.foundationalPrompt);
+  assert.equal(persistedAgent.rolePrompt, expectedRole.rolePrompt);
+});
+
+test("canonical sync rejects template structure drift without applying its prompt", async () => {
+  assert.equal((await seed()).code, 0);
+  const direct = await directTemplate();
+  const step = direct.steps[0]!;
+  await db.taskTemplateStep.update({
+    where: { id: step.id },
+    data: { attachmentsFromPrevious: !step.attachmentsFromPrevious, prompt: "step prompt drift" },
+  });
+
+  const synced = await sync();
+  assert.notEqual(synced.code, 0, synced.output);
+  assert.match(synced.output, /attachmentsFromPrevious/u);
+  assert.equal((await db.taskTemplateStep.findUniqueOrThrow({ where: { id: step.id } })).prompt, "step prompt drift");
+});
+
+test("canonical sync rejects role structure drift without applying its prompts", async () => {
+  assert.equal((await seed()).code, 0);
+  const agent = await db.agent.findFirstOrThrow({ where: { name: "librarian" } });
+  await db.agent.update({
+    where: { id: agent.id },
+    data: { inboxAccess: !agent.inboxAccess, foundationalPrompt: "foundation drift", rolePrompt: "role drift" },
+  });
+
+  const synced = await sync();
+  assert.notEqual(synced.code, 0, synced.output);
+  assert.match(synced.output, /inboxAccess/u);
+  const persisted = await db.agent.findUniqueOrThrow({ where: { id: agent.id } });
+  assert.equal(persisted.foundationalPrompt, "foundation drift");
+  assert.equal(persisted.rolePrompt, "role drift");
+});
+
 /* ------------------------------------------------------- the verifier negatives */
 
 /** Each of these is a way the contract could be violated in the database while
@@ -182,6 +240,28 @@ const negatives: Array<{ name: string; break: () => Promise<void>; expect: RegEx
       await db.taskTemplateStep.update({ where: { id: blind.id }, data: { attachmentsFromPrevious: true } });
     },
     expect: /attachmentsFromPrevious/u,
+  },
+  {
+    name: "role frontmatter drift",
+    break: async () => {
+      const agent = await db.agent.findFirstOrThrow({ where: { name: "librarian" } });
+      await db.agent.update({ where: { id: agent.id }, data: { inboxAccess: !agent.inboxAccess } });
+    },
+    expect: /inboxAccess/u,
+  },
+  {
+    name: "foundational prompt drift",
+    break: async () => {
+      await db.agent.updateMany({ where: { name: "librarian" }, data: { foundationalPrompt: "drift" } });
+    },
+    expect: /foundational prompt/u,
+  },
+  {
+    name: "role prompt drift",
+    break: async () => {
+      await db.agent.updateMany({ where: { name: "librarian" }, data: { rolePrompt: "drift" } });
+    },
+    expect: /role prompt/u,
   },
 ];
 

--- a/packages/api/src/preflight-goal-execution.dbtest.ts
+++ b/packages/api/src/preflight-goal-execution.dbtest.ts
@@ -34,7 +34,7 @@ execFileSync("git", [
 ]);
 // The authority the recorded revalidation names; the preflight refuses to pass
 // without them, so these are the real values, not placeholders.
-const MASTER_SHA = "29aac967f373ec6fd96f52b8289724f76eb4721f";
+const MASTER_SHA = "8d69ee8544196a3310b3d63caf8ce5ec9a0e023b";
 const CONTROL_PLANE_A_SHA = "29f8dd354cb99d671c2e2e4e9e23716fd8004f3d";
 
 let fixture: ReturnType<typeof stageAtPreviousMigration>;

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -4,22 +4,31 @@ import test from "node:test";
 import {
   AssigneeType,
   CANONICAL_AGENT_DEFAULTS,
-  CANONICAL_TEMPLATE_STEPS,
   executionModeFor,
   INTEGRATOR_AGENT_NAME,
   INTEGRATOR_SENTINEL_MODEL,
+  INTEGRATOR_TEMPLATE_NAME,
   Prisma,
   RunnerKind,
   RunnerPreference,
+  loadTemplateStepSources,
   type PrismaClient,
 } from "@agentos/db";
 
 import { instantiateTemplate } from "./templates.js";
 
 test("instantiating the canonical feature template creates twelve tasks including the mechanical integrator", async () => {
+  const canonicalTemplateSteps = await loadTemplateStepSources(INTEGRATOR_TEMPLATE_NAME);
   const created: Array<Record<string, any>> = [];
   const runs: Array<Record<string, any>> = [];
-  const agents = new Map(CANONICAL_AGENT_DEFAULTS.map((contract, index) => [contract.name, {
+  const agents = new Map<string, {
+    id: string;
+    name: string;
+    model: string;
+    runnerPreference: RunnerPreference;
+    foundationalPrompt: string;
+    rolePrompt: string;
+  }>(CANONICAL_AGENT_DEFAULTS.map((contract, index) => [contract.name, {
     id: `agent-${index + 1}`,
     name: contract.name,
     model: contract.model,
@@ -27,7 +36,7 @@ test("instantiating the canonical feature template creates twelve tasks includin
     foundationalPrompt: "foundation",
     rolePrompt: "role",
   }]));
-  const steps = CANONICAL_TEMPLATE_STEPS.map((contract) => {
+  const steps = canonicalTemplateSteps.map((contract) => {
     const agent = contract.agentName ? agents.get(contract.agentName)! : null;
     return {
       id: `step-${contract.stepIndex}`,
@@ -104,7 +113,7 @@ test("instantiating the canonical feature template creates twelve tasks includin
   assert.equal(created[11]!.assigneeAgent?.runnerPreference, RunnerPreference.INHERIT);
   assert.equal(created[11]!.opensPullRequest, false);
   assert.equal(executionModeFor(created[11]!.templateStep), "mechanical");
-  assert.deepEqual(created.map((task) => task.outputKind ?? task.templateStep.outputKind), CANONICAL_TEMPLATE_STEPS.map((step) => step.outputKind));
+  assert.deepEqual(created.map((task) => task.outputKind ?? task.templateStep.outputKind), canonicalTemplateSteps.map((step) => step.outputKind));
   assert.equal(runs.length, 1);
   assert.equal(runs[0]!.runner, RunnerKind.CLAUDE);
   assert.equal(runs[0]!.branch, "feature/twelve-steps");

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { readdir, readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -20,7 +22,12 @@ import {
   catalogRunnerForModel,
   DIRECT_TEMPLATE_NAME,
 } from "../src/agent-contract.js";
-import { loadAllTemplateStepSources, loadTemplateStepSources } from "../src/template-sources.js";
+import {
+  CANONICAL_TEMPLATE_SOURCE_SPECS,
+  loadAllTemplateStepSources,
+  loadTemplateStepSources,
+  templateStepStructureDifferences,
+} from "../src/template-sources.js";
 
 const rolesRoot = fileURLToPath(new URL("../../../agents/roles/", import.meta.url));
 
@@ -169,6 +176,38 @@ test("the complete template source inventory contains only the twelve-step and d
   assert.deepEqual([...templates.keys()], [INTEGRATOR_TEMPLATE_NAME, DIRECT_TEMPLATE_NAME]);
   assert.equal(templates.get(INTEGRATOR_TEMPLATE_NAME)?.length, 12);
   assert.equal(templates.get(DIRECT_TEMPLATE_NAME)?.length, 6);
+});
+
+test("the complete template source inventory rejects an unregistered workflow directory", async () => {
+  const sourceRoot = await mkdtemp(join(tmpdir(), "agentos-template-sources-"));
+  try {
+    await Promise.all(CANONICAL_TEMPLATE_SOURCE_SPECS.map(({ name }) => mkdir(join(sourceRoot, name))));
+    await mkdir(join(sourceRoot, "unregistered-workflow"));
+    await assert.rejects(
+      loadAllTemplateStepSources(sourceRoot),
+      /canonical template inventory must be exactly/u,
+    );
+  } finally {
+    await rm(sourceRoot, { recursive: true, force: true });
+  }
+});
+
+test("canonical prompt sync can detect every Markdown-owned structural field", async () => {
+  const expected = (await loadTemplateStepSources(DIRECT_TEMPLATE_NAME))[0]!;
+  const persisted = {
+    assigneeAgent: { name: expected.agentName! },
+    assigneeType: "AGENT",
+    approvalGate: expected.approvalGate,
+    outputKind: expected.outputKind,
+    attachmentsFromPrevious: expected.attachmentsFromPrevious,
+    opensPullRequest: expected.opensPullRequest,
+    spawnPolicy: expected.spawnPolicy,
+  };
+  assert.deepEqual(templateStepStructureDifferences(persisted, expected), []);
+  assert.deepEqual(
+    templateStepStructureDifferences({ ...persisted, attachmentsFromPrevious: !persisted.attachmentsFromPrevious }, expected),
+    ["attachmentsFromPrevious"],
+  );
 });
 
 test("the sentinel may bind only step 12, and step 12 only the sentinel", () => {

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -17,6 +17,11 @@ import {
 } from "../src/merge-integrator.js";
 
 import {
+  loadAgentSources,
+  type PersistedRoleStructure,
+  roleSourceStructureDifferences,
+} from "../src/agent-sources.js";
+import {
   assertCanonicalAgentSources,
   CANONICAL_AGENT_DEFAULTS,
   catalogRunnerForModel,
@@ -26,6 +31,7 @@ import {
   CANONICAL_TEMPLATE_SOURCE_SPECS,
   loadAllTemplateStepSources,
   loadTemplateStepSources,
+  type PersistedTemplateStepStructure,
   templateStepStructureDifferences,
 } from "../src/template-sources.js";
 
@@ -192,9 +198,27 @@ test("the complete template source inventory rejects an unregistered workflow di
   }
 });
 
+test("the complete template source inventory rejects a missing workflow or non-directory entry", async () => {
+  const missingRoot = await mkdtemp(join(tmpdir(), "agentos-template-sources-missing-"));
+  const fileRoot = await mkdtemp(join(tmpdir(), "agentos-template-sources-file-"));
+  try {
+    await mkdir(join(missingRoot, INTEGRATOR_TEMPLATE_NAME));
+    await assert.rejects(loadAllTemplateStepSources(missingRoot), /canonical template inventory must be exactly/u);
+
+    await mkdir(join(fileRoot, INTEGRATOR_TEMPLATE_NAME));
+    await writeFile(join(fileRoot, DIRECT_TEMPLATE_NAME), "not a directory\n");
+    await assert.rejects(loadAllTemplateStepSources(fileRoot), /must contain only canonical template directories/u);
+  } finally {
+    await Promise.all([
+      rm(missingRoot, { recursive: true, force: true }),
+      rm(fileRoot, { recursive: true, force: true }),
+    ]);
+  }
+});
+
 test("canonical prompt sync can detect every Markdown-owned structural field", async () => {
   const expected = (await loadTemplateStepSources(DIRECT_TEMPLATE_NAME))[0]!;
-  const persisted = {
+  const persisted: PersistedTemplateStepStructure = {
     assigneeAgent: { name: expected.agentName! },
     assigneeType: "AGENT",
     approvalGate: expected.approvalGate,
@@ -204,10 +228,40 @@ test("canonical prompt sync can detect every Markdown-owned structural field", a
     spawnPolicy: expected.spawnPolicy,
   };
   assert.deepEqual(templateStepStructureDifferences(persisted, expected), []);
-  assert.deepEqual(
-    templateStepStructureDifferences({ ...persisted, attachmentsFromPrevious: !persisted.attachmentsFromPrevious }, expected),
-    ["attachmentsFromPrevious"],
-  );
+  const mutations: Array<[string, PersistedTemplateStepStructure]> = [
+    ["agent", { ...persisted, assigneeAgent: { name: "different-agent" } }],
+    ["assigneeType", { ...persisted, assigneeType: "HUMAN" }],
+    ["approvalGate", { ...persisted, approvalGate: !persisted.approvalGate }],
+    ["outputKind", { ...persisted, outputKind: "different-output" }],
+    ["attachmentsFromPrevious", { ...persisted, attachmentsFromPrevious: !persisted.attachmentsFromPrevious }],
+    ["opensPullRequest", { ...persisted, opensPullRequest: !persisted.opensPullRequest }],
+    ["spawnPolicy", { ...persisted, spawnPolicy: { tier: "sub" } }],
+  ];
+  for (const [field, mutation] of mutations) {
+    assert.deepEqual(templateStepStructureDifferences(mutation, expected), [field]);
+  }
+});
+
+test("canonical prompt sync can detect every role frontmatter field", async () => {
+  const role = (await loadAgentSources()).roles.find(({ name }) => name === "librarian")!;
+  const persisted: PersistedRoleStructure = {
+    title: role.title,
+    model: role.model,
+    runnerPreference: role.runnerPreference,
+    inboxAccess: role.inboxAccess,
+    collaborators: role.collaborators.map((name) => ({ allowedAgent: { name } })),
+  };
+  assert.deepEqual(roleSourceStructureDifferences(persisted, role), []);
+  const mutations: Array<[string, PersistedRoleStructure]> = [
+    ["title", { ...persisted, title: "Different title" }],
+    ["model", { ...persisted, model: "different-model" }],
+    ["runnerPreference", { ...persisted, runnerPreference: RunnerPreference.CLAUDE }],
+    ["inboxAccess", { ...persisted, inboxAccess: !persisted.inboxAccess }],
+    ["collaborators", { ...persisted, collaborators: [{ allowedAgent: { name: "default" } }] }],
+  ];
+  for (const [field, mutation] of mutations) {
+    assert.deepEqual(roleSourceStructureDifferences(mutation, role), [field]);
+  }
 });
 
 test("the sentinel may bind only step 12, and step 12 only the sentinel", () => {

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -17,11 +17,10 @@ import {
 import {
   assertCanonicalAgentSources,
   CANONICAL_AGENT_DEFAULTS,
-  CANONICAL_TEMPLATE_STEPS,
   catalogRunnerForModel,
   DIRECT_TEMPLATE_NAME,
-  DIRECT_TEMPLATE_STEPS,
 } from "../src/agent-contract.js";
+import { loadAllTemplateStepSources, loadTemplateStepSources } from "../src/template-sources.js";
 
 const rolesRoot = fileURLToPath(new URL("../../../agents/roles/", import.meta.url));
 
@@ -83,10 +82,11 @@ test("the split review prompts enforce persisted-range, blind-order, adjudicatio
   assert.match(finalReview, /label `opus_blind_review`/u);
 });
 
-test("the canonical twelve-step template splits code review and preserves mechanical merge", () => {
-  assert.equal(CANONICAL_TEMPLATE_STEPS.length, 12);
+test("the canonical twelve-step template sources split code review and preserve mechanical merge", async () => {
+  const templateSteps = await loadTemplateStepSources();
+  assert.equal(templateSteps.length, 12);
   assert.deepEqual(
-    CANONICAL_TEMPLATE_STEPS.map(({ stepIndex, agentName, outputKind }) => ({ stepIndex, agentName, outputKind })),
+    templateSteps.map(({ stepIndex, agentName, outputKind }) => ({ stepIndex, agentName, outputKind })),
     [
       { stepIndex: 1, agentName: "spec", outputKind: "spec" },
       { stepIndex: 2, agentName: "plan", outputKind: "plan" },
@@ -102,15 +102,21 @@ test("the canonical twelve-step template splits code review and preserves mechan
       { stepIndex: 12, agentName: "merge-integrator", outputKind: "merge-result" },
     ],
   );
-  assert.equal(CANONICAL_TEMPLATE_STEPS.some((step) => step.agentName === "code-reviewer"), false);
-  assert.equal(CANONICAL_TEMPLATE_STEPS.find((step) => step.stepIndex === 7)?.attachmentsFromPrevious, false);
-  assert.equal(CANONICAL_TEMPLATE_STEPS.find((step) => step.stepIndex === 9)?.attachmentsFromPrevious, true);
+  assert.equal(templateSteps.some((step) => step.agentName === "code-reviewer"), false);
+  assert.equal(templateSteps.find((step) => step.stepIndex === 7)?.attachmentsFromPrevious, false);
+  assert.equal(templateSteps.find((step) => step.stepIndex === 9)?.attachmentsFromPrevious, true);
+  assert.equal(templateSteps.every((step) => step.prompt.length > 0), true);
+  assert.equal(templateSteps.every((step) => step.spawnPolicy === null), true);
+  assert.match(templateSteps[1]!.prompt, /this run's id/u);
+  assert.match(templateSteps[2]!.prompt, /merge or split decisions priced against frontier width/u);
+  assert.match(templateSteps[3]!.prompt, /run id labelled `plan_authoring`/u);
 });
 
-test("only implementation opens a pull request, and the integrator is not a model row", () => {
-  const opening = CANONICAL_TEMPLATE_STEPS.filter((step) => step.opensPullRequest).map((step) => step.stepIndex);
+test("only implementation opens a pull request, and the integrator is not a model row", async () => {
+  const templateSteps = await loadTemplateStepSources();
+  const opening = templateSteps.filter((step) => step.opensPullRequest).map((step) => step.stepIndex);
   assert.deepEqual(opening, [5]);
-  const integrator = CANONICAL_TEMPLATE_STEPS.find((step) => step.stepIndex === INTEGRATOR_STEP_INDEX)!;
+  const integrator = templateSteps.find((step) => step.stepIndex === INTEGRATOR_STEP_INDEX)!;
   assert.equal(integrator.agentName, INTEGRATOR_AGENT_NAME);
   assert.equal(integrator.outputKind, INTEGRATOR_OUTPUT_KIND);
   assert.equal(integrator.approvalGate, false);
@@ -123,9 +129,10 @@ test("only implementation opens a pull request, and the integrator is not a mode
   assert.equal(catalogRunnerForModel(sentinel.model), null);
 });
 
-test("the direct template keeps the review spine, drops planning, and ends at the human gate", () => {
+test("the direct template sources keep the review spine, drop planning, and end at the human gate", async () => {
+  const directTemplateSteps = await loadTemplateStepSources(DIRECT_TEMPLATE_NAME);
   assert.deepEqual(
-    DIRECT_TEMPLATE_STEPS.map(({ stepIndex, agentName, outputKind }) => ({ stepIndex, agentName, outputKind })),
+    directTemplateSteps.map(({ stepIndex, agentName, outputKind }) => ({ stepIndex, agentName, outputKind })),
     [
       { stepIndex: 1, agentName: "senior-dev", outputKind: "implementation" },
       { stepIndex: 2, agentName: "review-coordinator-sol", outputKind: "sol-findings" },
@@ -137,22 +144,31 @@ test("the direct template keeps the review spine, drops planning, and ends at th
   );
   // Only implementation opens the chain's pull request; the blind review
   // starts blind; regression verification reads the fix diff.
-  assert.deepEqual(DIRECT_TEMPLATE_STEPS.filter((step) => step.opensPullRequest).map((step) => step.stepIndex), [1]);
-  assert.equal(DIRECT_TEMPLATE_STEPS.find((step) => step.stepIndex === 3)?.attachmentsFromPrevious, false);
-  assert.equal(DIRECT_TEMPLATE_STEPS.find((step) => step.stepIndex === 5)?.attachmentsFromPrevious, true);
+  assert.deepEqual(directTemplateSteps.filter((step) => step.opensPullRequest).map((step) => step.stepIndex), [1]);
+  assert.equal(directTemplateSteps.find((step) => step.stepIndex === 3)?.attachmentsFromPrevious, false);
+  assert.equal(directTemplateSteps.find((step) => step.stepIndex === 5)?.attachmentsFromPrevious, true);
+  assert.match(directTemplateSteps[0]!.prompt, /brief is the specification of record/u);
+  assert.match(directTemplateSteps[5]!.prompt, /no mechanical merge step/u);
   // The human pull-request gate is the terminal step: the integrator's
   // bidirectional binding admits no mechanical merge outside the twelve-step
   // template, so no direct step may bind the sentinel.
-  const last = DIRECT_TEMPLATE_STEPS.at(-1)!;
+  const last = directTemplateSteps.at(-1)!;
   assert.equal(last.approvalGate, true);
   assert.equal(last.agentName, null);
-  for (const step of DIRECT_TEMPLATE_STEPS) {
+  for (const step of directTemplateSteps) {
     assert.notEqual(step.agentName, INTEGRATOR_AGENT_NAME);
     assert.equal(
       integratorBindingValid(step.agentName, { stepIndex: step.stepIndex, outputKind: step.outputKind, taskTemplate: { name: DIRECT_TEMPLATE_NAME } }),
       true,
     );
   }
+});
+
+test("the complete template source inventory contains only the twelve-step and direct workflows", async () => {
+  const templates = await loadAllTemplateStepSources();
+  assert.deepEqual([...templates.keys()], [INTEGRATOR_TEMPLATE_NAME, DIRECT_TEMPLATE_NAME]);
+  assert.equal(templates.get(INTEGRATOR_TEMPLATE_NAME)?.length, 12);
+  assert.equal(templates.get(DIRECT_TEMPLATE_NAME)?.length, 6);
 });
 
 test("the sentinel may bind only step 12, and step 12 only the sentinel", () => {

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -19,6 +19,8 @@ import {
   CANONICAL_AGENT_DEFAULTS,
   CANONICAL_TEMPLATE_STEPS,
   catalogRunnerForModel,
+  DIRECT_TEMPLATE_NAME,
+  DIRECT_TEMPLATE_STEPS,
 } from "../src/agent-contract.js";
 
 const rolesRoot = fileURLToPath(new URL("../../../agents/roles/", import.meta.url));
@@ -70,8 +72,8 @@ test("the split review prompts enforce persisted-range, blind-order, adjudicatio
   const blindWrite = finalReview.indexOf("reviews/opus-blind-findings.md");
   const firstReportRead = finalReview.indexOf("reviews/sol-findings.md", blindWrite);
   assert.ok(blindWrite >= 0 && firstReportRead > blindWrite, "blind findings must be persisted before the first report is read");
-  assert.match(finalReview, /revised slice set from `.chain\/<chain branch>\/`/u);
-  assert.match(finalReview, /both are reachable in the tree at `head`/u);
+  assert.match(finalReview, /revised slice set from `.chain\/<chain branch>\/slices\/` where the chain carries one/u);
+  assert.match(finalReview, /reachable in the tree at `head`/u);
   assert.match(finalReview, /same defect reported by both is adopted at the higher severity/u);
   assert.equal(frontmatterValue(finalReview, "inboxAccess"), "true");
   assert.match(finalReview, /stop in this step, and use Inbox to present both\s+bodies of evidence to the human/u);
@@ -119,6 +121,38 @@ test("only implementation opens a pull request, and the integrator is not a mode
   // string, so `assertCanonicalAgentSources`' runner/model mismatch check
   // cannot fire on it and nothing maps it onto a real adapter.
   assert.equal(catalogRunnerForModel(sentinel.model), null);
+});
+
+test("the direct template keeps the review spine, drops planning, and ends at the human gate", () => {
+  assert.deepEqual(
+    DIRECT_TEMPLATE_STEPS.map(({ stepIndex, agentName, outputKind }) => ({ stepIndex, agentName, outputKind })),
+    [
+      { stepIndex: 1, agentName: "senior-dev", outputKind: "implementation" },
+      { stepIndex: 2, agentName: "review-coordinator-sol", outputKind: "sol-findings" },
+      { stepIndex: 3, agentName: "review-coordinator-opus", outputKind: "must-fix" },
+      { stepIndex: 4, agentName: "senior-dev", outputKind: "fixed-implementation" },
+      { stepIndex: 5, agentName: "review-coordinator-opus", outputKind: "regression-verification" },
+      { stepIndex: 6, agentName: null, outputKind: "approval" },
+    ],
+  );
+  // Only implementation opens the chain's pull request; the blind review
+  // starts blind; regression verification reads the fix diff.
+  assert.deepEqual(DIRECT_TEMPLATE_STEPS.filter((step) => step.opensPullRequest).map((step) => step.stepIndex), [1]);
+  assert.equal(DIRECT_TEMPLATE_STEPS.find((step) => step.stepIndex === 3)?.attachmentsFromPrevious, false);
+  assert.equal(DIRECT_TEMPLATE_STEPS.find((step) => step.stepIndex === 5)?.attachmentsFromPrevious, true);
+  // The human pull-request gate is the terminal step: the integrator's
+  // bidirectional binding admits no mechanical merge outside the twelve-step
+  // template, so no direct step may bind the sentinel.
+  const last = DIRECT_TEMPLATE_STEPS.at(-1)!;
+  assert.equal(last.approvalGate, true);
+  assert.equal(last.agentName, null);
+  for (const step of DIRECT_TEMPLATE_STEPS) {
+    assert.notEqual(step.agentName, INTEGRATOR_AGENT_NAME);
+    assert.equal(
+      integratorBindingValid(step.agentName, { stepIndex: step.stepIndex, outputKind: step.outputKind, taskTemplate: { name: DIRECT_TEMPLATE_NAME } }),
+      true,
+    );
+  }
 });
 
 test("the sentinel may bind only step 12, and step 12 only the sentinel", () => {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,6 +1,6 @@
 import { AssigneeType, Prisma, PrismaClient } from "@prisma/client";
 
-import { CANONICAL_TEMPLATE_STEPS } from "../src/agent-contract.js";
+import { CANONICAL_TEMPLATE_STEPS, DIRECT_TEMPLATE_NAME, DIRECT_TEMPLATE_STEPS } from "../src/agent-contract.js";
 import { loadAgentSources } from "../src/agent-sources.js";
 import {
   INTEGRATOR_AGENT_NAME,
@@ -184,7 +184,43 @@ const main = async (): Promise<void> => {
     });
   }
 
-  console.log(`Seeded ${project.name} from agents/ with ${sources.roles.length} agents and the twelve-step feature template.`);
+  const directTemplate = await prisma.taskTemplate.upsert({
+    where: { projectId_name: { projectId: project.id, name: DIRECT_TEMPLATE_NAME } },
+    update: {
+      description: "Direct-tier workflow: implementation from the task brief, dual independent code review with blind adjudication, fix application, regression verification, and human pull-request review. No spec or plan phase and no mechanical merge.",
+      variables: ["branchName"],
+    },
+    create: {
+      projectId: project.id,
+      name: DIRECT_TEMPLATE_NAME,
+      description: "Direct-tier workflow: implementation from the task brief, dual independent code review with blind adjudication, fix application, regression verification, and human pull-request review. No spec or plan phase and no mechanical merge.",
+      variables: ["branchName"],
+    },
+  });
+  const directStep = (stepIndex: number) => {
+    const step = DIRECT_TEMPLATE_STEPS.find((candidate) => candidate.stepIndex === stepIndex);
+    if (!step) throw new Error(`Missing direct template step ${stepIndex}`);
+    return step;
+  };
+  const directSteps = [
+    [1, "Implementation", directStep(1).agentName, AssigneeType.AGENT, null, directStep(1).approvalGate, directStep(1).outputKind, "Implement this task on {{branchName}} directly from the feature brief below — a direct chain carries no spec or plan phase, so the brief is the specification of record. Copy the brief verbatim to `.chain/{{branchName}}/spec.md` on {{branchName}} before implementing, so every later reviewer reads the same authority. Run the suites touching your changes and the end-to-end tests, and record the implementation range — the base commit you started from and the final head — in your task output; leave publication of the branch to the runner. Complete when the brief's behavior is demonstrably delivered and tests are green at the recorded head.", null, directStep(1).opensPullRequest],
+    [2, "Code review (Sol)", directStep(2).agentName, AssigneeType.AGENT, null, directStep(2).approvalGate, directStep(2).outputKind, "Review the complete integrated implementation diff from the frozen pre-implementation base through the delivered head. Persist stable evidence-backed findings as the task output.", null, directStep(2).opensPullRequest],
+    [3, "Code review and adjudication (Opus)", directStep(3).agentName, AssigneeType.AGENT, null, directStep(3).approvalGate, directStep(3).outputKind, "Blind-review the complete integrated implementation diff and persist independent findings before reading the first review. Then apply the canonical merge matrix and persist the closed must-fix list.", null, directStep(3).opensPullRequest],
+    [4, "Apply review fixes", directStep(4).agentName, AssigneeType.AGENT, null, directStep(4).approvalGate, directStep(4).outputKind, "Apply the complete closed must-fix list and rerun every affected regression.", null, directStep(4).opensPullRequest],
+    [5, "Regression verification", directStep(5).agentName, AssigneeType.AGENT, null, directStep(5).approvalGate, directStep(5).outputKind, "Review the full fix diff as one unit, account for every must-fix ID, rerun relevant regressions, and bind the verdict to the exact fixed head for human review.", null, directStep(5).opensPullRequest],
+    [6, "Human PR review", directStep(6).agentName, AssigneeType.HUMAN, null, directStep(6).approvalGate, directStep(6).outputKind, "Review the pull request for {{branchName}} at the exact head approved by regression verification. A direct chain has no mechanical merge step: approving this gate authorizes you to merge the pull request yourself.", null, directStep(6).opensPullRequest],
+  ] as const;
+  for (const [stepIndex, name, agentName, assigneeType, runner, approvalGate, outputKind, prompt, spawnPolicy, opensPullRequest] of directSteps) {
+    const assigneeAgentId: string | null = agentName ? (agentByName.get(agentName)?.id ?? null) : null;
+    if (agentName && !assigneeAgentId) throw new Error(`Missing seeded agent ${agentName}`);
+    await prisma.taskTemplateStep.upsert({
+      where: { taskTemplateId_stepIndex: { taskTemplateId: directTemplate.id, stepIndex } },
+      update: { name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: directStep(stepIndex).attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
+      create: { taskTemplateId: directTemplate.id, stepIndex, name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: directStep(stepIndex).attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
+    });
+  }
+
+  console.log(`Seeded ${project.name} from agents/ with ${sources.roles.length} agents, the twelve-step feature template, and the six-step direct template.`);
 };
 
 try {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,6 +1,6 @@
 import { AssigneeType, Prisma, PrismaClient } from "@prisma/client";
 
-import { CANONICAL_TEMPLATE_STEPS, DIRECT_TEMPLATE_NAME, DIRECT_TEMPLATE_STEPS } from "../src/agent-contract.js";
+import { DIRECT_TEMPLATE_NAME } from "../src/agent-contract.js";
 import { loadAgentSources } from "../src/agent-sources.js";
 import {
   INTEGRATOR_AGENT_NAME,
@@ -9,6 +9,7 @@ import {
   legacyNineStepTemplateName,
   legacyTenStepTemplateName,
 } from "../src/merge-integrator.js";
+import { loadAllTemplateStepSources } from "../src/template-sources.js";
 
 // The loader this seed used to carry moved to `packages/db/src/agent-sources.ts`
 // so that OSS-B0's first-run onboarding can read the same `agents/` contract
@@ -29,7 +30,9 @@ const HISTORICAL_NINE_STEP_CONTRACT = [
 ] as const;
 
 const main = async (): Promise<void> => {
-  const sources = await loadAgentSources();
+  const [sources, templateStepsByName] = await Promise.all([loadAgentSources(), loadAllTemplateStepSources()]);
+  const templateSteps = templateStepsByName.get(INTEGRATOR_TEMPLATE_NAME)!;
+  const directTemplateSteps = templateStepsByName.get(DIRECT_TEMPLATE_NAME)!;
   const project = await prisma.project.upsert({
     where: { slug: "agentos-example" },
     update: {},
@@ -152,35 +155,31 @@ const main = async (): Promise<void> => {
       },
     });
   });
-  const canonicalStep = (stepIndex: number) => {
-    const step = CANONICAL_TEMPLATE_STEPS.find((candidate) => candidate.stepIndex === stepIndex);
-    if (!step) throw new Error(`Missing canonical template step ${stepIndex}`);
-    return step;
-  };
-  // The tuple carries `opensPullRequest` as its tenth element and both branches
-  // of the upsert set it. `templates.ts` copies the value onto every materialized
-  // task row. Only implementation creates the chain PR; every later row reuses it.
-  const steps = [
-    [1, "Write a spec", canonicalStep(1).agentName, AssigneeType.AGENT, null, canonicalStep(1).approvalGate, canonicalStep(1).outputKind, "Write a detailed feature specification for {{branchName}} and persist it for human approval.", null, canonicalStep(1).opensPullRequest],
-    [2, "Plan", canonicalStep(2).agentName, AssigneeType.AGENT, null, canonicalStep(2).approvalGate, canonicalStep(2).outputKind, "Turn the approved spec into a tracer-bullet slice set engineered for parallel execution: many slices with empty blocked_by, a shallow critical path. Write the chain artifacts under `.chain/{{branchName}}/` on {{branchName}} — the approved spec copied to `spec.md`, one file per slice at `slices/<NN>-<slug>.md`, and this run's id in `sessions.md` under the label `plan_authoring`. Each slice file carries YAML frontmatter — `id` (unique, matching its file's `<NN>-<slug>`), `title`, `blocked_by` (a list of existing slice ids, never its own), `files_hint` (a list of repo-relative paths), `risk` (boolean, true exactly when the slice touches persisted data or an irreversible external action) — and body sections Delivers and Acceptance. Each slice cuts one demonstrable path through every layer it needs and fits a single fresh context window. blocked_by carries only true prerequisites and stays acyclic; slice boundaries keep files_hint overlap between independent slices rare. Stage a wide refactor as expand-migrate-contract slices rather than one tracer bullet. Every acceptance criterion is red at the frozen base and names the verification that turns it green. The plan is complete when every spec requirement maps to exactly one slice's Delivers and every file above is committed to {{branchName}}.", null, canonicalStep(2).opensPullRequest],
-    [3, "Plan review", canonicalStep(3).agentName, AssigneeType.AGENT, null, canonicalStep(3).approvalGate, canonicalStep(3).outputKind, "Review every vertical slice against the approved specification and frozen base: standalone demonstration, layer coverage and context size, true blocked_by prerequisites, merge or split decisions priced against frontier width, expand-migrate-contract staging for wide refactors, and acceptance criteria that fail at base and turn green under the named verification.", null, canonicalStep(3).opensPullRequest],
-    [4, "Revise plan", canonicalStep(4).agentName, AssigneeType.AGENT, null, canonicalStep(4).approvalGate, canonicalStep(4).outputKind, "Attempt to resume the planning session with the run id labelled `plan_authoring` in `.chain/{{branchName}}/sessions.md`; if exact resume is unavailable, follow your role's new-session fallback. Revise the slice set against the plan-review findings by editing the slice files in place under `.chain/{{branchName}}/slices/`, preserving the planning invariants — tracer-bullet cut, acyclic true blocked_by, wide frontier and shallow critical path, rare files_hint overlap between independent slices, risk true exactly for persisted data or an irreversible external action, every acceptance criterion red at the frozen base. On a successful resume the `plan_authoring` id stands; in a new session add this session's id under `plan_revision`. Commit to {{branchName}}. The revised slice set is the implementation authority: complete when every must-fix finding has a resolving slice edit, every should-fix a recorded decision, and every spec requirement still maps to exactly one slice.", null, canonicalStep(4).opensPullRequest],
-    [5, "Implementation", canonicalStep(5).agentName, AssigneeType.AGENT, null, canonicalStep(5).approvalGate, canonicalStep(5).outputKind, "Implement the approved slice set on {{branchName}} by frontier waves. Read every slice under `.chain/{{branchName}}/slices/`; the frontier — every slice whose blocked_by is fully merged — forms the next wave. Run all slices of a wave in parallel, each as one background subprocess in its own git worktree at the subordinate tier fixed in your role configuration, escalating any slice whose frontmatter flags risk as that configuration directs. At the wave barrier, merge finished worktrees back serially in ascending slice id, resolve conflicts in that order, and rerun the affected tests before opening the next wave. After the final wave, run the end-to-end suite and record the implementation range — the base commit you started from and the final head — in your task output; leave publication of the branch to the runner. Complete when every slice's acceptance criteria are green at the recorded head.", null, canonicalStep(5).opensPullRequest],
-    [6, "Code review (Sol)", canonicalStep(6).agentName, AssigneeType.AGENT, null, canonicalStep(6).approvalGate, canonicalStep(6).outputKind, "Review the complete integrated implementation diff from the frozen pre-implementation base through the delivered head. Persist stable evidence-backed findings as the task output.", null, canonicalStep(6).opensPullRequest],
-    [7, "Code review and adjudication (Opus)", canonicalStep(7).agentName, AssigneeType.AGENT, null, canonicalStep(7).approvalGate, canonicalStep(7).outputKind, "Blind-review the complete integrated implementation diff and persist independent findings before reading the first review. Then apply the canonical merge matrix and persist the closed must-fix list.", null, canonicalStep(7).opensPullRequest],
-    [8, "Apply review fixes", canonicalStep(8).agentName, AssigneeType.AGENT, null, canonicalStep(8).approvalGate, canonicalStep(8).outputKind, "Apply the complete closed must-fix list and rerun every affected regression.", null, canonicalStep(8).opensPullRequest],
-    [9, "Regression verification", canonicalStep(9).agentName, AssigneeType.AGENT, null, canonicalStep(9).approvalGate, canonicalStep(9).outputKind, "Review the full fix diff as one unit, account for every must-fix ID, rerun relevant regressions, and bind the verdict to the exact fixed head for human review.", null, canonicalStep(9).opensPullRequest],
-    [10, "Librarian", canonicalStep(10).agentName, AssigneeType.AGENT, null, canonicalStep(10).approvalGate, canonicalStep(10).outputKind, "Update internal documentation to match the delivered code.", null, canonicalStep(10).opensPullRequest],
-    [11, "Human PR review", canonicalStep(11).agentName, AssigneeType.HUMAN, null, canonicalStep(11).approvalGate, canonicalStep(11).outputKind, "Review the pull request for {{branchName}} at the exact head approved by regression verification and authorize its merge against the evidence presented in the approval card.", null, canonicalStep(11).opensPullRequest],
-    [12, "Merge execution", canonicalStep(12).agentName, AssigneeType.AGENT, null, canonicalStep(12).approvalGate, canonicalStep(12).outputKind, "Execute the authorized merge mechanically. No model runs this step: @agentos/merge-executor claims it, re-verifies every precondition against the live pull request, and merges only under the step-11 human authorization for that exact head.", null, canonicalStep(12).opensPullRequest],
+  const stepNames = [
+    "Write a spec",
+    "Plan",
+    "Plan review",
+    "Revise plan",
+    "Implementation",
+    "Code review (Sol)",
+    "Code review and adjudication (Opus)",
+    "Apply review fixes",
+    "Regression verification",
+    "Librarian",
+    "Human PR review",
+    "Merge execution",
   ] as const;
-  for (const [stepIndex, name, agentName, assigneeType, runner, approvalGate, outputKind, prompt, spawnPolicy, opensPullRequest] of steps) {
+  for (const step of templateSteps) {
+    const { stepIndex, agentName, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, spawnPolicy } = step;
+    const name = stepNames[stepIndex - 1];
+    if (!name) throw new Error(`Missing canonical template step name ${stepIndex}`);
+    const assigneeType = agentName === null ? AssigneeType.HUMAN : AssigneeType.AGENT;
     const assigneeAgentId: string | null = agentName ? (agentByName.get(agentName)?.id ?? null) : null;
     if (agentName && !assigneeAgentId) throw new Error(`Missing seeded agent ${agentName}`);
     await prisma.taskTemplateStep.upsert({
       where: { taskTemplateId_stepIndex: { taskTemplateId: template.id, stepIndex } },
-      update: { name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: canonicalStep(stepIndex).attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
-      create: { taskTemplateId: template.id, stepIndex, name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: canonicalStep(stepIndex).attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
+      update: { name, assigneeAgentId, assigneeType, runner: null, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
+      create: { taskTemplateId: template.id, stepIndex, name, assigneeAgentId, assigneeType, runner: null, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
     });
   }
 
@@ -197,26 +196,25 @@ const main = async (): Promise<void> => {
       variables: ["branchName"],
     },
   });
-  const directStep = (stepIndex: number) => {
-    const step = DIRECT_TEMPLATE_STEPS.find((candidate) => candidate.stepIndex === stepIndex);
-    if (!step) throw new Error(`Missing direct template step ${stepIndex}`);
-    return step;
-  };
-  const directSteps = [
-    [1, "Implementation", directStep(1).agentName, AssigneeType.AGENT, null, directStep(1).approvalGate, directStep(1).outputKind, "Implement this task on {{branchName}} directly from the feature brief below — a direct chain carries no spec or plan phase, so the brief is the specification of record. Copy the brief verbatim to `.chain/{{branchName}}/spec.md` on {{branchName}} before implementing, so every later reviewer reads the same authority. Run the suites touching your changes and the end-to-end tests, and record the implementation range — the base commit you started from and the final head — in your task output; leave publication of the branch to the runner. Complete when the brief's behavior is demonstrably delivered and tests are green at the recorded head.", null, directStep(1).opensPullRequest],
-    [2, "Code review (Sol)", directStep(2).agentName, AssigneeType.AGENT, null, directStep(2).approvalGate, directStep(2).outputKind, "Review the complete integrated implementation diff from the frozen pre-implementation base through the delivered head. Persist stable evidence-backed findings as the task output.", null, directStep(2).opensPullRequest],
-    [3, "Code review and adjudication (Opus)", directStep(3).agentName, AssigneeType.AGENT, null, directStep(3).approvalGate, directStep(3).outputKind, "Blind-review the complete integrated implementation diff and persist independent findings before reading the first review. Then apply the canonical merge matrix and persist the closed must-fix list.", null, directStep(3).opensPullRequest],
-    [4, "Apply review fixes", directStep(4).agentName, AssigneeType.AGENT, null, directStep(4).approvalGate, directStep(4).outputKind, "Apply the complete closed must-fix list and rerun every affected regression.", null, directStep(4).opensPullRequest],
-    [5, "Regression verification", directStep(5).agentName, AssigneeType.AGENT, null, directStep(5).approvalGate, directStep(5).outputKind, "Review the full fix diff as one unit, account for every must-fix ID, rerun relevant regressions, and bind the verdict to the exact fixed head for human review.", null, directStep(5).opensPullRequest],
-    [6, "Human PR review", directStep(6).agentName, AssigneeType.HUMAN, null, directStep(6).approvalGate, directStep(6).outputKind, "Review the pull request for {{branchName}} at the exact head approved by regression verification. A direct chain has no mechanical merge step: approving this gate authorizes you to merge the pull request yourself.", null, directStep(6).opensPullRequest],
+  const directStepNames = [
+    "Implementation",
+    "Code review (Sol)",
+    "Code review and adjudication (Opus)",
+    "Apply review fixes",
+    "Regression verification",
+    "Human PR review",
   ] as const;
-  for (const [stepIndex, name, agentName, assigneeType, runner, approvalGate, outputKind, prompt, spawnPolicy, opensPullRequest] of directSteps) {
+  for (const step of directTemplateSteps) {
+    const { stepIndex, agentName, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, spawnPolicy } = step;
+    const name = directStepNames[stepIndex - 1];
+    if (!name) throw new Error(`Missing direct template step name ${stepIndex}`);
+    const assigneeType = agentName === null ? AssigneeType.HUMAN : AssigneeType.AGENT;
     const assigneeAgentId: string | null = agentName ? (agentByName.get(agentName)?.id ?? null) : null;
     if (agentName && !assigneeAgentId) throw new Error(`Missing seeded agent ${agentName}`);
     await prisma.taskTemplateStep.upsert({
       where: { taskTemplateId_stepIndex: { taskTemplateId: directTemplate.id, stepIndex } },
-      update: { name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: directStep(stepIndex).attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
-      create: { taskTemplateId: directTemplate.id, stepIndex, name, assigneeAgentId, assigneeType, runner, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious: directStep(stepIndex).attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
+      update: { name, assigneeAgentId, assigneeType, runner: null, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
+      create: { taskTemplateId: directTemplate.id, stepIndex, name, assigneeAgentId, assigneeType, runner: null, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
     });
   }
 

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -1,60 +1,13 @@
-import { readFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-
 import { PrismaClient } from "@prisma/client";
-import ts from "typescript";
 
-import { DIRECT_TEMPLATE_NAME } from "../src/agent-contract.js";
 import { loadAgentSources } from "../src/agent-sources.js";
-import { INTEGRATOR_TEMPLATE_NAME } from "../src/merge-integrator.js";
+import { loadAllTemplateStepSources } from "../src/template-sources.js";
 
-// Every template the seed states prompts for, every step of each, and every
-// role under agents/, is synced. A hand-kept subset is how a prompt edit
-// silently misses production.
-const SEED_STEP_VARIABLES: Record<string, string> = {
-  steps: INTEGRATOR_TEMPLATE_NAME,
-  directSteps: DIRECT_TEMPLATE_NAME,
-};
-
-const loadStepPrompts = async (): Promise<Map<string, Map<number, string>>> => {
-  const seedPath = fileURLToPath(new URL("./seed.ts", import.meta.url));
-  const sourceText = await readFile(seedPath, "utf8");
-  const source = ts.createSourceFile(seedPath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-  const arrays = new Map<string, ts.ArrayLiteralExpression>();
-  const visit = (node: ts.Node): void => {
-    if (ts.isVariableDeclaration(node)
-      && ts.isIdentifier(node.name)
-      && node.name.text in SEED_STEP_VARIABLES
-      && node.initializer
-      && ts.isAsExpression(node.initializer)
-      && ts.isArrayLiteralExpression(node.initializer.expression)) {
-      arrays.set(SEED_STEP_VARIABLES[node.name.text]!, node.initializer.expression);
-      return;
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(source);
-  const missing = Object.values(SEED_STEP_VARIABLES).filter((name) => !arrays.has(name));
-  if (missing.length > 0) throw new Error(`Seed steps tuple array(s) not found in prisma/seed.ts for: ${missing.join(", ")}`);
-
-  const byTemplate = new Map<string, Map<number, string>>();
-  for (const [templateName, elements] of arrays) {
-    const prompts = new Map<number, string>();
-    for (const element of elements.elements) {
-      if (!ts.isArrayLiteralExpression(element)) continue;
-      const indexNode = element.elements[0];
-      const promptNode = element.elements[7];
-      if (!indexNode || !ts.isNumericLiteral(indexNode) || !promptNode || !ts.isStringLiteral(promptNode)) continue;
-      prompts.set(Number(indexNode.text), promptNode.text);
-    }
-    if (prompts.size === 0) throw new Error(`No step prompts were found in prisma/seed.ts for ${templateName}`);
-    byTemplate.set(templateName, prompts);
-  }
-  return byTemplate;
-};
-
+// Every canonical template, every step of each, and every role under agents/
+// is synced. Omitting any source here would let a prompt edit silently miss
+// production, so the loader owns the complete template inventory.
 const main = async (): Promise<void> => {
-  const [stepPrompts, sources] = await Promise.all([loadStepPrompts(), loadAgentSources()]);
+  const [templateSources, sources] = await Promise.all([loadAllTemplateStepSources(), loadAgentSources()]);
   const rolePrompts = new Map(sources.roles.map((role) => [role.name, role.rolePrompt]));
   const roleNames = [...rolePrompts.keys()];
 
@@ -63,7 +16,7 @@ const main = async (): Promise<void> => {
     const result = await prisma.$transaction(async (tx) => {
       const updatedSteps: Record<string, Record<number, number>> = {};
       let templateCount = 0;
-      for (const [templateName, prompts] of stepPrompts) {
+      for (const [templateName, steps] of templateSources) {
         const templates = await tx.taskTemplate.findMany({
           where: { name: templateName },
           select: { id: true },
@@ -71,18 +24,23 @@ const main = async (): Promise<void> => {
         if (templates.length === 0) throw new Error(`Template ${templateName} was not found`);
         templateCount += templates.length;
         const templateIds = templates.map((template) => template.id);
+        const present = await tx.taskTemplateStep.count({ where: { taskTemplateId: { in: templateIds } } });
+        const expected = templates.length * steps.length;
+        if (present !== expected) {
+          throw new Error(`Expected ${expected} total steps on ${templates.length} ${templateName} templates; found ${present}`);
+        }
+
         const updated: Record<number, number> = {};
-        for (const stepIndex of [...prompts.keys()].sort((left, right) => left - right)) {
-          const prompt = prompts.get(stepIndex)!;
-          const present = await tx.taskTemplateStep.count({
-            where: { taskTemplateId: { in: templateIds }, stepIndex },
+        for (const step of steps) {
+          const stepCount = await tx.taskTemplateStep.count({
+            where: { taskTemplateId: { in: templateIds }, stepIndex: step.stepIndex },
           });
-          if (present !== templates.length) {
-            throw new Error(`Expected step ${stepIndex} on ${templates.length} ${templateName} templates; found ${present}`);
+          if (stepCount !== templates.length) {
+            throw new Error(`Expected step ${step.stepIndex} on ${templates.length} ${templateName} templates; found ${stepCount}`);
           }
-          updated[stepIndex] = (await tx.taskTemplateStep.updateMany({
-            where: { taskTemplateId: { in: templateIds }, stepIndex, prompt: { not: prompt } },
-            data: { prompt },
+          updated[step.stepIndex] = (await tx.taskTemplateStep.updateMany({
+            where: { taskTemplateId: { in: templateIds }, stepIndex: step.stepIndex, prompt: { not: step.prompt } },
+            data: { prompt: step.prompt },
           })).count;
         }
         updatedSteps[templateName] = updated;

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from "@prisma/client";
 
 import { loadAgentSources } from "../src/agent-sources.js";
-import { loadAllTemplateStepSources } from "../src/template-sources.js";
+import { loadAllTemplateStepSources, templateStepStructureDifferences } from "../src/template-sources.js";
 
 // Every canonical template, every step of each, and every role under agents/
 // is synced. Omitting any source here would let a prompt edit silently miss
@@ -32,11 +32,27 @@ const main = async (): Promise<void> => {
 
         const updated: Record<number, number> = {};
         for (const step of steps) {
-          const stepCount = await tx.taskTemplateStep.count({
+          const persistedSteps = await tx.taskTemplateStep.findMany({
             where: { taskTemplateId: { in: templateIds }, stepIndex: step.stepIndex },
+            select: {
+              taskTemplateId: true,
+              assigneeAgent: { select: { name: true } },
+              assigneeType: true,
+              approvalGate: true,
+              outputKind: true,
+              attachmentsFromPrevious: true,
+              opensPullRequest: true,
+              spawnPolicy: true,
+            },
           });
-          if (stepCount !== templates.length) {
-            throw new Error(`Expected step ${step.stepIndex} on ${templates.length} ${templateName} templates; found ${stepCount}`);
+          if (persistedSteps.length !== templates.length) {
+            throw new Error(`Expected step ${step.stepIndex} on ${templates.length} ${templateName} templates; found ${persistedSteps.length}`);
+          }
+          for (const persisted of persistedSteps) {
+            const differences = templateStepStructureDifferences(persisted, step);
+            if (differences.length > 0) {
+              throw new Error(`${templateName} step ${step.stepIndex} on template ${persisted.taskTemplateId} differs from canonical Markdown structure: ${differences.join(", ")}`);
+            }
           }
           updated[step.stepIndex] = (await tx.taskTemplateStep.updateMany({
             where: { taskTemplateId: { in: templateIds }, stepIndex: step.stepIndex, prompt: { not: step.prompt } },

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -14,6 +14,11 @@ const main = async (): Promise<void> => {
   const prisma = new PrismaClient();
   try {
     const result = await prisma.$transaction(async (tx) => {
+      const canonicalProject = await tx.project.findUnique({
+        where: { slug: "agentos-example" },
+        select: { id: true },
+      });
+      if (!canonicalProject) throw new Error("Canonical project agentos-example was not found");
       const updatedSteps: Record<string, Record<number, number>> = {};
       let templateCount = 0;
       for (const [templateName, steps] of templateSources) {
@@ -63,7 +68,7 @@ const main = async (): Promise<void> => {
       }
 
       const presentAgents = await tx.agent.findMany({
-        where: { name: { in: roleNames } },
+        where: { projectId: canonicalProject.id, archivedAt: null, name: { in: roleNames } },
         select: {
           id: true,
           name: true,
@@ -94,6 +99,8 @@ const main = async (): Promise<void> => {
         }
         updatedRoles[name] = (await tx.agent.updateMany({
           where: {
+            projectId: canonicalProject.id,
+            archivedAt: null,
             name,
             OR: [
               { foundationalPrompt: { not: sources.foundationalPrompt } },

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -4,41 +4,53 @@ import { fileURLToPath } from "node:url";
 import { PrismaClient } from "@prisma/client";
 import ts from "typescript";
 
+import { DIRECT_TEMPLATE_NAME } from "../src/agent-contract.js";
 import { loadAgentSources } from "../src/agent-sources.js";
 import { INTEGRATOR_TEMPLATE_NAME } from "../src/merge-integrator.js";
 
-// Every step the seed states a prompt for, and every role under agents/, is
-// synced. A hand-kept subset is how a prompt edit silently misses production.
-const loadStepPrompts = async (): Promise<Map<number, string>> => {
+// Every template the seed states prompts for, every step of each, and every
+// role under agents/, is synced. A hand-kept subset is how a prompt edit
+// silently misses production.
+const SEED_STEP_VARIABLES: Record<string, string> = {
+  steps: INTEGRATOR_TEMPLATE_NAME,
+  directSteps: DIRECT_TEMPLATE_NAME,
+};
+
+const loadStepPrompts = async (): Promise<Map<string, Map<number, string>>> => {
   const seedPath = fileURLToPath(new URL("./seed.ts", import.meta.url));
   const sourceText = await readFile(seedPath, "utf8");
   const source = ts.createSourceFile(seedPath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
-  let steps: ts.ArrayLiteralExpression | null = null;
+  const arrays = new Map<string, ts.ArrayLiteralExpression>();
   const visit = (node: ts.Node): void => {
     if (ts.isVariableDeclaration(node)
       && ts.isIdentifier(node.name)
-      && node.name.text === "steps"
+      && node.name.text in SEED_STEP_VARIABLES
       && node.initializer
       && ts.isAsExpression(node.initializer)
       && ts.isArrayLiteralExpression(node.initializer.expression)) {
-      steps = node.initializer.expression;
+      arrays.set(SEED_STEP_VARIABLES[node.name.text]!, node.initializer.expression);
       return;
     }
     ts.forEachChild(node, visit);
   };
   visit(source);
-  if (!steps) throw new Error("Canonical seed steps tuple array was not found in prisma/seed.ts");
+  const missing = Object.values(SEED_STEP_VARIABLES).filter((name) => !arrays.has(name));
+  if (missing.length > 0) throw new Error(`Seed steps tuple array(s) not found in prisma/seed.ts for: ${missing.join(", ")}`);
 
-  const prompts = new Map<number, string>();
-  for (const element of (steps as ts.ArrayLiteralExpression).elements) {
-    if (!ts.isArrayLiteralExpression(element)) continue;
-    const indexNode = element.elements[0];
-    const promptNode = element.elements[7];
-    if (!indexNode || !ts.isNumericLiteral(indexNode) || !promptNode || !ts.isStringLiteral(promptNode)) continue;
-    prompts.set(Number(indexNode.text), promptNode.text);
+  const byTemplate = new Map<string, Map<number, string>>();
+  for (const [templateName, elements] of arrays) {
+    const prompts = new Map<number, string>();
+    for (const element of elements.elements) {
+      if (!ts.isArrayLiteralExpression(element)) continue;
+      const indexNode = element.elements[0];
+      const promptNode = element.elements[7];
+      if (!indexNode || !ts.isNumericLiteral(indexNode) || !promptNode || !ts.isStringLiteral(promptNode)) continue;
+      prompts.set(Number(indexNode.text), promptNode.text);
+    }
+    if (prompts.size === 0) throw new Error(`No step prompts were found in prisma/seed.ts for ${templateName}`);
+    byTemplate.set(templateName, prompts);
   }
-  if (prompts.size === 0) throw new Error("No template step prompts were found in prisma/seed.ts");
-  return prompts;
+  return byTemplate;
 };
 
 const main = async (): Promise<void> => {
@@ -49,25 +61,31 @@ const main = async (): Promise<void> => {
   const prisma = new PrismaClient();
   try {
     const result = await prisma.$transaction(async (tx) => {
-      const templates = await tx.taskTemplate.findMany({
-        where: { name: INTEGRATOR_TEMPLATE_NAME },
-        select: { id: true },
-      });
-      if (templates.length === 0) throw new Error(`Template ${INTEGRATOR_TEMPLATE_NAME} was not found`);
-      const templateIds = templates.map((template) => template.id);
-      const updatedSteps: Record<number, number> = {};
-      for (const stepIndex of [...stepPrompts.keys()].sort((left, right) => left - right)) {
-        const prompt = stepPrompts.get(stepIndex)!;
-        const present = await tx.taskTemplateStep.count({
-          where: { taskTemplateId: { in: templateIds }, stepIndex },
+      const updatedSteps: Record<string, Record<number, number>> = {};
+      let templateCount = 0;
+      for (const [templateName, prompts] of stepPrompts) {
+        const templates = await tx.taskTemplate.findMany({
+          where: { name: templateName },
+          select: { id: true },
         });
-        if (present !== templates.length) {
-          throw new Error(`Expected step ${stepIndex} on ${templates.length} canonical templates; found ${present}`);
+        if (templates.length === 0) throw new Error(`Template ${templateName} was not found`);
+        templateCount += templates.length;
+        const templateIds = templates.map((template) => template.id);
+        const updated: Record<number, number> = {};
+        for (const stepIndex of [...prompts.keys()].sort((left, right) => left - right)) {
+          const prompt = prompts.get(stepIndex)!;
+          const present = await tx.taskTemplateStep.count({
+            where: { taskTemplateId: { in: templateIds }, stepIndex },
+          });
+          if (present !== templates.length) {
+            throw new Error(`Expected step ${stepIndex} on ${templates.length} ${templateName} templates; found ${present}`);
+          }
+          updated[stepIndex] = (await tx.taskTemplateStep.updateMany({
+            where: { taskTemplateId: { in: templateIds }, stepIndex, prompt: { not: prompt } },
+            data: { prompt },
+          })).count;
         }
-        updatedSteps[stepIndex] = (await tx.taskTemplateStep.updateMany({
-          where: { taskTemplateId: { in: templateIds }, stepIndex, prompt: { not: prompt } },
-          data: { prompt },
-        })).count;
+        updatedSteps[templateName] = updated;
       }
 
       const presentAgents = await tx.agent.findMany({
@@ -86,9 +104,11 @@ const main = async (): Promise<void> => {
           data: { rolePrompt },
         })).count;
       }
-      return { templates: templates.length, updatedSteps, updatedRoles };
+      return { templates: templateCount, updatedSteps, updatedRoles };
     });
-    const updated = Object.values(result.updatedSteps).reduce((sum, count) => sum + count, 0)
+    const updated = Object.values(result.updatedSteps)
+      .flatMap((byStep) => Object.values(byStep))
+      .reduce((sum, count) => sum + count, 0)
       + Object.values(result.updatedRoles).reduce((sum, count) => sum + count, 0);
     console.log(JSON.stringify({ ...result, updated }));
   } finally {

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 
-import { loadAgentSources } from "../src/agent-sources.js";
+import { loadAgentSources, roleSourceStructureDifferences } from "../src/agent-sources.js";
 import { loadAllTemplateStepSources, templateStepStructureDifferences } from "../src/template-sources.js";
 
 // Every canonical template, every step of each, and every role under agents/
@@ -8,8 +8,8 @@ import { loadAllTemplateStepSources, templateStepStructureDifferences } from "..
 // production, so the loader owns the complete template inventory.
 const main = async (): Promise<void> => {
   const [templateSources, sources] = await Promise.all([loadAllTemplateStepSources(), loadAgentSources()]);
-  const rolePrompts = new Map(sources.roles.map((role) => [role.name, role.rolePrompt]));
-  const roleNames = [...rolePrompts.keys()];
+  const rolesByName = new Map(sources.roles.map((role) => [role.name, role]));
+  const roleNames = [...rolesByName.keys()];
 
   const prisma = new PrismaClient();
   try {
@@ -64,18 +64,43 @@ const main = async (): Promise<void> => {
 
       const presentAgents = await tx.agent.findMany({
         where: { name: { in: roleNames } },
-        select: { name: true },
+        select: {
+          id: true,
+          name: true,
+          title: true,
+          model: true,
+          runnerPreference: true,
+          inboxAccess: true,
+          collaborators: { select: { allowedAgent: { select: { name: true } } } },
+        },
       });
-      const presentRoleNames = new Set(presentAgents.map((agent) => agent.name));
+      const agentsByName = new Map<string, typeof presentAgents>();
+      for (const agent of presentAgents) {
+        const matches = agentsByName.get(agent.name) ?? [];
+        matches.push(agent);
+        agentsByName.set(agent.name, matches);
+      }
       for (const name of roleNames) {
-        if (!presentRoleNames.has(name)) throw new Error(`Agent ${name} was not found`);
+        if (!agentsByName.has(name)) throw new Error(`Agent ${name} was not found`);
       }
       const updatedRoles: Record<string, number> = {};
       for (const name of roleNames) {
-        const rolePrompt = rolePrompts.get(name)!;
+        const role = rolesByName.get(name)!;
+        for (const agent of agentsByName.get(name)!) {
+          const differences = roleSourceStructureDifferences(agent, role);
+          if (differences.length > 0) {
+            throw new Error(`Agent ${name} (${agent.id}) differs from canonical Markdown structure: ${differences.join(", ")}`);
+          }
+        }
         updatedRoles[name] = (await tx.agent.updateMany({
-          where: { name, rolePrompt: { not: rolePrompt } },
-          data: { rolePrompt },
+          where: {
+            name,
+            OR: [
+              { foundationalPrompt: { not: sources.foundationalPrompt } },
+              { rolePrompt: { not: role.rolePrompt } },
+            ],
+          },
+          data: { foundationalPrompt: sources.foundationalPrompt, rolePrompt: role.rolePrompt },
         })).count;
       }
       return { templates: templateCount, updatedSteps, updatedRoles };

--- a/packages/db/prisma/verify-agent-template.ts
+++ b/packages/db/prisma/verify-agent-template.ts
@@ -1,23 +1,26 @@
-import { PrismaClient } from "@prisma/client";
+import { AssigneeType, PrismaClient } from "@prisma/client";
 
+import {
+  CANONICAL_AGENT_DEFAULTS,
+  DIRECT_TEMPLATE_NAME,
+  IMPLEMENTATION_PLAN_OUTPUT_KINDS,
+  catalogRunnerForModel,
+  isTemplateRunnerInherited,
+} from "../src/agent-contract.js";
 import {
   INTEGRATOR_AGENT_NAME,
   INTEGRATOR_OUTPUT_KIND,
   INTEGRATOR_SENTINEL_MODEL,
   INTEGRATOR_STEP_INDEX,
+  INTEGRATOR_TEMPLATE_NAME,
+  integratorBindingValid,
 } from "../src/merge-integrator.js";
-
-import {
-  CANONICAL_AGENT_DEFAULTS,
-  CANONICAL_TEMPLATE_STEPS,
-  IMPLEMENTATION_PLAN_OUTPUT_KINDS,
-  catalogRunnerForModel,
-  isTemplateRunnerInherited,
-} from "../src/agent-contract.js";
+import { loadAllTemplateStepSources } from "../src/template-sources.js";
 
 const prisma = new PrismaClient();
 
 const main = async (): Promise<void> => {
+  const templateSources = await loadAllTemplateStepSources();
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   const activeAgents = await prisma.agent.findMany({
     where: { projectId: project.id, archivedAt: null },
@@ -40,45 +43,57 @@ const main = async (): Promise<void> => {
     }
   }
 
-  const template = await prisma.taskTemplate.findUniqueOrThrow({
-    where: { projectId_name: { projectId: project.id, name: "compound-engineer-workflow" } },
+  const templates = await prisma.taskTemplate.findMany({
+    where: { projectId: project.id, name: { in: [...templateSources.keys()] } },
     include: { steps: { include: { assigneeAgent: true }, orderBy: { stepIndex: "asc" } } },
+    orderBy: { name: "asc" },
   });
-  if (template.steps.length !== CANONICAL_TEMPLATE_STEPS.length) {
-    throw new Error(`template must contain ${CANONICAL_TEMPLATE_STEPS.length} steps; found ${template.steps.length}`);
+  if (templates.length !== templateSources.size) {
+    throw new Error(`expected ${templateSources.size} canonical templates; found ${templates.length}`);
   }
-  for (const expected of CANONICAL_TEMPLATE_STEPS) {
-    const step = template.steps.find((candidate) => candidate.stepIndex === expected.stepIndex);
-    if (!step) throw new Error(`template is missing step ${expected.stepIndex}`);
-    if ((step.assigneeAgent?.name ?? null) !== expected.agentName) {
-      throw new Error(`template step ${step.stepIndex} must bind ${expected.agentName ?? "HUMAN"}; found ${step.assigneeAgent?.name ?? "HUMAN"}`);
+
+  for (const [templateName, expectedSteps] of templateSources) {
+    const template = templates.find((candidate) => candidate.name === templateName);
+    if (!template) throw new Error(`template ${templateName} was not found`);
+    if (template.steps.length !== expectedSteps.length) {
+      throw new Error(`${templateName} must contain ${expectedSteps.length} steps; found ${template.steps.length}`);
     }
-    if (step.outputKind !== expected.outputKind) {
-      throw new Error(`template step ${step.stepIndex} must persist ${expected.outputKind}; found ${step.outputKind}`);
-    }
-    if (step.approvalGate !== expected.approvalGate) {
-      throw new Error(`template step ${step.stepIndex} approval gate must be ${expected.approvalGate}; found ${step.approvalGate}`);
-    }
-    if (step.stepIndex < INTEGRATOR_STEP_INDEX && !isTemplateRunnerInherited(step.runner)) {
-      throw new Error(`template step ${step.stepIndex} must inherit its Agent runner; found ${step.runner}`);
-    }
-    if (step.spawnPolicy !== null) throw new Error(`template step ${step.stepIndex} must not claim an unimplemented spawn policy`);
-    if (step.opensPullRequest !== expected.opensPullRequest) {
-      throw new Error(`template step ${step.stepIndex} opensPullRequest must be ${expected.opensPullRequest}; found ${step.opensPullRequest}`);
-    }
-    if (step.attachmentsFromPrevious !== expected.attachmentsFromPrevious) {
-      throw new Error(`template step ${step.stepIndex} attachmentsFromPrevious must be ${expected.attachmentsFromPrevious}; found ${step.attachmentsFromPrevious}`);
+    for (const expected of expectedSteps) {
+      const step = template.steps.find((candidate) => candidate.stepIndex === expected.stepIndex);
+      if (!step) throw new Error(`${templateName} is missing step ${expected.stepIndex}`);
+      if ((step.assigneeAgent?.name ?? null) !== expected.agentName) {
+        throw new Error(`${templateName} step ${step.stepIndex} must bind ${expected.agentName ?? "HUMAN"}; found ${step.assigneeAgent?.name ?? "HUMAN"}`);
+      }
+      const expectedAssigneeType = expected.agentName === null ? AssigneeType.HUMAN : AssigneeType.AGENT;
+      if (step.assigneeType !== expectedAssigneeType) {
+        throw new Error(`${templateName} step ${step.stepIndex} assignee type must be ${expectedAssigneeType}; found ${step.assigneeType}`);
+      }
+      if (step.outputKind !== expected.outputKind) {
+        throw new Error(`${templateName} step ${step.stepIndex} must persist ${expected.outputKind}; found ${step.outputKind}`);
+      }
+      if (step.approvalGate !== expected.approvalGate) {
+        throw new Error(`${templateName} step ${step.stepIndex} approval gate must be ${expected.approvalGate}; found ${step.approvalGate}`);
+      }
+      if (step.prompt !== expected.prompt) {
+        throw new Error(`${templateName} step ${step.stepIndex} prompt differs from its canonical Markdown source`);
+      }
+      if (!isTemplateRunnerInherited(step.runner)) {
+        throw new Error(`${templateName} step ${step.stepIndex} must inherit its Agent runner; found ${step.runner}`);
+      }
+      if (JSON.stringify(step.spawnPolicy) !== JSON.stringify(expected.spawnPolicy)) {
+        throw new Error(`${templateName} step ${step.stepIndex} spawnPolicy differs from its canonical Markdown source`);
+      }
+      if (step.opensPullRequest !== expected.opensPullRequest) {
+        throw new Error(`${templateName} step ${step.stepIndex} opensPullRequest must be ${expected.opensPullRequest}; found ${step.opensPullRequest}`);
+      }
+      if (step.attachmentsFromPrevious !== expected.attachmentsFromPrevious) {
+        throw new Error(`${templateName} step ${step.stepIndex} attachmentsFromPrevious must be ${expected.attachmentsFromPrevious}; found ${step.attachmentsFromPrevious}`);
+      }
     }
   }
 
-  // The integrator step, asserted explicitly rather than only through the
-  // generic loop. The pre-integrator runner-inheritance bound above protects
-  // business steps from a template-pinned runner that would override the Agent's own;
-  // step 12 has no Agent runner to inherit at all, because nothing spawns for
-  // it. These assertions are what stands in for that protection: an LLM model on
-  // this row, or a `true` opensPullRequest, would mean a model CLI could be
-  // handed the merge step or the merge step could publish.
-  const integrator = template.steps.find((step) => step.stepIndex === INTEGRATOR_STEP_INDEX);
+  const compound = templates.find((template) => template.name === INTEGRATOR_TEMPLATE_NAME)!;
+  const integrator = compound.steps.find((step) => step.stepIndex === INTEGRATOR_STEP_INDEX);
   if (!integrator) throw new Error(`template must contain step ${INTEGRATOR_STEP_INDEX}`);
   if (integrator.assigneeAgent?.name !== INTEGRATOR_AGENT_NAME) {
     throw new Error(`template step ${INTEGRATOR_STEP_INDEX} must bind ${INTEGRATOR_AGENT_NAME}; found ${integrator.assigneeAgent?.name ?? "HUMAN"}`);
@@ -95,14 +110,32 @@ const main = async (): Promise<void> => {
   if (integrator.approvalGate !== false) throw new Error(`template step ${INTEGRATOR_STEP_INDEX} must not carry an approval gate`);
   if (integrator.opensPullRequest !== false) throw new Error(`template step ${INTEGRATOR_STEP_INDEX} must not open a pull request`);
   if (integrator.spawnPolicy !== null) throw new Error(`template step ${INTEGRATOR_STEP_INDEX} must not claim a spawn policy`);
-  const executor = template.steps.find((step) => step.assigneeAgent?.name === "implementation-plan-executioner");
+
+  const executor = compound.steps.find((step) => step.assigneeAgent?.name === "implementation-plan-executioner");
   if (!executor) throw new Error("template must contain an implementation-plan-executioner step");
-  const priorPlan = template.steps.some((step) => (
+  const priorPlan = compound.steps.some((step) => (
     step.stepIndex < executor.stepIndex
       && IMPLEMENTATION_PLAN_OUTPUT_KINDS.includes(step.outputKind as typeof IMPLEMENTATION_PLAN_OUTPUT_KINDS[number])
   ));
   if (!priorPlan) throw new Error("implementation-plan-executioner requires an earlier plan or revised-plan output");
-  process.stdout.write(`Agent/template contract verified for ${activeAgents.length} active agents and ${template.steps.length} steps.\n`);
+
+  const direct = templates.find((template) => template.name === DIRECT_TEMPLATE_NAME)!;
+  const directLast = direct.steps.at(-1)!;
+  if (directLast.assigneeAgent !== null || directLast.approvalGate !== true) {
+    throw new Error(`${DIRECT_TEMPLATE_NAME} must end at a human approval gate`);
+  }
+  for (const step of direct.steps) {
+    if (!integratorBindingValid(step.assigneeAgent?.name ?? null, {
+      stepIndex: step.stepIndex,
+      outputKind: step.outputKind,
+      taskTemplate: { name: DIRECT_TEMPLATE_NAME },
+    })) {
+      throw new Error(`${DIRECT_TEMPLATE_NAME} step ${step.stepIndex} violates the integrator binding contract`);
+    }
+  }
+
+  const stepCount = templates.reduce((sum, template) => sum + template.steps.length, 0);
+  process.stdout.write(`Agent/template contract verified for ${activeAgents.length} active agents and ${stepCount} steps across ${templates.length} templates.\n`);
 };
 
 try {

--- a/packages/db/prisma/verify-agent-template.ts
+++ b/packages/db/prisma/verify-agent-template.ts
@@ -1,12 +1,12 @@
 import { AssigneeType, PrismaClient } from "@prisma/client";
 
 import {
-  CANONICAL_AGENT_DEFAULTS,
   DIRECT_TEMPLATE_NAME,
   IMPLEMENTATION_PLAN_OUTPUT_KINDS,
   catalogRunnerForModel,
   isTemplateRunnerInherited,
 } from "../src/agent-contract.js";
+import { loadAgentSources, roleSourceStructureDifferences } from "../src/agent-sources.js";
 import {
   INTEGRATOR_AGENT_NAME,
   INTEGRATOR_OUTPUT_KIND,
@@ -20,13 +20,14 @@ import { loadAllTemplateStepSources } from "../src/template-sources.js";
 const prisma = new PrismaClient();
 
 const main = async (): Promise<void> => {
-  const templateSources = await loadAllTemplateStepSources();
+  const [templateSources, agentSources] = await Promise.all([loadAllTemplateStepSources(), loadAgentSources()]);
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   const activeAgents = await prisma.agent.findMany({
     where: { projectId: project.id, archivedAt: null },
+    include: { collaborators: { select: { allowedAgent: { select: { name: true } } } } },
     orderBy: { name: "asc" },
   });
-  const expectedByName = new Map(CANONICAL_AGENT_DEFAULTS.map((agent) => [agent.name, agent]));
+  const expectedByName = new Map(agentSources.roles.map((agent) => [agent.name, agent]));
   const actualNames = activeAgents.map((agent) => agent.name).sort();
   const expectedNames = [...expectedByName.keys()].sort();
   if (JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
@@ -34,8 +35,15 @@ const main = async (): Promise<void> => {
   }
   for (const agent of activeAgents) {
     const expected = expectedByName.get(agent.name)!;
-    if (agent.model !== expected.model || agent.runnerPreference !== expected.runner) {
-      throw new Error(`${agent.name} differs from canonical default: expected ${expected.runner}/${expected.model}; found ${agent.runnerPreference}/${agent.model}`);
+    const differences = roleSourceStructureDifferences(agent, expected);
+    if (differences.length > 0) {
+      throw new Error(`${agent.name} differs from canonical Markdown structure: ${differences.join(", ")}`);
+    }
+    if (agent.foundationalPrompt !== agentSources.foundationalPrompt) {
+      throw new Error(`${agent.name} foundational prompt differs from its canonical Markdown source`);
+    }
+    if (agent.rolePrompt !== expected.rolePrompt) {
+      throw new Error(`${agent.name} role prompt differs from its canonical Markdown source`);
     }
     const catalogRunner = catalogRunnerForModel(agent.model);
     if (catalogRunner && catalogRunner !== agent.runnerPreference) {

--- a/packages/db/src/agent-contract.ts
+++ b/packages/db/src/agent-contract.ts
@@ -42,6 +42,25 @@ export const CANONICAL_TEMPLATE_STEPS = [
   { stepIndex: 12, agentName: "merge-integrator", outputKind: "merge-result", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
 ] as const;
 
+/**
+ * The Direct tier: no spec or plan phase, and no mechanical merge — the
+ * integrator's bidirectional binding admits only step 12 of the twelve-step
+ * template, so a direct chain ends at its human pull-request gate and the
+ * human merges. Implementation is senior-dev, not the executioner, whose
+ * contract presumes an existing reviewed plan.
+ */
+export const DIRECT_TEMPLATE_NAME = "direct-engineer-workflow";
+
+export const DIRECT_TEMPLATE_STEPS = [
+  { stepIndex: 1, agentName: "senior-dev", outputKind: "implementation", approvalGate: false, opensPullRequest: true, attachmentsFromPrevious: false },
+  { stepIndex: 2, agentName: "review-coordinator-sol", outputKind: "sol-findings", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
+  // Blind review must persist its own report before reading step 2.
+  { stepIndex: 3, agentName: "review-coordinator-opus", outputKind: "must-fix", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: false },
+  { stepIndex: 4, agentName: "senior-dev", outputKind: "fixed-implementation", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
+  { stepIndex: 5, agentName: "review-coordinator-opus", outputKind: "regression-verification", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
+  { stepIndex: 6, agentName: null, outputKind: "approval", approvalGate: true, opensPullRequest: false, attachmentsFromPrevious: true },
+] as const;
+
 export const IMPLEMENTATION_PLAN_OUTPUT_KINDS = ["plan", "revised-plan"] as const;
 
 export const catalogRunnerForModel = (raw: string): RunnerPreference | null => {

--- a/packages/db/src/agent-contract.ts
+++ b/packages/db/src/agent-contract.ts
@@ -20,28 +20,6 @@ export const CANONICAL_AGENT_DEFAULTS = [
   { name: "spec", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
 ] as const;
 
-export const CANONICAL_TEMPLATE_STEPS = [
-  { stepIndex: 1, agentName: "spec", outputKind: "spec", approvalGate: true, opensPullRequest: false, attachmentsFromPrevious: false },
-  { stepIndex: 2, agentName: "plan", outputKind: "plan", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-  { stepIndex: 3, agentName: "review-coordinator", outputKind: "plan-review", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-  { stepIndex: 4, agentName: "plan-reviser", outputKind: "revised-plan", approvalGate: true, opensPullRequest: false, attachmentsFromPrevious: true },
-  { stepIndex: 5, agentName: "implementation-plan-executioner", outputKind: "implementation", approvalGate: false, opensPullRequest: true, attachmentsFromPrevious: true },
-  { stepIndex: 6, agentName: "review-coordinator-sol", outputKind: "sol-findings", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-  // Blind review must persist its own report before reading step 6.
-  { stepIndex: 7, agentName: "review-coordinator-opus", outputKind: "must-fix", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: false },
-  { stepIndex: 8, agentName: "senior-dev", outputKind: "fixed-implementation", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-  // Regression verification consumes the complete step-8 fix diff.
-  { stepIndex: 9, agentName: "review-coordinator-opus", outputKind: "regression-verification", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-  { stepIndex: 10, agentName: "librarian", outputKind: "documentation", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-  { stepIndex: 11, agentName: null, outputKind: "approval", approvalGate: true, opensPullRequest: false, attachmentsFromPrevious: true },
-  // Step 12 executes the merge mechanically and publishes nothing:
-  // `opensPullRequest: false` is load-bearing, because `templates.ts` copies it
-  // onto the materialized task row and `enqueueTaskRun` copies that onto the
-  // run. Step 5 is the only row allowed to create the chain's pull request;
-  // every review, fix, documentation, approval, and merge row reuses it.
-  { stepIndex: 12, agentName: "merge-integrator", outputKind: "merge-result", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-] as const;
-
 /**
  * The Direct tier: no spec or plan phase, and no mechanical merge — the
  * integrator's bidirectional binding admits only step 12 of the twelve-step
@@ -50,17 +28,6 @@ export const CANONICAL_TEMPLATE_STEPS = [
  * contract presumes an existing reviewed plan.
  */
 export const DIRECT_TEMPLATE_NAME = "direct-engineer-workflow";
-
-export const DIRECT_TEMPLATE_STEPS = [
-  { stepIndex: 1, agentName: "senior-dev", outputKind: "implementation", approvalGate: false, opensPullRequest: true, attachmentsFromPrevious: false },
-  { stepIndex: 2, agentName: "review-coordinator-sol", outputKind: "sol-findings", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-  // Blind review must persist its own report before reading step 2.
-  { stepIndex: 3, agentName: "review-coordinator-opus", outputKind: "must-fix", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: false },
-  { stepIndex: 4, agentName: "senior-dev", outputKind: "fixed-implementation", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-  { stepIndex: 5, agentName: "review-coordinator-opus", outputKind: "regression-verification", approvalGate: false, opensPullRequest: false, attachmentsFromPrevious: true },
-  { stepIndex: 6, agentName: null, outputKind: "approval", approvalGate: true, opensPullRequest: false, attachmentsFromPrevious: true },
-] as const;
-
 export const IMPLEMENTATION_PLAN_OUTPUT_KINDS = ["plan", "revised-plan"] as const;
 
 export const catalogRunnerForModel = (raw: string): RunnerPreference | null => {

--- a/packages/db/src/agent-sources.ts
+++ b/packages/db/src/agent-sources.ts
@@ -22,10 +22,10 @@ import { fileURLToPath } from "node:url";
 import { RunnerPreference } from "@prisma/client";
 
 import { assertCanonicalAgentSources, CANONICAL_AGENT_DEFAULTS } from "./agent-contract.js";
+import { parseInlineList, parsePromptDocument, requiredFrontmatter } from "./prompt-document.js";
 
 const agentsRoot = fileURLToPath(new URL("../../../agents/", import.meta.url));
 
-type FrontmatterDocument = { attributes: Record<string, string>; body: string };
 export type RoleSource = {
   name: string;
   title: string;
@@ -37,33 +37,6 @@ export type RoleSource = {
 };
 export type AgentSources = { foundationalPrompt: string; roles: RoleSource[] };
 
-const parseDocument = (source: string, filePath: string): FrontmatterDocument => {
-  const normalized = source.replace(/\r\n/g, "\n");
-  if (!normalized.startsWith("---\n")) throw new Error(`${filePath} must start with frontmatter`);
-  const end = normalized.indexOf("\n---\n", 4);
-  if (end < 0) throw new Error(`${filePath} has unterminated frontmatter`);
-  const attributes: Record<string, string> = {};
-  for (const line of normalized.slice(4, end).split("\n")) {
-    const separator = line.indexOf(":");
-    if (separator < 1) throw new Error(`${filePath} has invalid frontmatter line: ${line}`);
-    attributes[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
-  }
-  return { attributes, body: normalized.slice(end + 5).trim() };
-};
-
-const required = (document: FrontmatterDocument, key: string, filePath: string): string => {
-  const value = document.attributes[key];
-  if (!value) throw new Error(`${filePath} is missing ${key}`);
-  return value;
-};
-
-const parseList = (value: string | undefined, filePath: string, key: string): string[] => {
-  if (value === undefined) throw new Error(`${filePath} is missing ${key}`);
-  if (!value.startsWith("[") || !value.endsWith("]")) throw new Error(`${filePath} ${key} must be an inline list`);
-  const content = value.slice(1, -1).trim();
-  return content === "" ? [] : content.split(",").map((item) => item.trim()).filter(Boolean);
-};
-
 const runnerPreference = (value: string, filePath: string): RunnerPreference => {
   const runner = value.toUpperCase();
   if (!(runner in RunnerPreference)) throw new Error(`${filePath} has unsupported runner ${value}`);
@@ -72,22 +45,22 @@ const runnerPreference = (value: string, filePath: string): RunnerPreference => 
 
 export const loadAgentSources = async (): Promise<AgentSources> => {
   const foundationalFile = `${agentsRoot}foundational.md`;
-  const foundationalPrompt = parseDocument(await readFile(foundationalFile, "utf8"), foundationalFile).body;
+  const foundationalPrompt = parsePromptDocument(await readFile(foundationalFile, "utf8"), foundationalFile).body;
   const roleDirectory = `${agentsRoot}roles`;
   const roleFiles = (await readdir(roleDirectory)).filter((name) => name.endsWith(".md")).sort();
   const roles: RoleSource[] = [];
   for (const filename of roleFiles) {
     const filePath = `${roleDirectory}/${filename}`;
-    const document = parseDocument(await readFile(filePath, "utf8"), filePath);
-    const inboxAccess = required(document, "inboxAccess", filePath);
+    const document = parsePromptDocument(await readFile(filePath, "utf8"), filePath);
+    const inboxAccess = requiredFrontmatter(document, "inboxAccess", filePath);
     if (inboxAccess !== "true" && inboxAccess !== "false") throw new Error(`${filePath} inboxAccess must be true or false`);
     roles.push({
-      name: required(document, "name", filePath),
-      title: required(document, "title", filePath),
-      model: required(document, "model", filePath),
-      runnerPreference: runnerPreference(required(document, "runner", filePath), filePath),
+      name: requiredFrontmatter(document, "name", filePath),
+      title: requiredFrontmatter(document, "title", filePath),
+      model: requiredFrontmatter(document, "model", filePath),
+      runnerPreference: runnerPreference(requiredFrontmatter(document, "runner", filePath), filePath),
       inboxAccess: inboxAccess === "true",
-      collaborators: parseList(document.attributes.collaborators, filePath, "collaborators"),
+      collaborators: parseInlineList(document.attributes.collaborators, filePath, "collaborators"),
       rolePrompt: document.body,
     });
   }

--- a/packages/db/src/agent-sources.ts
+++ b/packages/db/src/agent-sources.ts
@@ -17,6 +17,7 @@
  * form read the identical directory.
  */
 import { readdir, readFile } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
 import { fileURLToPath } from "node:url";
 
 import { RunnerPreference } from "@prisma/client";
@@ -36,6 +37,32 @@ export type RoleSource = {
   rolePrompt: string;
 };
 export type AgentSources = { foundationalPrompt: string; roles: RoleSource[] };
+
+export type PersistedRoleStructure = {
+  title: string;
+  model: string;
+  runnerPreference: RunnerPreference;
+  inboxAccess: boolean;
+  collaborators: Array<{ allowedAgent: { name: string } }>;
+};
+
+export const roleSourceStructureDifferences = (
+  actual: PersistedRoleStructure,
+  expected: RoleSource,
+): string[] => {
+  const actualCollaborators = actual.collaborators.map(({ allowedAgent }) => allowedAgent.name).sort();
+  const expectedCollaborators = [...expected.collaborators].sort();
+  const fields = [
+    ["title", actual.title, expected.title],
+    ["model", actual.model, expected.model],
+    ["runnerPreference", actual.runnerPreference, expected.runnerPreference],
+    ["inboxAccess", actual.inboxAccess, expected.inboxAccess],
+    ["collaborators", actualCollaborators, expectedCollaborators],
+  ] as const;
+  return fields
+    .filter(([, actualValue, expectedValue]) => !isDeepStrictEqual(actualValue, expectedValue))
+    .map(([field]) => field);
+};
 
 const runnerPreference = (value: string, filePath: string): RunnerPreference => {
   const runner = value.toUpperCase();

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -22,4 +22,5 @@ export * from "./task-source.js";
 export * from "./failure-envelope.js";
 export * from "./agent-sources.js";
 export * from "./agent-contract.js";
+export * from "./template-sources.js";
 export * from "./verify-starter-onboarding.js";

--- a/packages/db/src/preflight-goal-execution.dbtest.ts
+++ b/packages/db/src/preflight-goal-execution.dbtest.ts
@@ -53,7 +53,7 @@ execFileSync("git", [
 // The recorded authority evidence, so these cases stop on the condition they are
 // about rather than on `authority`. The preflight checks both the signed
 // attestation content and that its commits are ancestors of HEAD.
-const MASTER_SHA = "29aac967f373ec6fd96f52b8289724f76eb4721f";
+const MASTER_SHA = "8d69ee8544196a3310b3d63caf8ce5ec9a0e023b";
 const CONTROL_PLANE_A_SHA = "29f8dd354cb99d671c2e2e4e9e23716fd8004f3d";
 
 /**

--- a/packages/db/src/prompt-document.ts
+++ b/packages/db/src/prompt-document.ts
@@ -1,0 +1,30 @@
+export type FrontmatterDocument = { attributes: Record<string, string>; body: string };
+
+export const parsePromptDocument = (source: string, filePath: string): FrontmatterDocument => {
+  const normalized = source.replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) throw new Error(`${filePath} must start with frontmatter`);
+  const end = normalized.indexOf("\n---\n", 4);
+  if (end < 0) throw new Error(`${filePath} has unterminated frontmatter`);
+  const attributes: Record<string, string> = {};
+  for (const line of normalized.slice(4, end).split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator < 1) throw new Error(`${filePath} has invalid frontmatter line: ${line}`);
+    const key = line.slice(0, separator).trim();
+    if (key in attributes) throw new Error(`${filePath} has duplicate frontmatter key ${key}`);
+    attributes[key] = line.slice(separator + 1).trim();
+  }
+  return { attributes, body: normalized.slice(end + 5).trim() };
+};
+
+export const requiredFrontmatter = (document: FrontmatterDocument, key: string, filePath: string): string => {
+  const value = document.attributes[key];
+  if (!value) throw new Error(`${filePath} is missing ${key}`);
+  return value;
+};
+
+export const parseInlineList = (value: string | undefined, filePath: string, key: string): string[] => {
+  if (value === undefined) throw new Error(`${filePath} is missing ${key}`);
+  if (!value.startsWith("[") || !value.endsWith("]")) throw new Error(`${filePath} ${key} must be an inline list`);
+  const content = value.slice(1, -1).trim();
+  return content === "" ? [] : content.split(",").map((item) => item.trim()).filter(Boolean);
+};

--- a/packages/db/src/template-sources.ts
+++ b/packages/db/src/template-sources.ts
@@ -1,5 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
 import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 import type { Prisma } from "@prisma/client";
 
@@ -34,6 +36,35 @@ export type TemplateStepSource = {
   prompt: string;
 };
 
+export type PersistedTemplateStepStructure = {
+  assigneeAgent: { name: string } | null;
+  assigneeType: string;
+  approvalGate: boolean;
+  outputKind: string;
+  attachmentsFromPrevious: boolean;
+  opensPullRequest: boolean;
+  spawnPolicy: Prisma.JsonValue;
+};
+
+export const templateStepStructureDifferences = (
+  actual: PersistedTemplateStepStructure,
+  expected: TemplateStepSource,
+): string[] => {
+  const expectedAssigneeType = expected.agentName === null ? "HUMAN" : "AGENT";
+  const fields = [
+    ["agent", actual.assigneeAgent?.name ?? null, expected.agentName],
+    ["assigneeType", actual.assigneeType, expectedAssigneeType],
+    ["approvalGate", actual.approvalGate, expected.approvalGate],
+    ["outputKind", actual.outputKind, expected.outputKind],
+    ["attachmentsFromPrevious", actual.attachmentsFromPrevious, expected.attachmentsFromPrevious],
+    ["opensPullRequest", actual.opensPullRequest, expected.opensPullRequest],
+    ["spawnPolicy", actual.spawnPolicy, expected.spawnPolicy],
+  ] as const;
+  return fields
+    .filter(([, actualValue, expectedValue]) => !isDeepStrictEqual(actualValue, expectedValue))
+    .map(([field]) => field);
+};
+
 const parseBoolean = (value: string, filePath: string, key: string): boolean => {
   if (value !== "true" && value !== "false") throw new Error(`${filePath} ${key} must be true or false`);
   return value === "true";
@@ -62,17 +93,18 @@ const parseSpawnPolicy = (value: string, filePath: string): Prisma.InputJsonObje
 
 export const loadTemplateStepSources = async (
   templateName: CanonicalTemplateName = INTEGRATOR_TEMPLATE_NAME,
+  sourceRoot: string = templatesRoot,
 ): Promise<TemplateStepSource[]> => {
   const sourceSpec = CANONICAL_TEMPLATE_SOURCE_SPECS.find((candidate) => candidate.name === templateName);
   if (!sourceSpec) throw new Error(`Unknown canonical template source ${templateName}`);
-  const templateRoot = `${templatesRoot}${templateName}/`;
+  const templateRoot = join(sourceRoot, templateName);
   const files = (await readdir(templateRoot)).sort();
   const steps: TemplateStepSource[] = [];
   for (const filename of files) {
     if (!/^\d{2}-[a-z0-9]+(?:-[a-z0-9]+)*\.md$/u.test(filename)) {
-      throw new Error(`${templateRoot}${filename} must be named <NN>-<slug>.md`);
+      throw new Error(`${join(templateRoot, filename)} must be named <NN>-<slug>.md`);
     }
-    const filePath = `${templateRoot}${filename}`;
+    const filePath = join(templateRoot, filename);
     const document = parsePromptDocument(await readFile(filePath, "utf8"), filePath);
     const keys = Object.keys(document.attributes).sort();
     const expectedKeys = [...STRUCTURAL_FIELDS].sort();
@@ -106,9 +138,21 @@ export const loadTemplateStepSources = async (
   return steps;
 };
 
-export const loadAllTemplateStepSources = async (): Promise<Map<CanonicalTemplateName, TemplateStepSource[]>> => {
+export const loadAllTemplateStepSources = async (
+  sourceRoot: string = templatesRoot,
+): Promise<Map<CanonicalTemplateName, TemplateStepSource[]>> => {
+  const rootEntries = await readdir(sourceRoot, { withFileTypes: true });
+  const nonDirectories = rootEntries.filter((entry) => !entry.isDirectory()).map((entry) => entry.name).sort();
+  if (nonDirectories.length > 0) {
+    throw new Error(`${sourceRoot} must contain only canonical template directories; found ${nonDirectories.join(", ")}`);
+  }
+  const actualNames = rootEntries.map((entry) => entry.name).sort();
+  const expectedNames = CANONICAL_TEMPLATE_SOURCE_SPECS.map(({ name }) => name).sort();
+  if (JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
+    throw new Error(`${sourceRoot} canonical template inventory must be exactly ${expectedNames.join(", ")}; found ${actualNames.join(", ")}`);
+  }
   const entries = await Promise.all(CANONICAL_TEMPLATE_SOURCE_SPECS.map(async ({ name }) => (
-    [name, await loadTemplateStepSources(name)] as const
+    [name, await loadTemplateStepSources(name, sourceRoot)] as const
   )));
   return new Map(entries);
 };

--- a/packages/db/src/template-sources.ts
+++ b/packages/db/src/template-sources.ts
@@ -1,0 +1,114 @@
+import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import type { Prisma } from "@prisma/client";
+
+import { DIRECT_TEMPLATE_NAME } from "./agent-contract.js";
+import { INTEGRATOR_TEMPLATE_NAME } from "./merge-integrator.js";
+import { parsePromptDocument, requiredFrontmatter } from "./prompt-document.js";
+
+const templatesRoot = fileURLToPath(new URL("../../../agents/templates/", import.meta.url));
+export const CANONICAL_TEMPLATE_SOURCE_SPECS = [
+  { name: INTEGRATOR_TEMPLATE_NAME, stepCount: 12 },
+  { name: DIRECT_TEMPLATE_NAME, stepCount: 6 },
+] as const;
+export type CanonicalTemplateName = (typeof CANONICAL_TEMPLATE_SOURCE_SPECS)[number]["name"];
+const STRUCTURAL_FIELDS = [
+  "stepIndex",
+  "agent",
+  "approvalGate",
+  "outputKind",
+  "attachmentsFromPrevious",
+  "opensPullRequest",
+  "spawnPolicy",
+] as const;
+
+export type TemplateStepSource = {
+  stepIndex: number;
+  agentName: string | null;
+  approvalGate: boolean;
+  outputKind: string;
+  attachmentsFromPrevious: boolean;
+  opensPullRequest: boolean;
+  spawnPolicy: Prisma.InputJsonObject | null;
+  prompt: string;
+};
+
+const parseBoolean = (value: string, filePath: string, key: string): boolean => {
+  if (value !== "true" && value !== "false") throw new Error(`${filePath} ${key} must be true or false`);
+  return value === "true";
+};
+
+const parseStepIndex = (value: string, filePath: string): number => {
+  if (!/^\d+$/u.test(value)) throw new Error(`${filePath} stepIndex must be a positive integer`);
+  const stepIndex = Number(value);
+  if (!Number.isSafeInteger(stepIndex) || stepIndex < 1) throw new Error(`${filePath} stepIndex must be a positive integer`);
+  return stepIndex;
+};
+
+const parseSpawnPolicy = (value: string, filePath: string): Prisma.InputJsonObject | null => {
+  if (value === "null") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(`${filePath} spawnPolicy must be null or a JSON object`);
+  }
+  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error(`${filePath} spawnPolicy must be null or a JSON object`);
+  }
+  return parsed as Prisma.InputJsonObject;
+};
+
+export const loadTemplateStepSources = async (
+  templateName: CanonicalTemplateName = INTEGRATOR_TEMPLATE_NAME,
+): Promise<TemplateStepSource[]> => {
+  const sourceSpec = CANONICAL_TEMPLATE_SOURCE_SPECS.find((candidate) => candidate.name === templateName);
+  if (!sourceSpec) throw new Error(`Unknown canonical template source ${templateName}`);
+  const templateRoot = `${templatesRoot}${templateName}/`;
+  const files = (await readdir(templateRoot)).sort();
+  const steps: TemplateStepSource[] = [];
+  for (const filename of files) {
+    if (!/^\d{2}-[a-z0-9]+(?:-[a-z0-9]+)*\.md$/u.test(filename)) {
+      throw new Error(`${templateRoot}${filename} must be named <NN>-<slug>.md`);
+    }
+    const filePath = `${templateRoot}${filename}`;
+    const document = parsePromptDocument(await readFile(filePath, "utf8"), filePath);
+    const keys = Object.keys(document.attributes).sort();
+    const expectedKeys = [...STRUCTURAL_FIELDS].sort();
+    if (JSON.stringify(keys) !== JSON.stringify(expectedKeys)) {
+      throw new Error(`${filePath} frontmatter must contain exactly ${STRUCTURAL_FIELDS.join(", ")}`);
+    }
+    const stepIndex = parseStepIndex(requiredFrontmatter(document, "stepIndex", filePath), filePath);
+    if (Number(filename.slice(0, 2)) !== stepIndex) throw new Error(`${filePath} prefix does not match stepIndex ${stepIndex}`);
+    const agent = requiredFrontmatter(document, "agent", filePath);
+    if (document.body.length === 0) throw new Error(`${filePath} has an empty prompt body`);
+    steps.push({
+      stepIndex,
+      agentName: agent === "null" ? null : agent,
+      approvalGate: parseBoolean(requiredFrontmatter(document, "approvalGate", filePath), filePath, "approvalGate"),
+      outputKind: requiredFrontmatter(document, "outputKind", filePath),
+      attachmentsFromPrevious: parseBoolean(requiredFrontmatter(document, "attachmentsFromPrevious", filePath), filePath, "attachmentsFromPrevious"),
+      opensPullRequest: parseBoolean(requiredFrontmatter(document, "opensPullRequest", filePath), filePath, "opensPullRequest"),
+      spawnPolicy: parseSpawnPolicy(requiredFrontmatter(document, "spawnPolicy", filePath), filePath),
+      prompt: document.body,
+    });
+  }
+  if (steps.length !== sourceSpec.stepCount) {
+    throw new Error(`${templateRoot} must contain exactly ${sourceSpec.stepCount} step prompts; found ${steps.length}`);
+  }
+  const indexes = steps.map((step) => step.stepIndex);
+  if (new Set(indexes).size !== indexes.length) throw new Error(`${templateRoot} contains duplicate stepIndex values`);
+  const expectedIndexes = Array.from({ length: sourceSpec.stepCount }, (_, index) => index + 1);
+  if (JSON.stringify(indexes) !== JSON.stringify(expectedIndexes)) {
+    throw new Error(`${templateRoot} stepIndex values must be contiguous from 1 through ${sourceSpec.stepCount}`);
+  }
+  return steps;
+};
+
+export const loadAllTemplateStepSources = async (): Promise<Map<CanonicalTemplateName, TemplateStepSource[]>> => {
+  const entries = await Promise.all(CANONICAL_TEMPLATE_SOURCE_SPECS.map(async ({ name }) => (
+    [name, await loadTemplateStepSources(name)] as const
+  )));
+  return new Map(entries);
+};


### PR DESCRIPTION
## Summary
- move compound and direct workflow prompts into canonical Markdown templates
- sync both templates with full-coverage, fail-loud validation
- verify canonical role configuration without touching the Direct integrator boundary

## Verification
- MERGE GATE: PASS 3ad16d6103658e4e4b2cf4e0a578ee721083fb2e
- Opus high review: PASS 3ad16d6103658e4e4b2cf4e0a578ee721083fb2e
- production database read-only drift check: 0 template, step, prompt, or role mismatches

Merge gate ran on the machine performing this merge.