### PR TITLE
fix(web): preserve wrapped Markdown list items and numbering

### DIFF
--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -509,7 +509,7 @@ const inline = (text: string, keyPrefix: string): ReactNode[] =>
  *  code) plus fenced code blocks and http/https links. Tables stay unsupported. */
 export const Markdown = ({ text }: { text: string }): ReactNode => {
   const blocks: ReactNode[] = [];
-  let list: { ordered: boolean; items: string[] } | null = null;
+  let list: { ordered: true; start: number; items: string[] } | { ordered: false; items: string[] } | null = null;
   let fence: { language: string; lines: string[] } | null = null;
   const flushFence = (): void => {
     if (!fence) return;
@@ -524,10 +524,11 @@ export const Markdown = ({ text }: { text: string }): ReactNode => {
   };
   const flush = (): void => {
     if (!list) return;
-    const { ordered, items } = list;
-    blocks.push(ordered
-      ? <ol key={`b${blocks.length}`} className={cn(MD_LIST, "list-decimal")}>{items.map((item, index) => <li key={index} className="my-[3px]">{inline(item, `l${index}`)}</li>)}</ol>
-      : <ul key={`b${blocks.length}`} className={cn(MD_LIST, "list-disc")}>{items.map((item, index) => <li key={index} className="my-[3px]">{inline(item, `l${index}`)}</li>)}</ul>);
+    if (list.ordered) {
+      blocks.push(<ol key={`b${blocks.length}`} start={list.start} className={cn(MD_LIST, "list-decimal")}>{list.items.map((item, index) => <li key={index} className="my-[3px]">{inline(item, `l${index}`)}</li>)}</ol>);
+    } else {
+      blocks.push(<ul key={`b${blocks.length}`} className={cn(MD_LIST, "list-disc")}>{list.items.map((item, index) => <li key={index} className="my-[3px]">{inline(item, `l${index}`)}</li>)}</ul>);
+    }
     list = null;
   };
   for (const line of text.split("\n")) {
@@ -540,16 +541,22 @@ export const Markdown = ({ text }: { text: string }): ReactNode => {
     // Inside a fence nothing is markdown: no bullets, no headings, no inline.
     if (fence) { fence.lines.push(line); continue; }
     const bullet = /^\s*[-*]\s+(.*)$/.exec(line);
-    const ordered = /^\s*\d+[.)]\s+(.*)$/.exec(line);
+    const ordered = /^\s*(\d+)[.)]\s+(.*)$/.exec(line);
     const heading = /^#{1,6}\s+(.*)$/.exec(line);
+    const continuation = /^ {2,}\S.*$/.exec(line);
     if (bullet) {
       if (list && !list.ordered) list.items.push(bullet[1] ?? "");
       else { flush(); list = { ordered: false, items: [bullet[1] ?? ""] }; }
       continue;
     }
     if (ordered) {
-      if (list?.ordered) list.items.push(ordered[1] ?? "");
-      else { flush(); list = { ordered: true, items: [ordered[1] ?? ""] }; }
+      if (list?.ordered) list.items.push(ordered[2] ?? "");
+      else { flush(); list = { ordered: true, start: Number.parseInt(ordered[1] ?? "1", 10), items: [ordered[2] ?? ""] }; }
+      continue;
+    }
+    if (list && continuation && !heading) {
+      const lastIndex = list.items.length - 1;
+      list.items[lastIndex] = `${list.items[lastIndex]!} ${continuation[0].trim()}`;
       continue;
     }
     flush();

--- a/apps/web/src/tests/markdown.test.tsx
+++ b/apps/web/src/tests/markdown.test.tsx
@@ -48,6 +48,38 @@ test("lists, bold and inline code still render as before", () => {
   assert.match(markup, /<code[^>]*>code<\/code>/);
 });
 
+test("hard-wrapped ordered items stay in one list and keep their text", () => {
+  const markup = renderToStaticMarkup(<Markdown text={"1. first item\n  first continuation\n2. second item\n   second continuation\n3. third item\n  third continuation"} />);
+  assert.equal((markup.match(/<ol\b/g) ?? []).length, 1);
+  assert.equal((markup.match(/<li\b/g) ?? []).length, 3);
+  assert.match(markup, /first item first continuation/);
+  assert.match(markup, /second item second continuation/);
+  assert.match(markup, /third item third continuation/);
+});
+
+test("ordered lists preserve a non-one starting number", () => {
+  const markup = renderToStaticMarkup(<Markdown text={"4. fourth\n5. fifth"} />);
+  assert.match(markup, /<ol[^>]*start="4"[^>]*>/);
+});
+
+test("hard-wrapped unordered items stay in one list and keep their text", () => {
+  const markup = renderToStaticMarkup(<Markdown text={"- first item\n   first continuation\n- second item\n  second continuation"} />);
+  assert.equal((markup.match(/<ul\b/g) ?? []).length, 1);
+  assert.equal((markup.match(/<li\b/g) ?? []).length, 2);
+  assert.match(markup, /first item first continuation/);
+  assert.match(markup, /second item second continuation/);
+});
+
+test("headings, blank lines, inline code and fenced blocks remain separated", () => {
+  const markup = renderToStaticMarkup(<Markdown text={"# Heading\n\n- item\n  wrapped\n\n1. numbered\n\n`inline`\n\n```\n- raw\n```"} />);
+  assert.match(markup, /<strong[^>]*>Heading<\/strong>/);
+  assert.equal((markup.match(/<ul\b/g) ?? []).length, 1);
+  assert.equal((markup.match(/<ol\b/g) ?? []).length, 1);
+  assert.match(markup, /<code[^>]*>inline<\/code>/);
+  assert.match(markup, /- raw/);
+  assert.doesNotMatch(markup, /<li[^>]*>[^<]*raw/);
+});
+
 test("compactTokens is honest about absence and never rounds to a fake zero", () => {
   assert.equal(compactTokens(null), "—");
   assert.equal(compactTokens(undefined), "—");


### PR DESCRIPTION
## Summary

The line-oriented Markdown renderer flushed an open list whenever a hard-wrapped continuation line did not match a list marker, so one list became several one-item lists and each ordered list restarted at 1.

This change keeps an indented (at least two spaces) non-markdown line in the current list item, joining it with a space, and records the first ordered marker so the rendered `<ol>` carries the correct `start` value. Blank lines, headings, fences, and inline parsing retain their existing paths.

## Tests

- Added regression coverage for three-item hard-wrapped ordered lists and continuation text.
- Added coverage for ordered lists beginning at `4.`.
- Added coverage for hard-wrapped unordered lists.
- Kept fenced code, headings, inline code, and blank-line separation covered.
- `npm run build -w @agentos/web`
- `npm test -w @agentos/web` (383 passed)
- `npm run typecheck`
- `npm run lint`