### PR TITLE
Make senior-dev-luna the direct-chain implementation default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,20 @@ Instantiating a direct chain: the `description` you pass is the chain's
 specification of record — write it as a feature brief per
 `docs/BRIEF-TEMPLATE.md` before instantiating.
 
+Implementation-step tier (Leo ruling 2026-08-21, two tiers): the template
+default is `senior-dev-luna` (gpt-5.6-luna:max) and it stays for work whose
+brief enumerates its change points. Patch the step's assignee to
+`senior-dev-high` (gpt-5.6-sol:high) before starting the chain when any of
+these holds: the change touches persisted data (Prisma schema or
+migrations), it touches a defense-list path (merge gate, gate worker,
+migrations, release authority, merge-automation machinery), or the change
+surface is large or cross-cutting enough that the brief cannot enumerate its
+change points. When unsure, treat as met and upgrade. The apply-review-fixes
+step is never reassigned to Luna: it keeps `senior-dev` (Sol), upgraded to
+`senior-dev-high` under the same criteria. The chain's dual blind review,
+closed must-fix fix step, and head-bound regression gate are what license
+the Luna default; a task dispatched outside a chain does not inherit it.
+
 A backlog card leaves the board the moment its content is taken over, and by
 whoever takes it over: dispatching a chain from a card, or recording the
 decisions that settle a discussion card, ends with archiving that card (with

--- a/agents/README.md
+++ b/agents/README.md
@@ -36,7 +36,7 @@ spawnPolicy: null                      # null or an inline JSON object
 
 The `compound-engineer-workflow` directory contains exactly twelve files and `direct-engineer-workflow` exactly six, each with contiguous indexes. The filename prefix must match `stepIndex`, and only these structural keys are accepted. Step display names remain seed-owned presentation metadata; all execution structure and prompt text live in the Markdown sources.
 
-Exact canonical model and runner defaults live in the role frontmatter and `packages/db/src/agent-contract.ts`; task-chain routing is governed by the routing contract this repository's operator maintains outside the published tree. A task template binds roles, while each Agent owns its default runner, model, and reasoning effort. Template steps normally leave `runner` unset so the Agent configuration remains the single runtime authority. `inboxAccess` is least-privilege: granted only where the role contract requires talking to the human (`default`, `spec`, `plan`, `plan-reviser`, `senior-dev`, `implementation-plan-executioner`, `review-coordinator-opus`).
+Exact canonical model and runner defaults live in the role frontmatter and `packages/db/src/agent-contract.ts`; task-chain routing is governed by the routing contract this repository's operator maintains outside the published tree. A task template binds roles, while each Agent owns its default runner, model, and reasoning effort. Template steps normally leave `runner` unset so the Agent configuration remains the single runtime authority. `inboxAccess` is least-privilege: granted only where the role contract requires talking to the human (`default`, `spec`, `plan`, `plan-reviser`, `senior-dev`, `senior-dev-luna`, `implementation-plan-executioner`, `review-coordinator-opus`).
 
 Approval is task metadata, not an Agent personality. Roles read the current
 task's `approvalGate`; they do not hard-code a pause or send a second Inbox
@@ -45,7 +45,7 @@ shorter-route rules live only in the routing contract.
 
 The seed installs two templates over these roles: the twelve-step Full
 Assurance chain, and the six-step direct chain (`direct-engineer-workflow`) —
-implementation by `senior-dev` from the task brief, the same dual blind review
+implementation by `senior-dev-luna` from the task brief, the same dual blind review
 spine, and a terminal human pull-request gate with no mechanical merge. Both
 step contracts live in their Markdown directories under `templates/`.
 

--- a/agents/roles/senior-dev-luna.md
+++ b/agents/roles/senior-dev-luna.md
@@ -1,0 +1,30 @@
+---
+name: senior-dev-luna
+title: Senior Developer (Luna max)
+model: gpt-5.6-luna:max
+runner: codex
+inboxAccess: true
+collaborators: []
+---
+You are the implementing developer. Your one job: implement the assigned
+work in the granted repo, exactly as the brief specifies.
+
+The brief is the specification of record. Implement what it enumerates and
+nothing beyond it: when the brief names change points, touch those and leave
+behavior outside the assignment untouched; when something in the brief is
+ambiguous or contradicts the actual code, do not improvise a wider change —
+pick the narrowest reading that satisfies the brief's acceptance criteria
+and record the reading you chose in the activity log.
+
+Work on the branch the task names. Run the repo's available tests — always
+the suites touching your changes, and the end-to-end tests when the task
+calls for them — and fix what your changes broke. Record in the activity
+log any suite you could not run and any failure demonstrably unrelated to
+your change. Commit with messages that say what changed and why.
+
+You are done when the brief's behavior is demonstrably delivered, tests
+pass, and the commits are in the granted repo. Never hand off with a
+regression you know about. Summarize the result in the activity log and
+finish the task. Inbox the human only when you are truly blocked — a
+missing credential, a failing dependency outside the repo, a contradiction
+in the task itself — and say what you tried first.

--- a/agents/templates/direct-engineer-workflow/01-implementation.md
+++ b/agents/templates/direct-engineer-workflow/01-implementation.md
@@ -1,6 +1,6 @@
 ---
 stepIndex: 1
-agent: senior-dev
+agent: senior-dev-luna
 approvalGate: false
 outputKind: implementation
 attachmentsFromPrevious: false

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -103,7 +103,7 @@ test("a fresh seed writes the twelve-step mechanical template and six-step direc
 
   const direct = await directTemplate();
   assert.equal(direct.steps.length, 6);
-  assert.equal(direct.steps[0]?.assigneeAgent?.name, "senior-dev");
+  assert.equal(direct.steps[0]?.assigneeAgent?.name, "senior-dev-luna");
   assert.equal(direct.steps[0]?.opensPullRequest, true);
   assert.match(direct.steps[0]?.prompt ?? "", /brief is the specification of record/u);
   assert.equal(direct.steps[2]?.attachmentsFromPrevious, false);

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -147,7 +147,7 @@ test("the direct template sources keep the review spine, drop planning, and end 
   assert.deepEqual(
     directTemplateSteps.map(({ stepIndex, agentName, outputKind }) => ({ stepIndex, agentName, outputKind })),
     [
-      { stepIndex: 1, agentName: "senior-dev", outputKind: "implementation" },
+      { stepIndex: 1, agentName: "senior-dev-luna", outputKind: "implementation" },
       { stepIndex: 2, agentName: "review-coordinator-sol", outputKind: "sol-findings" },
       { stepIndex: 3, agentName: "review-coordinator-opus", outputKind: "must-fix" },
       { stepIndex: 4, agentName: "senior-dev", outputKind: "fixed-implementation" },

--- a/packages/db/src/agent-contract.ts
+++ b/packages/db/src/agent-contract.ts
@@ -17,6 +17,7 @@ export const CANONICAL_AGENT_DEFAULTS = [
   { name: "review-coordinator-opus", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
   { name: "review-coordinator-sol", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
   { name: "senior-dev", model: "gpt-5.6-sol:medium", runner: RunnerPreference.CODEX },
+  { name: "senior-dev-luna", model: "gpt-5.6-luna:max", runner: RunnerPreference.CODEX },
   { name: "spec", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
 ] as const;
 
@@ -24,7 +25,7 @@ export const CANONICAL_AGENT_DEFAULTS = [
  * The Direct tier: no spec or plan phase, and no mechanical merge — the
  * integrator's bidirectional binding admits only step 12 of the twelve-step
  * template, so a direct chain ends at its human pull-request gate and the
- * human merges. Implementation is senior-dev, not the executioner, whose
+ * human merges. Implementation is senior-dev-luna, not the executioner, whose
  * contract presumes an existing reviewed plan.
  */
 export const DIRECT_TEMPLATE_NAME = "direct-engineer-workflow";


### PR DESCRIPTION
The direct chain's downstream assurance (dual blind review, closed must-fix fix step, head-bound regression gate) licenses a cheaper implementation tier. This adds the canonical senior-dev-luna role (gpt-5.6-luna:max, codex runner), switches direct step 1's default to it, and records the two-tier dispatch criteria in AGENTS.md: upgrade to Sol high for persisted-data changes, defense-list paths, or change surfaces the brief cannot enumerate. The apply-review-fixes step keeps senior-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)