### PR TITLE
Chain branch handoff and salvage-before-destroy

### DIFF
--- a/.chain/chain-branch-handoff/spec.md
+++ b/.chain/chain-branch-handoff/spec.md
@@ -1,0 +1,115 @@
+# Feature brief: chain branch handoff and salvage-before-destroy
+
+Status: pending dispatch as a direct-engineer-workflow chain (template
+cmt1n48zh001impg5cup0c1zw, repo agentos cmsv8gofe0005mpj2esyr3a0e), only
+after the "Template chain retry branch" chain (c28b4c05, PR #22) has merged -
+shared files in packages/db/src/workflow.ts and packages/api/src/app.ts.
+Pass this brief verbatim as the instantiation `description`; suggested
+branchName: `chain-branch-handoff`. Implementation hits structural risk
+(runner/api component boundary, chain machinery) - patch step 1 assignee to
+senior-dev-high before starting. Covers board cards cmt2druxs (chain branch
+handoff bugs, minus the automatic-retry defect fixed by c28b4c05) and
+cmt2p1p0o (salvage-before-destroy; folded in per Leo 2026-08-21 - same
+salvage family). Queue ruling: this chain runs next; DAG Phase 2, control
+gaps, sequencing follow.
+
+Incidents 2026-08-21: (a) chain 7b459c83 - an operator-retried step run
+adopted the WIP-salvage lineage and published to agentos/<taskId>/run-3, so
+the declared chain branch never existed and the successor died at clone;
+fixed by hand-PATCHing steps 2-6. (b) deploy-chain run cmt2lgs92 - after
+event-ingestion poisoning starved its heartbeat (separate card cmt2omrr8),
+delivery could not complete and the runner's cleanup deleted the workspace
+repo with the branch never pushed: 64 minutes of implementation destroyed
+with zero durable trace, and the loss was labeled transient-provider.
+
+---
+
+A chain survives retries, lost leases, and runner cleanup without losing
+work or needing manual branch surgery: every run's work is durable before
+its workspace can be destroyed, and every new run starts from where the
+chain actually published.
+
+Background: Publication evidence in this codebase is `Run.pushedBranch` and
+nothing else. Two run-creating paths still lose the chain branch after the
+automatic-retry fix: the operator retry route (packages/api/src/app.ts)
+passes the prior run to `resolveRunBranches` (packages/db/src/workflow.ts)
+and `inheritedBase` can adopt a WIP-salvage ref (`agentos/<taskId>/run-<n>`)
+as the new run's published name; successor activation creates the
+successor's first run with `prior = null`, so template chains resolve the
+declared `targetBranch` verbatim and clone a ref that may exist nowhere. And
+upstream of both, the runner's cleanup path (packages/runner: runner.ts
+cleanup / workspace.ts cleanupWorkspace) deletes the workspace whether or
+not the branch state was ever pushed - so any death between claim and
+delivery erases the work that the resolver changes below would otherwise
+recover.
+
+Changes:
+1. Operator retry of a chain step derives the new run's head from the
+   chain's declared branch, never from salvage lineage; salvage refs remain
+   eligible as the *base* when they hold the newest published work, but must
+   not become the published head's name.
+2. Successor activation resolves the successor's clone base from the chain's
+   newest published ref - `pushedBranch` evidence scoped by chainId and
+   repoId across sibling steps - falling back to the declared
+   targetBranch/default branch only when no sibling published anything.
+3. Both changes go through `resolveRunBranches` (single decision point per
+   its own contract), not new per-call-site logic.
+4. Salvage before destroy: the runner pushes the workspace's current branch
+   state to the run's salvage ref (`agentos/<taskId>/run-<n>`) before any
+   workspace deletion, on every terminal path including failed delivery and
+   a dead lease - the push needs git credentials, not a live platform lease.
+   Deletion proceeds only after the salvage push is confirmed durable (or
+   there is verifiably nothing to push: no commits past the clone base and a
+   clean tree, recorded as such). A salvage push that fails leaves the
+   workspace in place with cleanup marked failed and the reason named.
+5. The salvage ref pushed by change 4 is exactly the publication evidence
+   changes 1-2 consume (`pushedBranch` recorded when the push lands, on
+   whatever write path remains available; if no API write is possible the
+   ref itself is still on the remote and the resolver's chain-scoped lookup
+   finds it on the next run's activation).
+6. A run reconciled as lost while its session is still resumable and its
+   runner alive gets one resume attempt (the machinery waiting-inbox runs
+   already use) before a from-scratch rerun; resume failure falls through to
+   a fresh run, which now starts from the salvaged base. If bounded reuse of
+   the existing resume path is not achievable inside this chain's scope,
+   deliver changes 1-5 and record the resume gap explicitly in the PR and
+   task output instead of forcing it.
+7. A loss caused by lease expiry or reconciliation is classified as what it
+   is (platform/lease loss), not transient-provider; the failure reason
+   names the starved heartbeat or expired lease.
+
+Out of scope: the automatic-retry path (fixed by c28b4c05 - rebase on it,
+do not re-fix); the event-ingestion NUL-byte defect and heartbeat/flush
+ordering (card cmt2omrr8, separate chain); chain-to-chain sequencing; run
+cancel and operator controls; merge-tail machinery; periodic mid-run
+checkpointing beyond terminal salvage; any change to how `pushedBranch` is
+written by the normal delivery path.
+
+Constraints: publication evidence is read exclusively from `Run.pushedBranch`
+scoped by repo, per the existing resolver invariants, with the remote
+salvage ref as its on-remote counterpart; no database migration; a chain
+with no publications anywhere behaves exactly as today; cleanup never
+reports success when the salvage push did not land; no silent fallback -
+every degraded path names its reason.
+
+Acceptance:
+1. Automated test (incident a shape): a chain step with a failed run whose
+   salvage push succeeded, when operator-retried, gets a run whose `branch`
+   is the declared chain branch and whose base is the salvage ref; the
+   retried run publishes the declared name.
+2. Automated test: activating a successor whose predecessor published only
+   under a salvage name yields a first run whose clone base is that
+   published ref; with a predecessor that published the declared branch,
+   behavior is unchanged; a chain with no publications resolves exactly as
+   before.
+3. Runner test (incident b shape): a run whose delivery fails after commits
+   exist in the workspace pushes its salvage ref before cleanup and cleanup
+   only then removes the workspace; with a dead lease the push still
+   happens; with nothing to push, cleanup records that and proceeds; a
+   failed salvage push leaves the workspace and marks cleanup failed.
+4. Test: a reconciled-lost run with a resumable session gets one resume
+   attempt before a fresh run is queued (or the recorded gap per change 6).
+5. Test: reconciliation-declared losses carry the new failure class/reason,
+   not transient-provider.
+6. Existing api, db and runner suites green (scratch TEST_DATABASE_URL and
+   RUNNER_WORKSPACE_ROOT per repository testing rules).

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -3676,9 +3676,12 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
 
   app.post("/runner/workspaces/salvaged", async (context) => {
     const body = await readJson(context.req.raw, reclaimSalvageInput);
-    return await acknowledgeReclaimSalvage(db, body)
-      ? context.json({ ok: true })
-      : context.json({ error: "Salvage publication is not authorized by an open reclaim intent" }, 409);
+    const repair = await acknowledgeReclaimSalvage(db, body);
+    return repair === false
+      ? context.json({ error: "Salvage publication is not authorized by an open reclaim intent" }, 409)
+      : repair === "already-started"
+        ? context.json({ error: "Salvage is durable, but the replacement already started from its prior base" }, 409)
+        : context.json({ ok: true, replacementRepair: repair });
   });
 
   app.post("/runner/tasks/claim", async (context) => {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -123,7 +123,9 @@ import {
   runnerFor,
 } from "./execution.js";
 import { createArchivedRunNoticeScheduler, noteArchivedQueuedRuns, reconcileDatabaseRuns } from "./reconcile.js";
-import { acknowledgeReclaimSalvage, publishReclaimIntents, recordReclaimOutcomes } from "./workspace-reclaim.js";
+import {
+  acknowledgeReclaimSalvage, publishReclaimIntents, recordReclaimOutcomes, repairReplacementAfterSalvage,
+} from "./workspace-reclaim.js";
 import { decryptSecret, encryptSecret } from "./secrets.js";
 import { suspendForInbox } from "./inbox.js";
 import { createStarterInstallation, onboardingInput, onboardingStatus } from "./onboarding.js";
@@ -576,6 +578,13 @@ const publicationInput = z.object({
   runnerId: z.string().trim().min(1).max(120),
   fencingToken: fence,
   pushedBranch: z.string().trim().min(1).max(255),
+});
+const leaseIndependentCleanupInput = z.object({
+  runnerId: z.string().trim().min(1).max(120),
+  fencingToken: fence,
+  cleanupStatus: z.nativeEnum(CleanupStatus),
+  cleanupFailureReason: z.string().max(4000).optional(),
+  workspaceRetained: z.boolean(),
 });
 const startInput = z.object({
   runnerId: z.string().trim().min(1).max(120),
@@ -3876,6 +3885,20 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             `Pinned run ${run.id} targets ${run.targetBranch ?? "no commit"}, but its source step now records ${implementationRange.implementationHeadSha}`,
           );
         }
+        const targetBranchPublished = run.targetBranch !== null && await tx.run.findFirst({
+          where: {
+            repoId: candidate.repo.id,
+            pushedBranch: run.targetBranch,
+            task: candidate.task.chainId && candidate.task.chainIndex !== null
+              ? {
+                projectId: candidate.task.projectId,
+                chainId: candidate.task.chainId,
+                chainIndex: { not: null },
+              }
+              : { id: candidate.task.id },
+          },
+          select: { id: true },
+        }) !== null;
         return {
           task: candidate.task,
           agent: candidate.agent,
@@ -3889,6 +3912,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           // from. Carry the first run's durable base separately for PR create.
           run: {
             ...run,
+            targetBranchPublished,
             pullRequestBase: chainFirstRun?.targetBranch ?? candidate.repo.defaultBranch,
             pinnedBaseSha: candidate.task.templateStep?.baseFromStepIndex == null ? null : run.targetBranch,
             implementationBaseSha: implementationRange?.implementationBaseSha ?? null,
@@ -4019,31 +4043,55 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         },
         data: { pushedBranch: body.pushedBranch },
       });
-      if (ack.count !== 1 || !salvage || !run?.taskId) return ack;
-      // Reconciliation may have queued the replacement between lease loss and
-      // this lease-independent salvage ACK. Repair that still-unclaimed row in
-      // the same transaction, with resolveRunBranches making the decision, so
-      // it does not clone the fallback while the durable salvage ref is known.
-      const queued = await tx.run.findFirst({
-        where: { taskId: run.taskId, runNumber: run.runNumber + 1, status: RunStatus.QUEUED },
-        select: { id: true },
+      if (ack.count !== 1 || !salvage || !run?.taskId) return { count: ack.count, repair: "none" as const };
+      const repair = await repairReplacementAfterSalvage(tx, {
+        taskId: run.taskId,
+        runNumber: run.runNumber,
+        branch: run.branch,
       });
-      if (!queued) return ack;
-      const task = await tx.task.findUnique({
-        where: { id: run.taskId },
-        include: { repo: true, templateStep: true },
-      });
-      if (!task?.repo) return ack;
-      const branches = await resolveRunBranches(tx, { ...task, repo: task.repo }, { branch: run.branch });
-      await tx.run.updateMany({
-        where: { id: queued.id, status: RunStatus.QUEUED },
-        data: { branch: branches.branch, targetBranch: branches.targetBranch },
-      });
-      return ack;
+      return { count: ack.count, repair };
     });
-    return updated.count === 1
-      ? context.json({ ok: true })
+    return updated.count === 1 && updated.repair !== "already-started"
+      ? context.json({ ok: true, replacementRepair: updated.repair })
+      : updated.count === 1
+        ? context.json({ error: "Salvage is durable, but the replacement already started from its prior base" }, 409)
       : context.json({ error: "Stale fencing token" }, 409);
+  });
+
+  // Cleanup is still runner-owned after the live lease is gone. This endpoint
+  // can update only cleanup bookkeeping for the exact runner/fence that owned
+  // an expired or terminal run; it cannot change the run outcome or publish a
+  // branch.
+  app.post("/runner/runs/:runId/cleanup", async (context) => {
+    const runId = id.parse(context.req.param("runId"));
+    const body = await readJson(context.req.raw, leaseIndependentCleanupInput);
+    const now = new Date();
+    const run = await db.run.findUnique({
+      where: { id: runId },
+      select: { runnerId: true, fencingToken: true, leaseExpiresAt: true, status: true },
+    });
+    const expiredOrTerminal = run && (
+      run.leaseExpiresAt === null || run.leaseExpiresAt <= now
+      || !activeRunStatuses.includes(run.status as typeof activeRunStatuses[number])
+    );
+    if (!run || run.runnerId !== body.runnerId || run.fencingToken !== body.fencingToken || !expiredOrTerminal) {
+      return context.json({ error: "Cleanup outcome is not authorized for a live or foreign run" }, 409);
+    }
+    await db.$transaction(async (tx) => {
+      await tx.run.update({
+        where: { id: runId },
+        data: { workspaceRetained: body.workspaceRetained },
+      });
+      await tx.session.updateMany({
+        where: { runId },
+        data: {
+          cleanupStatus: body.cleanupStatus,
+          cleanupEndedAt: now,
+          cleanupFailureReason: body.cleanupFailureReason ?? null,
+        },
+      });
+    });
+    return context.json({ ok: true });
   });
 
   app.post("/runner/runs/:runId/events", async (context) => {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -123,7 +123,7 @@ import {
   runnerFor,
 } from "./execution.js";
 import { createArchivedRunNoticeScheduler, noteArchivedQueuedRuns, reconcileDatabaseRuns } from "./reconcile.js";
-import { publishReclaimIntents, recordReclaimOutcomes } from "./workspace-reclaim.js";
+import { acknowledgeReclaimSalvage, publishReclaimIntents, recordReclaimOutcomes } from "./workspace-reclaim.js";
 import { decryptSecret, encryptSecret } from "./secrets.js";
 import { suspendForInbox } from "./inbox.js";
 import { createStarterInstallation, onboardingInput, onboardingStatus } from "./onboarding.js";
@@ -557,6 +557,11 @@ const reclaimReportInput = z.object({
     outcome: z.enum(["REMOVED", "REFUSED", "FAILED"]),
     failureReason: z.string().max(2000).nullable().optional(),
   })).max(5000),
+});
+const reclaimSalvageInput = z.object({
+  runnerId: z.string().trim().min(1).max(120),
+  runId: id,
+  pushedBranch: z.string().trim().min(1).max(255),
 });
 const heartbeatInput = z.object({
   runnerId: z.string().trim().min(1).max(120),
@@ -3660,6 +3665,13 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return context.json(await recordReclaimOutcomes(db, body));
   });
 
+  app.post("/runner/workspaces/salvaged", async (context) => {
+    const body = await readJson(context.req.raw, reclaimSalvageInput);
+    return await acknowledgeReclaimSalvage(db, body)
+      ? context.json({ ok: true })
+      : context.json({ error: "Salvage publication is not authorized by an open reclaim intent" }, 409);
+  });
+
   app.post("/runner/tasks/claim", async (context) => {
     const body = await readJson(context.req.raw, claimInput);
     const principal = context.get("principal");
@@ -3971,15 +3983,63 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/runner/runs/:runId/publication", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, publicationInput);
-    const updated = await db.run.updateMany({
-      where: {
-        id: runId,
-        runnerId: body.runnerId,
-        fencingToken: body.fencingToken,
-        leaseExpiresAt: { gt: new Date() },
-        status: { in: activeRunStatuses },
+    const now = new Date();
+    const run = await db.run.findUnique({
+      where: { id: runId },
+      select: {
+        runnerId: true, fencingToken: true, leaseExpiresAt: true, status: true,
+        taskId: true, repoId: true, runNumber: true, pushedBranch: true, branch: true,
       },
-      data: { pushedBranch: body.pushedBranch },
+    });
+    const owned = run?.runnerId === body.runnerId && run.fencingToken === body.fencingToken;
+    const live = owned && run.leaseExpiresAt !== null && run.leaseExpiresAt > now
+      && activeRunStatuses.includes(run.status as typeof activeRunStatuses[number]);
+    // Salvage is the one publication allowed after lease loss. It is confined
+    // to this run's deterministic per-run ref, requires the same runner and
+    // fencing token that owned the workspace, and cannot replace a different
+    // publication already acknowledged for the run. Git durability does not
+    // depend on a live platform lease; making its ACK depend on one used to
+    // leave a pushed recovery ref invisible to the resolver.
+    const salvageBranch = run?.taskId
+      ? `agentos/${run.taskId}/run-${run.runNumber}`
+      : null;
+    const salvage = owned && run?.repoId !== null
+      && body.pushedBranch === salvageBranch
+      && (run?.pushedBranch === null || run?.pushedBranch === body.pushedBranch);
+    if (!live && !salvage) return context.json({ error: "Stale fencing token" }, 409);
+    const updated = await db.$transaction(async (tx) => {
+      const ack = await tx.run.updateMany({
+        where: {
+          id: runId,
+          runnerId: body.runnerId,
+          fencingToken: body.fencingToken,
+          ...(live
+            ? { leaseExpiresAt: { gt: now }, status: { in: activeRunStatuses } }
+            : { OR: [{ pushedBranch: null }, { pushedBranch: body.pushedBranch }] }),
+        },
+        data: { pushedBranch: body.pushedBranch },
+      });
+      if (ack.count !== 1 || !salvage || !run?.taskId) return ack;
+      // Reconciliation may have queued the replacement between lease loss and
+      // this lease-independent salvage ACK. Repair that still-unclaimed row in
+      // the same transaction, with resolveRunBranches making the decision, so
+      // it does not clone the fallback while the durable salvage ref is known.
+      const queued = await tx.run.findFirst({
+        where: { taskId: run.taskId, runNumber: run.runNumber + 1, status: RunStatus.QUEUED },
+        select: { id: true },
+      });
+      if (!queued) return ack;
+      const task = await tx.task.findUnique({
+        where: { id: run.taskId },
+        include: { repo: true, templateStep: true },
+      });
+      if (!task?.repo) return ack;
+      const branches = await resolveRunBranches(tx, { ...task, repo: task.repo }, { branch: run.branch });
+      await tx.run.updateMany({
+        where: { id: queued.id, status: RunStatus.QUEUED },
+        data: { branch: branches.branch, targetBranch: branches.targetBranch },
+      });
+      return ack;
     });
     return updated.count === 1
       ? context.json({ ok: true })

--- a/packages/api/src/chain-branch.dbtest.ts
+++ b/packages/api/src/chain-branch.dbtest.ts
@@ -590,6 +590,8 @@ test("an operator-retried template step publishes its declared head from the lat
   assert.equal(retried.status, 201, JSON.stringify(retried.body));
   assert.equal(retried.body.branch, declared);
   assert.equal(retried.body.targetBranch, salvage);
+  const retryRow = await db.run.findFirstOrThrow({ where: { taskId: task.id, runNumber: 2 } });
+  assert.equal((await claimRun(retryRow.id)).run.targetBranchPublished, true);
 });
 
 test("a successor first run clones the predecessor's salvage publication", async () => {
@@ -612,6 +614,7 @@ test("a successor first run clones the predecessor's salvage publication", async
   const successor = await db.run.findFirstOrThrow({ where: { taskId: second.id, runNumber: 1 } });
   assert.equal(successor.branch, `agentos/${chain.chainId}`);
   assert.equal(successor.targetBranch, salvage);
+  assert.equal((await claimRun(successor.id)).run.targetBranchPublished, true);
 });
 
 test("T11: a post-push publication ACK survives lease loss and bases the retry on the shared branch", async () => {
@@ -658,6 +661,35 @@ test("a lost run may ACK only its exact salvage ref after lease expiry", async (
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: run.id } })).pushedBranch, salvage);
   const repaired = await db.run.findUniqueOrThrow({ where: { id: queuedBeforeAck.id } });
   assert.equal(repaired.targetBranch, salvage);
+});
+
+test("late salvage revokes and repairs a replacement claimed before start", async () => {
+  const seed = await seedProject("late-salvage-vs-claim");
+  const task = await postTask(seed.project.id, {
+    name: "Lost", description: "d", assigneeAgentId: seed.agent.id, repoId: seed.repo.id,
+  });
+  const run = await db.run.findFirstOrThrow({ where: { taskId: task.body.id } });
+  const lostClaim = await claimRun(run.id);
+  await db.run.update({ where: { id: run.id }, data: {
+    status: "RUNNING", leaseExpiresAt: new Date(Date.now() - 60_000), heartbeatAt: null,
+  } });
+  await reconcileDatabaseRuns(db, new Date());
+  const replacement = await db.run.findFirstOrThrow({ where: { taskId: task.body.id, runNumber: 2 } });
+  const staleClaim = await claimRun(replacement.id);
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: replacement.id } })).status, "CLAIMED");
+
+  const salvage = `agentos/${task.body.id}/run-1`;
+  const accepted = await publishViaRoute(lostClaim, salvage);
+  assert.equal(accepted.status, 200, JSON.stringify(accepted.body));
+  assert.equal(accepted.body.replacementRepair, "requeued");
+  const invalidated = await db.run.findUniqueOrThrow({ where: { id: replacement.id } });
+  assert.equal(invalidated.status, "CANCELLED");
+  assert.equal(invalidated.runnerId, "runner-1", "the stale runner retains cleanup ownership for its distinct workspace");
+  const repaired = await db.run.findFirstOrThrow({ where: { taskId: task.body.id, runNumber: 3 } });
+  assert.equal(repaired.status, "QUEUED");
+  assert.equal(repaired.targetBranch, salvage);
+  assert.notEqual(repaired.id, replacement.id);
+  assert.equal((await startRunViaRoute(staleClaim, "stale/head")).status, 409, "the revoked claim must not start");
 });
 
 test("T12: a non-chain requeue is unchanged", async () => {

--- a/packages/api/src/chain-branch.dbtest.ts
+++ b/packages/api/src/chain-branch.dbtest.ts
@@ -246,13 +246,13 @@ test("T2: the base branch follows the chain, not the task", async () => {
   assert.equal(thirdRun.targetBranch, shared);
 });
 
-test("T3: a failed run's WIP salvage push is not evidence that the shared branch exists", async () => {
+test("T3: a failed run's WIP salvage push is the successor's durable clone base", async () => {
   // The payload below is exactly what the runner emits after a WIP salvage:
   // `branch` is the workspace branch (the shared one), `pushStatus` is SUCCEEDED
   // — and `deliverFailedWorkspace` pushed `agentos/<taskId>/run-<n>` instead.
   // Inferring publication from `branch` + `pushStatus` would send step ② to
-  // clone a ref nobody ever created, and the chain would die in provisioning
-  // with nothing but "clone failed" to go on. That is why `pushedBranch` exists.
+  // clone a ref nobody ever created. `pushedBranch` names the durable salvage
+  // ref that the successor must actually clone.
   const seed = await seedProject("t3");
   const chainId = `chain-${Date.now()}`;
   const shared = expectedBranch(seed.project.id, chainId);
@@ -284,9 +284,9 @@ test("T3: a failed run's WIP salvage push is not evidence that the shared branch
   });
   assert.equal(completed.status, 200, JSON.stringify(completed.body));
   const secondRun = await db.run.findFirstOrThrow({ where: { taskId: second.id, status: "QUEUED" } });
-  assert.equal(secondRun.targetBranch, seed.repo.defaultBranch);
+  assert.equal(secondRun.targetBranch, `agentos/${first.body.id}/run-1`);
   assert.notEqual(secondRun.targetBranch, shared);
-  assert.equal(secondRun.branch, shared, "it still pushes to the chain's branch — it just cannot base on it yet");
+  assert.equal(secondRun.branch, shared, "the successor still publishes the declared chain branch");
 });
 
 test("T4: the first step of a chain that has published nothing bases on the default branch", async () => {
@@ -566,6 +566,54 @@ test("T10: an operator retry lands on the shared branch", async () => {
   assert.equal(retried.body.targetBranch, shared);
 });
 
+test("an operator-retried template step publishes its declared head from the latest salvage base", async () => {
+  const seed = await seedProject("operator-template-salvage");
+  const template = await db.taskTemplate.create({ data: {
+    projectId: seed.project.id, name: "operator-template", description: "t", variables: [],
+    steps: { create: [0, 1].map((stepIndex) => ({
+      stepIndex, name: `Step ${stepIndex}`, assigneeType: "AGENT" as const,
+      assigneeAgentId: seed.agent.id, prompt: `do ${stepIndex}`,
+    })) },
+  } });
+  const chain = await instantiateTemplate(db, seed.project.id, template.id, {
+    repoId: seed.repo.id, variables: {}, autoStart: true,
+  });
+  const task = chain.tasks[0]!;
+  const declared = `agentos/${chain.chainId}`;
+  const salvage = `agentos/${task.id}/run-1`;
+  await runStep(task.id, {
+    exitCode: 1, terminalSuccess: false, failureClass: "TASK_FAILED", retryable: false,
+    branch: salvage, pushStatus: "SUCCEEDED", pushedBranch: salvage,
+  });
+
+  const retried = await operatorRequest(`/tasks/${task.id}/retry`, { method: "POST" });
+  assert.equal(retried.status, 201, JSON.stringify(retried.body));
+  assert.equal(retried.body.branch, declared);
+  assert.equal(retried.body.targetBranch, salvage);
+});
+
+test("a successor first run clones the predecessor's salvage publication", async () => {
+  const seed = await seedProject("successor-salvage");
+  const template = await db.taskTemplate.create({ data: {
+    projectId: seed.project.id, name: "successor-template", description: "t", variables: [],
+    steps: { create: [0, 1].map((stepIndex) => ({
+      stepIndex, name: `Step ${stepIndex}`, assigneeType: "AGENT" as const,
+      assigneeAgentId: seed.agent.id, prompt: `do ${stepIndex}`,
+    })) },
+  } });
+  const chain = await instantiateTemplate(db, seed.project.id, template.id, {
+    repoId: seed.repo.id, variables: {}, autoStart: true,
+  });
+  const first = chain.tasks[0]!;
+  const second = chain.tasks[1]!;
+  const salvage = `agentos/${first.id}/run-1`;
+  await runStep(first.id, { pushedBranch: salvage });
+
+  const successor = await db.run.findFirstOrThrow({ where: { taskId: second.id, runNumber: 1 } });
+  assert.equal(successor.branch, `agentos/${chain.chainId}`);
+  assert.equal(successor.targetBranch, salvage);
+});
+
 test("T11: a post-push publication ACK survives lease loss and bases the retry on the shared branch", async () => {
   const seed = await seedProject("t11");
   const chainId = `chain-${Date.now()}`;
@@ -586,6 +634,30 @@ test("T11: a post-push publication ACK survives lease loss and bases the retry o
   const requeued = await db.run.findFirstOrThrow({ where: { taskId: first.body.id, runNumber: 2 } });
   assert.equal(requeued.branch, shared);
   assert.equal(requeued.targetBranch, shared, "the ACK is durable before terminal completion");
+});
+
+test("a lost run may ACK only its exact salvage ref after lease expiry", async () => {
+  const seed = await seedProject("late-salvage-ack");
+  const task = await postTask(seed.project.id, {
+    name: "Lost", description: "d", assigneeAgentId: seed.agent.id, repoId: seed.repo.id,
+  });
+  const run = await db.run.findFirstOrThrow({ where: { taskId: task.body.id } });
+  const claim = await claimRun(run.id);
+  await db.run.update({ where: { id: run.id }, data: {
+    status: "RUNNING", leaseExpiresAt: new Date(Date.now() - 60_000), heartbeatAt: null,
+  } });
+  await reconcileDatabaseRuns(db, new Date());
+  const queuedBeforeAck = await db.run.findFirstOrThrow({ where: { taskId: task.body.id, runNumber: 2 } });
+  assert.equal(queuedBeforeAck.targetBranch, seed.repo.defaultBranch);
+
+  const arbitrary = await publishViaRoute(claim, "some/arbitrary-head");
+  assert.equal(arbitrary.status, 409);
+  const salvage = `agentos/${task.body.id}/run-1`;
+  const accepted = await publishViaRoute(claim, salvage);
+  assert.equal(accepted.status, 200);
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: run.id } })).pushedBranch, salvage);
+  const repaired = await db.run.findUniqueOrThrow({ where: { id: queuedBeforeAck.id } });
+  assert.equal(repaired.targetBranch, salvage);
 });
 
 test("T12: a non-chain requeue is unchanged", async () => {

--- a/packages/api/src/reconcile.test.ts
+++ b/packages/api/src/reconcile.test.ts
@@ -167,12 +167,14 @@ test("startup reconciliation does not fail when archived notice persistence fail
 test("lease-loss requeue for an archived agent becomes visible through the sweep", async () => {
   const now = new Date("2026-08-16T06:00:00.000Z");
   let queued: Record<string, unknown> | undefined;
+  let lostUpdate: Record<string, unknown> | undefined;
   const activities: Record<string, unknown>[] = [];
   const candidate = {
-    id: "lost-1", heartbeatAt: new Date(now.getTime() - 20 * 60_000), projectId: "project-1",
+    id: "lost-1", heartbeatAt: new Date(now.getTime() - 20 * 60_000),
+    leaseExpiresAt: new Date(now.getTime() - 10 * 60_000), projectId: "project-1",
     taskId: "task-1", goalId: null, agentId: "agent-1", repoId: "repo-1", runNumber: 1,
-    runner: "CLAUDE", model: "model", targetBranch: "main", promptHash: "hash",
-    maxDurationMin: 120, stallTimeoutMin: 10, maxRunsPerTask: 3,
+    runner: "CLAUDE", model: "model", targetBranch: "main", branch: "feature/x", promptHash: "hash",
+    maxDurationMin: 120, stallTimeoutMin: 10, maxRunsPerTask: 3, budgetGrants: 0,
   };
   const database = {
     run: {
@@ -183,7 +185,7 @@ test("lease-loss requeue for an archived agent becomes visible through the sweep
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
       $queryRaw: async () => [{ id: "task-1", archivedAt: null }],
       run: {
-        updateMany: async () => ({ count: 1 }),
+        updateMany: async ({ data }: { data: Record<string, unknown> }) => { lostUpdate = data; return { count: 1 }; },
         create: async ({ data }: { data: Record<string, unknown> }) => { queued = data; return { id: "retry-2", ...data }; },
       },
       session: { updateMany: async () => ({ count: 1 }) },
@@ -202,6 +204,8 @@ test("lease-loss requeue for an archived agent becomes visible through the sweep
     },
   } as unknown as PrismaClient;
   assert.equal(await reconcileDatabaseRuns(database, now), 1);
+  assert.equal(lostUpdate?.failureClass, "CANCELLED_OR_TIMED_OUT");
+  assert.match(String(lostUpdate?.failureReason), /heartbeat starved.*lease expired/i);
   assert.equal(await noteArchivedQueuedRuns(database), 1);
   assert.match(String(activities[0]?.body), /Archived.*run 2/);
 });

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -85,6 +85,7 @@ export const reconcileDatabaseRuns = async (db: PrismaClient, now = new Date()):
       },
       select: {
         heartbeatAt: true,
+        leaseExpiresAt: true,
         id: true,
         projectId: true,
         taskId: true,
@@ -124,6 +125,11 @@ export const reconcileDatabaseRuns = async (db: PrismaClient, now = new Date()):
   if (orphans.length === 0 && expiredInboxRuns.length === 0) return 0;
   await db.$transaction(async (tx) => {
     for (const run of orphans) {
+      const leaseLossReason = !run.leaseExpiresAt
+        ? "Platform lease missing during startup reconciliation; runner heartbeat authority was lost"
+        : run.heartbeatAt === null
+          ? `Platform lease expired at ${run.leaseExpiresAt.toISOString()} without a recorded runner heartbeat`
+          : `Runner heartbeat starved after ${run.heartbeatAt.toISOString()}; platform lease expired at ${run.leaseExpiresAt.toISOString()}`;
       // Order PATCH and retry creation through the same Task-row mutex. The
       // task is re-read after this lock before opensPullRequest is snapshotted.
       if (run.taskId) await lockTaskRow(tx, run.taskId);
@@ -140,11 +146,11 @@ export const reconcileDatabaseRuns = async (db: PrismaClient, now = new Date()):
           endedAt: now,
           leaseExpiresAt: null,
           sessionTokenRevokedAt: now,
-          failureClass: FailureClass.TRANSIENT_PROVIDER,
+          failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
           retryable: true,
           maxRunsPerTask: budgetCeiling,
           budgetGrants,
-          failureReason: "Run orphaned or lease expired during startup reconciliation",
+          failureReason: leaseLossReason,
         },
       });
       if (lost.count !== 1) continue;
@@ -154,7 +160,7 @@ export const reconcileDatabaseRuns = async (db: PrismaClient, now = new Date()):
           executionStatus: SessionExecutionStatus.LOST,
           cleanupStatus: CleanupStatus.PENDING,
           endedAt: now,
-          failureReason: "Run orphaned or lease expired during startup reconciliation",
+          failureReason: leaseLossReason,
         },
       });
       if (!run.taskId) continue;

--- a/packages/api/src/runners.test.ts
+++ b/packages/api/src/runners.test.ts
@@ -63,6 +63,7 @@ const makeDatabase = (candidates: Record<string, unknown>[] = []): PrismaClient 
   const tx = {
     run: {
       findMany: async () => candidates,
+      findFirst: async () => null,
       updateMany: async () => ({ count: 1 }),
       findUniqueOrThrow: async ({ where }: { where: { id: string } }) => ({ id: where.id, status: RunStatus.CLAIMED }),
     },

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -88,6 +88,7 @@ test("instantiating the canonical feature template creates twelve tasks includin
       findFirst: async () => created.find((item) => item.targetBranch !== "main") ?? null,
     },
     run: {
+      findFirst: async () => null,
       create: async ({ data }: { data: Record<string, any> }) => { const run = { id: "run-1", ...data }; runs.push(run); return run; },
       update: async ({ data }: { data: Record<string, any> }) => { Object.assign(runs[0]!, data); return runs[0]; },
     },

--- a/packages/api/src/workflow.test.ts
+++ b/packages/api/src/workflow.test.ts
@@ -519,7 +519,7 @@ const branchTx = (rows: Array<{
       if (typeof where.pushedBranch === "string") {
         return scoped.find((row) => row.pushedBranch === where.pushedBranch) ?? null;
       }
-      assert.deepEqual(orderBy, { runNumber: "desc" });
+      assert.deepEqual(orderBy, [{ createdAt: "desc" }, { id: "desc" }]);
       return [...scoped].sort((a, b) => b.runNumber - a.runNumber)[0] ?? null;
     },
   },
@@ -592,6 +592,45 @@ test("a template retry falls back to its own targetBranch but still honours a si
     templateId: "template-1", targetBranch: "main", repo: { defaultBranch: "main" },
   }, { branch: "agentos/chain-1" }), {
     branch: "agentos/chain-1", targetBranch: "agentos/chain-1",
+  });
+});
+
+test("a template operator retry publishes the declared head while basing on the newest salvage", async () => {
+  const salvage = "agentos/task-1/run-2";
+  const tx = branchTx([
+    { taskId: "task-1", chainId: "chain-1", repoId: "repo-1", runNumber: 2, pushedBranch: salvage },
+  ], "declared/chain-head");
+  assert.deepEqual(await resolveRunBranches(tx, {
+    id: "task-1", projectId: "project-1", repoId: "repo-1", chainId: "chain-1", chainIndex: 0,
+    templateId: "template-1", targetBranch: "main", repo: { defaultBranch: "main" },
+  }, { branch: salvage }), {
+    branch: "declared/chain-head",
+    targetBranch: salvage,
+  });
+});
+
+test("a successor first run bases on the newest sibling publication whatever ref carried it", async () => {
+  const salvage = "agentos/task-1/run-2";
+  const tx = branchTx([
+    { taskId: "task-1", chainId: "chain-1", repoId: "repo-1", runNumber: 2, pushedBranch: salvage },
+  ], "declared/chain-head");
+  assert.deepEqual(await resolveRunBranches(tx, {
+    id: "task-2", projectId: "project-1", repoId: "repo-1", chainId: "chain-1", chainIndex: 1,
+    templateId: "template-1", targetBranch: "declared/chain-head", repo: { defaultBranch: "main" },
+  }, null), {
+    branch: "declared/chain-head",
+    targetBranch: salvage,
+  });
+
+  const declared = branchTx([
+    { taskId: "task-1", chainId: "chain-1", repoId: "repo-1", runNumber: 1, pushedBranch: "declared/chain-head" },
+  ], "declared/chain-head");
+  assert.deepEqual(await resolveRunBranches(declared, {
+    id: "task-2", projectId: "project-1", repoId: "repo-1", chainId: "chain-1", chainIndex: 1,
+    templateId: "template-1", targetBranch: "declared/chain-head", repo: { defaultBranch: "main" },
+  }, null), {
+    branch: "declared/chain-head",
+    targetBranch: "declared/chain-head",
   });
 });
 

--- a/packages/api/src/workspace-reclaim.dbtest.ts
+++ b/packages/api/src/workspace-reclaim.dbtest.ts
@@ -15,6 +15,7 @@ import { PrismaClient } from "@agentos/db";
 import { reclaimWorkspaces } from "@agentos/runner/reclaim";
 import type { RunnerConfig } from "@agentos/runner/config";
 
+import { reconcileDatabaseRuns } from "./reconcile.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
@@ -412,11 +413,17 @@ test("reclaim salvage acknowledgement rebases an already-queued retry", async ()
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: replacement.id } })).targetBranch, salvage);
 });
 
-test("an expired run records lease-independent cleanup failure from its owning fence", async () => {
+test("a reconciled-lost run records lease-independent cleanup failure from its owning fence", async () => {
   const root = await scratchRoot("lease-cleanup");
   const runnerId = "runner-lease-cleanup";
   const { run, fencingToken } = await seedRun({ root, runnerId, status: "RUNNING" });
   await db.run.update({ where: { id: run.id }, data: { leaseExpiresAt: new Date(Date.now() - 60_000) } });
+  assert.ok(await reconcileDatabaseRuns(db, new Date()) > 0);
+  const lost = await db.run.findUniqueOrThrow({ where: { id: run.id }, include: { session: true } });
+  assert.equal(lost.status, "LOST");
+  assert.equal(lost.runnerId, runnerId);
+  assert.equal(lost.fencingToken, fencingToken);
+  assert.equal(lost.session?.cleanupStatus, "PENDING");
   const response = await call(root, `/runner/runs/${run.id}/cleanup`, {
     runnerId,
     fencingToken,

--- a/packages/api/src/workspace-reclaim.dbtest.ts
+++ b/packages/api/src/workspace-reclaim.dbtest.ts
@@ -380,3 +380,54 @@ test("an old runner that never asks leaves its workspaces in place, and nothing 
   assert.equal(untouched.workspaceReclaimAt, null);
   assert.equal(untouched.workspaceReclaimedAt, null);
 });
+
+test("reclaim salvage acknowledgement rebases an already-queued retry", async () => {
+  const root = await scratchRoot("salvage-repair");
+  const runnerId = "runner-salvage-repair";
+  const seeded = await seedRun({ root, runnerId, status: "LOST", pushedBranch: null });
+  await db.run.update({
+    where: { id: seeded.run.id },
+    data: { workspaceReclaimAt: new Date(), leaseExpiresAt: null },
+  });
+  const replacement = await db.run.create({ data: {
+    projectId: seeded.project.id,
+    taskId: seeded.task.id,
+    agentId: seeded.agent.id,
+    repoId: seeded.repo.id,
+    runNumber: 2,
+    dedupeKey: `task:${seeded.task.id}:run:2`,
+    runner: "CLAUDE",
+    model: "claude",
+    promptHash: "hash-2",
+    status: "QUEUED",
+    targetBranch: seeded.repo.defaultBranch,
+    maxRunsPerTask: 5,
+  } });
+  const salvage = `agentos/${seeded.task.id}/run-1`;
+  const response = await call(root, "/runner/workspaces/salvaged", {
+    runnerId, runId: seeded.run.id, pushedBranch: salvage,
+  });
+  assert.equal(response.status, 200, JSON.stringify(response.body));
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } })).pushedBranch, salvage);
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: replacement.id } })).targetBranch, salvage);
+});
+
+test("an expired run records lease-independent cleanup failure from its owning fence", async () => {
+  const root = await scratchRoot("lease-cleanup");
+  const runnerId = "runner-lease-cleanup";
+  const { run, fencingToken } = await seedRun({ root, runnerId, status: "RUNNING" });
+  await db.run.update({ where: { id: run.id }, data: { leaseExpiresAt: new Date(Date.now() - 60_000) } });
+  const response = await call(root, `/runner/runs/${run.id}/cleanup`, {
+    runnerId,
+    fencingToken,
+    cleanupStatus: "FAILED",
+    cleanupFailureReason: "WIP salvage failed after lease expiry",
+    workspaceRetained: true,
+  });
+  assert.equal(response.status, 200, JSON.stringify(response.body));
+  const storedRun = await db.run.findUniqueOrThrow({ where: { id: run.id } });
+  const session = await db.session.findUniqueOrThrow({ where: { runId: run.id } });
+  assert.equal(storedRun.workspaceRetained, true);
+  assert.equal(session.cleanupStatus, "FAILED");
+  assert.equal(session.cleanupFailureReason, "WIP salvage failed after lease expiry");
+});

--- a/packages/api/src/workspace-reclaim.dbtest.ts
+++ b/packages/api/src/workspace-reclaim.dbtest.ts
@@ -109,6 +109,7 @@ const seedRun = async (options: {
   workspaceRetained?: boolean;
   workspacePath?: string | null;
   endedAt?: Date | null;
+  pushedBranch?: string | null;
 }) => {
   const suffix = `${Date.now()}-${seedCounter++}`;
   const project = await db.project.create({ data: { name: "Reclaim", slug: `reclaim-${suffix}` } });
@@ -131,6 +132,10 @@ const seedRun = async (options: {
     fencingToken, leaseExpiresAt: new Date(Date.now() + 60_000),
     status, model: "claude", promptHash: "hash", maxRunsPerTask: 5,
     workspaceRetained: options.workspaceRetained ?? false,
+    // These ownership/retry fixtures predate terminal salvage and exercise a
+    // workspace whose normal delivery is already durable. Tests for an
+    // unpublished workspace opt back into null explicitly.
+    pushedBranch: options.pushedBranch === undefined ? "already/durable" : options.pushedBranch,
     ...(options.endedAt === undefined ? {} : { endedAt: options.endedAt }),
   } });
   // Written after create so a caller can ask for the canonical path without

--- a/packages/api/src/workspace-reclaim.dbtest.ts
+++ b/packages/api/src/workspace-reclaim.dbtest.ts
@@ -413,6 +413,44 @@ test("reclaim salvage acknowledgement rebases an already-queued retry", async ()
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: replacement.id } })).targetBranch, salvage);
 });
 
+test("reclaim salvage acknowledgement refuses cleanup after the replacement started", async () => {
+  const root = await scratchRoot("salvage-started-replacement");
+  const runnerId = "runner-salvage-started";
+  const seeded = await seedRun({ root, runnerId, status: "LOST", pushedBranch: null });
+  await db.run.update({
+    where: { id: seeded.run.id },
+    data: { workspaceReclaimAt: new Date(), leaseExpiresAt: null },
+  });
+  const replacement = await db.run.create({ data: {
+    projectId: seeded.project.id,
+    taskId: seeded.task.id,
+    agentId: seeded.agent.id,
+    repoId: seeded.repo.id,
+    runNumber: 2,
+    dedupeKey: `task:${seeded.task.id}:run:2`,
+    runner: "CLAUDE",
+    runnerId: "replacement-runner",
+    fencingToken: `2:${seeded.task.id}:replacement`,
+    leaseExpiresAt: new Date(Date.now() + 60_000),
+    model: "claude",
+    promptHash: "hash-2",
+    status: "RUNNING",
+    startedAt: new Date(),
+    targetBranch: seeded.repo.defaultBranch,
+    maxRunsPerTask: 5,
+  } });
+  const salvage = `agentos/${seeded.task.id}/run-1`;
+
+  const response = await call(root, "/runner/workspaces/salvaged", {
+    runnerId, runId: seeded.run.id, pushedBranch: salvage,
+  });
+
+  assert.equal(response.status, 409, JSON.stringify(response.body));
+  assert.match(String(response.body.error), /replacement already started/u);
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } })).pushedBranch, salvage);
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: replacement.id } })).targetBranch, seeded.repo.defaultBranch);
+});
+
 test("a reconciled-lost run records lease-independent cleanup failure from its owning fence", async () => {
   const root = await scratchRoot("lease-cleanup");
   const runnerId = "runner-lease-cleanup";

--- a/packages/api/src/workspace-reclaim.test.ts
+++ b/packages/api/src/workspace-reclaim.test.ts
@@ -77,12 +77,14 @@ test("reclaim salvage ACK accepts only the owner's deterministic ref while the i
     id: "run-3", runnerId: "runner-1", taskId: "task-1", runNumber: 3,
     status: RunStatus.LOST, workspaceReclaimAt: new Date(), workspaceReclaimedAt: null, pushedBranch: null,
   };
-  const db = {
+  const db: any = {
     run: {
       findUnique: async () => ({ ...stored, pushedBranch: written }),
+      findFirst: async () => null,
       updateMany: async ({ data }: { data: { pushedBranch: string } }) => { written = data.pushedBranch; return { count: 1 }; },
     },
-  } as unknown as PrismaClient;
+  };
+  db.$transaction = async (operation: (tx: any) => unknown) => operation(db);
   assert.equal(await acknowledgeReclaimSalvage(db, {
     runnerId: "runner-2", runId: stored.id, pushedBranch: "agentos/task-1/run-3",
   }), false);

--- a/packages/api/src/workspace-reclaim.test.ts
+++ b/packages/api/src/workspace-reclaim.test.ts
@@ -4,7 +4,9 @@ import test from "node:test";
 
 import { RunStatus, type PrismaClient } from "@agentos/db";
 
-import { publishReclaimIntents, terminalRunStatuses, workspaceKeepStatuses } from "./workspace-reclaim.js";
+import {
+  acknowledgeReclaimSalvage, publishReclaimIntents, terminalRunStatuses, workspaceKeepStatuses,
+} from "./workspace-reclaim.js";
 
 type Row = {
   id: string;
@@ -61,9 +63,36 @@ const inventory = (directories: string[], runnerId = "runner-1") => ({ runnerId,
 test("the control plane offers a finished run's directory and publishes the intent", async () => {
   const { db, runUpdates } = fakeDb([row("done")]);
   const plan = await publishReclaimIntents(db, inventory(["done"]), 2);
-  assert.deepEqual(plan.reclaim, [{ runId: "done", workspacePath: null }]);
+  assert.deepEqual(plan.reclaim, [{
+    runId: "done", workspacePath: null,
+    taskId: undefined, runNumber: undefined, baseSha: undefined, pushedBranch: undefined,
+  }]);
   assert.deepEqual(runUpdates.map(({ ids }) => ids), [["done"]]);
   assert.ok(runUpdates[0]!.data.workspaceReclaimAt instanceof Date);
+});
+
+test("reclaim salvage ACK accepts only the owner's deterministic ref while the intent is open", async () => {
+  let written: string | null = null;
+  const stored = {
+    id: "run-3", runnerId: "runner-1", taskId: "task-1", runNumber: 3,
+    status: RunStatus.LOST, workspaceReclaimAt: new Date(), workspaceReclaimedAt: null, pushedBranch: null,
+  };
+  const db = {
+    run: {
+      findUnique: async () => ({ ...stored, pushedBranch: written }),
+      updateMany: async ({ data }: { data: { pushedBranch: string } }) => { written = data.pushedBranch; return { count: 1 }; },
+    },
+  } as unknown as PrismaClient;
+  assert.equal(await acknowledgeReclaimSalvage(db, {
+    runnerId: "runner-2", runId: stored.id, pushedBranch: "agentos/task-1/run-3",
+  }), false);
+  assert.equal(await acknowledgeReclaimSalvage(db, {
+    runnerId: "runner-1", runId: stored.id, pushedBranch: "arbitrary/head",
+  }), false);
+  assert.equal(await acknowledgeReclaimSalvage(db, {
+    runnerId: "runner-1", runId: stored.id, pushedBranch: "agentos/task-1/run-3",
+  }), true);
+  assert.equal(written, "agentos/task-1/run-3");
 });
 
 test("a directory the database has never heard of is kept, never offered", async () => {

--- a/packages/api/src/workspace-reclaim.test.ts
+++ b/packages/api/src/workspace-reclaim.test.ts
@@ -93,7 +93,7 @@ test("reclaim salvage ACK accepts only the owner's deterministic ref while the i
   }), false);
   assert.equal(await acknowledgeReclaimSalvage(db, {
     runnerId: "runner-1", runId: stored.id, pushedBranch: "agentos/task-1/run-3",
-  }), true);
+  }), "none");
   assert.equal(written, "agentos/task-1/run-3");
 });
 

--- a/packages/api/src/workspace-reclaim.ts
+++ b/packages/api/src/workspace-reclaim.ts
@@ -61,6 +61,10 @@ export type ReclaimOffer = {
    * clone window, before /start persisted a path.
    */
   workspacePath: string | null;
+  taskId?: string | null;
+  runNumber?: number;
+  baseSha?: string | null;
+  pushedBranch?: string | null;
 };
 
 export type ReclaimPlan = {
@@ -97,7 +101,11 @@ export type ReclaimReport = {
   runnerId: string;
   /** Telemetry for the audit record. Authority comes from `runnerId` alone. */
   workspaceRoot: string;
-  results: Array<{ runId: string; outcome: ReclaimOutcome; failureReason?: string | null | undefined }>;
+  results: Array<{
+    runId: string;
+    outcome: ReclaimOutcome;
+    failureReason?: string | null | undefined;
+  }>;
 };
 
 const audit = (event: string, detail: Record<string, unknown>): void => {
@@ -106,6 +114,10 @@ const audit = (event: string, detail: Record<string, unknown>): void => {
 
 type ReclaimCandidate = {
   id: string;
+  taskId: string | null;
+  runNumber: number;
+  baseSha: string | null;
+  pushedBranch: string | null;
   runnerId: string | null;
   workspacePath: string | null;
   status: RunStatus;
@@ -159,7 +171,8 @@ export const publishReclaimIntents = async (
   const runs = directories.length === 0 ? [] : await db.run.findMany({
     where: { id: { in: directories } },
     select: {
-      id: true, runnerId: true, workspacePath: true, status: true,
+      id: true, taskId: true, runNumber: true, baseSha: true, pushedBranch: true,
+      runnerId: true, workspacePath: true, status: true,
       workspaceRetained: true, endedAt: true, workspaceReclaimAt: true, workspaceReclaimedAt: true,
     },
   }) as ReclaimCandidate[];
@@ -225,7 +238,14 @@ export const publishReclaimIntents = async (
       audit("keep-noncanonical-workspace-path", { root, runId: run.id, workspacePath: run.workspacePath });
       continue;
     }
-    reclaim.push({ runId: run.id, workspacePath: run.workspacePath });
+    reclaim.push({
+      runId: run.id,
+      workspacePath: run.workspacePath,
+      taskId: run.taskId,
+      runNumber: run.runNumber,
+      baseSha: run.baseSha,
+      pushedBranch: run.pushedBranch,
+    });
     if (!run.workspaceReclaimAt) publish.push(run.id);
     if (run.workspaceRetained) unretain.push(run.id);
   }
@@ -285,7 +305,10 @@ const applyOutcome = async (
 ): Promise<ApplyResult> => db.$transaction(async (tx) => {
   const run = await tx.run.findUnique({
     where: { id: result.runId },
-    select: { id: true, runnerId: true, status: true, workspaceReclaimAt: true, workspaceReclaimedAt: true },
+    select: {
+      id: true,
+      runnerId: true, status: true, workspaceReclaimAt: true, workspaceReclaimedAt: true,
+    },
   });
   // Only an intent this API published, for a finished run, reported by the
   // runner that owns it, and not already answered for.
@@ -356,6 +379,39 @@ export const recordReclaimOutcomes = async (
     audit("reclaimed", { caller: report.runnerId, root: report.workspaceRoot, ...tally });
   }
   return tally;
+};
+
+/** A retained/lost workspace can outlive its run lease. The owning runner uses
+ * this narrow ACK after pushing the deterministic salvage ref and before it
+ * deletes the directory; unlike run publication it is authorized by the open
+ * reclaim intent and recorded runner ownership, not by an expired fence. */
+export const acknowledgeReclaimSalvage = async (
+  db: PrismaClient,
+  input: { runnerId: string; runId: string; pushedBranch: string },
+): Promise<boolean> => {
+  const run = await db.run.findUnique({
+    where: { id: input.runId },
+    select: {
+      id: true, runnerId: true, taskId: true, runNumber: true, status: true,
+      workspaceReclaimAt: true, workspaceReclaimedAt: true, pushedBranch: true,
+    },
+  });
+  const expected = run?.taskId ? `agentos/${run.taskId}/run-${run.runNumber}` : null;
+  if (!run || !ownedByCaller(run, input.runnerId) || !isTerminal(run.status)
+    || !run.workspaceReclaimAt || run.workspaceReclaimedAt
+    || input.pushedBranch !== expected
+    || (run.pushedBranch !== null && run.pushedBranch !== input.pushedBranch)) return false;
+  const updated = await db.run.updateMany({
+    where: {
+      id: run.id,
+      runnerId: input.runnerId,
+      workspaceReclaimAt: { not: null },
+      workspaceReclaimedAt: null,
+      OR: [{ pushedBranch: null }, { pushedBranch: input.pushedBranch }],
+    },
+    data: { pushedBranch: input.pushedBranch },
+  });
+  return updated.count === 1;
 };
 
 /** How many published intents are still waiting for their owner to act. */

--- a/packages/api/src/workspace-reclaim.ts
+++ b/packages/api/src/workspace-reclaim.ts
@@ -1,6 +1,9 @@
 import { resolve } from "node:path";
 
-import { CleanupStatus, RunStatus, type PrismaClient } from "@agentos/db";
+import {
+  CleanupStatus, enqueueTaskRun, FailureClass, resolveRunBranches, RunStatus, SessionExecutionStatus,
+  type Prisma, type PrismaClient,
+} from "@agentos/db";
 
 /**
  * Workspace GC ownership (issue #115).
@@ -389,29 +392,94 @@ export const acknowledgeReclaimSalvage = async (
   db: PrismaClient,
   input: { runnerId: string; runId: string; pushedBranch: string },
 ): Promise<boolean> => {
-  const run = await db.run.findUnique({
-    where: { id: input.runId },
-    select: {
-      id: true, runnerId: true, taskId: true, runNumber: true, status: true,
-      workspaceReclaimAt: true, workspaceReclaimedAt: true, pushedBranch: true,
-    },
+  return db.$transaction(async (tx) => {
+    const run = await tx.run.findUnique({
+      where: { id: input.runId },
+      select: {
+        id: true, runnerId: true, taskId: true, runNumber: true, status: true,
+        workspaceReclaimAt: true, workspaceReclaimedAt: true, pushedBranch: true, branch: true,
+      },
+    });
+    const expected = run?.taskId ? `agentos/${run.taskId}/run-${run.runNumber}` : null;
+    if (!run || !ownedByCaller(run, input.runnerId) || !isTerminal(run.status)
+      || !run.workspaceReclaimAt || run.workspaceReclaimedAt
+      || input.pushedBranch !== expected
+      || (run.pushedBranch !== null && run.pushedBranch !== input.pushedBranch)) return false;
+    const updated = await tx.run.updateMany({
+      where: {
+        id: run.id,
+        runnerId: input.runnerId,
+        workspaceReclaimAt: { not: null },
+        workspaceReclaimedAt: null,
+        OR: [{ pushedBranch: null }, { pushedBranch: input.pushedBranch }],
+      },
+      data: { pushedBranch: input.pushedBranch },
+    });
+    if (updated.count !== 1 || !run.taskId) return false;
+    await repairReplacementAfterSalvage(tx, {
+      taskId: run.taskId,
+      runNumber: run.runNumber,
+      branch: run.branch,
+    });
+    return true;
   });
-  const expected = run?.taskId ? `agentos/${run.taskId}/run-${run.runNumber}` : null;
-  if (!run || !ownedByCaller(run, input.runnerId) || !isTerminal(run.status)
-    || !run.workspaceReclaimAt || run.workspaceReclaimedAt
-    || input.pushedBranch !== expected
-    || (run.pushedBranch !== null && run.pushedBranch !== input.pushedBranch)) return false;
-  const updated = await db.run.updateMany({
-    where: {
-      id: run.id,
-      runnerId: input.runnerId,
-      workspaceReclaimAt: { not: null },
-      workspaceReclaimedAt: null,
-      OR: [{ pushedBranch: null }, { pushedBranch: input.pushedBranch }],
-    },
-    data: { pushedBranch: input.pushedBranch },
+};
+
+/** Recomputes the immediate replacement after a late salvage publication.
+ * A claimed row has not crossed /start yet, but reusing its id would let the old
+ * runner clean the same directory a new runner is provisioning. Terminate that
+ * row while preserving its cleanup ownership, refund the platform-caused
+ * attempt, and enqueue a fresh row with a distinct workspace id. */
+export const repairReplacementAfterSalvage = async (
+  tx: Prisma.TransactionClient,
+  run: { taskId: string; runNumber: number; branch: string | null },
+): Promise<"none" | "repaired" | "requeued" | "already-started"> => {
+  const replacement = await tx.run.findFirst({
+    where: { taskId: run.taskId, runNumber: run.runNumber + 1 },
+    select: { id: true, status: true, startedAt: true },
   });
-  return updated.count === 1;
+  if (!replacement) return "none";
+  if (replacement.status === RunStatus.CLAIMED && replacement.startedAt === null) {
+    const revokedAt = new Date();
+    const revoked = await tx.run.updateMany({
+      where: { id: replacement.id, status: RunStatus.CLAIMED, startedAt: null },
+      data: {
+        status: RunStatus.CANCELLED,
+        endedAt: revokedAt,
+        leaseExpiresAt: null,
+        sessionTokenRevokedAt: revokedAt,
+        failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
+        failureReason: "Claim invalidated before start because late salvage changed its clone base",
+        retryable: true,
+        maxRunsPerTask: { increment: 1 },
+        budgetGrants: { increment: 1 },
+      },
+    });
+    if (revoked.count !== 1) return "already-started";
+    await tx.session.updateMany({
+      where: { runId: replacement.id },
+      data: {
+        executionStatus: SessionExecutionStatus.CANCELLED,
+        endedAt: revokedAt,
+        failureReason: "Claim invalidated before start because late salvage changed its clone base",
+      },
+    });
+    await enqueueTaskRun(tx, run.taskId, revokedAt);
+    return "requeued";
+  } else if (replacement.status !== RunStatus.QUEUED) {
+    return "already-started";
+  }
+  const task = await tx.task.findUnique({
+    where: { id: run.taskId },
+    include: { repo: true, templateStep: true },
+  });
+  if (!task?.repo) return "already-started";
+  const branches = await resolveRunBranches(tx, { ...task, repo: task.repo }, { branch: run.branch });
+  const repaired = await tx.run.updateMany({
+    where: { id: replacement.id, status: RunStatus.QUEUED },
+    data: { branch: branches.branch, targetBranch: branches.targetBranch },
+  });
+  return repaired.count === 1 ? "repaired" : "already-started";
 };
 
 /** How many published intents are still waiting for their owner to act. */

--- a/packages/api/src/workspace-reclaim.ts
+++ b/packages/api/src/workspace-reclaim.ts
@@ -388,10 +388,12 @@ export const recordReclaimOutcomes = async (
  * this narrow ACK after pushing the deterministic salvage ref and before it
  * deletes the directory; unlike run publication it is authorized by the open
  * reclaim intent and recorded runner ownership, not by an expired fence. */
+export type ReplacementRepair = "none" | "repaired" | "requeued" | "already-started";
+
 export const acknowledgeReclaimSalvage = async (
   db: PrismaClient,
   input: { runnerId: string; runId: string; pushedBranch: string },
-): Promise<boolean> => {
+): Promise<false | ReplacementRepair> => {
   return db.$transaction(async (tx) => {
     const run = await tx.run.findUnique({
       where: { id: input.runId },
@@ -416,12 +418,11 @@ export const acknowledgeReclaimSalvage = async (
       data: { pushedBranch: input.pushedBranch },
     });
     if (updated.count !== 1 || !run.taskId) return false;
-    await repairReplacementAfterSalvage(tx, {
+    return repairReplacementAfterSalvage(tx, {
       taskId: run.taskId,
       runNumber: run.runNumber,
       branch: run.branch,
     });
-    return true;
   });
 };
 
@@ -433,7 +434,7 @@ export const acknowledgeReclaimSalvage = async (
 export const repairReplacementAfterSalvage = async (
   tx: Prisma.TransactionClient,
   run: { taskId: string; runNumber: number; branch: string | null },
-): Promise<"none" | "repaired" | "requeued" | "already-started"> => {
+): Promise<ReplacementRepair> => {
   const replacement = await tx.run.findFirst({
     where: { taskId: run.taskId, runNumber: run.runNumber + 1 },
     select: { id: true, status: true, startedAt: true },

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -327,34 +327,40 @@ const inheritedBase = async (
   task: RunBranchTask,
   prior: { branch: string | null } | null,
 ): Promise<string | null> => {
-  // No prior run at all: this is the pre-existing `prior?.branch ?? ...` answer
-  // for a first run, and skipping both queries keeps that path untouched.
-  if (!prior || !task.repoId) return null;
+  if (!task.repoId) return null;
   // Template steps of one chain share a branch, so the ref this retry wants may
-  // have been published by a *sibling* step. Everything else owns its branch —
-  // and a chainIndex-null row must stay isolated from indexed siblings carrying
-  // the same chainId (see resolveRunBranches) — so it asks about itself only.
-  const scope = task.templateId && task.chainId
-    ? { projectId: task.projectId, chainId: task.chainId }
-    : { id: task.id };
-  // Scoped by repo: the same branch name on two remotes is two unrelated refs.
-  const published = prior.branch
-    ? await tx.run.findFirst({
-      where: { pushedBranch: prior.branch, repoId: task.repoId, task: scope },
-      select: { id: true },
-    })
+  // have been published by a *sibling* step. This also applies to a successor's
+  // first run: `prior` is null there, but the predecessor's salvage ref is the
+  // newest durable tree the chain owns. Everything else asks about itself only.
+  // A chainIndex-null row stays isolated from indexed siblings carrying the
+  // same chainId (see resolveRunBranches).
+  const chainScope = task.chainId && task.chainIndex !== null
+    ? { projectId: task.projectId, chainId: task.chainId, chainIndex: { not: null } }
     : null;
-  if (published && prior.branch) return prior.branch;
-  // The workspace branch was never published, but a failed run's WIP salvage
-  // push (`agentos/<taskId>/run-<n>`, delivery.ts) may still hold this task's
-  // work. Basing on the newest one is how the retry keeps the progress that did
-  // reach the remote instead of silently restarting from the default branch.
-  const salvaged = await tx.run.findFirst({
-    where: { taskId: task.id, repoId: task.repoId, pushedBranch: { not: null } },
-    orderBy: { runNumber: "desc" },
+  if (!prior && !chainScope) return null;
+  const scope = chainScope
+    ? chainScope
+    : { id: task.id };
+  // A non-chain retry first asks the narrow historical question: did this task
+  // publish the workspace branch it is trying to continue? Chain retries skip
+  // this shortcut because a newer sibling salvage must outrank an older head.
+  if (!chainScope && prior?.branch) {
+    const exact = await tx.run.findFirst({
+      where: { repoId: task.repoId, pushedBranch: prior.branch, task: scope },
+      select: { pushedBranch: true },
+    });
+    if (exact?.pushedBranch) return exact.pushedBranch;
+  }
+  // `createdAt`, not a per-task runNumber, orders publications across sibling
+  // steps. Run rows are created serially along a chain; their updatedAt can move
+  // later for cleanup bookkeeping and is therefore not publication ordering.
+  // Scoped by repo: the same branch name on two remotes is two unrelated refs.
+  const published = await tx.run.findFirst({
+    where: { repoId: task.repoId, pushedBranch: { not: null }, task: scope },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     select: { pushedBranch: true },
   });
-  return salvaged?.pushedBranch ?? null;
+  return published?.pushedBranch ?? null;
 };
 
 /**
@@ -442,8 +448,8 @@ export const resolveRunBranches = async (
   }
 
   const shared = sharedChainBranch({ projectId: task.projectId, chainId: task.chainId });
-  // "Has any step of this chain actually published the shared branch *on this
-  // repo*?"
+  // "What is the newest ref any indexed step of this chain actually published
+  // on this repo?" It may be the declared head or a per-run salvage ref.
   //
   // Read `pushedBranch` and nothing else. It is written only after `git push`
   // returns, with the ref that was actually given to it, on both delivery paths
@@ -466,24 +472,10 @@ export const resolveRunBranches = async (
   // refs) and restricted to indexed tasks. A chainIndex-null row is the API's
   // isolated 1/1 malformed-chain case and must neither contribute nor consume
   // publication evidence for an indexed chain with the same chainId.
-  const published = task.repoId
-    ? await tx.run.findFirst({
-      where: {
-        pushedBranch: shared,
-        repoId: task.repoId,
-        task: { projectId: task.projectId, chainId: task.chainId, chainIndex: { not: null } },
-      },
-      select: { id: true },
-    })
-    : null;
-  // `prior?.branch` is deliberately not consulted here. Post-change it is always
-  // `shared`, so it would give the same answer; pre-change (a chain that spans
-  // the restart) it is a per-task branch, and honouring it would quietly keep a
-  // mixed chain mixed instead of falling through to the operator's targetBranch,
-  // which the rollback runbook names as the manual repair lever.
-  const targetBranch = published
-    ? shared
-    : task.targetBranch ?? task.repo.defaultBranch;
+  const published = await inheritedBase(tx, task, prior);
+  // `prior?.branch` is deliberately not consulted as publication evidence.
+  // Only pushedBranch proves that a cloneable remote ref exists.
+  const targetBranch = published ?? task.targetBranch ?? task.repo.defaultBranch;
 
   // targetBranch stays writable for chain steps but no longer routes them.
   // Silently ignoring an operator's value is a footgun, so say so once per run —

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -38,6 +38,7 @@ const claim: ClaimedTask = {
     maxRunsPerTask: 3,
     model: "codex",
     targetBranch: "main",
+    targetBranchPublished: false,
     pinnedBaseSha: null,
     implementationBaseSha: null,
     implementationHeadSha: null,

--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -306,7 +306,14 @@ export const completeRun = async (config: RunnerConfig, claim: ClaimedTask, comp
   });
 };
 
-export type ReclaimOffer = { runId: string; workspacePath: string | null };
+export type ReclaimOffer = {
+  runId: string;
+  workspacePath: string | null;
+  taskId?: string | null;
+  runNumber?: number;
+  baseSha?: string | null;
+  pushedBranch?: string | null;
+};
 export type ReclaimPlan = {
   /** Directories in the reported inventory this runner may remove. */
   reclaim: ReclaimOffer[];
@@ -357,6 +364,16 @@ export const reportReclaimOutcomes = async (
   }).catch((error: unknown) => {
     if ((error as { status?: number }).status === 404) return null;
     throw error;
+  });
+};
+
+export const recordReclaimPublication = async (
+  config: RunnerConfig,
+  body: { runnerId: string; runId: string; pushedBranch: string },
+): Promise<void> => {
+  await request(config, "/runner/workspaces/salvaged", {
+    method: "POST",
+    body: JSON.stringify(body),
   });
 };
 

--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -80,6 +80,9 @@ export type ClaimedTask = {
     maxRunsPerTask: number;
     model: string;
     targetBranch: string | null;
+    /** Whether targetBranch was selected from durable Run.pushedBranch evidence.
+     * When true, provisioning must not replace it with an older declared head. */
+    targetBranchPublished: boolean;
     /** Exact commit selected by baseFromStepIndex. Null means ordinary branch
      * provisioning; a value means fetch-only detached provisioning. */
     pinnedBaseSha: string | null;
@@ -222,6 +225,24 @@ export const recordPublishedBranch = async (
       runnerId: config.runnerId,
       fencingToken: claim.fencingToken,
       pushedBranch,
+    }),
+  });
+};
+
+/** Records cleanup after this runner has lost its live lease. The control plane
+ * accepts this only from the recorded runner/fence for an expired or terminal
+ * run; unlike completion, it carries no authority over run outcome. */
+export const recordLeaseIndependentCleanup = async (
+  config: RunnerConfig,
+  claim: ClaimedTask,
+  cleanup: { cleanupStatus: CleanupStatus; cleanupFailureReason?: string; workspaceRetained: boolean },
+): Promise<void> => {
+  await request(config, `/runner/runs/${claim.run.id}/cleanup`, {
+    method: "POST",
+    body: JSON.stringify({
+      runnerId: config.runnerId,
+      fencingToken: claim.fencingToken,
+      ...cleanup,
     }),
   });
 };

--- a/packages/runner/src/delivery.ts
+++ b/packages/runner/src/delivery.ts
@@ -407,16 +407,16 @@ export const deliverWorkspace = async (
  * them in sync: whatever ref is handed to `git push` is the ref reported as
  * `pushedBranch`.
  */
-export const deliverFailedWorkspace = async (
+export const salvageWorkspace = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  identity: { taskId: string; runId: string; runNumber: number; remoteUrl?: string },
   workspace: Workspace,
   command: CommandExecutor = executeCommand(config),
   retryOptions: RetryOptions = {},
 ): Promise<DeliveryResult | null> => {
   const env = workspaceEnvironment(config);
-  const remote = claim.repo.remoteUrl;
-  const branch = `agentos/${claim.task.id}/run-${claim.run.runNumber}`;
+  const remote = identity.remoteUrl ?? "origin";
+  const branch = `agentos/${identity.taskId}/run-${identity.runNumber}`;
   try {
     // Respect .gitignore while including tracked deletions and untracked files.
     await command("git", ["add", "-A"], workspace.path, env);
@@ -427,7 +427,7 @@ export const deliverFailedWorkspace = async (
         "-c", "user.email=runner@agentos.local",
         "-c", "commit.gpgSign=false",
         "-c", "core.hooksPath=/dev/null",
-        "commit", "--no-verify", "-m", `WIP salvage for AgentOS run ${claim.run.id}`,
+        "commit", "--no-verify", "-m", `WIP salvage for AgentOS run ${identity.runId}`,
       ], workspace.path, env);
     }
     const head = await command("git", ["rev-parse", "HEAD"], workspace.path, env);
@@ -451,3 +451,16 @@ export const deliverFailedWorkspace = async (
     return { pushStatus: "FAILED", pushRemote: remote, pushError: `WIP salvage failed: ${message}` };
   }
 };
+
+export const deliverFailedWorkspace = async (
+  config: RunnerConfig,
+  claim: ClaimedTask,
+  workspace: Workspace,
+  command: CommandExecutor = executeCommand(config),
+  retryOptions: RetryOptions = {},
+): Promise<DeliveryResult | null> => salvageWorkspace(config, {
+  taskId: claim.task.id,
+  runId: claim.run.id,
+  runNumber: claim.run.runNumber,
+  remoteUrl: claim.repo.remoteUrl,
+}, workspace, command, retryOptions);

--- a/packages/runner/src/provision-failure.test.ts
+++ b/packages/runner/src/provision-failure.test.ts
@@ -75,6 +75,7 @@ const claim = (remoteUrl: string): ClaimedTask => ({
     maxRunsPerTask: 2,
     model: "claude",
     targetBranch: "master",
+    targetBranchPublished: false,
     pinnedBaseSha: null,
     implementationBaseSha: null,
     implementationHeadSha: null,

--- a/packages/runner/src/reclaim.test.ts
+++ b/packages/runner/src/reclaim.test.ts
@@ -33,15 +33,14 @@ afterEach(() => { globalThis.fetch = originalFetch; });
 type Call = { path: string; body: Record<string, any> };
 
 /** Stands in for the control plane: answers the plan, records the report. */
-const stubApi = (plan: unknown, status = 200): Call[] => {
+const stubApi = (plan: unknown, status = 200, addCompatibilityEvidence = true): Call[] => {
   const calls: Call[] = [];
   const compatiblePlan = plan && typeof plan === "object" && "reclaim" in plan
     ? {
       ...plan,
-      reclaim: (plan as { reclaim: Array<Record<string, unknown>> }).reclaim.map((offer) => ({
-        pushedBranch: "already/durable",
-        ...offer,
-      })),
+      reclaim: (plan as { reclaim: Array<Record<string, unknown>> }).reclaim.map((offer) => addCompatibilityEvidence
+        ? { pushedBranch: "already/durable", ...offer }
+        : offer),
     }
     : plan;
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -117,6 +116,36 @@ test("a delayed reclaim salvages an unpublished retained workspace before deleti
   assert.equal(calls[1]!.path, "http://api.invalid/runner/workspaces/salvaged");
   assert.deepEqual(calls[1]!.body, { runnerId: "runner-1", runId: "run-1", pushedBranch: salvage });
   assert.deepEqual(calls[2]!.body.results, [{ runId: "run-1", outcome: "REMOVED" }]);
+});
+
+test("a pre-start workspace with no clone base is audited as nothing to salvage and removed", async () => {
+  const workspaceRoot = await root("pre-start");
+  const runPath = join(workspaceRoot, "clone-died");
+  await mkdir(runPath);
+  const calls = stubApi({
+    reclaim: [{
+      runId: "clone-died", workspacePath: null, taskId: "task-1", runNumber: 1,
+      baseSha: null, pushedBranch: null,
+    }],
+    verify: [], keep: [],
+  });
+  const sweep = await reclaimWorkspaces(config(workspaceRoot));
+  assert.deepEqual(sweep, { offered: 1, removed: 1, refused: 0, failed: 0, settled: 0 });
+  await assert.rejects(access(runPath));
+  assert.deepEqual(calls[1]!.body.results, [{ runId: "clone-died", outcome: "REMOVED" }]);
+});
+
+test("a legacy reclaim offer without pushedBranch refuses deletion", async () => {
+  const workspaceRoot = await root("legacy-offer");
+  const runPath = join(workspaceRoot, "legacy-run");
+  await mkdir(runPath);
+  const calls = stubApi({
+    reclaim: [{ runId: "legacy-run", workspacePath: runPath }], verify: [], keep: [],
+  }, 200, false);
+  const sweep = await reclaimWorkspaces(config(workspaceRoot));
+  assert.deepEqual(sweep, { offered: 1, removed: 0, refused: 1, failed: 0, settled: 0 });
+  await access(runPath);
+  assert.match(String(calls[1]!.body.results[0].failureReason), /omitted salvage publication evidence/u);
 });
 
 test("refuses an offer that escapes the configured root and deletes nothing", async () => {

--- a/packages/runner/src/reclaim.test.ts
+++ b/packages/runner/src/reclaim.test.ts
@@ -33,7 +33,12 @@ afterEach(() => { globalThis.fetch = originalFetch; });
 type Call = { path: string; body: Record<string, any> };
 
 /** Stands in for the control plane: answers the plan, records the report. */
-const stubApi = (plan: unknown, status = 200, addCompatibilityEvidence = true): Call[] => {
+const stubApi = (
+  plan: unknown,
+  status = 200,
+  addCompatibilityEvidence = true,
+  salvageStatus = 200,
+): Call[] => {
   const calls: Call[] = [];
   const compatiblePlan = plan && typeof plan === "object" && "reclaim" in plan
     ? {
@@ -49,6 +54,14 @@ const stubApi = (plan: unknown, status = 200, addCompatibilityEvidence = true): 
     if (path.endsWith("/runner/workspaces/reclaimable")) {
       return new Response(status === 200 ? JSON.stringify(compatiblePlan) : "no such route", {
         status, headers: { "content-type": status === 200 ? "application/json" : "text/plain" },
+      });
+    }
+    if (path.endsWith("/runner/workspaces/salvaged")) {
+      return new Response(JSON.stringify(salvageStatus === 200
+        ? { ok: true, replacementRepair: "none" }
+        : { error: "Salvage is durable, but the replacement already started from its prior base" }), {
+        status: salvageStatus,
+        headers: { "content-type": "application/json" },
       });
     }
     return new Response(JSON.stringify({ closed: 0, failed: 0 }), { status: 200, headers: { "content-type": "application/json" } });
@@ -116,6 +129,44 @@ test("a delayed reclaim salvages an unpublished retained workspace before deleti
   assert.equal(calls[1]!.path, "http://api.invalid/runner/workspaces/salvaged");
   assert.deepEqual(calls[1]!.body, { runnerId: "runner-1", runId: "run-1", pushedBranch: salvage });
   assert.deepEqual(calls[2]!.body.results, [{ runId: "run-1", outcome: "REMOVED" }]);
+});
+
+test("a delayed salvage ACK refusal retains the workspace after publishing its recovery ref", async () => {
+  const workspaceRoot = await root("salvage-started-replacement");
+  const remote = join(workspaceRoot, "origin.git");
+  const seed = join(workspaceRoot, "seed");
+  const runPath = join(workspaceRoot, "run-1");
+  git(workspaceRoot, "init", "--bare", "--initial-branch=master", remote);
+  git(workspaceRoot, "init", "--initial-branch=master", seed);
+  git(seed, "config", "user.name", "AgentOS Test");
+  git(seed, "config", "user.email", "runner@agentos.local");
+  await writeFile(join(seed, "base.txt"), "base\n");
+  git(seed, "add", "base.txt");
+  git(seed, "commit", "-m", "base");
+  git(seed, "remote", "add", "origin", remote);
+  git(seed, "push", "origin", "master");
+  git(workspaceRoot, "clone", "--branch", "master", remote, runPath);
+  const baseSha = git(runPath, "rev-parse", "HEAD");
+  await writeFile(join(runPath, "recovered.txt"), "keep\n");
+  const calls = stubApi({
+    reclaim: [{
+      runId: "run-1", workspacePath: runPath, taskId: "task-1", runNumber: 3,
+      baseSha, pushedBranch: null,
+    }],
+    verify: [], keep: [],
+  }, 200, true, 409);
+
+  const sweep = await reclaimWorkspaces(config(workspaceRoot), {
+    listDirectories: async () => ["run-1"],
+  });
+
+  assert.deepEqual(sweep, { offered: 1, removed: 0, refused: 0, failed: 1, settled: 0 });
+  await access(runPath);
+  const salvage = "agentos/task-1/run-3";
+  assert.match(git(workspaceRoot, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
+  assert.equal(calls[1]!.path, "http://api.invalid/runner/workspaces/salvaged");
+  assert.equal(calls[2]!.body.results[0].outcome, "FAILED");
+  assert.match(String(calls[2]!.body.results[0].failureReason), /replacement already started/u);
 });
 
 test("a pre-start workspace with no clone base is audited as nothing to salvage and removed", async () => {

--- a/packages/runner/src/reclaim.test.ts
+++ b/packages/runner/src/reclaim.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { access, chmod, mkdir, mkdtemp, rename, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -34,11 +35,20 @@ type Call = { path: string; body: Record<string, any> };
 /** Stands in for the control plane: answers the plan, records the report. */
 const stubApi = (plan: unknown, status = 200): Call[] => {
   const calls: Call[] = [];
+  const compatiblePlan = plan && typeof plan === "object" && "reclaim" in plan
+    ? {
+      ...plan,
+      reclaim: (plan as { reclaim: Array<Record<string, unknown>> }).reclaim.map((offer) => ({
+        pushedBranch: "already/durable",
+        ...offer,
+      })),
+    }
+    : plan;
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
     const path = String(input);
     calls.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
     if (path.endsWith("/runner/workspaces/reclaimable")) {
-      return new Response(status === 200 ? JSON.stringify(plan) : "no such route", {
+      return new Response(status === 200 ? JSON.stringify(compatiblePlan) : "no such route", {
         status, headers: { "content-type": status === 200 ? "application/json" : "text/plain" },
       });
     }
@@ -48,6 +58,7 @@ const stubApi = (plan: unknown, status = 200): Call[] => {
 };
 
 const root = async (label: string): Promise<string> => resolve(await mkdtemp(join(tmpdir(), `agentos-reclaim-${label}-`)));
+const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 
 test("removes exactly the directory the control plane offered and reports it", async () => {
   const workspaceRoot = await root("offer");
@@ -68,6 +79,44 @@ test("removes exactly the directory the control plane offered and reports it", a
   // a run id into a path, and it does so against its own configured root.
   assert.deepEqual([...calls[0]!.body.directories].sort(), ["bystander", "done-run"]);
   assert.deepEqual(calls[1]!.body.results, [{ runId: "done-run", outcome: "REMOVED" }]);
+});
+
+test("a delayed reclaim salvages an unpublished retained workspace before deleting it", async () => {
+  const workspaceRoot = await root("salvage");
+  const remote = join(workspaceRoot, "origin.git");
+  const seed = join(workspaceRoot, "seed");
+  const runPath = join(workspaceRoot, "run-1");
+  git(workspaceRoot, "init", "--bare", "--initial-branch=master", remote);
+  git(workspaceRoot, "init", "--initial-branch=master", seed);
+  git(seed, "config", "user.name", "AgentOS Test");
+  git(seed, "config", "user.email", "runner@agentos.local");
+  await writeFile(join(seed, "base.txt"), "base\n");
+  git(seed, "add", "base.txt");
+  git(seed, "commit", "-m", "base");
+  git(seed, "remote", "add", "origin", remote);
+  git(seed, "push", "origin", "master");
+  git(workspaceRoot, "clone", "--branch", "master", remote, runPath);
+  const baseSha = git(runPath, "rev-parse", "HEAD");
+  await writeFile(join(runPath, "recovered.txt"), "keep\n");
+  const calls = stubApi({
+    reclaim: [{
+      runId: "run-1", workspacePath: runPath, taskId: "task-1", runNumber: 3,
+      baseSha, pushedBranch: null,
+    }],
+    verify: [], keep: [],
+  });
+
+  const sweep = await reclaimWorkspaces(config(workspaceRoot), {
+    listDirectories: async () => ["run-1"],
+  });
+
+  assert.deepEqual(sweep, { offered: 1, removed: 1, refused: 0, failed: 0, settled: 0 });
+  await assert.rejects(access(runPath));
+  const salvage = "agentos/task-1/run-3";
+  assert.match(git(workspaceRoot, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
+  assert.equal(calls[1]!.path, "http://api.invalid/runner/workspaces/salvaged");
+  assert.deepEqual(calls[1]!.body, { runnerId: "runner-1", runId: "run-1", pushedBranch: salvage });
+  assert.deepEqual(calls[2]!.body.results, [{ runId: "run-1", outcome: "REMOVED" }]);
 });
 
 test("refuses an offer that escapes the configured root and deletes nothing", async () => {

--- a/packages/runner/src/reclaim.ts
+++ b/packages/runner/src/reclaim.ts
@@ -186,6 +186,10 @@ export const reclaimWorkspaces = async (
       results.push({ runId: offer.runId, outcome: "REMOVED" });
       continue;
     }
+    if (offer.pushedBranch === undefined) {
+      refuse(offer, "Reclaim offer omitted salvage publication evidence; refusing mixed-version deletion");
+      continue;
+    }
     try {
       let pushedBranch: string | undefined;
       // New control planes always include pushedBranch. Null means no durable
@@ -193,36 +197,46 @@ export const reclaimWorkspaces = async (
       // obligation as inline runner cleanup. An omitted field is accepted only
       // for compatibility with the pre-salvage reclaim protocol.
       if (offer.pushedBranch === null) {
-        if (!offer.taskId || offer.runNumber === undefined || !offer.baseSha) {
-          throw new Error("Salvage required before reclaim, but taskId, runNumber, or clone base is missing");
-        }
-        const workspace = {
-          path: authorized.path,
-          branch: "",
-          baseSha: offer.baseSha,
-        };
-        const gitResult = await captureWorkspaceResult(config, workspace);
-        const salvage = await salvageWorkspace(config, {
-          taskId: offer.taskId,
-          runId: offer.runId,
-          runNumber: offer.runNumber,
-        }, { ...workspace, branch: gitResult.branch });
-        if (salvage?.pushStatus === "FAILED") {
-          throw new Error(salvage.pushError ?? "WIP salvage failed before reclaim");
-        }
-        pushedBranch = salvage?.pushedBranch;
-        if (pushedBranch) {
-          await recordReclaimPublication(config, {
-            runnerId: config.runnerId,
-            runId: offer.runId,
-            pushedBranch,
-          });
-        }
-        if (!pushedBranch) {
+        // baseSha is written only after provisioning completes. Null therefore
+        // proves this run never had a cloned base against which local work could
+        // exist; audit that fact and reclaim the directory left by the failed
+        // clone. Identity fields are required only once a base exists.
+        if (offer.baseSha === null) {
           audit("nothing-to-salvage", {
             runId: offer.runId,
-            reason: "clean tree with no commits past the clone base",
+            reason: "run never completed provisioning and has no clone base",
           });
+        } else if (!offer.taskId || offer.runNumber === undefined || !offer.baseSha) {
+          throw new Error("Salvage required before reclaim, but taskId, runNumber, or clone base is missing");
+        } else {
+          const workspace = {
+            path: authorized.path,
+            branch: "",
+            baseSha: offer.baseSha,
+          };
+          const gitResult = await captureWorkspaceResult(config, workspace);
+          const salvage = await salvageWorkspace(config, {
+            taskId: offer.taskId,
+            runId: offer.runId,
+            runNumber: offer.runNumber,
+          }, { ...workspace, branch: gitResult.branch });
+          if (salvage?.pushStatus === "FAILED") {
+            throw new Error(salvage.pushError ?? "WIP salvage failed before reclaim");
+          }
+          pushedBranch = salvage?.pushedBranch;
+          if (pushedBranch) {
+            await recordReclaimPublication(config, {
+              runnerId: config.runnerId,
+              runId: offer.runId,
+              pushedBranch,
+            });
+          }
+          if (!pushedBranch) {
+            audit("nothing-to-salvage", {
+              runId: offer.runId,
+              reason: "clean tree with no commits past the clone base",
+            });
+          }
         }
       }
       await remove(config, authorized.path);

--- a/packages/runner/src/reclaim.ts
+++ b/packages/runner/src/reclaim.ts
@@ -1,9 +1,13 @@
 import { lstat, readdir, realpath } from "node:fs/promises";
 import { join, resolve, sep } from "node:path";
 
-import { fetchReclaimPlan, reportReclaimOutcomes, type ReclaimOffer, type ReclaimResult } from "./api.js";
+import {
+  fetchReclaimPlan, recordReclaimPublication, reportReclaimOutcomes,
+  type ReclaimOffer, type ReclaimResult,
+} from "./api.js";
 import type { RunnerConfig } from "./config.js";
-import { cleanupWorkspace } from "./workspace.js";
+import { salvageWorkspace } from "./delivery.js";
+import { captureWorkspaceResult, cleanupWorkspace } from "./workspace.js";
 
 /**
  * Workspace GC, from the side that owns the disk (issue #115).
@@ -183,6 +187,44 @@ export const reclaimWorkspaces = async (
       continue;
     }
     try {
+      let pushedBranch: string | undefined;
+      // New control planes always include pushedBranch. Null means no durable
+      // publication exists yet, so this delayed cleanup owns the same salvage
+      // obligation as inline runner cleanup. An omitted field is accepted only
+      // for compatibility with the pre-salvage reclaim protocol.
+      if (offer.pushedBranch === null) {
+        if (!offer.taskId || offer.runNumber === undefined || !offer.baseSha) {
+          throw new Error("Salvage required before reclaim, but taskId, runNumber, or clone base is missing");
+        }
+        const workspace = {
+          path: authorized.path,
+          branch: "",
+          baseSha: offer.baseSha,
+        };
+        const gitResult = await captureWorkspaceResult(config, workspace);
+        const salvage = await salvageWorkspace(config, {
+          taskId: offer.taskId,
+          runId: offer.runId,
+          runNumber: offer.runNumber,
+        }, { ...workspace, branch: gitResult.branch });
+        if (salvage?.pushStatus === "FAILED") {
+          throw new Error(salvage.pushError ?? "WIP salvage failed before reclaim");
+        }
+        pushedBranch = salvage?.pushedBranch;
+        if (pushedBranch) {
+          await recordReclaimPublication(config, {
+            runnerId: config.runnerId,
+            runId: offer.runId,
+            pushedBranch,
+          });
+        }
+        if (!pushedBranch) {
+          audit("nothing-to-salvage", {
+            runId: offer.runId,
+            reason: "clean tree with no commits past the clone base",
+          });
+        }
+      }
       await remove(config, authorized.path);
       sweep.removed += 1;
       results.push({ runId: offer.runId, outcome: "REMOVED" });

--- a/packages/runner/src/run-output.test.ts
+++ b/packages/runner/src/run-output.test.ts
@@ -124,6 +124,7 @@ const claim = (remoteUrl: string): ClaimedTask => ({
     maxRunsPerTask: 1,
     model: "claude",
     targetBranch: "master",
+    targetBranchPublished: false,
     pinnedBaseSha: null,
     implementationBaseSha: null,
     implementationHeadSha: null,

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, test } from "node:test";
@@ -183,6 +183,23 @@ const codexStub = (log: string, authFails = false, configReportPath?: string): s
   'echo \'{"type":"item.completed","item":{"type":"agent_message","text":"installed"}}\'',
   'echo \'{"type":"turn.completed"}\'',
   "exit 0",
+].join("\n");
+
+const failingCodexStub = (log: string, mutation = ":"): string => [
+  "#!/bin/sh",
+  `echo "$@" >> ${log}`,
+  'case "$1" in',
+  '  --version) echo "codex-cli 0.147.0"; exit 0 ;;',
+  '  exec)',
+  '    if [ "$2" = "--help" ]; then echo "resume --json --model --config --dangerously-bypass-approvals-and-sandbox"; exit 0; fi',
+  '    if [ "$2" = "resume" ] && [ "$3" = "--help" ]; then echo "SESSION_ID --json --model --config --dangerously-bypass-approvals-and-sandbox read from stdin"; exit 0; fi',
+  '    ;;',
+  '  login) echo "Logged in using ChatGPT"; exit 0 ;;',
+  "esac",
+  "cat > /dev/null",
+  mutation,
+  'echo \'{"type":"error","message":"agent execution failed"}\'',
+  "exit 1",
 ].join("\n");
 
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -658,6 +675,160 @@ test("session-config cleanup failure does not turn delivered work into a failed 
     assert.match(String(completion.body.cleanupFailureReason), /session CLI config retained at/u);
     assert.equal((await stat(configRoot)).isDirectory(), true);
     await rm(dirname(configRoot), { recursive: true, force: true });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a failed run salvages commits before cleanup and records the exact durable ref", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-salvage-"));
+  try {
+    const workspaces = join(root, "workspaces");
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    await writeFile(binary, failingCodexStub(log, 'printf "work\\n" > recovered.txt'));
+    await chmod(binary, 0o755);
+    const remote = await seedRemote(root);
+    const posts: Array<{ path: string; body: Record<string, any> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
+
+    await executeClaim(configured, {
+      ...mechanicalClaim,
+      executionMode: "agent",
+      runner: "CODEX",
+      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
+      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
+      run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
+    });
+
+    const salvage = "agentos/task-10/run-1";
+    const publication = posts.find((post) => post.path.endsWith("/publication"));
+    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    assert.equal(publication?.body.pushedBranch, salvage);
+    assert.equal(completion?.body.pushedBranch, salvage);
+    assert.equal(completion?.body.cleanupStatus, "SUCCEEDED");
+    assert.ok(posts.indexOf(publication!) < posts.indexOf(completion!), "publication must precede terminal completion");
+    assert.match(git(root, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
+    await assert.rejects(access(join(workspaces, "run-10")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a dead delivery lease still salvages before cleanup without terminal API authority", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-dead-lease-salvage-"));
+  try {
+    const workspaces = join(root, "workspaces");
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    await writeFile(binary, failingCodexStub(log, 'printf "work\\n" > recovered.txt'));
+    await chmod(binary, 0o755);
+    const remote = await seedRemote(root);
+    const posts: Array<{ path: string; body: Record<string, any> }> = [];
+    let started = false;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
+      if (path.endsWith("/start")) started = true;
+      if (started && path.endsWith("/heartbeat")) {
+        return new Response(JSON.stringify({ error: "Stale fencing token" }), { status: 409, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
+
+    await executeClaim(configured, {
+      ...mechanicalClaim,
+      executionMode: "agent",
+      runner: "CODEX",
+      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
+      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
+      run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
+    });
+
+    const salvage = "agentos/task-10/run-1";
+    assert.equal(posts.find((post) => post.path.endsWith("/publication"))?.body.pushedBranch, salvage);
+    assert.equal(posts.some((post) => post.path.endsWith("/complete")), false);
+    assert.match(git(root, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
+    await assert.rejects(access(join(workspaces, "run-10")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a clean failed run records that there is nothing to salvage before cleanup", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-clean-failure-"));
+  try {
+    const workspaces = join(root, "workspaces");
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    await writeFile(binary, failingCodexStub(log));
+    await chmod(binary, 0o755);
+    const remote = await seedRemote(root);
+    const posts: Array<{ path: string; body: Record<string, any> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
+
+    await executeClaim(configured, {
+      ...mechanicalClaim,
+      executionMode: "agent",
+      runner: "CODEX",
+      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
+      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
+      run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
+    });
+
+    assert.equal(posts.some((post) => post.path.endsWith("/publication")), false);
+    assert.ok(posts.some((post) => post.path.endsWith("/activity")
+      && String(post.body.body).includes("nothing to salvage")));
+    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    assert.equal(completion?.body.cleanupStatus, "SUCCEEDED");
+    assert.equal(completion?.body.workspaceRetained, false);
+    await assert.rejects(access(join(workspaces, "run-10")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a failed salvage keeps the workspace and reports cleanup failure", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-salvage-failure-"));
+  try {
+    const workspaces = join(root, "workspaces");
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    const missingRemote = join(root, "missing-origin.git");
+    await writeFile(binary, failingCodexStub(log,
+      `printf "work\\n" > recovered.txt; git remote set-url origin ${missingRemote}`));
+    await chmod(binary, 0o755);
+    const remote = await seedRemote(root);
+    const posts: Array<{ path: string; body: Record<string, any> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
+
+    await executeClaim(configured, {
+      ...mechanicalClaim,
+      executionMode: "agent",
+      runner: "CODEX",
+      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
+      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
+      run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
+    });
+
+    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    assert.equal(completion?.body.cleanupStatus, "FAILED");
+    assert.equal(completion?.body.workspaceRetained, true);
+    assert.match(String(completion?.body.cleanupFailureReason), /WIP salvage failed/u);
+    await access(join(workspaces, "run-10", "recovered.txt"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -62,6 +62,7 @@ const mechanicalClaim: ClaimedTask = {
     maxRunsPerTask: 3,
     model: "mechanical/merge-executor-v1",
     targetBranch: "master",
+    targetBranchPublished: false,
     pinnedBaseSha: null,
     implementationBaseSha: null,
     implementationHeadSha: null,
@@ -200,6 +201,25 @@ const failingCodexStub = (log: string, mutation = ":"): string => [
   mutation,
   'echo \'{"type":"error","message":"agent execution failed"}\'',
   "exit 1",
+].join("\n");
+
+const successfulCodexMutationStub = (log: string, mutation: string): string => [
+  "#!/bin/sh",
+  `echo "$@" >> ${log}`,
+  'case "$1" in',
+  '  --version) echo "codex-cli 0.147.0"; exit 0 ;;',
+  '  exec)',
+  '    if [ "$2" = "--help" ]; then echo "resume --json --model --config --dangerously-bypass-approvals-and-sandbox"; exit 0; fi',
+  '    if [ "$2" = "resume" ] && [ "$3" = "--help" ]; then echo "SESSION_ID --json --model --config --dangerously-bypass-approvals-and-sandbox read from stdin"; exit 0; fi',
+  '    ;;',
+  '  login) echo "Logged in using ChatGPT"; exit 0 ;;',
+  "esac",
+  "cat > /dev/null",
+  mutation,
+  'echo \'{"type":"thread.started","thread_id":"thread-mutation"}\'',
+  'echo \'{"type":"item.completed","item":{"type":"agent_message","text":"implemented"}}\'',
+  'echo \'{"type":"turn.completed"}\'',
+  "exit 0",
 ].join("\n");
 
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -680,7 +700,7 @@ test("session-config cleanup failure does not turn delivered work into a failed 
   }
 });
 
-test("a failed run salvages commits before cleanup and records the exact durable ref", async () => {
+test("default failed-workspace retention still salvages and records the exact durable ref", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-salvage-"));
   try {
     const workspaces = join(root, "workspaces");
@@ -694,7 +714,7 @@ test("a failed run salvages commits before cleanup and records the exact durable
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
     }) as typeof fetch;
-    const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
+    const configured = codexOnly(workspaces, root, binary);
 
     await executeClaim(configured, {
       ...mechanicalClaim,
@@ -710,10 +730,11 @@ test("a failed run salvages commits before cleanup and records the exact durable
     const completion = posts.find((post) => post.path.endsWith("/complete"));
     assert.equal(publication?.body.pushedBranch, salvage);
     assert.equal(completion?.body.pushedBranch, salvage);
-    assert.equal(completion?.body.cleanupStatus, "SUCCEEDED");
+    assert.equal(completion?.body.cleanupStatus, "RETAINED");
+    assert.equal(completion?.body.workspaceRetained, true);
     assert.ok(posts.indexOf(publication!) < posts.indexOf(completion!), "publication must precede terminal completion");
     assert.match(git(root, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
-    await assert.rejects(access(join(workspaces, "run-10")));
+    await access(join(workspaces, "run-10", "recovered.txt"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -828,6 +849,139 @@ test("a failed salvage keeps the workspace and reports cleanup failure", async (
     assert.equal(completion?.body.cleanupStatus, "FAILED");
     assert.equal(completion?.body.workspaceRetained, true);
     assert.match(String(completion?.body.cleanupFailureReason), /WIP salvage failed/u);
+    await access(join(workspaces, "run-10", "recovered.txt"));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("successful execution with failed delivery salvages before removing the workspace", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-delivery-failure-salvage-"));
+  try {
+    const workspaces = join(root, "workspaces");
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    await writeFile(binary, successfulCodexMutationStub(log, 'printf "delivered work\\n" > recovered.txt'));
+    await chmod(binary, 0o755);
+    const remote = await seedRemote(root);
+    const hook = join(remote, "hooks", "pre-receive");
+    await writeFile(hook, [
+      "#!/bin/sh",
+      "while read old new ref; do",
+      '  [ "$ref" = "refs/heads/declared/head" ] && exit 1',
+      "done",
+      "exit 0",
+    ].join("\n"));
+    await chmod(hook, 0o755);
+    const posts: Array<{ path: string; body: Record<string, any> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
+    await executeClaim(configured, {
+      ...mechanicalClaim,
+      executionMode: "agent",
+      runner: "CODEX",
+      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
+      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
+      run: {
+        ...mechanicalClaim.run,
+        model: "gpt-5.6-sol",
+        maxRunsPerTask: 3,
+        branch: "declared/head",
+      },
+    });
+    const salvage = "agentos/task-10/run-1";
+    const publication = posts.find((post) => post.path.endsWith("/publication"));
+    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    assert.equal(completion?.body.terminalSuccess, false);
+    assert.match(String(completion?.body.failureReason), /push|remote|receive/u);
+    assert.equal(completion?.body.pushedBranch, salvage);
+    assert.equal(completion?.body.cleanupStatus, "SUCCEEDED");
+    assert.ok(posts.indexOf(publication!) < posts.indexOf(completion!), "salvage publication must precede cleanup completion");
+    assert.match(git(root, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
+    await assert.rejects(access(join(workspaces, "run-10")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a successful pinned review never publishes its dirty detached checkout", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-pinned-no-salvage-"));
+  try {
+    const workspaces = join(root, "workspaces");
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    await writeFile(binary, successfulCodexMutationStub(log, 'printf "review scratch\\n" > review.txt'));
+    await chmod(binary, 0o755);
+    const remote = await seedRemote(root);
+    const pinned = git(root, `--git-dir=${remote}`, "rev-parse", "refs/heads/master");
+    const posts: Array<{ path: string; body: Record<string, any> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    await executeClaim({ ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 }, {
+      ...mechanicalClaim,
+      executionMode: "agent",
+      runner: "CODEX",
+      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
+      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
+      run: {
+        ...mechanicalClaim.run,
+        model: "gpt-5.6-sol",
+        targetBranch: pinned,
+        pinnedBaseSha: pinned,
+        implementationBaseSha: pinned,
+        implementationHeadSha: pinned,
+      },
+    });
+    assert.equal(posts.some((post) => post.path.endsWith("/publication")), false);
+    assert.equal(posts.find((post) => post.path.endsWith("/complete"))?.body.terminalSuccess, true);
+    assert.throws(() => git(root, `--git-dir=${remote}`, "show-ref", "refs/heads/agentos/task-10/run-1"));
+    await assert.rejects(access(join(workspaces, "run-10")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a dead-lease salvage failure is durably reported and retains the workspace", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-dead-lease-salvage-failure-"));
+  try {
+    const workspaces = join(root, "workspaces");
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    await writeFile(binary, failingCodexStub(log, 'printf "work\\n" > recovered.txt'));
+    await chmod(binary, 0o755);
+    const remote = await seedRemote(root);
+    const hook = join(remote, "hooks", "pre-receive");
+    await writeFile(hook, "#!/bin/sh\nexit 1\n");
+    await chmod(hook, 0o755);
+    const posts: Array<{ path: string; body: Record<string, any> }> = [];
+    let started = false;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
+      if (path.endsWith("/start")) started = true;
+      if (started && path.endsWith("/heartbeat")) {
+        return new Response(JSON.stringify({ error: "Stale fencing token" }), { status: 409, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    await executeClaim({ ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 }, {
+      ...mechanicalClaim,
+      executionMode: "agent",
+      runner: "CODEX",
+      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
+      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
+      run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
+    });
+    const cleanup = posts.find((post) => post.path.endsWith("/cleanup"));
+    assert.equal(cleanup?.body.cleanupStatus, "FAILED");
+    assert.equal(cleanup?.body.workspaceRetained, true);
+    assert.match(String(cleanup?.body.cleanupFailureReason), /WIP salvage failed/u);
+    assert.equal(posts.some((post) => post.path.endsWith("/complete")), false);
     await access(join(workspaces, "run-10", "recovered.txt"));
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { access, chmod, mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { afterEach, test } from "node:test";
 
 import { adapters } from "./adapters.js";
@@ -29,6 +29,11 @@ const config = (workspaceRoot: string): RunnerConfig => ({
   runAsPrefix: [],
   binaries: { CLAUDE: "claude", CODEX: "codex", PI: "pi" },
 });
+
+const testSession = (root: string): ClaimedTask["session"] => ({ id: `test-${basename(root)}` });
+const cleanupTestSession = async (root: string): Promise<void> => {
+  await rm(join(tmpdir(), "agentos-session-config", testSession(root).id), { recursive: true, force: true });
+};
 
 const mechanicalClaim: ClaimedTask = {
   executionMode: "mechanical",
@@ -709,6 +714,7 @@ test("default failed-workspace retention still salvages and records the exact du
     await writeFile(binary, failingCodexStub(log, 'printf "work\\n" > recovered.txt'));
     await chmod(binary, 0o755);
     const remote = await seedRemote(root);
+    await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
@@ -720,6 +726,7 @@ test("default failed-workspace retention still salvages and records the exact du
       ...mechanicalClaim,
       executionMode: "agent",
       runner: "CODEX",
+      session: testSession(root),
       repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
       agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
       run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
@@ -736,6 +743,7 @@ test("default failed-workspace retention still salvages and records the exact du
     assert.match(git(root, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
     await access(join(workspaces, "run-10", "recovered.txt"));
   } finally {
+    await cleanupTestSession(root);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -749,6 +757,7 @@ test("a dead delivery lease still salvages before cleanup without terminal API a
     await writeFile(binary, failingCodexStub(log, 'printf "work\\n" > recovered.txt'));
     await chmod(binary, 0o755);
     const remote = await seedRemote(root);
+    await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     let started = false;
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -766,6 +775,7 @@ test("a dead delivery lease still salvages before cleanup without terminal API a
       ...mechanicalClaim,
       executionMode: "agent",
       runner: "CODEX",
+      session: testSession(root),
       repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
       agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
       run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
@@ -777,6 +787,7 @@ test("a dead delivery lease still salvages before cleanup without terminal API a
     assert.match(git(root, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
     await assert.rejects(access(join(workspaces, "run-10")));
   } finally {
+    await cleanupTestSession(root);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -790,6 +801,7 @@ test("a clean failed run records that there is nothing to salvage before cleanup
     await writeFile(binary, failingCodexStub(log));
     await chmod(binary, 0o755);
     const remote = await seedRemote(root);
+    await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
@@ -801,6 +813,7 @@ test("a clean failed run records that there is nothing to salvage before cleanup
       ...mechanicalClaim,
       executionMode: "agent",
       runner: "CODEX",
+      session: testSession(root),
       repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
       agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
       run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
@@ -814,6 +827,7 @@ test("a clean failed run records that there is nothing to salvage before cleanup
     assert.equal(completion?.body.workspaceRetained, false);
     await assert.rejects(access(join(workspaces, "run-10")));
   } finally {
+    await cleanupTestSession(root);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -829,6 +843,7 @@ test("a failed salvage keeps the workspace and reports cleanup failure", async (
       `printf "work\\n" > recovered.txt; git remote set-url origin ${missingRemote}`));
     await chmod(binary, 0o755);
     const remote = await seedRemote(root);
+    await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
@@ -840,6 +855,7 @@ test("a failed salvage keeps the workspace and reports cleanup failure", async (
       ...mechanicalClaim,
       executionMode: "agent",
       runner: "CODEX",
+      session: testSession(root),
       repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
       agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
       run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
@@ -851,6 +867,7 @@ test("a failed salvage keeps the workspace and reports cleanup failure", async (
     assert.match(String(completion?.body.cleanupFailureReason), /WIP salvage failed/u);
     await access(join(workspaces, "run-10", "recovered.txt"));
   } finally {
+    await cleanupTestSession(root);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -864,6 +881,7 @@ test("successful execution with failed delivery salvages before removing the wor
     await writeFile(binary, successfulCodexMutationStub(log, 'printf "delivered work\\n" > recovered.txt'));
     await chmod(binary, 0o755);
     const remote = await seedRemote(root);
+    await seedCodexAuth(root);
     const hook = join(remote, "hooks", "pre-receive");
     await writeFile(hook, [
       "#!/bin/sh",
@@ -883,6 +901,7 @@ test("successful execution with failed delivery salvages before removing the wor
       ...mechanicalClaim,
       executionMode: "agent",
       runner: "CODEX",
+      session: testSession(root),
       repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
       agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
       run: {
@@ -903,6 +922,7 @@ test("successful execution with failed delivery salvages before removing the wor
     assert.match(git(root, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
     await assert.rejects(access(join(workspaces, "run-10")));
   } finally {
+    await cleanupTestSession(root);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -916,6 +936,7 @@ test("a successful pinned review never publishes its dirty detached checkout", a
     await writeFile(binary, successfulCodexMutationStub(log, 'printf "review scratch\\n" > review.txt'));
     await chmod(binary, 0o755);
     const remote = await seedRemote(root);
+    await seedCodexAuth(root);
     const pinned = git(root, `--git-dir=${remote}`, "rev-parse", "refs/heads/master");
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -926,6 +947,7 @@ test("a successful pinned review never publishes its dirty detached checkout", a
       ...mechanicalClaim,
       executionMode: "agent",
       runner: "CODEX",
+      session: testSession(root),
       repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
       agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
       run: {
@@ -942,6 +964,7 @@ test("a successful pinned review never publishes its dirty detached checkout", a
     assert.throws(() => git(root, `--git-dir=${remote}`, "show-ref", "refs/heads/agentos/task-10/run-1"));
     await assert.rejects(access(join(workspaces, "run-10")));
   } finally {
+    await cleanupTestSession(root);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -955,6 +978,7 @@ test("a failed pinned review reports failure without publishing its dirty detach
     await writeFile(binary, failingCodexStub(log, 'printf "review scratch\\n" > review.txt'));
     await chmod(binary, 0o755);
     const remote = await seedRemote(root);
+    await seedCodexAuth(root);
     const pinned = git(root, `--git-dir=${remote}`, "rev-parse", "refs/heads/master");
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -966,6 +990,7 @@ test("a failed pinned review reports failure without publishing its dirty detach
       ...mechanicalClaim,
       executionMode: "agent",
       runner: "CODEX",
+      session: testSession(root),
       repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
       agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
       run: {
@@ -986,6 +1011,7 @@ test("a failed pinned review reports failure without publishing its dirty detach
     assert.throws(() => git(root, `--git-dir=${remote}`, "show-ref", "refs/heads/agentos/task-10/run-1"));
     await assert.rejects(access(join(workspaces, "run-10")));
   } finally {
+    await cleanupTestSession(root);
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -999,6 +1025,7 @@ test("a dead-lease salvage failure is durably reported and retains the workspace
     await writeFile(binary, failingCodexStub(log, 'printf "work\\n" > recovered.txt'));
     await chmod(binary, 0o755);
     const remote = await seedRemote(root);
+    await seedCodexAuth(root);
     const hook = join(remote, "hooks", "pre-receive");
     await writeFile(hook, "#!/bin/sh\nexit 1\n");
     await chmod(hook, 0o755);
@@ -1017,6 +1044,7 @@ test("a dead-lease salvage failure is durably reported and retains the workspace
       ...mechanicalClaim,
       executionMode: "agent",
       runner: "CODEX",
+      session: testSession(root),
       repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
       agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
       run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
@@ -1028,6 +1056,7 @@ test("a dead-lease salvage failure is durably reported and retains the workspace
     assert.equal(posts.some((post) => post.path.endsWith("/complete")), false);
     await access(join(workspaces, "run-10", "recovered.txt"));
   } finally {
+    await cleanupTestSession(root);
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -946,6 +946,50 @@ test("a successful pinned review never publishes its dirty detached checkout", a
   }
 });
 
+test("a failed pinned review reports failure without publishing its dirty detached checkout", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-failed-pinned-no-salvage-"));
+  try {
+    const workspaces = join(root, "workspaces");
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    await writeFile(binary, failingCodexStub(log, 'printf "review scratch\\n" > review.txt'));
+    await chmod(binary, 0o755);
+    const remote = await seedRemote(root);
+    const pinned = git(root, `--git-dir=${remote}`, "rev-parse", "refs/heads/master");
+    const posts: Array<{ path: string; body: Record<string, any> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    await executeClaim({ ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 }, {
+      ...mechanicalClaim,
+      executionMode: "agent",
+      runner: "CODEX",
+      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
+      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
+      run: {
+        ...mechanicalClaim.run,
+        model: "gpt-5.6-sol",
+        targetBranch: pinned,
+        pinnedBaseSha: pinned,
+        implementationBaseSha: pinned,
+        implementationHeadSha: pinned,
+      },
+    });
+
+    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    assert.equal(completion?.body.terminalSuccess, false);
+    assert.match(String(completion?.body.failureReason), /agent execution failed/u);
+    assert.equal(completion?.body.pushedBranch, undefined);
+    assert.equal(posts.some((post) => post.path.endsWith("/publication")), false);
+    assert.throws(() => git(root, `--git-dir=${remote}`, "show-ref", "refs/heads/agentos/task-10/run-1"));
+    await assert.rejects(access(join(workspaces, "run-10")));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("a dead-lease salvage failure is durably reported and retains the workspace", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-dead-lease-salvage-failure-"));
   try {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -79,6 +79,10 @@ const cleanup = async (
 }> => {
   if (!workspace) return { cleanupStatus: "SUCCEEDED", workspaceRetained: false, salvage: null };
   let salvage: Awaited<ReturnType<typeof deliverFailedWorkspace>> = null;
+  // A pinned review/verification checkout is disposable by contract. It may
+  // be intentionally stale and dirty, but it never owns a publishable branch:
+  // neither success nor failure may turn its scratch state into chain
+  // publication evidence.
   if (!alreadyDurable && !workspace.pinnedBaseSha) {
     let gitResult = { branch: workspace.branch, baseSha: workspace.baseSha, headSha: workspace.baseSha };
     try {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -66,16 +66,78 @@ const appendRetainedSessionConfig = (reason: string, path: string | null): strin
 
 const cleanup = async (
   config: RunnerConfig,
+  claim: ClaimedTask,
   workspace: Workspace | null,
   retain: boolean,
-): Promise<{ cleanupStatus: CleanupStatus; cleanupFailureReason?: string; workspaceRetained: boolean }> => {
-  if (!workspace) return { cleanupStatus: "SUCCEEDED", workspaceRetained: false };
-  if (retain) return { cleanupStatus: "RETAINED", workspaceRetained: true };
+  alreadyDurable = false,
+): Promise<{
+  cleanupStatus: CleanupStatus;
+  cleanupFailureReason?: string;
+  workspaceRetained: boolean;
+  salvage: Awaited<ReturnType<typeof deliverFailedWorkspace>>;
+}> => {
+  if (!workspace) return { cleanupStatus: "SUCCEEDED", workspaceRetained: false, salvage: null };
+  let salvage: Awaited<ReturnType<typeof deliverFailedWorkspace>> = null;
+  if (!alreadyDurable && !workspace.pinnedBaseSha) {
+    let gitResult = { branch: workspace.branch, baseSha: workspace.baseSha, headSha: workspace.baseSha };
+    try {
+      gitResult = await captureWorkspaceResult(config, workspace);
+    } catch (error: unknown) {
+      return {
+        cleanupStatus: "FAILED",
+        cleanupFailureReason: `Salvage preflight failed: ${errorMessage(error)}`,
+        workspaceRetained: true,
+        salvage: null,
+      };
+    }
+    salvage = await deliverFailedWorkspace(config, claim, { ...workspace, branch: gitResult.branch });
+    if (salvage?.pushStatus === "FAILED") {
+      return {
+        cleanupStatus: "FAILED",
+        cleanupFailureReason: salvage.pushError ?? "WIP salvage failed",
+        workspaceRetained: true,
+        salvage,
+      };
+    }
+    if (salvage?.pushedBranch) {
+      try {
+        await recordPublishedBranch(config, claim, salvage.pushedBranch);
+      } catch (error: unknown) {
+        await appendActivity(config, claim,
+          `Salvage ref '${salvage.pushedBranch}' is durable, but its publication ACK failed: ${errorMessage(error)}`,
+          { stream: "runner" }).catch(() => undefined);
+        return {
+          cleanupStatus: "FAILED",
+          cleanupFailureReason: `Salvage publication ACK failed: ${errorMessage(error)}`,
+          workspaceRetained: true,
+          salvage,
+        };
+      }
+    } else {
+      console.warn(JSON.stringify({
+        audit: "workspace-cleanup",
+        event: "nothing-to-salvage",
+        runId: claim.run.id,
+        reason: "clean tree with no commits past the clone base",
+      }));
+      await appendActivity(config, claim,
+        "Workspace cleanup verified there was nothing to salvage: clean tree with no commits past the clone base",
+        { stream: "runner" }).catch((error: unknown) => {
+        console.error(JSON.stringify({
+          audit: "workspace-cleanup",
+          event: "nothing-to-salvage-activity-failed",
+          runId: claim.run.id,
+          error: errorMessage(error),
+        }));
+      });
+    }
+  }
+  if (retain) return { cleanupStatus: "RETAINED", workspaceRetained: true, salvage };
   try {
     await cleanupWorkspace(config, workspace.path);
-    return { cleanupStatus: "SUCCEEDED", workspaceRetained: false };
+    return { cleanupStatus: "SUCCEEDED", workspaceRetained: false, salvage };
   } catch (error: unknown) {
-    return { cleanupStatus: "FAILED", cleanupFailureReason: errorMessage(error), workspaceRetained: false };
+    return { cleanupStatus: "FAILED", cleanupFailureReason: errorMessage(error), workspaceRetained: true, salvage };
   }
 };
 
@@ -180,7 +242,7 @@ export const executeClaim = async (
       return;
     }
     if (claim.run.runNumber > claim.run.maxRunsPerTask) {
-      const finishedCleanup = await cleanup(config, workspace, false);
+      const { salvage: _salvage, ...finishedCleanup } = await cleanup(config, claim, workspace, false);
       await completeRun(config, claim, {
         exitCode: null,
         terminalEventSeen: false,
@@ -229,14 +291,14 @@ export const executeClaim = async (
     const preflight = await adapter.preflight({ config, runner: claim.runner, model: claim.run.model, env });
     if (fencingRejected) {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
-      await cleanup(config, workspace, false);
+      await cleanup(config, claim, workspace, false);
       return;
     }
     if (!preflight.ok) {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
       const evidence = preflightEvidence(preflight.error ?? "Preflight failed");
       const classified = adapter.classifyError(evidence);
-      const finishedCleanup = await cleanup(config, workspace, config.failedWorkspaceRetention > 0);
+      const { salvage: _salvage, ...finishedCleanup } = await cleanup(config, claim, workspace, config.failedWorkspaceRetention > 0);
       const retainedPath = await retainedSessionConfigPath(claim.runner, scratch);
       await completeRun(config, claim, {
         ...evidence,
@@ -339,7 +401,7 @@ export const executeClaim = async (
     adoptLeaseVerdict(lease);
     if (fencingRejected) {
       if (waitingInbox) return;
-      await cleanup(config, workspace, false);
+      await cleanup(config, claim, workspace, false);
       return;
     }
     const executionSucceeded = adapterExecutionSucceeded(evidence);
@@ -371,22 +433,24 @@ export const executeClaim = async (
           retryOptions,
         ));
     }
-    else {
-      // The workspace is about to be destroyed; commit and salvage its trackable changes.
-      const salvage = await deliverUnderLease(lease, (retryOptions) =>
-        deliverFailedWorkspace(config, claim, delivered, undefined, retryOptions))
-        .catch((error: unknown) => {
-          void appendActivity(config, claim, `WIP salvage failed: ${errorMessage(error)}`, { stream: "runner" }).catch(() => undefined);
-          return null;
-        });
-      if (salvage) {
-        delivery = salvage;
-        if (salvage.headSha) gitResult = { ...gitResult, headSha: salvage.headSha };
-        await appendActivity(config, claim, salvage.deliveryInstructions ?? salvage.pushError ?? "WIP salvage attempted", { stream: "runner" })
-          .catch(() => undefined);
-      }
+    const primaryDelivery = delivery;
+    const succeeded = executionSucceeded && primaryDelivery?.pushStatus !== "FAILED";
+    const cleaned = await cleanup(
+      config,
+      claim,
+      workspace,
+      !succeeded && config.failedWorkspaceRetention > 0,
+      // Pinned review/verification checkouts are disposable at every outcome;
+      // their stale scratch state must never become chain publication evidence.
+      succeeded || Boolean(workspace.pinnedBaseSha),
+    );
+    if (!succeeded && cleaned.salvage) {
+      delivery = cleaned.salvage;
+      if (cleaned.salvage.headSha) gitResult = { ...gitResult, headSha: cleaned.salvage.headSha };
+      await appendActivity(config, claim,
+        cleaned.salvage.deliveryInstructions ?? cleaned.salvage.pushError ?? "WIP salvage attempted",
+        { stream: "runner" }).catch(() => undefined);
     }
-    let succeeded = executionSucceeded && delivery?.pushStatus !== "FAILED";
     retainSessionConfig = !succeeded;
     let scratchCleanupFailure: string | null = null;
     if (scratch) {
@@ -405,15 +469,15 @@ export const executeClaim = async (
         }
       }
     }
-    const classified = succeeded ? null : delivery?.failureClass
-      ? { failureClass: delivery.failureClass, retryable: false }
+    const { salvage: _salvage, ...finishedCleanup } = cleaned;
+    const classified = succeeded ? null : primaryDelivery?.failureClass
+      ? { failureClass: primaryDelivery.failureClass, retryable: false }
       : adapter.classifyError(evidence);
-    // Destructured off rather than spread: `failure` holds a live error object
-    // for the envelope builder, and everything else in a DeliveryResult goes on
-    // the wire. TypeScript does not flag excess properties introduced by a
-    // spread, so nothing but this line keeps it out of the completion payload.
-    const { failure: deliveryFailure, ...deliveryPayload } = delivery ?? { pushStatus: "NOT_REQUESTED" as const };
-    const finishedCleanup = await cleanup(config, workspace, !succeeded && config.failedWorkspaceRetention > 0);
+    // The normal delivery failure remains the failure-envelope evidence even
+    // when terminal salvage subsequently succeeds. The wire publication is the
+    // salvage result, because it names the ref that actually became durable.
+    const { failure: deliveryFailure } = primaryDelivery ?? {};
+    const { failure: _deliveryError, ...deliveryPayload } = delivery ?? { pushStatus: "NOT_REQUESTED" as const };
     const retainedPath = await retainedSessionConfigPath(claim.runner, scratch);
     const cleanupFailureReason = [
       finishedCleanup.cleanupFailureReason,
@@ -439,7 +503,7 @@ export const executeClaim = async (
       // A salvage push failure must not mask why the run itself failed.
       ...(!succeeded ? {
         failureReason: appendRetainedSessionConfig(
-          budgetReason ?? (executionSucceeded ? delivery?.pushError : null) ?? failureReasonFromEvidence(evidence),
+          budgetReason ?? (executionSucceeded ? primaryDelivery?.pushError : null) ?? failureReasonFromEvidence(evidence),
           retainedPath,
         ),
       } : {}),
@@ -474,12 +538,13 @@ export const executeClaim = async (
     if (handle) await adapter.kill(handle, RUNNER_EXCEPTION_REASON).catch(() => undefined);
     if (fencingRejected) {
       if (waitingInbox) return;
-      if (workspace) await cleanup(config, workspace, false);
+      if (workspace) await cleanup(config, claim, workspace, false);
       return;
     }
     const evidence = preflightEvidence(message);
     const classified = adapter.classifyError(evidence);
-    const finishedCleanup = await cleanup(config, workspace, config.failedWorkspaceRetention > 0);
+    const cleaned = await cleanup(config, claim, workspace, config.failedWorkspaceRetention > 0);
+    const { salvage, ...finishedCleanup } = cleaned;
     let restorationFailure: string | null = null;
     if (claim.runner === "CODEX" && scratch && sessionConfigRemoved) {
       try {
@@ -524,6 +589,7 @@ export const executeClaim = async (
       // it — it is reconstructed from the error, not from the process.
       output: producedOutput,
       ...(workspace ? { branch: workspace.branch, baseSha: workspace.baseSha, headSha: workspace.baseSha } : {}),
+      ...(salvage ?? {}),
       ...finishedCleanup,
       ...(scratchCleanupFailure ? {
         cleanupStatus: "FAILED" as const,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -20,6 +20,7 @@ import {
   completeRun,
   heartbeat as sendHeartbeat,
   recordPublishedBranch,
+  recordLeaseIndependentCleanup,
   reportCliAvailability,
   reportPreflight,
   startRun,
@@ -291,7 +292,11 @@ export const executeClaim = async (
     const preflight = await adapter.preflight({ config, runner: claim.runner, model: claim.run.model, env });
     if (fencingRejected) {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
-      await cleanup(config, claim, workspace, false);
+      const cleaned = await cleanup(config, claim, workspace, false);
+      const { salvage: _salvage, ...cleanupOutcome } = cleaned;
+      await recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((error: unknown) => {
+        console.error(`Unable to record lease-independent cleanup outcome: ${errorMessage(error)}`);
+      });
       return;
     }
     if (!preflight.ok) {
@@ -401,7 +406,11 @@ export const executeClaim = async (
     adoptLeaseVerdict(lease);
     if (fencingRejected) {
       if (waitingInbox) return;
-      await cleanup(config, claim, workspace, false);
+      const cleaned = await cleanup(config, claim, workspace, false);
+      const { salvage: _salvage, ...cleanupOutcome } = cleaned;
+      await recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((error: unknown) => {
+        console.error(`Unable to record lease-independent cleanup outcome: ${errorMessage(error)}`);
+      });
       return;
     }
     const executionSucceeded = adapterExecutionSucceeded(evidence);
@@ -538,7 +547,13 @@ export const executeClaim = async (
     if (handle) await adapter.kill(handle, RUNNER_EXCEPTION_REASON).catch(() => undefined);
     if (fencingRejected) {
       if (waitingInbox) return;
-      if (workspace) await cleanup(config, claim, workspace, false);
+      if (workspace) {
+        const cleaned = await cleanup(config, claim, workspace, false);
+        const { salvage: _salvage, ...cleanupOutcome } = cleaned;
+        await recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((reportError: unknown) => {
+          console.error(`Unable to record lease-independent cleanup outcome: ${errorMessage(reportError)}`);
+        });
+      }
       return;
     }
     const evidence = preflightEvidence(message);

--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -64,6 +64,51 @@ test("provisioning trusts an already-published intended head after its database 
   }
 });
 
+test("a resolver-confirmed newer salvage base outranks an existing declared head", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agentos-workspace-salvage-base-"));
+  try {
+    const remote = join(root, "origin.git");
+    const seed = join(root, "seed");
+    git(root, "init", "--bare", "--initial-branch=main", remote);
+    git(root, "init", "--initial-branch=main", seed);
+    git(seed, "config", "user.name", "AgentOS Test");
+    git(seed, "config", "user.email", "runner@agentos.local");
+    await writeFile(join(seed, "tree.txt"), "base\n");
+    git(seed, "add", "tree.txt");
+    git(seed, "commit", "-m", "base");
+    git(seed, "remote", "add", "origin", remote);
+    git(seed, "push", "-u", "origin", "main");
+    const declared = "agentos/chain/shared";
+    git(seed, "switch", "-c", declared);
+    await writeFile(join(seed, "tree.txt"), "older declared\n");
+    git(seed, "commit", "-am", "declared");
+    git(seed, "push", "origin", declared);
+    const salvage = "agentos/task-1/run-2";
+    await writeFile(join(seed, "tree.txt"), "newer salvage\n");
+    git(seed, "commit", "-am", "salvage");
+    git(seed, "push", "origin", `HEAD:${salvage}`);
+    const salvageSha = git(seed, "rev-parse", "HEAD");
+    const config = {
+      workspaceRoot: join(root, "workspaces"), runAsPrefix: [],
+      path: process.env.PATH ?? "/usr/bin:/bin", home: process.env.HOME ?? root,
+    } as unknown as RunnerConfig;
+    const claim = {
+      task: { id: "task-1" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
+      run: {
+        id: "run-3", runNumber: 3, targetBranch: salvage,
+        targetBranchPublished: true, branch: declared,
+      },
+    } as ClaimedTask;
+    const workspace = await provisionWorkspace(config, claim);
+    assert.equal(workspace.branch, declared);
+    assert.equal(workspace.baseSha, salvageSha);
+    assert.equal(await readFile(join(workspace.path, "tree.txt"), "utf8"), "newer salvage\n");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("a pinned workspace fetches only the recorded commit and never creates the chain ref", async () => {
   const root = await mkdtemp(join(tmpdir(), "agentos-workspace-pinned-"));
   try {

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -365,7 +365,7 @@ export const provisionWorkspace = async (
     // truth instead of the stale fallback base. Derived chain heads are unique
     // per project+chain, so this cannot accidentally adopt another chain.
     let cloneTarget = target;
-    if (branch !== target) {
+    if (branch !== target && !claim.run.targetBranchPublished) {
       try {
         await runWithNetworkRetry("git", ["ls-remote"],
           ({ timeoutMs }) => execute(config, "git", ["ls-remote", "--exit-code", "--heads", claim.repo.remoteUrl, `refs/heads/${branch}`], root, env, { timeoutMs }),


### PR DESCRIPTION
Automated delivery for AgentOS task cmt2pj2nw07jwmpjfirg41x0o.

Resume gap: bounded reuse of the existing resumable-session path was not implemented. That path is currently limited to WAITING_INBOX, while reconciliation revokes a LOST run session before creating a replacement; safely reusing it would require a new lost-run lease/session transition contract outside this change. Fresh reruns instead start from the durable terminal salvage base.