### PR TITLE
Fix board card and task detail ordering

### DIFF
--- a/apps/web/src/pages/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail.tsx
@@ -377,16 +377,6 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
               : <EmptyState>{t("common.loading")}</EmptyState>}
         </Card>
 
-        {task.chainId === null ? null
-          : chain.data && chain.data.chainId !== null
-            ? <ChainList chain={chain.data} taskId={taskId} pending={pending} onStart={startStep} />
-            : chain.loading ? <Card title={t("chain.title")}><EmptyState>{t("chain.loading")}</EmptyState></Card>
-              : <Card title={t("chain.title")}><ErrorNotice message={chain.error?.message ?? t("chain.error")} onRetry={chain.reload} /></Card>}
-
-        <TaskPrompt description={task.description} />
-
-        <TaskOutput poll={output} />
-
         <Card title={t("taskDetail.runs.title")} extra={<span className={COUNT}>{runs.length}</span>} flush>
           <Table>
             <TableHeader>
@@ -405,6 +395,16 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
           </Table>
           {runs.length === 0 ? <EmptyState>{t("taskDetail.runs.empty")}</EmptyState> : null}
         </Card>
+
+        {task.chainId === null ? null
+          : chain.data && chain.data.chainId !== null
+            ? <ChainList chain={chain.data} taskId={taskId} pending={pending} onStart={startStep} />
+            : chain.loading ? <Card title={t("chain.title")}><EmptyState>{t("chain.loading")}</EmptyState></Card>
+              : <Card title={t("chain.title")}><ErrorNotice message={chain.error?.message ?? t("chain.error")} onRetry={chain.reload} /></Card>}
+
+        <TaskPrompt description={task.description} />
+
+        <TaskOutput poll={output} />
 
         <Activity taskId={taskId} />
       </div>

--- a/apps/web/src/tests/task-detail.test.tsx
+++ b/apps/web/src/tests/task-detail.test.tsx
@@ -19,6 +19,10 @@ test("every task-detail run row uses the projected cost with estimate and token 
   assert.doesNotMatch(source, /money\(run\.session\?\.costUsd/u);
 });
 
+test("the Runs section is rendered before the Chain section", () => {
+  assert.ok(source.indexOf('t("taskDetail.runs.title")') < source.indexOf("<ChainList chain={chain.data}"));
+});
+
 const output = (body: string): TaskStepOutput => ({
   id: "o1", taskId: "t1", runId: "r1", kind: "review", body,
   createdAt: "2026-08-16T00:00:00.000Z", updatedAt: "2026-08-16T00:00:00.000Z",

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -1438,20 +1438,18 @@ test("partitionArchivable keeps the busy tasks out of the archive set and counts
  *  page, the chain-progress page, and the recurring groupBy the full shape adds. */
 const boardDatabase = (rows: Array<Record<string, unknown>>): PrismaClient => {
   let call = 0;
-  const taskRows = rows.map(({ runActivity: _runActivity, ...row }) => row);
-  const activities = rows.flatMap((row, rowIndex) => (row.runActivity as Array<{ at: Date }> | undefined ?? []).map((event, eventIndex) => ({
-    runId: `activity-${rowIndex}-${eventIndex}`, taskId: String(row.id), at: event.at,
-  })));
+  const taskRows = [...rows].sort((left, right) => (
+    (right.createdAt as Date).getTime() - (left.createdAt as Date).getTime()
+      || String(left.id).localeCompare(String(right.id))
+  ));
   return {
     task: {
-      findMany: async () => (call++ === 0 ? taskRows : []),
+      findMany: async (args: Record<string, unknown> | undefined) => {
+        if (call++ !== 0) return [];
+        assert.deepEqual(args?.orderBy, [{ createdAt: "desc" }, { id: "asc" }]);
+        return taskRows;
+      },
       groupBy: async () => [],
-    },
-    run: {
-      findMany: async () => activities.map(({ runId: id, taskId }) => ({ id, taskId })),
-    },
-    sessionEvent: {
-      groupBy: async () => activities.map(({ runId, at }) => ({ runId, _max: { at } })),
     },
   } as unknown as PrismaClient;
 };
@@ -1460,6 +1458,7 @@ const taskRow = (overrides: Record<string, unknown> = {}): Record<string, unknow
   id: "t1", projectId: "p1", name: "Ship the thing", status: "TODO", failureReason: null,
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null, approvalGate: false,
   templateId: null, source: "MANUAL", chainId: null, chainIndex: null,
+  createdAt: new Date("2026-08-16T00:00:00.000Z"),
   updatedAt: new Date("2026-08-16T00:00:00.000Z"), templateStep: null,
   assigneeAgent: { id: "a1", title: "Senior Developer", model: "gpt-5.6-sol:medium" },
   runs: [{
@@ -1509,40 +1508,31 @@ test("the board derives a shared title and badge for API-created chains", async 
   });
 });
 
-test("GET /tasks?enrich=false skips all latest-activity queries", async () => {
+test("GET /tasks?enrich=false keeps creation ordering without enrichment queries", async () => {
   await withTokens(async () => {
-    const database = boardDatabase([taskRow()]);
-    let runQueried = false;
-    let eventQueried = false;
-    const stub = database as unknown as {
-      run: { findMany: () => Promise<never[]> };
-      sessionEvent: { groupBy: () => Promise<never[]> };
-    };
-    stub.run.findMany = async () => { runQueried = true; return []; };
-    stub.sessionEvent.groupBy = async () => { eventQueried = true; return []; };
-    const response = await getTasks(database, "?enrich=false");
+    const response = await getTasks(boardDatabase([
+      taskRow({ id: "older", createdAt: new Date("2026-08-15T00:00:00Z") }),
+      taskRow({ id: "newer", createdAt: new Date("2026-08-16T00:00:00Z") }),
+    ]), "?enrich=false");
     assert.equal(response.status, 200);
-    assert.equal(runQueried, false);
-    assert.equal(eventQueried, false);
+    const body = await response.json() as Array<{ id: string }>;
+    assert.deepEqual(body.map(({ id }) => id), ["newer", "older"]);
   });
 });
 
-test("board and full task views order every status by newest run activity", async () => {
+test("board and full task views order by createdAt descending with a stable id tie-break", async () => {
   await withTokens(async () => {
-    const event = (value: string) => ({ at: new Date(value) });
     const rows = [
-      taskRow({ id: "newer-created", status: "DONE", updatedAt: new Date("2026-08-16T12:00:00Z"), runActivity: [event("2026-08-16T13:00:00Z")] }),
-      taskRow({ id: "later-finished", status: "DONE", updatedAt: new Date("2026-08-16T08:00:00Z"), runActivity: [event("2026-08-16T14:00:00Z")] }),
-      taskRow({ id: "todo-old", status: "TODO", updatedAt: new Date("2026-08-16T09:00:00Z"), runs: [] }),
-      taskRow({ id: "todo-new", status: "TODO", updatedAt: new Date("2026-08-16T10:00:00Z"), runs: [] }),
+      taskRow({ id: "older-recently-updated", createdAt: new Date("2026-08-15T00:00:00Z"), updatedAt: new Date("2026-08-20T00:00:00Z") }),
+      taskRow({ id: "b-tie", createdAt: new Date("2026-08-16T00:00:00Z"), updatedAt: new Date("2026-08-18T00:00:00Z") }),
+      taskRow({ id: "newest", createdAt: new Date("2026-08-17T00:00:00Z"), updatedAt: new Date("2026-08-17T00:00:00Z") }),
+      taskRow({ id: "a-tie", createdAt: new Date("2026-08-16T00:00:00Z"), updatedAt: new Date("2026-08-19T00:00:00Z") }),
     ];
     for (const query of ["?view=board", ""]) {
       const response = await getTasks(boardDatabase(rows), query);
       assert.equal(response.status, 200);
-      const body = await response.json() as Array<{ id: string; status: string; runs?: Array<Record<string, unknown>> }>;
-      assert.deepEqual(body.filter(({ status }) => status === "DONE").map(({ id }) => id), ["later-finished", "newer-created"]);
-      assert.deepEqual(body.filter(({ status }) => status === "TODO").map(({ id }) => id), ["todo-new", "todo-old"]);
-      assert.equal("runActivity" in body[0]!, false, "test-only sorting evidence must not leak into the wire shape");
+      const body = await response.json() as Array<{ id: string }>;
+      assert.deepEqual(body.map(({ id }) => id), ["newest", "a-tie", "b-tie", "older-recently-updated"]);
     }
   });
 });

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -82,7 +82,7 @@ import { getMimeType } from "hono/utils/mime";
 import { z } from "zod";
 
 import { authenticate, issueSessionToken, principalMayAccess, type Principal } from "./auth.js";
-import { boardCard, byLatestRunActivity, chainDisplayByTask, etagFor, etagMatches, serializeUsageCost } from "./board.js";
+import { boardCard, chainDisplayByTask, etagFor, etagMatches, serializeUsageCost } from "./board.js";
 import { isValidBranchName } from "./branch-name.js";
 import { LOOPBACK_BROWSER_ORIGINS, originMayReachHandlers } from "./local-origin.js";
 import { createRunnerRegistry } from "./runners.js";
@@ -2135,33 +2135,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       : archived === "true" ? { archivedAt: { not: null } }
       : {};
     const where = { ...(projectId ? { projectId } : {}), ...archivedFilter };
-    const orderBy = [{ updatedAt: "desc" as const }, { id: "asc" as const }];
-
-    /** Latest append-only run event per task. Querying all runs matters: a
-     * queued retry can be the highest runNumber while its predecessor still
-     * owns the task's newest recorded event. */
-    const latestRunActivity = async (taskIds: string[]): Promise<Map<string, Date>> => {
-      if (taskIds.length === 0) return new Map();
-      const runs = await db.run.findMany({
-        where: { taskId: { in: taskIds } },
-        select: { id: true, taskId: true },
-      });
-      const taskByRun = new Map(runs.flatMap((run) => run.taskId === null ? [] : [[run.id, run.taskId] as const]));
-      const events = runs.length === 0 ? [] : await db.sessionEvent.groupBy({
-        by: ["runId"],
-        where: { runId: { in: runs.map(({ id: runId }) => runId) } },
-        _max: { at: true },
-      });
-      const latest = new Map<string, Date>();
-      for (const event of events) {
-        const taskId = taskByRun.get(event.runId);
-        const at = event._max.at;
-        if (taskId === undefined || at === null) continue;
-        const previous = latest.get(taskId);
-        if (previous === undefined || previous < at) latest.set(taskId, at);
-      }
-      return latest;
-    };
+    const orderBy = [{ createdAt: "desc" as const }, { id: "asc" as const }];
 
     // `chainProgress` / `recurringLastFiredAt` / `position` cost two extra
     // queries over the whole task table, and `Projects.tsx` polls this endpoint
@@ -2261,10 +2235,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           stepOutput: { select: { kind: true, body: true, runId: true } },
         },
       });
-      const ordered = byLatestRunActivity(rows, await latestRunActivity(rows.map(({ id: taskId }) => taskId)));
-      const progressFor = await chainProgressLookup(ordered);
-      const displayByTask = chainDisplayByTask(ordered);
-      return validated(context, ordered.map((row) => boardCard(row, progressFor(row), displayByTask.get(row.id))));
+      const progressFor = await chainProgressLookup(rows);
+      const displayByTask = chainDisplayByTask(rows);
+      return validated(context, rows.map((row) => boardCard(row, progressFor(row), displayByTask.get(row.id))));
     }
 
     const tasks = await db.task.findMany({
@@ -2283,15 +2256,12 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         },
       },
     });
-    const orderedTasks = enrich
-      ? byLatestRunActivity(tasks, await latestRunActivity(tasks.map(({ id: taskId }) => taskId)))
-      : tasks;
-    const progressFor = await chainProgressLookup(orderedTasks);
+    const progressFor = await chainProgressLookup(tasks);
 
     // The Automations page needs `Last run` on a *collapsed* row, and a poll
     // that only mounts while a row is expanded can never supply it. Skipped
     // entirely on a board with no automations.
-    const cronIds = !enrich ? [] : orderedTasks.filter((task) => task.scheduleKind === ScheduleKind.CRON).map((task) => task.id);
+    const cronIds = !enrich ? [] : tasks.filter((task) => task.scheduleKind === ScheduleKind.CRON).map((task) => task.id);
     const firedGroups = cronIds.length === 0 ? [] : await db.task.groupBy({
       by: ["recurringSourceTaskId"],
       where: { recurringSourceTaskId: { in: cronIds } },
@@ -2300,7 +2270,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     });
     const firedByDefinition = new Map(firedGroups.map((group) => [group.recurringSourceTaskId, group]));
 
-    return validated(context, orderedTasks.map((task) => ({
+    return validated(context, tasks.map((task) => ({
       ...task,
       chainProgress: progressFor(task),
       recurringLastFiredAt: firedByDefinition.get(task.id)?._max.createdAt ?? null,

--- a/packages/api/src/board.test.ts
+++ b/packages/api/src/board.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { Prisma } from "@agentos/db";
 
-import { type BoardRow, boardCard, byLatestRunActivity, chainDisplayByTask, etagFor, etagMatches, taskChainName } from "./board.js";
+import { type BoardRow, boardCard, chainDisplayByTask, etagFor, etagMatches, taskChainName } from "./board.js";
 
 const session = (overrides: Partial<NonNullable<BoardRow["runs"][number]["session"]>> = {}): NonNullable<BoardRow["runs"][number]["session"]> => ({
   costUsd: null, inputTokens: null, cachedInputTokens: null, outputTokens: null, startedAt: null, endedAt: null, ...overrides,
@@ -138,17 +138,6 @@ test("a direct chain prefix is not guessed from one row or a partial match", () 
   ]);
   assert.deepEqual(displays.get("solo"), { chainName: null, displayName: "Release: Build" });
   assert.deepEqual(displays.get("a"), { chainName: null, displayName: "Release: Build" });
-});
-
-test("tasks sort newest run-event activity first with an updatedAt fallback and stable ties", () => {
-  const at = (value: string) => new Date(value);
-  const rows = [
-    row({ id: "later-created", status: "DONE", updatedAt: at("2026-08-16T12:00:00Z") }),
-    row({ id: "earlier-created-later-finish", status: "DONE", updatedAt: at("2026-08-16T08:00:00Z") }),
-    row({ id: "no-runs", updatedAt: at("2026-08-16T15:00:00Z"), runs: [] }),
-  ];
-  const activity = new Map([["later-created", at("2026-08-16T13:00:00Z")], ["earlier-created-later-finish", at("2026-08-16T14:00:00Z")]]);
-  assert.deepEqual(byLatestRunActivity(rows, activity).map(({ id }) => id), ["no-runs", "earlier-created-later-finish", "later-created"]);
 });
 
 test("chainProgress is passed through, not recomputed", () => {

--- a/packages/api/src/board.ts
+++ b/packages/api/src/board.ts
@@ -155,15 +155,6 @@ export const chainDisplayByTask = (rows: readonly Pick<BoardRow, "id" | "project
   return result;
 };
 
-type ActivityRow = { id: string; updatedAt: Date };
-
-/** Stable newest-activity-first ordering shared by both task-list shapes. */
-export const byLatestRunActivity = <T extends ActivityRow>(rows: T[], activityByTask: ReadonlyMap<string, Date>): T[] => [...rows].sort((left, right) => {
-  const leftAt = activityByTask.get(left.id) ?? left.updatedAt;
-  const rightAt = activityByTask.get(right.id) ?? right.updatedAt;
-  return rightAt.getTime() - leftAt.getTime() || left.id.localeCompare(right.id);
-});
-
 export const boardCard = (
   row: BoardRow,
   chainProgress: (ChainProgress & { position: number | null }) | null,


### PR DESCRIPTION
## Summary

- order task lists by `createdAt` descending with an `id` tie-break, independent of run activity
- remove the now-unused latest-run activity sorter and its run/session-event queries
- render Runs above Chain on the task detail page

## Tests

- `npm test -w @agentos/api` (419 passed, 1 skipped)
- `npm run build -w @agentos/web`
- `npm test -w @agentos/web` (384 passed)
- `npm run typecheck -w @agentos/api`
- `npm run typecheck -w @agentos/web`
- `npm run lint`
- `MERGE GATE: PASS 25a07fbbd082bef9a82a1bb84a049da69cf060a8` (local dispatcher slot)

🤖 Generated with [Codex](https://openai.com/codex/)