### PR TITLE
fix(runner): make child proxy explicitly opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,11 +112,14 @@ RUNNER_RUN_AS_PREFIX=
 # prints whichever one is in force in its {"runtime":"agentos-runner",...} startup line.
 # RUNNER_NODE_BINARY=/opt/agentos/bin/node
 
-# Uppercase proxy variables are captured once at runner startup and copied
-# unchanged into Claude and Codex child environments. They are not CLI settings.
-# HTTP_PROXY=http://127.0.0.1:7890
-# HTTPS_PROXY=http://127.0.0.1:7890
-# NO_PROXY=127.0.0.1,localhost
+# Optional platform-owned proxy for Claude and Codex child processes. All three
+# are unset by default, so an open-source installation does not use a proxy.
+# Configure them only in the installation's private .env; they remain available
+# even though Claude user settings are deliberately excluded. Conventional
+# HTTP_PROXY / HTTPS_PROXY / NO_PROXY variables are not inherited by children.
+# RUNNER_HTTP_PROXY=http://127.0.0.1:7897
+# RUNNER_HTTPS_PROXY=http://127.0.0.1:7897
+# RUNNER_NO_PROXY=127.0.0.1,localhost
 
 CLAUDE_BINARY=claude
 CODEX_BINARY=codex

--- a/packages/runner/src/config.test.ts
+++ b/packages/runner/src/config.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { DEFAULT_API_URL, loadRunnerConfig } from "./config.js";
+import { DEFAULT_API_URL, loadRunnerConfig, runnerProxyEnvironment } from "./config.js";
 import { LocalApiDestinationError } from "./local-origin.js";
 
 const require = createRequire(import.meta.url);
@@ -37,6 +37,43 @@ test("the default workspace root matches the API's definition of it", () => {
 test("the daemon reports the runner package version", () => {
   const metadata = require("../package.json") as { version: string };
   assert.equal(loadRunnerConfig().daemonVersion, metadata.version);
+});
+
+test("runner proxy configuration is opt-in and maps to child-standard names", () => {
+  assert.deepEqual(runnerProxyEnvironment({}), {});
+  assert.deepEqual(runnerProxyEnvironment({
+    RUNNER_HTTP_PROXY: "http://127.0.0.1:7897",
+    RUNNER_HTTPS_PROXY: "http://127.0.0.1:7897",
+    RUNNER_NO_PROXY: "127.0.0.1,localhost",
+  }), {
+    HTTP_PROXY: "http://127.0.0.1:7897",
+    http_proxy: "http://127.0.0.1:7897",
+    HTTPS_PROXY: "http://127.0.0.1:7897",
+    https_proxy: "http://127.0.0.1:7897",
+    NO_PROXY: "127.0.0.1,localhost",
+    no_proxy: "127.0.0.1,localhost",
+  });
+});
+
+test("runner proxy configuration ignores inherited conventional values", () => {
+  assert.deepEqual(runnerProxyEnvironment({
+    HTTP_PROXY: "http://inherited.invalid:8000",
+    HTTPS_PROXY: "http://inherited.invalid:8000",
+    NO_PROXY: "inherited.invalid",
+    RUNNER_HTTP_PROXY: "http://127.0.0.1:7897",
+    RUNNER_HTTPS_PROXY: "",
+    RUNNER_NO_PROXY: "localhost",
+  }), {
+    HTTP_PROXY: "http://127.0.0.1:7897",
+    http_proxy: "http://127.0.0.1:7897",
+    NO_PROXY: "localhost",
+    no_proxy: "localhost",
+  });
+  assert.deepEqual(runnerProxyEnvironment({
+    HTTP_PROXY: "http://legacy.invalid:7890",
+    HTTPS_PROXY: "http://legacy.invalid:7890",
+    NO_PROXY: "localhost",
+  }), {});
 });
 
 test("the tool inactivity deadline defaults to 30 minutes and rejects unsafe values", () => {

--- a/packages/runner/src/config.ts
+++ b/packages/runner/src/config.ts
@@ -41,10 +41,22 @@ export type RunnerConfig = {
 export const defaultSessionConfigBaselineRoot = (): string =>
   fileURLToPath(new URL("../assets/session-config-baseline", import.meta.url));
 
-export const runnerProxyEnvironment = (): NodeJS.ProcessEnv => Object.fromEntries(
-  ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy"]
-    .flatMap((name) => process.env[name] === undefined ? [] : [[name, process.env[name]!]]),
-);
+const runnerProxyVariables = [
+  [["HTTP_PROXY", "http_proxy"], "RUNNER_HTTP_PROXY"],
+  [["HTTPS_PROXY", "https_proxy"], "RUNNER_HTTPS_PROXY"],
+  [["NO_PROXY", "no_proxy"], "RUNNER_NO_PROXY"],
+] as const;
+
+/**
+ * Builds the proxy environment owned by the runner, not by a CLI's user
+ * settings. RUNNER_* is the only operator surface, so an unrelated proxy in
+ * the runner daemon's own environment cannot silently reach child processes.
+ */
+export const runnerProxyEnvironment = (env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv =>
+  Object.fromEntries(runnerProxyVariables.flatMap(([childNames, configuredName]) => {
+    const value = env[configuredName];
+    return value ? childNames.map((childName) => [childName, value]) : [];
+  }));
 
 const splitPrefix = (value: string): string[] => value.trim() ? value.trim().split(/\s+/u) : [];
 


### PR DESCRIPTION
## Summary

- add dedicated `RUNNER_HTTP_PROXY`, `RUNNER_HTTPS_PROXY`, and `RUNNER_NO_PROXY` operator settings
- keep child proxying disabled when those settings are absent, regardless of host conventional proxy variables
- preserve Claude host-settings isolation while allowing an installation-owned proxy

## Validation

- `npm test -w @agentos/runner` (170 passed, 1 skipped because it requires root)
- `npm run typecheck -w @agentos/runner`
- `npx biome lint packages/runner/src/config.ts packages/runner/src/config.test.ts`