### PR TITLE
[codex] route regression verification to Sol

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -56,7 +56,10 @@ no longer needed so a seed cannot silently turn an experiment into a release
 default.
 
 `review-coordinator` reviews plans only. `review-coordinator-sol` performs the
-first integrated-diff review. `review-coordinator-opus` performs the blind final
-review, must-fix adjudication, and post-fix exact-head regression verification.
+first integrated-diff review and post-fix exact-head regression verification.
+`review-coordinator-opus` performs the blind final review and must-fix
+adjudication. Existing task rows keep the assignee captured when their chain was
+created, so the Opus role retains regression instructions for legacy chains
+that were instantiated before the template binding changed.
 Legacy reviewer roles remain only as archived database history and must not be
 assigned to new tasks or templates.

--- a/agents/REVIEW-PACKAGE.md
+++ b/agents/REVIEW-PACKAGE.md
@@ -26,12 +26,14 @@ red at the frozen base.
 
 `review-coordinator-sol` performs the first implementation review over the
 complete integrated diff from the frozen pre-implementation base. It persists
-stable findings as its committed task output.
+stable findings as its committed task output. After adjudication and fixes it
+performs the whole-diff regression verification over every must-fix and binds
+its verdict to the exact head eligible for merge readiness.
 
 `review-coordinator-opus` first persists an independent blind review, then reads
 the first report and applies the canonical merge matrix to close the must-fix
-list. After fixes it owns one whole-diff regression verification over every
-must-fix and binds its verdict to the exact head eligible for human review.
+list. Its role prompt retains post-fix regression instructions only for task
+rows instantiated before the canonical template moved that phase to Sol.
 
 Security and risk-focused verification follow an evidence ladder: inspect the
 implementation and existing tests, run the narrow named regressions, and report
@@ -61,8 +63,8 @@ Roster convergence does not rewrite or interrupt an active chain.
 
 - Exactly twelve role files pass the canonical source contract, including the
   mechanical merge sentinel.
-- Full Assurance step 3 binds `review-coordinator`; steps 6, 7, and 9 bind the
-  first reviewer and final reviewer as specified by the canonical contract.
+- Full Assurance step 3 binds `review-coordinator`; steps 6 and 9 bind
+  `review-coordinator-sol`, and step 7 binds `review-coordinator-opus`.
 - The first report is durable before the final reviewer reads it.
 - The closed must-fix list follows the canonical merge matrix and the post-fix
   verdict accounts for every must-fix at one exact head.

--- a/agents/roles/review-coordinator-sol.md
+++ b/agents/roles/review-coordinator-sol.md
@@ -6,10 +6,11 @@ runner: codex
 inboxAccess: false
 collaborators: []
 ---
-You are the first code review coordinator. Your one job: independently review
-the complete integrated implementation diff and persist evidence-backed
-findings. You never fix the implementation and never narrow the review to the
-last commit.
+You are the Sol code review coordinator. You own two distinct chain phases:
+the first independent review of the complete integrated implementation diff,
+and post-fix regression verification. You never adjudicate the two initial
+reviews, never fix the implementation, and never narrow a review to the last
+commit.
 
 Establish exact review authority before judging the code. Take the implementation base and head SHAs from the implementation step's persisted output and verify both resolve in the tree.
 Refuse an ambiguous or drifting range. Review the complete
@@ -40,3 +41,14 @@ Persist the complete report only as the AgentOS task output; do not write or
 commit a report or session record to the chain branch. Record the exact base,
 head, commands run, and finding counts in the activity log. Finish only after
 the platform output is durable.
+
+For post-fix regression verification, read the closed must-fix list, the
+adjudication output, the fixed-implementation output, the exact pre-fix head,
+and the proposed fixed head from the complete persisted review package. Review
+the entire fix diff as one unit, account for every must-fix ID, rerun the
+relevant regressions, and run the repository's required exact-head gate. Verify
+that each defect is closed, the fix preserves the specification, and the
+combined fixes introduce no regression. Persist the required structured
+verdict as the AgentOS task output and bind it to the exact fixed head. Any
+unresolved item or newly discovered defect returns the chain to the fix phase;
+do not start another full review round.

--- a/agents/templates/compound-engineer-workflow/09-regression-verification.md
+++ b/agents/templates/compound-engineer-workflow/09-regression-verification.md
@@ -1,6 +1,6 @@
 ---
 stepIndex: 9
-agent: review-coordinator-opus
+agent: review-coordinator-sol
 approvalGate: false
 outputKind: regression-verification
 attachmentsFromPrevious: true

--- a/agents/templates/direct-engineer-workflow/05-regression-verification.md
+++ b/agents/templates/direct-engineer-workflow/05-regression-verification.md
@@ -1,6 +1,6 @@
 ---
 stepIndex: 5
-agent: review-coordinator-opus
+agent: review-coordinator-sol
 approvalGate: false
 outputKind: regression-verification
 attachmentsFromPrevious: true

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -62,7 +62,7 @@ This is the target shape of the seeded `compound-engineer-workflow` template and
 | ⑥a 代码评审（Sol 路） | review-coordinator-sol | CODEX, sol, high | base=⑤启动前冻结 commit，head=⑤记录的结束 commit，审完整 integrated diff；`codex exec review`，custom prompt 注入 Fowler smell 基线与「Spec 轴每条 finding 引 spec 原文」；findings 仅持久化为 TaskStepOutput，不写入或推送链分支 |
 | ⑥b 代码评审+终裁（Opus 路） | review-coordinator-opus | CLAUDE, opus-5, high | workspace 以⑤记录的结束 commit 做 fetch-level isolated detached checkout；claim 以 non-report metadata 提供 immutable base/head；先将独立 Standards/Spec 评审持久化为 intermediate TaskStepOutput，成功写入后才解锁并读取⑥a，再按正典合并矩阵终裁 must-fix 清单（Sol 独报须验证后采纳）；最终报告与 provider session id 仅落 platform output |
 | ⑦ 修复 | senior-dev | CODEX, sol, medium | 按封闭 must-fix 清单修；修复 diff 触及任一结构风险升 sol:high（本合同的 product-owner 裁定） |
-| ⑥c 回归核销 | review-coordinator-opus | CLAUDE, opus-5, high | 从 predecessor TaskStepOutput 读取闭合 must-fix 与修复结果，对完整修复 diff 整体回归核销（exact-head=人工验收对象）；优先以 platform output 中的显式 provider session id resume ⑥b，实测不通过则独立新窗完整读取 persisted review package |
+| ⑥c 回归核销 | review-coordinator-sol | CODEX, sol, high | 从完整 persisted review package 读取闭合 must-fix、⑥b 终裁与修复结果，对完整修复 diff 整体回归核销并绑定 exact head；不 resume ⑥b 的 Opus session |
 | ⑧ wiki | librarian | CODEX, terra, medium | 自 luna:high 改此（luna:high 违「Luna 一律 max」硬禁令；Terra $2/$12） |
 | ⑨ 人工 PR 审查 | 人工闸 | — | 不变 |
 
@@ -70,9 +70,9 @@ In summary, Full Assurance runs specification and planning through implementatio
 
 ## Review structure
 
-Steps ⑥a, ⑥b, and ⑥c form the two-route blind-review flow. Review reports and session records live only in TaskStepOutput/platform output and never on the chain branch. ⑥a independently reviews the integrated diff and persists its findings there. ⑥b receives the immutable implementation base/head as non-report claim metadata and runs from a fetch-level isolated detached checkout pinned to ⑤'s recorded end commit; it completes and persists its own Standards/Spec review before the successful write unlocks ⑥a, then performs final adjudication. After ⑦ closes the must-fix list from predecessor outputs, ⑥c verifies the complete repair diff and binds human acceptance to the verified exact head.
+Steps ⑥a, ⑥b, and ⑥c form the two-route blind-review flow. Review reports and session records live only in TaskStepOutput/platform output and never on the chain branch. ⑥a independently reviews the integrated diff and persists its findings there. ⑥b receives the immutable implementation base/head as non-report claim metadata and runs from a fetch-level isolated detached checkout pinned to ⑤'s recorded end commit; it completes and persists its own Standards/Spec review before the successful write unlocks ⑥a, then performs final adjudication. After ⑦ closes the must-fix list from predecessor outputs, ⑥c uses Sol to read the complete persisted review package, verifies the complete repair diff, and binds acceptance to the verified exact head.
 
-Luna may write only when the dispatch route's safeguards and rollback conditions have been verified. Blind review requires the adjudicator to persist an independent review before reading the other route. Findings carry a stable ID, location, evidence, and severity; P0/P1 findings are must-fix. After repair, the adjudicator verifies the complete must-fix diff, and that verified exact head becomes the human-review target.
+Luna may write only when the dispatch route's safeguards and rollback conditions have been verified. Blind review requires the adjudicator to persist an independent review before reading the other route. Findings carry a stable ID, location, evidence, and severity; P0/P1 findings are must-fix. After repair, the Sol regression verifier accounts for the adjudicated must-fix list over the complete fix diff, and that verified exact head becomes the acceptance target.
 
 ## Human approval placement
 

--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -125,7 +125,8 @@ The job then performs exactly this sequence and stops at the first failure:
    only after a zero exit and non-empty output;
 5. run `npm run db:migrate-goal-execution` from staging with the two authority
    SHAs read from that revision's `release-authority.json`;
-6. run `npm run db:sync-canonical-prompts`; structural drift is a terminal
+6. run `npm run db:sync-canonical-prompts`; structural drift outside an
+   explicitly source-declared assignee transition is a terminal
    refusal and is never changed with SQL;
 7. verify the staged generated Prisma client, recheck the barrier and blocking
    statuses, swap the staged `dist/` trees and target `node_modules`, and

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -156,6 +156,47 @@ test("canonical sync restores step, merge-resolver role, and foundational prompt
   assert.equal(persistedAgent.rolePrompt, expectedRole.rolePrompt);
 });
 
+test("canonical sync adopts the declared Sol regression assignee transition without rewriting instantiated tasks", async () => {
+  assert.equal((await seed()).code, 0);
+  const direct = await directTemplate();
+  const compound = await db.taskTemplate.findUniqueOrThrow({
+    where: { projectId_name: { projectId: direct.projectId, name: INTEGRATOR_TEMPLATE_NAME } },
+    include: { steps: { include: { assigneeAgent: true }, orderBy: { stepIndex: "asc" } } },
+  });
+  const regressionSteps = [
+    direct.steps.find(({ stepIndex }) => stepIndex === 5)!,
+    compound.steps.find(({ stepIndex }) => stepIndex === 9)!,
+  ];
+  const opus = await db.agent.findFirstOrThrow({
+    where: { projectId: direct.projectId, name: "review-coordinator-opus" },
+  });
+  await Promise.all(regressionSteps.map((step) => db.taskTemplateStep.update({
+    where: { id: step.id }, data: { assigneeAgentId: opus.id, prompt: "previous release prompt" },
+  })));
+  const existingTasks = await Promise.all(regressionSteps.map((step, index) => db.task.create({ data: {
+    projectId: direct.projectId,
+    templateId: step.taskTemplateId,
+    templateStepId: step.id,
+    name: `Already instantiated regression ${index + 1}`,
+    description: "legacy assignment",
+    assigneeType: "AGENT",
+    assigneeAgentId: opus.id,
+    status: "TODO",
+    chainId: `legacy-chain-${index + 1}`,
+    chainIndex: step.stepIndex,
+  } })));
+
+  const synced = await sync();
+  assert.equal(synced.code, 0, synced.output);
+  assert.match(synced.output, /"adoptedAssignees":2/u);
+  const [adoptedSteps, preservedTasks] = await Promise.all([
+    db.taskTemplateStep.findMany({ where: { id: { in: regressionSteps.map(({ id }) => id) } }, include: { assigneeAgent: true } }),
+    db.task.findMany({ where: { id: { in: existingTasks.map(({ id }) => id) } }, include: { assigneeAgent: true } }),
+  ]);
+  assert.deepEqual(adoptedSteps.map(({ assigneeAgent }) => assigneeAgent?.name), ["review-coordinator-sol", "review-coordinator-sol"]);
+  assert.deepEqual(preservedTasks.map(({ assigneeAgent }) => assigneeAgent?.name), ["review-coordinator-opus", "review-coordinator-opus"]);
+});
+
 test("canonical sync rejects template structure drift without applying its prompt", async () => {
   assert.equal((await seed()).code, 0);
   const direct = await directTemplate();

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -68,7 +68,7 @@ const seedReadiness = async () => {
     rolePrompt: "role",
   } });
   const [regressionAgent, reviewAgent, integratorAgent] = await Promise.all([
-    makeAgent("review-coordinator-opus"),
+    makeAgent("review-coordinator-sol"),
     makeAgent("review-coordinator"),
     makeAgent("merge-integrator", INTEGRATOR_SENTINEL_MODEL),
   ]);

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -35,7 +35,7 @@ const seedRegression = async () => {
     model: "gpt-5.6-sol:high", runnerPreference: "CODEX", foundationalPrompt: "foundation", rolePrompt: "role",
   } });
   const [regressionAgent, resolverAgent, fixAgent] = await Promise.all([
-    makeAgent("review-coordinator-opus"), makeAgent("merge-resolver"), makeAgent("senior-dev"),
+    makeAgent("review-coordinator-sol"), makeAgent("merge-resolver"), makeAgent("senior-dev"),
   ]);
   const repo = await db.repo.create({ data: {
     projectId: project.id, name: "widgets", remoteUrl: "https://github.com/acme/widgets.git",

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -80,6 +80,9 @@ test("the split review prompts enforce persisted-range, blind-order, adjudicatio
   assert.match(firstReview, /quote the exact governing\s+specification text/u);
   assert.match(firstReview, /codex exec review -m gpt-5\.6-sol -c model_reasoning_effort=high/u);
   assert.match(firstReview, /review the changes from <implementation base sha> to <delivered head sha>/u);
+  assert.match(firstReview, /post-fix regression verification/u);
+  assert.match(firstReview, /entire fix diff as one unit/u);
+  assert.match(firstReview, /exact fixed head/u);
 
   const blindWrite = finalReview.indexOf("intermediate AgentOS task output");
   const firstReportRead = finalReview.indexOf("predecessor step outputs", blindWrite);
@@ -109,7 +112,7 @@ test("the canonical twelve-step template sources split code review and preserve 
       { stepIndex: 6, agentName: "review-coordinator-sol", outputKind: "sol-findings" },
       { stepIndex: 7, agentName: "review-coordinator-opus", outputKind: "must-fix" },
       { stepIndex: 8, agentName: "senior-dev", outputKind: "fixed-implementation" },
-      { stepIndex: 9, agentName: "review-coordinator-opus", outputKind: "regression-verification" },
+      { stepIndex: 9, agentName: "review-coordinator-sol", outputKind: "regression-verification" },
       { stepIndex: 10, agentName: "librarian", outputKind: "documentation" },
       { stepIndex: 11, agentName: "review-coordinator", outputKind: "merge-authorization" },
       { stepIndex: 12, agentName: "merge-integrator", outputKind: "merge-result" },
@@ -151,7 +154,7 @@ test("the direct template sources keep the review spine, drop planning, and end 
       { stepIndex: 2, agentName: "review-coordinator-sol", outputKind: "sol-findings" },
       { stepIndex: 3, agentName: "review-coordinator-opus", outputKind: "must-fix" },
       { stepIndex: 4, agentName: "senior-dev", outputKind: "fixed-implementation" },
-      { stepIndex: 5, agentName: "review-coordinator-opus", outputKind: "regression-verification" },
+      { stepIndex: 5, agentName: "review-coordinator-sol", outputKind: "regression-verification" },
       { stepIndex: 6, agentName: "review-coordinator", outputKind: "merge-authorization" },
       { stepIndex: 7, agentName: "merge-integrator", outputKind: "merge-result" },
     ],

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -3,6 +3,11 @@ import { PrismaClient } from "@prisma/client";
 import { loadAgentSources, roleSourceStructureDifferences } from "../src/agent-sources.js";
 import { loadAllTemplateStepSources, templateStepStructureDifferences } from "../src/template-sources.js";
 
+const ASSIGNEE_TRANSITIONS = new Map([
+  ["compound-engineer-workflow:9", { from: "review-coordinator-opus", to: "review-coordinator-sol" }],
+  ["direct-engineer-workflow:5", { from: "review-coordinator-opus", to: "review-coordinator-sol" }],
+]);
+
 // Every canonical template, every step of each, and every role under agents/
 // is synced. Omitting any source here would let a prompt edit silently miss
 // production, so the loader owns the complete template inventory.
@@ -20,11 +25,12 @@ const main = async (): Promise<void> => {
       });
       if (!canonicalProject) throw new Error("Canonical project agentos-example was not found");
       const updatedSteps: Record<string, Record<number, number>> = {};
+      let adoptedAssignees = 0;
       let templateCount = 0;
       for (const [templateName, steps] of templateSources) {
         const templates = await tx.taskTemplate.findMany({
           where: { name: templateName },
-          select: { id: true },
+          select: { id: true, projectId: true },
         });
         if (templates.length === 0) throw new Error(`Template ${templateName} was not found`);
         templateCount += templates.length;
@@ -40,6 +46,7 @@ const main = async (): Promise<void> => {
           const persistedSteps = await tx.taskTemplateStep.findMany({
             where: { taskTemplateId: { in: templateIds }, stepIndex: step.stepIndex },
             select: {
+              id: true,
               taskTemplateId: true,
               assigneeAgent: { select: { name: true } },
               assigneeType: true,
@@ -56,8 +63,30 @@ const main = async (): Promise<void> => {
           }
           for (const persisted of persistedSteps) {
             const differences = templateStepStructureDifferences(persisted, step);
-            if (differences.length > 0) {
+            const transition = ASSIGNEE_TRANSITIONS.get(`${templateName}:${step.stepIndex}`);
+            const adoptsCanonicalAssignee = differences.length === 1
+              && differences[0] === "agent"
+              && transition?.from === (persisted.assigneeAgent?.name ?? null)
+              && transition.to === step.agentName;
+            if (differences.length > 0 && !adoptsCanonicalAssignee) {
               throw new Error(`${templateName} step ${step.stepIndex} on template ${persisted.taskTemplateId} differs from canonical Markdown structure: ${differences.join(", ")}`);
+            }
+            if (adoptsCanonicalAssignee) {
+              const projectId = templates.find(({ id }) => id === persisted.taskTemplateId)?.projectId;
+              const assignee = projectId
+                ? await tx.agent.findFirst({
+                  where: { projectId, name: transition.to, archivedAt: null },
+                  select: { id: true },
+                })
+                : null;
+              if (!assignee) {
+                throw new Error(`${templateName} step ${step.stepIndex} cannot adopt ${transition.to}: active target Agent was not found in the template project`);
+              }
+              await tx.taskTemplateStep.update({
+                where: { id: persisted.id },
+                data: { assigneeAgentId: assignee.id },
+              });
+              adoptedAssignees += 1;
             }
           }
           updated[step.stepIndex] = (await tx.taskTemplateStep.updateMany({
@@ -111,9 +140,9 @@ const main = async (): Promise<void> => {
           data: { foundationalPrompt: sources.foundationalPrompt, rolePrompt: role.rolePrompt },
         })).count;
       }
-      return { templates: templateCount, updatedSteps, updatedRoles };
+      return { templates: templateCount, adoptedAssignees, updatedSteps, updatedRoles };
     });
-    const updated = Object.values(result.updatedSteps)
+    const updated = result.adoptedAssignees + Object.values(result.updatedSteps)
       .flatMap((byStep) => Object.values(byStep))
       .reduce((sum, count) => sum + count, 0)
       + Object.values(result.updatedRoles).reduce((sum, count) => sum + count, 0);


### PR DESCRIPTION
## What changed

- bind direct step 5 and compound step 9 regression verification to review-coordinator-sol
- retain Opus for blind review and must-fix adjudication
- add a source-declared deployment transition that updates canonical template bindings without rewriting instantiated Task rows
- update role, governance, runbook, and regression-tail tests

## Why

Reduce Opus usage from two review-phase runs to one per chain while preserving the blind cross-provider adjudication order.

## Impact

Newly instantiated canonical chains use Sol for initial review and regression verification, with Opus used once for blind adjudication. Existing instantiated chains retain their captured assignees.

## Validation

MERGE GATE: PASS a4f200aa5f4991a339bc30027f78c9d26e3d169d

The gate ran on agentos-gate against baseline 6f2bb4dd7338bd411d9258a8e6bda7727d377513.