### PR TITLE
feat: add simplification discovery skill

### DIFF
--- a/.agents/skills/agentos-find-simplifications/SKILL.md
+++ b/.agents/skills/agentos-find-simplifications/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: agentos-find-simplifications
+description: "Find evidence-backed AgentOS simplification candidates and group them for Leo's approval before implementation."
+---
+
+# AgentOS simplification discovery
+
+Run a manual, full-repository survey when Leo decides AgentOS feels bloated. The outcome is a small set of well-proven deletion or consolidation themes, not code changes.
+
+## Authority boundary
+
+This skill is discovery-only.
+
+- Keep the survey read-only. Do not edit source, tests, configuration, prompts, documentation, or repository records.
+- Do not create a branch, brief, backlog card, chain, pull request, or Agent Note unless Leo separately asks for that action.
+- Stop after presenting the candidate report. Ask Leo to select theme IDs and separately approve any public-interface removal IDs.
+- After approval, handle each selected theme through the repository's normal brief, chain, review, pull-request, and exact-head merge-gate process. Approval of a theme is not approval of unlisted deletions.
+
+Use the current repository instructions as authority. Bind every report to an exact commit and state whether it represents `HEAD`, `origin/main`, or a dirty working tree. The serving checkout remains read-only; if later work must persist an artifact or run mutating validation, use an isolated worktree.
+
+## Survey the whole tracked tree
+
+First establish the repository's actual shape with `git status`, `git rev-parse`, `git ls-files`, workspace manifests, package scripts, and current architecture or operating docs. Derive areas from the repository rather than relying on a cached package list.
+
+Cover every tracked area, but classify these corpora separately:
+
+1. Production runtime: application and package source that ships or runs.
+2. Non-production support: tests, fixtures, demos, snapshots, and test-only helpers.
+3. Operational surfaces: scripts, CI, configuration, Docker, loaders, manifests, prompts, role definitions, and workflow templates.
+4. Documentation: current product, contributor, governance, release, and runbook material.
+5. Protected or excluded material: generated output, vendored code, frozen records, migration history, intentional mirrors, and files whose repository contract forbids modification.
+
+Use `git log --stat`, `git log --numstat`, and recent change history to locate churn and duplicated maintenance, but treat size and churn only as leads. Complete the coverage inventory even after finding a strong candidate.
+
+## Prove candidates from repository-native evidence
+
+Use `rg`, `rg --files`, and `git grep` first. Search exact symbols, imports and exports, route and event names, wire strings, config keys, package names, script names, filenames, prompt identifiers, and dynamic loader registrations. Read every plausible call site before assigning a verdict.
+
+For each candidate:
+
+1. Separate production consumers, non-production consumers, and ambiguous or dynamic consumers.
+2. Trace re-exports, package entrypoints, CLI/API surfaces, reflection, generated registration, Prisma use, scripts, CI, Docker, prompts, manifests, and workflow dispatch.
+3. Read nearby rationale and relevant history. Current documented intent can defeat a static unused-code lead.
+4. Name the exact deletion, fold, demotion, or replacement and estimate the net surface removed, including tests and documentation that exist only for that behavior.
+5. State the capability, flexibility, compatibility, or defense the repository would give up.
+6. Define observable validation for a later implementation task.
+
+Tests are behavior evidence, not automatic authority. Tests or docs as the only consumers can support removal when the behavior itself is obsolete. Zero in-repository references never proves that an exported API has no external consumers.
+
+For asynchronous, concurrent, ownership, cancellation, retry, or lifecycle code, map owners, states, transitions, terminal outcomes, cleanup, and rollback before proposing consolidation. Mirrored flags are a candidate only when they encode the same fact and no distinct transition or failure boundary depends on them.
+
+Repository-native evidence is the required stack. Knip is not part of this workflow: do not install or configure it, add persistent analysis dependencies, or wire a scanner into CI or the merge gate. A preinstalled scanner may supply leads, but never deletion authority.
+
+## Prefer high-value simplifications
+
+Strong leads include:
+
+- an internal symbol, helper, package surface, config knob, script, prompt, or event with no production consumer;
+- behavior consumed only by obsolete tests or documentation;
+- two representations, lifecycle mechanisms, or sources of truth that mirror the same fact;
+- seam methods every implementation carries but no caller uses;
+- speculative generality with no current product owner;
+- invariants, rollback paths, fixtures, or dedicated tests that protect only an unused behavior;
+- hand-rolled infrastructure replaceable by an existing dependency or supported Node builtin when the result is net deletion rather than relocated complexity;
+- repeated logic that can move behind one existing owner without broadening that owner's public interface.
+
+Reject or downgrade leads based only on file size, aesthetic preference, a one-off typo, static-tool output, or duplication required by localization, generated artifacts, independent failure domains, security boundaries, or repository policy.
+
+## Classify before grouping
+
+Assign exactly one verdict to every investigated lead:
+
+- `confirmed-internal-delete`: internal removal or folding supported by strong consumer and intent evidence.
+- `public-removal-needs-Leo`: exported API, CLI, protocol, wire format, configuration contract, or other externally consumable surface. List it separately; target an approved removal to the next minor release while AgentOS is pre-1.0.
+- `defense-or-persisted-separate-task`: persisted data, Prisma schema or migrations, merge authorization or automation, release authority, ownership, locking, workspace containment, security, secrets, or other defense-list behavior. Report the opportunity, but require a separate Sol high task and explicit Leo approval before implementation.
+- `intentional-keep`: complexity or duplication justified by a current owner, contract, boundary, or deliberate architecture.
+- `rejected`: the evidence did not prove a net simplification or a production consumer still needs the behavior.
+
+Representative defense paths include `packages/db/prisma/**`, `scripts/merge-gate.sh`, `scripts/gate-worker/**`, release-authority surfaces, merge-executor and merge-evidence paths, and ownership or workspace-containment code. Discover current paths and semantics before classifying; the list is not exhaustive.
+
+## Report and stop
+
+Read [references/candidate-report.md](references/candidate-report.md) before writing the result. Give each candidate a stable ID and group related candidates into bounded themes that can later be implemented and validated independently.
+
+The report must account for every surveyed area, including areas with no accepted candidate, and must distinguish exclusions from completed coverage. Prefer a few high-confidence themes over a long list of guesses.
+
+End with only the consequential decisions Leo must make:
+
+1. Which theme IDs, if any, should advance to separate briefs and chains?
+2. Which `public-removal-needs-Leo` IDs, if any, are approved for a next-minor breaking removal?
+
+Do not implement while waiting for the answer.

--- a/.agents/skills/agentos-find-simplifications/agents/openai.yaml
+++ b/.agents/skills/agentos-find-simplifications/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "AgentOS Simplification Discovery"
+  short_description: "Prove simplification candidates before implementation"
+  default_prompt: "Use $agentos-find-simplifications to scan AgentOS and present evidence-backed simplification themes for Leo to approve."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/agentos-find-simplifications/references/candidate-report.md
+++ b/.agents/skills/agentos-find-simplifications/references/candidate-report.md
@@ -1,0 +1,68 @@
+# Candidate report contract
+
+Use this structure for a completed discovery run. Omit empty prose, but keep every evidence field so absence remains visible.
+
+## Baseline and coverage
+
+- Repository and exact commit
+- Compared ref, if any
+- Working-tree state
+- Survey date
+- Areas surveyed
+- Protected or excluded areas and the authority for each exclusion
+- Areas where evidence remained ambiguous
+
+List every top-level tracked area and its coverage result: accepted candidate IDs, investigated-but-kept IDs, or `no candidate`. A directory name alone is not coverage evidence; name the entrypoints, manifests, or owner surfaces inspected.
+
+## Theme summary
+
+For each bounded theme:
+
+- Theme ID and action-oriented title
+- Candidate IDs
+- Current complexity cost
+- Proposed end state
+- Net deletion or consolidation expected
+- Highest risk classification in the theme
+- Why the candidates belong in one independently verifiable change
+
+Keep public-interface candidates and defense or persisted-data candidates visually separate from ordinary internal themes.
+
+## Candidate record
+
+Use a stable ID such as `SIM-RUNNER-001`.
+
+### `<ID>`: `<action-oriented title>`
+
+- Theme: `<theme ID>`
+- Verdict: `confirmed-internal-delete` | `public-removal-needs-Leo` | `defense-or-persisted-separate-task` | `intentional-keep` | `rejected`
+- Surface: exact files, symbols, routes, events, config keys, scripts, prompts, or packages
+- Problem: what complexity exists and what maintenance cost it creates
+- Production consumers: each caller or `none found`, with searches and call-site interpretation
+- Non-production consumers: tests, fixtures, docs, snapshots, and support code
+- Dynamic entrypoints: loaders, reflection, manifests, CI, Docker, Prisma, wire formats, prompts, and workflow dispatch checked
+- Intent and history: current rationale, intentional architecture, and relevant change history
+- Proposal: exact deletion, fold, demotion, or replacement
+- Why not keep it: strongest argument against retaining the current surface
+- What we give up: behavior, compatibility, flexibility, failure isolation, rollback, or future option lost
+- Risk flags: public interface, persisted data, defense list, security, concurrency, migration, release, or `none`
+- Net effect: implementation and support surface removed minus glue or replacement added
+- Acceptance criteria: observable end state for the later implementation task
+- Validation: focused checks plus the repository-required review and exact-head gate path
+- Confidence: `high` | `medium` | `low`, with the remaining uncertainty
+
+Do not assign `confirmed-internal-delete` when production or dynamic consumption remains ambiguous. Use `rejected` when a production caller survives; use `intentional-keep` when the current architecture deliberately owns the cost.
+
+## Decision request
+
+Ask Leo only for decisions with material consequences:
+
+- theme IDs to advance;
+- public-removal IDs approved for the next minor release;
+- whether any defense or persisted-data candidate should receive a separate high-risk investigation.
+
+State that selecting a theme approves only its closed candidate list. New deletion opportunities found during implementation return to a later discovery report rather than expanding scope silently.
+
+## Persistence boundary
+
+Present the report in the conversation by default. If Leo asks to persist it, use the existing AgentOS backlog, brief, or private operator-record authority. Do not create an `.agents/notes` tree or a new repository record system.

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -3,6 +3,9 @@
   "source": "git-tracked-files+minted-artifacts",
   "defaultDisposition": "blocker",
   "include": [
+    { "glob": ".agents/skills/agentos-find-simplifications/SKILL.md", "purpose": "manual AgentOS simplification discovery workflow and approval boundary" },
+    { "glob": ".agents/skills/agentos-find-simplifications/agents/openai.yaml", "purpose": "Codex display metadata and explicit-only invocation policy for the simplification skill" },
+    { "glob": ".agents/skills/agentos-find-simplifications/references/candidate-report.md", "purpose": "evidence and decision contract for AgentOS simplification candidate reports" },
     { "glob": ".env.example", "purpose": "safe configuration template" },
     { "glob": ".github/workflows/ci.yml", "purpose": "continuous integration definition" },
     { "glob": ".gitignore", "purpose": "source hygiene" },


### PR DESCRIPTION
## Summary

- add an explicit-only AgentOS simplification discovery skill
- require full-tree, consumer-backed evidence and bounded theme approval before implementation
- keep Knip and other persistent scanners out of CI and the merge gate
- classify the skill files in the closed public snapshot

## Validation

- `MERGE GATE: PASS 976f8381864e387ef6f7742f8a3accf21de839d3`
- gate ran on `agentos-gate`
- skill creator `quick_validate.py`: PASS
- snapshot regression: 19/19 PASS
- public snapshot scan: 0 blockers, 0 unclassified
- frozen-doc check: PASS