### PR TITLE
feat: add subagent routing to simplification skill

### DIFF
--- a/.agents/skills/agentos-find-simplifications/SKILL.md
+++ b/.agents/skills/agentos-find-simplifications/SKILL.md
@@ -18,6 +18,19 @@ This skill is discovery-only.
 
 Use the current repository instructions as authority. Bind every report to an exact commit and state whether it represents `HEAD`, `origin/main`, or a dirty working tree. The serving checkout remains read-only; if later work must persist an artifact or run mutating validation, use an isolated worktree.
 
+## Model and delegation contract
+
+Run the discovery parent and final adjudication with `gpt-5.6-sol` at `high` reasoning effort. Confirm the effective parent model and effort before surveying; if either is different or cannot be established, stop before the scan and tell Leo which launch settings are required.
+
+When the runtime supports subagents, use available capacity to widen the read-only survey:
+
+- Spawn every survey worker with explicit `gpt-5.6-luna` and `max`; never rely on inherited or default model settings.
+- Give each worker a disjoint tracked corpus or subsystem and the same evidence fields required by the candidate report.
+- Workers gather coverage, consumers, dynamic entrypoints, intent, history, candidate leads, and unresolved ambiguity. They do not assign final verdicts or authorize deletion.
+- Wait for every worker, then have the Sol parent inspect the returned evidence, fill coverage gaps, reject thin leads, deduplicate candidates, and assign the final classifications.
+
+Choose the worker count from the available runtime capacity and independently useful partitions; do not encode a product version or fixed pool size. If subagents are unavailable, the Sol parent completes the same coverage serially and records that fact. Delegation changes throughput, not the evidence bar.
+
 ## Survey the whole tracked tree
 
 First establish the repository's actual shape with `git status`, `git rev-parse`, `git ls-files`, workspace manifests, package scripts, and current architecture or operating docs. Derive areas from the repository rather than relying on a cached package list.
@@ -83,6 +96,8 @@ Representative defense paths include `packages/db/prisma/**`, `scripts/merge-gat
 Read [references/candidate-report.md](references/candidate-report.md) before writing the result. Give each candidate a stable ID and group related candidates into bounded themes that can later be implemented and validated independently.
 
 The report must account for every surveyed area, including areas with no accepted candidate, and must distinguish exclusions from completed coverage. Prefer a few high-confidence themes over a long list of guesses.
+
+For each theme, read the current `AGENTS.md` `Dispatching chains` rules and recommend a chain type plus one implementation route: `Luna Max eligible` or `Sol High required`. State the exact routing reason. Treat this as a post-approval handoff recommendation, not implementation authority. A Luna subagent dispatched outside the required AgentOS chain does not inherit the chain's permission to implement.
 
 End with only the consequential decisions Leo must make:
 

--- a/.agents/skills/agentos-find-simplifications/agents/openai.yaml
+++ b/.agents/skills/agentos-find-simplifications/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "AgentOS Simplification Discovery"
   short_description: "Prove simplification candidates before implementation"
-  default_prompt: "Use $agentos-find-simplifications to scan AgentOS and present evidence-backed simplification themes for Leo to approve."
+  default_prompt: "Use $agentos-find-simplifications with a Sol High parent and Luna Max read-only survey workers, then present evidence-backed themes and implementation routes for Leo to approve."
 policy:
   allow_implicit_invocation: false

--- a/.agents/skills/agentos-find-simplifications/references/candidate-report.md
+++ b/.agents/skills/agentos-find-simplifications/references/candidate-report.md
@@ -8,6 +8,9 @@ Use this structure for a completed discovery run. Omit empty prose, but keep eve
 - Compared ref, if any
 - Working-tree state
 - Survey date
+- Parent model and reasoning effort
+- Subagent model and reasoning effort, or `serial parent-only survey`
+- Delegated areas and completion status
 - Areas surveyed
 - Protected or excluded areas and the authority for each exclusion
 - Areas where evidence remained ambiguous
@@ -24,6 +27,8 @@ For each bounded theme:
 - Proposed end state
 - Net deletion or consolidation expected
 - Highest risk classification in the theme
+- Recommended chain: `direct` | `compound` | `separate high-risk investigation`
+- Implementation route: `Luna Max eligible` | `Sol High required`, with the current `AGENTS.md` routing reason
 - Why the candidates belong in one independently verifiable change
 
 Keep public-interface candidates and defense or persisted-data candidates visually separate from ordinary internal themes.
@@ -49,6 +54,7 @@ Use a stable ID such as `SIM-RUNNER-001`.
 - Net effect: implementation and support surface removed minus glue or replacement added
 - Acceptance criteria: observable end state for the later implementation task
 - Validation: focused checks plus the repository-required review and exact-head gate path
+- Implementation routing impact: facts that make the owning theme Luna-eligible or require Sol High
 - Confidence: `high` | `medium` | `low`, with the remaining uncertainty
 
 Do not assign `confirmed-internal-delete` when production or dynamic consumption remains ambiguous. Use `rejected` when a production caller survives; use `intentional-keep` when the current architecture deliberately owns the cost.


### PR DESCRIPTION
## Summary

- route simplification discovery through a Sol High parent and Luna Max read-only survey workers
- keep final adjudication and deletion authority with the parent
- record per-theme implementation routing in the candidate report

## Validation

- skill validator: PASS
- snapshot tests: 19/19 PASS
- snapshot scan: 0 blockers, 0 unclassified
- frozen-doc check: PASS
- diff check: PASS
- MERGE GATE: PASS e538334b11eb5de1253e73397a588695ee6be86b

The full merge gate ran on the agentos-gate remote worker.