### PR TITLE
fix: allow unavailable task model metadata

### DIFF
--- a/.agents/skills/agentos-find-simplifications/SKILL.md
+++ b/.agents/skills/agentos-find-simplifications/SKILL.md
@@ -20,7 +20,7 @@ Use the current repository instructions as authority. Bind every report to an ex
 
 ## Model and delegation contract
 
-Run the discovery parent and final adjudication with `gpt-5.6-sol` at `high` reasoning effort. Confirm the effective parent model and effort before surveying; if either is different or cannot be established, stop before the scan and tell Leo which launch settings are required.
+Launch the discovery task with `gpt-5.6-sol` at `high` reasoning effort; the skill cannot reconfigure its parent task. If runtime metadata explicitly exposes the effective parent model and effort, record them and stop before surveying only when they conflict with this launch contract. If the runtime does not expose either field, record `requested gpt-5.6-sol/high; runtime metadata unavailable` and continue. Do not infer task settings from documentation, global defaults, process inspection, or environment variables.
 
 When the runtime supports subagents, use available capacity to widen the read-only survey:
 

--- a/.agents/skills/agentos-find-simplifications/agents/openai.yaml
+++ b/.agents/skills/agentos-find-simplifications/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "AgentOS Simplification Discovery"
   short_description: "Prove simplification candidates before implementation"
-  default_prompt: "Use $agentos-find-simplifications with a Sol High parent and Luna Max read-only survey workers, then present evidence-backed themes and implementation routes for Leo to approve."
+  default_prompt: "Use $agentos-find-simplifications for a read-only full-repository survey from a Sol High task, using Luna Max survey workers and presenting evidence-backed themes for Leo to approve."
 policy:
   allow_implicit_invocation: false

--- a/.agents/skills/agentos-find-simplifications/references/candidate-report.md
+++ b/.agents/skills/agentos-find-simplifications/references/candidate-report.md
@@ -8,7 +8,7 @@ Use this structure for a completed discovery run. Omit empty prose, but keep eve
 - Compared ref, if any
 - Working-tree state
 - Survey date
-- Parent model and reasoning effort
+- Parent model and reasoning effort, or `requested gpt-5.6-sol/high; runtime metadata unavailable`
 - Subagent model and reasoning effort, or `serial parent-only survey`
 - Delegated areas and completion status
 - Areas surveyed


### PR DESCRIPTION
## Summary

- stop only when exposed task metadata explicitly conflicts with the Sol High launch contract
- continue discovery when Codex does not expose parent model or effort metadata
- record the unavailable-metadata state in the candidate report

## Validation

- skill validator: PASS
- snapshot tests: 19/19 PASS
- snapshot scan: 0 blockers, 0 unclassified
- frozen-doc check: PASS
- diff check: PASS
- MERGE GATE: PASS bb200d9a7bb0287829bdb92e2e0236a7559d43c1

The full merge gate ran on the agentos-gate remote worker.