### PR TITLE
fix: decouple merge-tail auxiliary tasks

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -204,7 +204,6 @@ const createMergeTailRepairTask = async (
   const task = await tx.task.create({ data: {
     projectId: regressionTask.projectId,
     repoId: regressionTask.repoId,
-    followUpTaskId: regressionTask.id,
     name: `Autonomous merge tail: ${input.repairKind}`,
     description: prompt,
     assigneeType: "AGENT",
@@ -4595,6 +4594,30 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       // envelope's verdict decides *whether* the failure was external; it does
       // not get to raise the ceiling on this step either.
       const mechanical = isIntegratorStep(run.task?.templateStep ?? null);
+      const tailRows = succeeded && run.task
+        && !run.task.templateId && !run.task.chainId && !run.task.followUpTaskId
+        ? await tx.taskActivity.findMany({
+            where: { taskId: run.task.id },
+            select: { metadata: true },
+            orderBy: { createdAt: "desc" },
+            take: 20,
+          })
+        : [];
+      const repairMarker = tailRows.map((row) => asJsonObject(row.metadata)).find((metadata) => (
+        metadata?.kind === MERGE_TAIL_KIND.repairAttempt && typeof metadata.regressionTaskId === "string"
+      ));
+      const reviewMarker = tailRows.map((row) => asJsonObject(row.metadata)).find((metadata) => (
+        metadata?.kind === MERGE_TAIL_KIND.reviewObligation
+        && metadata.state === "open"
+        && typeof metadata.readinessTaskId === "string"
+        && typeof metadata.regressionTaskId === "string"
+      ));
+      const mergeTailAuxiliary = Boolean(repairMarker || reviewMarker);
+      const auxiliaryFollowUpTaskId = typeof repairMarker?.regressionTaskId === "string"
+        ? repairMarker.regressionTaskId
+        : typeof reviewMarker?.readinessTaskId === "string"
+          ? reviewMarker.readinessTaskId
+          : null;
       const refunded = external && !mechanical ? 1 : 0;
       const budgetCeiling = run.maxRunsPerTask + refunded;
       // The same refund, recorded apart from the ceiling it produced. The gates
@@ -4604,7 +4627,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       // row: a task's budget being edited mid-run must not retroactively refuse
       // an attempt already authorized.
       const budgetGrants = run.budgetGrants + refunded;
-      if (succeeded && run.task && (run.task.templateId || run.task.chainId || run.task.followUpTaskId)) {
+      if (succeeded && run.task && (run.task.templateId || run.task.chainId || run.task.followUpTaskId || mergeTailAuxiliary)) {
         await lockTask(tx, run.task.id);
       }
       // Join the Task-row exclusion protocol only when this completion can
@@ -4812,7 +4835,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
               : `Run ${run.runNumber} stopped before merging`,
             metadata: jsonValue({ exitCode: body.exitCode, mergeOutcome: outcome.outcome }),
           } });
-        } else if (succeeded && run.task && (run.task.templateId || run.task.chainId || run.task.followUpTaskId)) {
+        } else if (succeeded && run.task && (run.task.templateId || run.task.chainId || run.task.followUpTaskId || mergeTailAuxiliary)) {
           // A row that already exists is left exactly as its author wrote it.
           // This branch used to restamp `runId` and `metadata` onto a body it
           // did not touch, so a task whose run 1 wrote a real output and whose
@@ -4870,22 +4893,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           } else {
             await advanceTemplateTask(tx, run.taskId, run.id, process.env.FEISHU_DEFAULT_CHAT_ID ?? null, now, run.task.status);
           }
-        } else if (succeeded && (run.task?.chainId || run.task?.followUpTaskId)) {
-          const tailRows = await tx.taskActivity.findMany({
-            where: { taskId: run.taskId },
-            select: { metadata: true },
-            orderBy: { createdAt: "desc" },
-            take: 20,
-          });
-          const repairMarker = tailRows.map((row) => asJsonObject(row.metadata)).find((metadata) => (
-            metadata?.kind === MERGE_TAIL_KIND.repairAttempt && typeof metadata.regressionTaskId === "string"
-          ));
-          const reviewMarker = tailRows.map((row) => asJsonObject(row.metadata)).find((metadata) => (
-            metadata?.kind === MERGE_TAIL_KIND.reviewObligation
-            && metadata.state === "open"
-            && typeof metadata.readinessTaskId === "string"
-            && typeof metadata.regressionTaskId === "string"
-          ));
+        } else if (succeeded && run.task && (run.task.chainId || run.task.followUpTaskId || mergeTailAuxiliary)) {
           let repairUnable = false;
           let reviewRejected = false;
           if (reviewMarker
@@ -5052,7 +5060,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
               where: { id: run.taskId, status: run.task.status }, data: { status: TaskStatus.DONE, failureReason: null },
             });
             if (completed.count === 1) {
-              await activateChainSuccessor(tx, run.task, {
+              await activateChainSuccessor(tx, auxiliaryFollowUpTaskId
+                ? { ...run.task, followUpTaskId: auxiliaryFollowUpTaskId }
+                : run.task, {
                 sourceRunId: run.id,
                 chatId: process.env.FEISHU_DEFAULT_CHAT_ID ?? null,
               }, now);
@@ -5074,7 +5084,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             taskId: run.taskId,
             actorType: "runner",
             actorId: body.runnerId,
-            body: succeeded && (run.task?.templateId || run.task?.chainId || run.task?.followUpTaskId) ? `Run ${run.runNumber} succeeded; chain advanced or awaiting approval`
+            body: succeeded && (run.task?.templateId || run.task?.chainId || run.task?.followUpTaskId || mergeTailAuxiliary) ? `Run ${run.runNumber} succeeded; chain advanced or awaiting approval`
               : succeeded ? `Run ${run.runNumber} succeeded; task moved to review`
               : retryCreated ? `Run ${run.runNumber} failed; retry queued`
                 : `Run ${run.runNumber} failed; task moved to review`,

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -96,7 +96,6 @@ const createReviewObligation = async (
   const task = await tx.task.create({ data: {
     projectId: input.readinessTask.projectId,
     repoId: input.readinessTask.repoId,
-    followUpTaskId: input.readinessTask.id,
     name: "Autonomous merge tail: independent review",
     description: [
       `Blindly review the exact diff ${input.baseSha}..${input.headSha}.`,

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -128,6 +128,8 @@ const seedReadiness = async () => {
     assigneeAgentId: integratorAgent.id, status: TaskStatus.TODO, chainId, chainIndex: 7,
     targetBranch: "main", opensPullRequest: false,
   } });
+  await db.task.update({ where: { id: regression.id }, data: { followUpTaskId: readiness.id } });
+  await db.task.update({ where: { id: readiness.id }, data: { followUpTaskId: integrator.id } });
   const run = await db.run.create({ data: {
     projectId: project.id, taskId: regression.id, agentId: regressionAgent.id, repoId: repo.id,
     runNumber: 1, dedupeKey: `task:${regression.id}:run:1`, runner: "CODEX", model: regressionAgent.model,
@@ -159,7 +161,8 @@ test("a defense-list diff opens one blind review and blocks authorization until 
   const guarded = reader([{ filename: "scripts/merge-gate.sh", previousFilename: null, patch: "@@ -1 +1 @@\n-old\n+new" }]);
   assert.deepEqual(await readinessTick(db, guarded), { claimed: 1, authorized: 0, reviewing: 1, requeued: 0, stopped: 0 });
   assert.equal(await db.taskStepOutput.count({ where: { taskId: seeded.readiness.id } }), 0);
-  const review = await db.task.findFirstOrThrow({ where: { followUpTaskId: seeded.readiness.id, name: "Autonomous merge tail: independent review" } });
+  const review = await db.task.findFirstOrThrow({ where: { projectId: seeded.project.id, name: "Autonomous merge tail: independent review" } });
+  assert.equal(review.followUpTaskId, null);
   const reviewRun = await db.run.findFirstOrThrow({ where: { taskId: review.id } });
   assert.equal(reviewRun.model, "gpt-5.6-sol:medium");
   await db.taskActivity.create({ data: {

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -60,7 +60,7 @@ const seedRegression = async () => {
     } }),
   ]);
   const chainId = `chain-${Date.now()}`;
-  await db.task.create({ data: {
+  const fix = await db.task.create({ data: {
     projectId: project.id, repoId: repo.id, templateId: template.id, templateStepId: fixStep.id,
     name: "Fix", description: "fix", assigneeType: AssigneeType.AGENT, assigneeAgentId: fixAgent.id,
     status: TaskStatus.DONE, chainId, chainIndex: 4, targetBranch: "main",
@@ -70,6 +70,7 @@ const seedRegression = async () => {
     name: "Regression", description: "verify", assigneeType: AssigneeType.AGENT, assigneeAgentId: regressionAgent.id,
     status: TaskStatus.DOING, chainId, chainIndex: 5, targetBranch: "main",
   } });
+  await db.task.update({ where: { id: fix.id }, data: { followUpTaskId: regression.id } });
   const run = await db.run.create({ data: {
     projectId: project.id, taskId: regression.id, agentId: regressionAgent.id, repoId: repo.id,
     runNumber: 1, dedupeKey: `task:${regression.id}:run:1`, runner: "CODEX", model: regressionAgent.model,
@@ -101,6 +102,19 @@ const exercise = async (outcome: "refresh-conflict" | "gate-fail") => {
   assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, input)), "handled");
   return { ...seeded, input };
 };
+
+const repairFor = (
+  seeded: Awaited<ReturnType<typeof exercise>>,
+  repairKind: "refresh-conflict" | "gate-fix",
+) => db.task.findFirstOrThrow({ where: {
+  projectId: seeded.project.id,
+  name: `Autonomous merge tail: ${repairKind}`,
+} });
+
+const repairCount = (seeded: Awaited<ReturnType<typeof exercise>>) => db.task.count({ where: {
+  projectId: seeded.project.id,
+  name: { startsWith: "Autonomous merge tail:" },
+} });
 
 const completeRepair = async (
   seeded: Awaited<ReturnType<typeof exercise>>,
@@ -143,9 +157,10 @@ const completeRepair = async (
 
 test("a refresh conflict creates exactly one resolver and its completion re-runs regression", async () => {
   const seeded = await exercise("refresh-conflict");
-  const repair = await db.task.findFirstOrThrow({ where: { followUpTaskId: seeded.regression.id } });
+  const repair = await repairFor(seeded, "refresh-conflict");
+  assert.equal(repair.followUpTaskId, null);
   assert.equal((await db.agent.findUniqueOrThrow({ where: { id: repair.assigneeAgentId! } })).name, "merge-resolver");
-  assert.equal(await db.task.count({ where: { followUpTaskId: seeded.regression.id } }), 1);
+  assert.equal(await repairCount(seeded), 1);
   await completeRepair(seeded, repair.id, JSON.stringify({
     schemaVersion: 1, outcome: "resolved", startHeadSha: HEAD, targetHeadSha: BASE,
     resolvedHeadSha: RESOLVED, tradeOffs: [], changedTestExpectations: [],
@@ -159,18 +174,19 @@ test("a refresh conflict creates exactly one resolver and its completion re-runs
   assert.match(result.body, new RegExp(`${HEAD}.*${RESOLVED}`));
 
   assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
-  assert.equal(await db.task.count({ where: { followUpTaskId: seeded.regression.id } }), 1);
+  assert.equal(await repairCount(seeded), 1);
   assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 1);
 });
 
 test("a gate FAIL creates one fix-agent task and a second FAIL escalates with both heads in activity", async () => {
   const seeded = await exercise("gate-fail");
-  const repair = await db.task.findFirstOrThrow({ where: { followUpTaskId: seeded.regression.id } });
+  const repair = await repairFor(seeded, "gate-fix");
+  assert.equal(repair.followUpTaskId, null);
   assert.equal((await db.agent.findUniqueOrThrow({ where: { id: repair.assigneeAgentId! } })).name, "senior-dev");
   await completeRepair(seeded, repair.id, "Fixed the failing regression and reran the affected suite.");
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 2);
   assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
-  assert.equal(await db.task.count({ where: { followUpTaskId: seeded.regression.id } }), 1);
+  assert.equal(await repairCount(seeded), 1);
   assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 1);
   const trail = await db.taskActivity.findMany({ where: { taskId: seeded.regression.id }, select: { body: true } });
   assert.match(trail.map(({ body }) => body).join("\n"), new RegExp(`${HEAD}.*${BASE}`, "s"));
@@ -187,7 +203,7 @@ test("malformed, unknown, and head-unbound resolver outputs stop loudly", async 
   ];
   for (const [label, output, headSha] of cases) {
     const seeded = await exercise("refresh-conflict");
-    const repair = await db.task.findFirstOrThrow({ where: { followUpTaskId: seeded.regression.id } });
+    const repair = await repairFor(seeded, "refresh-conflict");
     await completeRepair(seeded, repair.id, output, headSha);
     const regression = await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } });
     assert.equal(regression.status, TaskStatus.REVIEW, label);
@@ -200,7 +216,7 @@ test("malformed, unknown, and head-unbound resolver outputs stop loudly", async 
 test("successful resolver and gate-fix completions rerun regression with exact-head PASS evidence", async () => {
   for (const outcome of ["refresh-conflict", "gate-fail"] as const) {
     const seeded = await exercise(outcome);
-    const repair = await db.task.findFirstOrThrow({ where: { followUpTaskId: seeded.regression.id } });
+    const repair = await repairFor(seeded, outcome === "gate-fail" ? "gate-fix" : outcome);
     const output = outcome === "refresh-conflict"
       ? JSON.stringify({
         schemaVersion: 1, outcome: "resolved", startHeadSha: HEAD, targetHeadSha: BASE,
@@ -226,7 +242,7 @@ test("successful resolver and gate-fix completions rerun regression with exact-h
 
 test("a resolver process failure escalates instead of leaving regression silently parked", async () => {
   const seeded = await exercise("refresh-conflict");
-  const repair = await db.task.findFirstOrThrow({ where: { followUpTaskId: seeded.regression.id } });
+  const repair = await repairFor(seeded, "refresh-conflict");
   const run = await db.run.findFirstOrThrow({ where: { taskId: repair.id } });
   const runnerId = "merge-tail-repair-runner";
   const fencingToken = `repair:${run.id}:1`;


### PR DESCRIPTION
## Summary
- stop auxiliary review and repair tasks from consuming the chain-only `followUpTaskId` relation
- resolve auxiliary successors from persisted merge-tail activity markers while preserving the existing activation protocol
- exercise real chain links across readiness and repair DB tests

## Verification
- focused merge-tail DB tests: 15/15 pass against scratch PostgreSQL
- API typecheck: pass
- lint: pass
- `MERGE GATE: PASS cbd7feda7dd404c9f75db13cfcd9ebb515a74130`

Gate ran on offshore worker `agentos-gate` (`remote-2`).