### PR TITLE
fix: align canonical agent model routing

### DIFF
--- a/agents/roles/frontend-dev.md
+++ b/agents/roles/frontend-dev.md
@@ -1,7 +1,7 @@
 ---
 name: frontend-dev
 title: Frontend Developer
-model: claude-opus-5:high
+model: claude-opus-5:medium
 runner: claude
 inboxAccess: false
 collaborators: []

--- a/agents/roles/review-coordinator-opus.md
+++ b/agents/roles/review-coordinator-opus.md
@@ -1,7 +1,7 @@
 ---
 name: review-coordinator-opus
 title: Code Review Coordinator (Opus)
-model: claude-opus-5:high
+model: claude-opus-5:medium
 runner: claude
 inboxAccess: true
 collaborators: []

--- a/agents/roles/spec.md
+++ b/agents/roles/spec.md
@@ -1,8 +1,8 @@
 ---
 name: spec
 title: Specification Writer
-model: claude-fable-5:medium
-runner: claude
+model: gpt-5.6-sol:high
+runner: codex
 inboxAccess: true
 collaborators: []
 ---

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -120,7 +120,7 @@ test("instantiating the canonical feature template creates twelve tasks includin
   assert.equal(executionModeFor(created[11]!.templateStep), "mechanical");
   assert.deepEqual(created.map((task) => task.outputKind ?? task.templateStep.outputKind), canonicalTemplateSteps.map((step) => step.outputKind));
   assert.equal(runs.length, 1);
-  assert.equal(runs[0]!.runner, RunnerKind.CLAUDE);
+  assert.equal(runs[0]!.runner, RunnerKind.CODEX);
   assert.equal(runs[0]!.branch, "feature/twelve-steps");
   assert.equal(runs.some((run) => run.taskId === created[11]!.id), false, "step 12 waits for server-side readiness and never queues at instantiation");
   assert.doesNotMatch(

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -62,6 +62,22 @@ test("canonical role frontmatter matches the Prisma seed contract", async () => 
   assert.equal(roles.length, CANONICAL_AGENT_DEFAULTS.length);
 });
 
+test("signed AgentOS model routing stays pinned in the canonical contract", () => {
+  const canonical = new Map(CANONICAL_AGENT_DEFAULTS.map((role) => [role.name, role]));
+  assert.deepEqual(canonical.get("spec"), {
+    name: "spec",
+    model: "gpt-5.6-sol:high",
+    runner: RunnerPreference.CODEX,
+  });
+  for (const name of ["frontend-dev", "review-coordinator-opus"] as const) {
+    assert.deepEqual(canonical.get(name), {
+      name,
+      model: "claude-opus-5:medium",
+      runner: RunnerPreference.CLAUDE,
+    });
+  }
+});
+
 test("the split review prompts enforce persisted-range, blind-order, adjudication, and regression contracts", async () => {
   const [planReview, firstReview, finalReview] = await Promise.all([
     roleSource("review-coordinator"),

--- a/packages/db/src/agent-contract.ts
+++ b/packages/db/src/agent-contract.ts
@@ -2,7 +2,7 @@ import { RunnerKind, RunnerPreference } from "@prisma/client";
 
 export const CANONICAL_AGENT_DEFAULTS = [
   { name: "default", model: "gpt-5.6-sol:medium", runner: RunnerPreference.CODEX },
-  { name: "frontend-dev", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
+  { name: "frontend-dev", model: "claude-opus-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "implementation-plan-executioner", model: "gpt-5.6-sol:medium", runner: RunnerPreference.CODEX },
   { name: "librarian", model: "gpt-5.6-terra:high", runner: RunnerPreference.CODEX },
   // Not an LLM role. The sentinel Agent row step 12 binds so a mechanical run
@@ -15,11 +15,11 @@ export const CANONICAL_AGENT_DEFAULTS = [
   { name: "plan", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "plan-reviser", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "review-coordinator", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
-  { name: "review-coordinator-opus", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
+  { name: "review-coordinator-opus", model: "claude-opus-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "review-coordinator-sol", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
   { name: "senior-dev", model: "gpt-5.6-sol:medium", runner: RunnerPreference.CODEX },
   { name: "senior-dev-luna", model: "gpt-5.6-luna:max", runner: RunnerPreference.CODEX },
-  { name: "spec", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
+  { name: "spec", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary\n- align canonical Agent role Markdown and seed contract with signed current model routing\n- pin spec to gpt-5.6-sol:high/CODEX\n- pin frontend-dev and review-coordinator-opus to claude-opus-5:medium/CLAUDE\n- add literal routing regression assertions and update the spec-runner template expectation\n\n## Why\nQuiet-window deployment of PR #50 correctly failed closed because live production already carried the signed current routing while repository Markdown still declared stale structural values.\n\n## Verification\n- MERGE GATE: PASS 77f5239c3e4b72b0ad6421f4301321d0b76cf3a8\n- Gate venue: offshore worker agentos-gate\n- independent Opus review: APPROVED after must-fix closure\n- API unit tests: 426 passed, 1 intentional skip\n- canonical contract tests: 12 passed