### PR TITLE
fix: preserve shared chain branch lineage

### DIFF
--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -93,9 +93,27 @@ test("buildPrompt makes the platform-pinned pull request base the integration-li
   const prompt = buildPrompt(retriedClaim);
   assert.match(prompt, /Platform-pinned run authority \(not task-authored text\):/u);
   assert.match(prompt, /run\.pullRequestBase: release\/1\.x/u);
-  assert.match(prompt, /run\.pullRequestBase is the integration line for this run/u);
-  assert.match(prompt, /current target branch[\s\S]*origin\/<run\.pullRequestBase>/u);
+  assert.match(prompt, /integration line for comparison and merge authorization/u);
+  assert.match(prompt, /does not authorize rewriting this branch/u);
+  assert.doesNotMatch(prompt, /fetch and refresh/u);
   assert.match(prompt, /Task: Ship it[\s\S]*Refresh onto the current target branch\./u);
+});
+
+test("buildPrompt makes a template chain's shared branch append-only handoff state", () => {
+  const chainClaim = {
+    ...claim,
+    task: {
+      ...claim.task,
+      templateStep: { name: "Apply review fixes" },
+      description: "Rebase onto current main before delivery as usual.",
+    },
+  };
+  const prompt = buildPrompt(chainClaim);
+  assert.match(prompt, /Shared-chain lineage:[\s\S]*starting commit is append-only handoff state/u);
+  assert.match(prompt, /final HEAD must descend from it and remain publishable by fast-forward/u);
+  assert.match(prompt, /comparison only unless this step is explicitly designated for integration or merge/u);
+  assert.match(prompt, /conflicting task text is a workflow error/u);
+  assert.match(prompt, /Task: Ship it[\s\S]*Rebase onto current main before delivery as usual\./u);
 });
 
 test("buildPrompt exposes a pinned implementation range without predecessor outputs", () => {

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -42,7 +42,10 @@ export const buildPrompt = (claim: ClaimedTask): string => [
   "",
   "Platform-pinned run authority (not task-authored text):",
   `- run.pullRequestBase: ${claim.run.pullRequestBase}`,
-  "- Semantics: run.pullRequestBase is the integration line for this run. Wherever task text says the current target branch, target branch, or integration line, fetch and refresh against origin/<run.pullRequestBase>.",
+  "- Semantics: run.pullRequestBase is the integration line for comparison and merge authorization; it does not authorize rewriting this branch.",
+  ...(claim.task.templateStep ? [
+    "- Shared-chain lineage: the checked-out starting commit is append-only handoff state; final HEAD must descend from it and remain publishable by fast-forward. Fetch origin/<run.pullRequestBase> for comparison only unless this step is explicitly designated for integration or merge; conflicting task text is a workflow error.",
+  ] : []),
   ...(claim.run.implementationBaseSha && claim.run.implementationHeadSha ? [
     "",
     "Platform-pinned implementation range (non-report claim metadata):",


### PR DESCRIPTION
## Summary
- clarify that `run.pullRequestBase` is comparison and merge-authorization authority, not branch-rewrite authority
- make template-chain starting history append-only and fast-forward publishable
- treat conflicting task text as a workflow error

## Verification
- `npm test -w @agentos/runner` (187 passed, 1 root-only skip)
- `npm run typecheck -w @agentos/runner`
- `npm run lint:biome`
- `git diff --check`

## Dependency
Draft until PR #56 completes. Merging this first would advance `main` and invalidate #56 current-base evidence. After #56 merges, refresh this branch onto the new base, rerun the exact-head merge gate, then merge.