### PR TITLE
fix: preserve completion across integrator stops

### DIFF
--- a/packages/api/src/merge-stop-state.dbtest.ts
+++ b/packages/api/src/merge-stop-state.dbtest.ts
@@ -16,6 +16,7 @@ import {
   enqueueTaskRun,
   legacyHumanTwelveStepTemplateName,
   MERGE_INTEGRATOR_KIND,
+  MERGE_INTEGRATOR_SCHEMA_VERSION,
   parseAuthorizationMetadata,
   parseStopAnswerMetadata,
   PrismaClient,
@@ -152,6 +153,110 @@ test("a legacy integrator base-drift stop retains an abandon-only manual exit", 
   const question = await stopQuestionFor(chain.integratorTask!.id);
   assert.ok(question, "legacy base-drift stop keeps a manual exit because it is not an automatic-recovery candidate");
   assert.deepEqual((question!.choices as Array<{ id: string }>).map((choice) => choice.id), ["abandon"]);
+});
+
+test("a fresh regression completion preserves success and parks a legacy-stopped integrator", async () => {
+  const chain = await seedIntegratorChain(db, {
+    label: "completion-legacy-stop-park",
+    shape: "legacy-seven-step-direct",
+  });
+  assert.ok(chain.readinessTask, "the historical readiness step exists");
+  assert.equal(chain.readinessTask.status, "DONE", "readiness was already complete before the fresh regression");
+  assert.ok(chain.integratorTask, "the integrator successor exists");
+
+  const stop = await db.taskActivity.create({ data: {
+    taskId: chain.integratorTask.id,
+    actorType: "control-plane",
+    body: "Mechanical merge stopped: base-drift",
+    metadata: {
+      kind: MERGE_INTEGRATOR_KIND.result,
+      schemaVersion: MERGE_INTEGRATOR_SCHEMA_VERSION,
+      outcome: "stopped",
+      condition: "base-drift",
+      evidence: "legacy stop without server-owned binding",
+    },
+  } });
+  await db.task.update({
+    where: { id: chain.integratorTask.id },
+    data: { status: "REVIEW", failureReason: "Mechanical merge stopped: base-drift" },
+  });
+
+  const regression = await db.run.create({ data: {
+    projectId: chain.project.id,
+    taskId: chain.gateTask.id,
+    agentId: chain.agent.id,
+    repoId: chain.repo.id,
+    runNumber: 2,
+    dedupeKey: `task:${chain.gateTask.id}:run:2`,
+    runner: "CLAUDE",
+    model: chain.agent.model,
+    promptHash: "fresh-regression",
+    status: "RUNNING",
+    runnerId: RUNNER,
+    maxRunsPerTask: 5,
+    fencingToken: `1:${chain.gateTask.id}:2`,
+    leaseExpiresAt: new Date(Date.now() + 600_000),
+  } });
+  await db.session.create({ data: {
+    runId: regression.id,
+    projectId: chain.project.id,
+    taskId: chain.gateTask.id,
+    agentId: chain.agent.id,
+    runner: "CLAUDE",
+    executionStatus: "RUNNING",
+  } });
+  const regressionOutput = JSON.stringify({
+    schemaVersion: 1,
+    outcome: "pass",
+    headSha: "a".repeat(40),
+    baseHeadSha: "b".repeat(40),
+    gateVerdict: "PASS",
+  });
+  await db.taskStepOutput.upsert({
+    where: { taskId: chain.gateTask.id },
+    create: {
+      taskId: chain.gateTask.id,
+      runId: regression.id,
+      kind: "regression-verification",
+      body: regressionOutput,
+      commitSha: "a".repeat(40),
+    },
+    update: {
+      runId: regression.id,
+      kind: "regression-verification",
+      body: regressionOutput,
+      commitSha: "a".repeat(40),
+    },
+  });
+  await db.task.update({ where: { id: chain.gateTask.id }, data: { status: "DOING" } });
+
+  const completion = await call("POST", `/runner/runs/${regression.id}/complete`, {
+    runnerId: RUNNER,
+    fencingToken: regression.fencingToken,
+    exitCode: 0,
+    terminalEventSeen: true,
+    terminalSuccess: true,
+    cleanupStatus: "SUCCEEDED",
+    headSha: "a".repeat(40),
+    output: regressionOutput,
+  }, RUNNER);
+
+  assert.equal(completion.status, 200);
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: regression.id } })).status, "SUCCEEDED");
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: chain.gateTask.id } })).status, "DONE");
+  const parked = await db.task.findUniqueOrThrow({ where: { id: chain.integratorTask.id } });
+  assert.equal(parked.status, "REVIEW");
+  assert.match(parked.failureReason ?? "", /predecessor success preserved/u);
+  assert.equal(await db.run.count({ where: { taskId: chain.integratorTask.id } }), 0, "the stopped successor was not queued");
+  assert.equal(await db.run.count({ where: { taskId: chain.gateTask.id } }), 2, "no automatic regression retry was scheduled");
+  const activity = await db.taskActivity.findFirst({
+    where: { taskId: chain.integratorTask.id, metadata: { path: ["sourceRunId"], equals: regression.id } },
+    orderBy: { createdAt: "desc" },
+  });
+  assert.ok(activity, "the park is auditable from the successful predecessor run");
+  assert.match(activity.body, /completed successfully and was preserved/u);
+  assert.equal((activity.metadata as any).condition, "base-drift");
+  assert.equal((activity.metadata as any).sourceStopId, stop.id);
 });
 
 test("Y1 the append-only stop history survives an output replacement", async () => {

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -765,6 +765,35 @@ type ChainSuccessorOptions = {
   archivedAssignee?: "park" | "throw";
 };
 
+const parkStoppedIntegratorSuccessor = async (
+  tx: Tx,
+  predecessor: ChainTask,
+  successor: ChainSuccessor,
+  stopped: NonNullable<Awaited<ReturnType<typeof stopStateFor>>>,
+  sourceRunId: string | null,
+): Promise<{ nextTaskId: string; gated: false }> => {
+  await tx.task.update({
+    where: { id: successor.id },
+    data: {
+      status: TaskStatus.REVIEW,
+      failureReason: `Merge integrator stopped on ${stopped.stop.condition}; predecessor success preserved and successor not activated`,
+    },
+  });
+  await tx.taskActivity.create({
+    data: {
+      taskId: successor.id,
+      actorType: "control-plane",
+      body: `Predecessor ${predecessor.name} completed successfully and was preserved; successor not activated because merge integrator stopped on ${stopped.stop.condition}`,
+      metadata: {
+        condition: stopped.stop.condition,
+        sourceRunId,
+        sourceStopId: stopped.stop.stopId,
+      },
+    },
+  });
+  return { nextTaskId: successor.id, gated: false };
+};
+
 /** Activates at most one chain/follow-up successor using the observed updatedAt as a CAS token. */
 const activateChainSuccessorInternal = async (
   tx: Tx,
@@ -932,6 +961,15 @@ const activateChainSuccessorInternal = async (
     return { nextTaskId: successor.id, gated: false };
   }
 
+  // Completion-triggered activation treats an unresolved downstream merge
+  // stop as a parked successor, not as a failure of the predecessor that just
+  // completed. Generic enqueue still throws IntegratorStoppedError, which is
+  // why interactive callers continue to receive their named 409 refusal.
+  const stopped = await stopStateFor(tx, successor.id);
+  if (stopped && (stopBypass?.integratorTaskId !== successor.id || stopBypass.sourceStopId !== stopped.stop.stopId)) {
+    return parkStoppedIntegratorSuccessor(tx, task, successor, stopped, options.sourceRunId ?? null);
+  }
+
   // An archived assignee parks the successor instead of throwing. enqueueTaskRun
   // raises ArchivedAssigneeError, which is not a P2002 and would escape the
   // savepoint catch below and roll back the caller's whole transaction — for
@@ -968,10 +1006,25 @@ const activateChainSuccessorInternal = async (
     await enqueueTaskRunInternal(tx, successor.id, now, stopBypass);
     if (hasSavepoint) await rawTx.$executeRawUnsafe!("RELEASE SAVEPOINT chain_successor_enqueue");
   } catch (error: unknown) {
-    if (!isUniqueConflict(error)) throw error;
+    // The preflight above is the normal path. The named-error branch is
+    // defense in depth for a stop recorded between that read and enqueue: both
+    // outcomes stay inside the savepoint so predecessor completion cannot be
+    // rolled back by downstream activation.
+    if (!isUniqueConflict(error) && !isIntegratorStoppedError(error)) throw error;
     if (hasSavepoint) {
       await rawTx.$executeRawUnsafe!("ROLLBACK TO SAVEPOINT chain_successor_enqueue");
       await rawTx.$executeRawUnsafe!("RELEASE SAVEPOINT chain_successor_enqueue");
+    }
+    if (isIntegratorStoppedError(error)) {
+      const stoppedAfterRollback = await stopStateFor(tx, successor.id);
+      if (!stoppedAfterRollback) throw error;
+      return parkStoppedIntegratorSuccessor(
+        tx,
+        task,
+        successor,
+        stoppedAfterRollback,
+        options.sourceRunId ?? null,
+      );
     }
     return { nextTaskId: successor.id, gated: false };
   }


### PR DESCRIPTION
## Problem

A successful predecessor completion and downstream successor activation currently share one transaction. If a stopped merge Integrator rejects enqueue with `IntegratorStoppedError`, the exception escapes the successor savepoint and rolls back the already-successful run and task transition.

## Change

- Preflight Integrator stop state before successor enqueue and park the successor in `REVIEW` with a named failure reason and auditable activity.
- Preserve the successful predecessor run and task transition while returning normal successor activation metadata.
- Catch `IntegratorStoppedError` after the enqueue savepoint as defense in depth for a stop recorded between preflight and enqueue.
- Keep interactive generic enqueue routes unchanged: they still return the existing named 409.
- Leave `activateRecoveryIntegratorSuccessor` and its server-owned stop bypass unchanged.

## Design rationale

The stop preflight mirrors the existing archived-assignee park pattern. The savepoint catch is intentionally retained as a second boundary because stop state can appear after preflight. Stop metadata remains audit-only here; it records `condition`, the successful predecessor `sourceRunId`, and `sourceStopId` without creating or widening recovery authority.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:db`: 388 pass
- Focused `merge-stop-state.dbtest.ts`: 20 pass, including the PR #44-shaped legacy-stop regression

## Merge gate

Gate ran on offshore worker `agentos-gate` against baseline `b851aa141e9a57cc1d2fbf6246413d63f89b7f3d`.

`MERGE GATE: PASS 6b5f031abf3eb817996236c2799911709b0acec6`

Log: `/home/ubuntu/gate/agentos/logs/20260822T162920Z-6b5f031abf3eb817996236c2799911709b0acec6.log`