### PR TITLE
Cancel unclaimed queued runs safely

### DIFF
--- a/docs/runbooks/legacy-integrator-stop.md
+++ b/docs/runbooks/legacy-integrator-stop.md
@@ -1,0 +1,100 @@
+# Legacy merge-integrator stop recovery
+
+This runbook is the operator procedure for a merge-integrator stop recorded
+before AgentOS owned the complete recovery identity. It documents recovery; it
+does not authorize an operator, script, or migration to manufacture missing
+identity.
+
+## Definition and boundary
+
+A legacy stop is the newest `mergeIntegrator.result` activity for a mechanical
+merge task when that result says `outcome: stopped` but lacks the server-owned
+`sourceRunId`, or when no server-owned `mergeIntegrator.intent` can bind the
+stopped attempt to its source Run and authorization. The Task being in `REVIEW`,
+a failed Run, or an old chain shape is not enough by itself to classify a stop
+as legacy.
+
+AgentOS rejects generic start, retry, and status-change requests while this
+stop is unresolved. That fail-closed behavior is intentional: neither a Task
+status nor a plausible pull request can replace the missing identity.
+
+The only supported recovery is the Inbox re-authorization protocol introduced
+with PR #54. It obtains fresh evidence, asks the operator to judge that
+evidence, and only then creates a new authorization and mechanical Run. It does
+not repair the old identity or reinterpret the old stop as trusted evidence.
+
+## Before answering
+
+1. Open the mechanical merge Task and its Activity history. Confirm the newest
+   `mergeIntegrator.result` is a stop and record its Task id, activity id,
+   condition, and evidence. Confirm the legacy definition above from the
+   server-returned metadata; do not infer missing fields from prose.
+2. Find the OPEN Inbox message whose dedupe key is
+   `merge-stop:<stop-activity-id>` and whose Task id is the same mechanical
+   merge Task. Verify its displayed condition and evidence match the activity.
+3. Verify the card actually offers `re-authorize`. Conditions such as ordinary
+   `base-drift`, `target-unresolvable`, or a post-merge incident deliberately
+   offer different dispositions. This runbook must not be used to add or
+   simulate a choice the server did not offer.
+4. Confirm there is no active mechanical Run for the Task. If one is active,
+   leave it alone and diagnose that inconsistent state separately.
+
+Any identity mismatch, ambiguous target, unrelated-chain evidence source, or
+missing same-chain Run and Session is a stop. Preserve the records and diagnose
+the producer; do not select a nearby record as a substitute.
+
+## Re-authorize through Inbox
+
+1. Choose `re-authorize` on the original stop card. Use the ordinary Inbox UI
+   or its authenticated decision endpoint. Do not start or patch the
+   integrator Task directly.
+2. If the original card was already answered `re-authorize` but no confirmation
+   card exists, replay the same decision on that same message. The PR #54
+   recovery path reads the append-only `refresh-requested` disposition under
+   the integrator Task lock and creates the missing request idempotently. Do not
+   create a replacement Inbox message.
+3. Verify this first decision creates exactly one OPEN confirmation card and
+   one `mergeIntegrator.evidenceRequest` activity with
+   `purpose: confirmation`. The request must name the same integrator Task and
+   target repository and pull request. Its `sourceRunId` must identify a real
+   preceding Run with a Session in the same chain.
+4. Before the confirmation card is filled, verify there is no new
+   `mergeIntegrator.authorization` activity and no new mechanical Run. The
+   placeholder is a request for evidence, not permission to merge.
+5. Wait for the control-plane evidence worker to fill the confirmation card.
+   Read the repository, pull request number, exact head and base SHAs, checks,
+   mergeability, and authorization status on the filled card. If collection
+   failed or any identity is stale or ambiguous, do not approve it.
+6. Approve only the filled, matching confirmation card. Approval must produce
+   one fresh server-owned authorization activity and one new QUEUED mechanical
+   Run bound to that authorization. A rejection instead requeues the
+   regression step; it must not run the server-owned readiness step as a model
+   task.
+7. Follow the normal merge-executor evidence checks in
+   `docs/runbooks/merge-executor.md`. Completion requires the recorded merge
+   result, exact merge parents, the base ref at that commit, and no `.chain/` in
+   the landed tree. Task or Run status alone is not completion evidence.
+
+Repeated decision submissions are allowed only as an idempotent replay of the
+same message and choice. They must not produce duplicate evidence requests,
+authorizations, or Runs.
+
+## Prohibited recovery methods
+
+- Do not add, edit, or copy a `sourceRunId`, `mergeIntegrator.intent`,
+  authorization activity, decision, review, or gate result.
+- Do not write directly to PostgreSQL, including a one-off repair or backfill.
+- Do not approve a placeholder, stale, failed, or ambiguously bound evidence
+  card.
+- Do not bypass the GitHub App merge path with a user token, direct base-branch
+  push, manual merge, or a different executor identity.
+- Do not broaden automatic recovery to conflicts, check failures, review
+  rejection, identity uncertainty, payload mismatch, external incidents, or
+  post-merge incidents.
+
+There is deliberately no automatic migration for legacy stops. A migration
+cannot reconstruct server-owned identity that was never recorded, and choosing
+a plausible historical Run would fabricate authority. Existing legacy stops
+remain fail closed until an operator completes the fresh Inbox
+re-authorization protocol above or selects another disposition the original
+server-issued stop card offers.

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -5336,6 +5336,81 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return session ? context.json(withMergeOutcome(session)) : context.json({ error: "Session not found" }, 404);
   });
 
+  app.post("/runs/:runId/cancel", async (context) => {
+    const runId = id.parse(context.req.param("runId"));
+    const result = await db.$transaction(async (tx) => {
+      const run = await tx.run.findUnique({
+        where: { id: runId },
+        select: {
+          id: true,
+          status: true,
+          taskId: true,
+          runNumber: true,
+          runnerId: true,
+          fencingToken: true,
+          leaseExpiresAt: true,
+          claimedAt: true,
+          session: { select: { id: true } },
+        },
+      });
+      if (!run) return { error: "Run not found", code: 404 as const };
+      if (run.status !== RunStatus.QUEUED) {
+        return { error: `Run is ${run.status}; only an unclaimed queued run can be cancelled`, code: 409 as const };
+      }
+      if (run.runnerId !== null || run.fencingToken !== null || run.leaseExpiresAt !== null
+        || run.claimedAt !== null || run.session !== null) {
+        return { error: "Run has already been claimed or leased", code: 409 as const };
+      }
+      if (!run.taskId) return { error: "Run is not attached to a Task", code: 409 as const };
+
+      const now = new Date();
+      const reason = "Cancelled by operator before runner claim";
+      // Run is the race authority. A runner claim and this cancellation both
+      // compare-and-set QUEUED, so exactly one can win without trusting the
+      // unlocked read above. The ownership-null predicates also fail closed if
+      // an inconsistent writer ever attaches a claim while leaving QUEUED.
+      const cancelled = await tx.run.updateMany({
+        where: {
+          id: run.id,
+          status: RunStatus.QUEUED,
+          runnerId: null,
+          fencingToken: null,
+          leaseExpiresAt: null,
+          claimedAt: null,
+          session: { is: null },
+        },
+        data: {
+          status: RunStatus.CANCELLED,
+          endedAt: now,
+          failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
+          failureReason: reason,
+          retryable: false,
+          retryAt: null,
+          sessionTokenRevokedAt: now,
+        },
+      });
+      if (cancelled.count !== 1) {
+        return { error: "Run was claimed while cancellation was being applied", code: 409 as const };
+      }
+
+      // Cancellation is terminal for this attempt. Live work lands in Review,
+      // matching other non-retry terminal paths; historical DONE/BACKLOG is
+      // not resurrected merely because an anomalous queued row was removed.
+      await tx.task.updateMany({
+        where: { id: run.taskId, status: { in: [TaskStatus.TODO, TaskStatus.DOING, TaskStatus.REVIEW] } },
+        data: { status: TaskStatus.REVIEW, failureReason: reason },
+      });
+      await tx.taskActivity.create({ data: {
+        taskId: run.taskId,
+        actorType: "operator",
+        body: `Run ${run.runNumber} cancelled before runner claim`,
+        metadata: { runId: run.id, priorStatus: RunStatus.QUEUED, status: RunStatus.CANCELLED },
+      } });
+      return { runId: run.id, taskId: run.taskId, status: RunStatus.CANCELLED };
+    });
+    return "error" in result ? context.json({ error: result.error }, result.code) : context.json(result);
+  });
+
   app.get("/runs/:runId/events", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const afterSeq = Number.parseInt(context.req.query("afterSeq") ?? "", 10);

--- a/packages/api/src/tasks.dbtest.ts
+++ b/packages/api/src/tasks.dbtest.ts
@@ -66,12 +66,69 @@ const seedTask = async (label: string, overrides: Record<string, unknown> = {}) 
 const seedRun = async (
   context: Awaited<ReturnType<typeof seedTask>>,
   runNumber: number,
-  status: "QUEUED" | "PROVISIONING" | "RUNNING" | "WAITING_INBOX" | "SUCCEEDED" | "FAILED",
+  status: "QUEUED" | "CLAIMED" | "PROVISIONING" | "RUNNING" | "WAITING_INBOX" | "SUCCEEDED" | "FAILED" | "CANCELLED",
 ) => db.run.create({ data: {
   projectId: context.project.id, taskId: context.task.id, agentId: context.agent.id, repoId: context.repo.id,
   runNumber, dedupeKey: `task:${context.task.id}:run:${runNumber}`, runner: "CLAUDE", model: "claude",
   promptHash: "hash", status, maxRunsPerTask: context.task.maxSessionsPerTask,
 } });
+
+// --- POST /runs/:runId/cancel ----------------------------------------------
+
+test("operator cancellation terminates an unclaimed queued run and lands its task in Review", async () => {
+  const context = await seedTask("cancel-queued", { status: "DOING" });
+  const run = await seedRun(context, 1, "QUEUED");
+
+  const response = await call("POST", `/runs/${run.id}/cancel`);
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body, { runId: run.id, taskId: context.task.id, status: "CANCELLED" });
+
+  const cancelled = await db.run.findUniqueOrThrow({ where: { id: run.id } });
+  assert.equal(cancelled.status, "CANCELLED");
+  assert.notEqual(cancelled.endedAt, null);
+  assert.equal(cancelled.failureClass, "CANCELLED_OR_TIMED_OUT");
+  assert.equal(cancelled.failureReason, "Cancelled by operator before runner claim");
+  assert.equal(cancelled.retryable, false);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: context.task.id } })).status, "REVIEW");
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: context.task.id,
+    actorType: "operator",
+    body: "Run 1 cancelled before runner claim",
+    metadata: { path: ["runId"], equals: run.id },
+  } }), 1);
+});
+
+test("operator cancellation refuses a claimed run without changing run or task", async () => {
+  const context = await seedTask("cancel-claimed", { status: "DOING" });
+  const run = await seedRun(context, 1, "CLAIMED");
+  await db.run.update({ where: { id: run.id }, data: {
+    runnerId: "runner-1",
+    fencingToken: `fence-${run.id}`,
+    leaseExpiresAt: new Date(Date.now() + 60_000),
+    claimedAt: new Date(),
+  } });
+
+  const response = await call("POST", `/runs/${run.id}/cancel`);
+  assert.equal(response.status, 409);
+  assert.match(response.body.error, /only an unclaimed queued run/);
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: run.id } })).status, "CLAIMED");
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: context.task.id } })).status, "DOING");
+  assert.equal(await db.taskActivity.count({ where: { taskId: context.task.id } }), 0);
+});
+
+test("repeated queued-run cancellation returns 409 and records one terminal transition", async () => {
+  const context = await seedTask("cancel-repeat", { status: "TODO" });
+  const run = await seedRun(context, 1, "QUEUED");
+
+  assert.equal((await call("POST", `/runs/${run.id}/cancel`)).status, 200);
+  const replay = await call("POST", `/runs/${run.id}/cancel`);
+  assert.equal(replay.status, 409);
+  assert.match(replay.body.error, /only an unclaimed queued run/);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: context.task.id,
+    body: "Run 1 cancelled before runner claim",
+  } }), 1);
+});
 
 // --- POST /tasks/:taskId/start ----------------------------------------------
 

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -58,6 +58,7 @@
     { "glob": "docs/release/v0.1.0-support-matrix.md", "purpose": "the authoritative support statement: what is Verified, Maintainer-verified, Experimental, Unverified and Unsupported, with the evidence boundary for each row" },
     { "glob": "docs/release/v0.2.0-release-notes.md", "purpose": "the release notes for v0.2.0, and the source text for the GitHub Release body of the same tag" },
     { "glob": "docs/runbooks/gate-worker.md", "purpose": "the offshore merge-gate worker and gate dispatcher runbook: slot model, red lines, deployment, troubleshooting" },
+    { "glob": "docs/runbooks/legacy-integrator-stop.md", "purpose": "fail-closed operator recovery procedure for legacy merge-integrator stops through fresh Inbox re-authorization evidence" },
     { "glob": "docs/runbooks/merge-executor.md", "purpose": "public GitHub App merge-executor provisioning, service isolation, verification, rotation, upgrade, and recovery authority" },
     { "glob": "docs/runbooks/quiet-window-auto-deploy.md", "purpose": "production macOS quiet-window auto-deploy installation, refusal, observation and recovery runbook" },
     { "glob": "package-lock.json", "purpose": "reproducible dependency graph" },

--- a/scripts/public-snapshot-scan.test.mjs
+++ b/scripts/public-snapshot-scan.test.mjs
@@ -372,6 +372,7 @@ test("the docs surface is closed and named one file at a time", () => {
     "docs/release/v0.1.0-support-matrix.md",
     "docs/release/v0.2.0-release-notes.md",
     "docs/runbooks/gate-worker.md",
+    "docs/runbooks/legacy-integrator-stop.md",
     "docs/runbooks/merge-executor.md",
     "docs/runbooks/quiet-window-auto-deploy.md",
   ]);


### PR DESCRIPTION
## Summary

- add operator-authenticated `POST /runs/:runId/cancel` for a never-claimed `QUEUED` Run
- converge a live Task to `REVIEW` and append an operator TaskActivity after the Run CAS wins
- document the only supported legacy Integrator-stop recovery through fresh Inbox re-authorization evidence
- publish the new runbook through the repository's exact-file public snapshot contract

## Design decisions

- Reuse the existing `RunStatus.CANCELLED` and `FailureClass.CANCELLED_OR_TIMED_OUT`; no schema migration is needed.
- "Never claimed" means `QUEUED` with null `runnerId`, `fencingToken`, `leaseExpiresAt`, and `claimedAt`, and no Session. This deliberately excludes an Inbox-resumed Run that was claimed historically and may still own workspace state.
- The Run-row `updateMany` is the race authority. Runner claim and operator cancellation both compare-and-set `QUEUED`, so only one transition can win. A claimed or active Run is never interrupted.
- A second cancellation returns `409` rather than pretending to perform another transition.
- A live `TODO`, `DOING`, or `REVIEW` Task lands in `REVIEW` with the cancellation reason. Historical `DONE` or `BACKLOG` is not resurrected by an anomalous queued-row cleanup.
- Legacy stops are not auto-migrated. Missing server-owned identity cannot be reconstructed without fabricating authority; recovery remains fail closed until a human uses the server-issued Inbox protocol.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test` (all workspace suites passed; expected schema-gate/root-only skips retained)
- focused `tasks.dbtest.ts`: 63/63 PASS
- full DB suite: 391/391 PASS against disposable PostgreSQL
- `npm run test:snapshot-scan`: 19/19 PASS
- `npm run snapshot:scan`: 565 tracked files classified, 0 blocker
- `MERGE GATE: PASS 46adf2a7a64c6b5b7ed24c472c9442de9f76bc63`

The exact-head gate ran on offshore worker `agentos-gate` remote-1. Full log:
`/home/ubuntu/gate/agentos/logs/20260822T165857Z-46adf2a7a64c6b5b7ed24c472c9442de9f76bc63.log`

Gate attempt 1 on `f6dec6fb0380d8fac51056042b673b2d873dcab8` failed because the new public runbook was not yet classified by `public-snapshot.json`. The exact-file manifest and its closed-surface test were updated, then the final head above passed the complete gate.
