### PR TITLE
fix(gate): serialize remote gate execution

### DIFF
--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -7,21 +7,15 @@ runtime-coupled, executable, configuration, or unknown change uses the full
 profile.
 
 A full profile is `npm ci`, a whole-workspace compile, unit tests, a throwaway
-PostgreSQL and the api dbtests — about 4 minutes on an idle worker, of which the
-dbtests are about 1½ and everything else together is about 2½. The
-dbtests were about 7 minutes until #146 moved that database's data directory
-into RAM and stopped it paying for durability it deletes seconds later, and
-about 3½ after that until they stopped queueing behind the one schema every
-file dropped and re-applied. The measurements are
-`scripts/gate-worker/bench-postgres.sh` (the container's settings) and
-`scripts/gate-worker/bench-dbtest-concurrency.sh` (how the files are executed);
-each alternates its two arms over one fixed commit, and they are the only thing
-these numbers should ever be updated from. The four minutes is those steps
-added up, not a stopwatch on a whole gate: two timed runs of one commit took
-4.8 and 5.3 minutes, and a second gate overlapped part of both — a busy worker
-is slower, because it permits two gates at once by design. That is pure
-compute, and it does not need to occupy the local machine. This runbook moves
-the compute to a remote server and leaves everything else where it was.
+PostgreSQL and the api dbtests. End-to-end worker logs measured on 2026-08-23
+were stable at about 6 minutes 7 seconds with the worker to themselves. Two
+overlapping full gates took 8 minutes 14 seconds and 8 minutes 42 seconds on the
+same four vCPUs, which is why the worker now exposes one execution slot. The
+install-free `docs-only` profile takes about 4 seconds. Use
+`scripts/gate-worker/bench-postgres.sh` and
+`scripts/gate-worker/bench-dbtest-concurrency.sh` when changing the database
+runner itself; each alternates its arms over one fixed commit so a tuning claim
+is not inferred from unrelated gate runs.
 
 Everything here is `scripts/gate-worker/`:
 
@@ -29,9 +23,9 @@ Everything here is `scripts/gate-worker/`:
 | --- | --- | --- |
 | `provision.sh` | the server | Installs the pinned toolchain and creates `~/gate/`. Idempotent, dry-run by default. |
 | `mirror-push.sh` | the local machine | Pushes one exact candidate and one exact baseline into immutable `refs/gate/.../<oid>` cache refs, creating `~/gate/<repo>/mirror.git` on first push, and installs `run-gate.sh` beside it. |
-| `run-gate.sh` | the server | Checks one oid out of its repository's mirror and runs `scripts/merge-gate.sh --expect-head <oid> --master <baseline-oid>` against it. |
+| `run-gate.sh` | the server | Holds the worker-wide execution lock, checks one oid out of its repository's mirror and runs `scripts/merge-gate.sh --expect-head <oid> --master <baseline-oid>` against it. |
 | `remote-gate.sh` | the local machine | One synchronous `ssh` call; returns the verdict line and the exit code. |
-| `gate-dispatch.sh` | the local machine | Freezes the candidate and integration baseline, then runs a gate in the first free slot: either worker slot first, local spillover only while both are busy. |
+| `gate-dispatch.sh` | the local machine | Freezes the candidate and integration baseline, then tries the worker slot first and the local slot while the worker is busy. |
 | `lib.sh` | the local machine | Shared repository-name derivation for the three local-side scripts. |
 
 The worker hosts one directory per repository, keyed by the origin repository's
@@ -47,9 +41,8 @@ A full gate saturates every core of whatever machine runs it. The dispatcher
 cannot know the candidate-selected profile before running it, so it rations
 machines, not processes: the local machine contributes **one** slot —
 it is also where the agent sessions and the local services live — and the
-worker contributes **two**, which is what its four vCPUs were measured to
-carry. Three slots, machine-wide, shared by every repository that dispatches
-from this machine.
+four-vCPU worker contributes **one**. Two slots, machine-wide, shared by every
+repository that dispatches from this machine.
 
 `gate-dispatch.sh` is the way to run a gate when anything else might also be
 running one:
@@ -62,13 +55,13 @@ scripts/gate-worker/gate-dispatch.sh <oid>
   supplied, the dispatcher fetches origin's current default branch without
   creating a local tracking ref, re-reads `origin HEAD`, and freezes that exact
   oid as the baseline before taking a slot.
-- Either remote slot is preferred. It runs `mirror-push.sh` before
+- The remote slot is preferred. It runs `mirror-push.sh` before
   `remote-gate.sh`, pushing only the frozen candidate and baseline under
   oid-named cache refs. The local checkout may be detached or single-branch;
   its incomplete ref namespace is never mirrored and cannot delete worker refs.
-- The local slot is spillover only while both remote slots are busy, and only
-  when this worktree is clean at `<oid>`.
-- All three busy: the dispatcher blocks and re-polls (default every 30s, for
+- The local slot is spillover only while the remote slot is busy, and only when
+  this worktree is clean at `<oid>`.
+- Both busy: the dispatcher blocks and re-polls (default every 30s, for
   60 minutes — `GATE_DISPATCH_POLL_SECONDS`, `GATE_DISPATCH_TIMEOUT_MINUTES`).
   On timeout it exits **75** with `GATE DISPATCH: NO SLOT`: nothing ran, no
   verdict exists, and re-dispatching is the recovery. A timeout that recurs
@@ -82,11 +75,14 @@ scripts/gate-worker/gate-dispatch.sh <oid>
   around it exits 76 rather than 75. Waiting for a lock nobody can take is
   waiting for nothing, and reporting it as a full queue hides what to fix.
 
-The accounting is three lock files under `~/.cache/gate-dispatch/`, outside any
-repository because the slots belong to the machines. They are the whole truth
-about dispatched gates, with one honest exception: running `merge-gate.sh` or
-`remote-gate.sh` directly bypasses the rationing, is invisible to it, and is the
-operator's own override to answer for.
+The dispatcher accounts for `remote-1` and `local` under
+`~/.cache/gate-dispatch/`, outside any repository because the slots belong to
+the machines. A direct `merge-gate.sh` bypasses that accounting. A direct
+`remote-gate.sh` bypasses the local lock too, but it cannot add worker capacity:
+every installed `run-gate.sh` contends for the worker-wide
+`~/gate/.full-gate.lock`, held with `flock` for the real process lifetime. If an
+SSH connection drops while its remote process survives, that process keeps the
+worker lock and a later invocation waits instead of running beside it.
 
 A lock is a file created with `ln`, holding the pid of the dispatcher that owns
 it. That shape is deliberate and `scripts/gate-worker/lib.sh` explains it:
@@ -94,8 +90,8 @@ it. That shape is deliberate and `scripts/gate-worker/lib.sh` explains it:
 slot lock names its owner from the instant it exists. A lock *directory* with a
 pid file written a moment later has a window in which it names nobody, and a
 second dispatcher reading that window calls the lock abandoned, deletes it, and
-takes the slot its owner is already gating in — three slots silently becoming
-more than three. Reclaiming a lock whose pid is gone is done by hard-linking it
+takes the slot its owner is already gating in — one slot silently becoming two
+gates. Reclaiming a lock whose pid is gone is done by hard-linking it
 to a witness name first, so of two dispatchers that both see the holder dead
 exactly one may act; a lock whose pid is still alive is never touched, and a
 lock that names no pid at all is never reclaimed automatically — it blocks the
@@ -315,14 +311,15 @@ the terminal for the whole gate.
 There is no queue file and no daemon by design: the state a queue would need is
 exactly the state that makes a worker something to operate rather than
 something to use, and the callers — agent sessions blocking on their own
-merges — are the backpressure.
+merges — are the backpressure. When both slots are occupied, every later caller
+waits and re-polls; requests are not pinned to a machine and strict FIFO order
+is not promised. The first waiter to acquire whichever slot frees runs there.
 
 The database step runs cores-1 files at once — three on this worker — each with
 a database of its own and its own subdirectory of the roots the gate exports.
-The worker permits two gates at the same time by design, so that is up to six
-test processes on four vCPU; `AGENTOS_DBTEST_CONCURRENCY` lowers it on a busier
-worker and `AGENTOS_DBTEST_PROVISION=0` puts the step back on one shared
-schema, serial.
+The worker permits one gate at a time, so that is up to three test processes on
+four vCPU; `AGENTOS_DBTEST_CONCURRENCY` lowers it on a busier worker and
+`AGENTOS_DBTEST_PROVISION=0` puts the step back on one shared schema, serial.
 
 ## Troubleshooting
 
@@ -358,7 +355,7 @@ ssh agentos-gate 'ls -la ~/gate/<repo>/worktrees'
 ssh agentos-gate 'rm -rf ~/gate/<repo>/worktrees/gate-<oid>-<stamp>-<pid> && git -C ~/gate/<repo>/mirror.git worktree prune'
 ```
 
-**`GATE DISPATCH: NO SLOT` keeps recurring** — the three slots are systemically
+**`GATE DISPATCH: NO SLOT` keeps recurring** — the two slots are systemically
 full. That is a capacity signal, not an error to retry harder: either stagger
 the merges, or revisit the worker's sizing with the bench scripts.
 

--- a/scripts/gate-worker/gate-dispatch.sh
+++ b/scripts/gate-worker/gate-dispatch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Run one merge gate in the first free slot: the offshore worker's two first,
-# then this machine only while both worker slots are busy. Runs ON THE LOCAL MACHINE:
+# Run one merge gate in the first free slot: the offshore worker first, then
+# this machine while the worker is busy. Runs ON THE LOCAL MACHINE:
 #
 #   scripts/gate-worker/gate-dispatch.sh                    # gate the local HEAD
 #   scripts/gate-worker/gate-dispatch.sh <oid>              # gate that commit
@@ -11,18 +11,17 @@
 # The slot model: gates are whole-machine loads, so what is being rationed is
 # machines, not processes. This machine contributes one slot — a gate saturates
 # every core, and the machine is also where the agent sessions and the local
-# services live — and the worker contributes two, which is what its four vCPUs
-# were measured to carry. Three slots, machine-wide, shared by every repository
-# that dispatches from this machine.
+# services live — and the four-vCPU worker contributes one. Two slots,
+# machine-wide, shared by every repository that dispatches from this machine.
 #
-# The accounting is three lock files under ${XDG_CACHE_HOME:-~/.cache}/
+# The accounting is two lock files under ${XDG_CACHE_HOME:-~/.cache}/
 # gate-dispatch/, outside any repository because the slots belong to the
 # machines, not to a checkout. lib.sh holds the locking itself and says why it
 # is shaped the way it is. Every dispatch on this machine contends for the same
-# three, which makes the local locks the whole truth — with one honest
-# exception: a merge-gate.sh or remote-gate.sh run directly, without this
-# script, is invisible to it. That is an operator overriding the rationing, and
-# the override is theirs to answer for; nothing here tries to detect it.
+# two. A direct merge-gate.sh is invisible to this accounting. A direct
+# remote-gate.sh bypasses the local accounting too, but run-gate.sh holds the
+# worker-wide execution lock for the real process lifetime, so it can wait but
+# cannot turn one worker slot into concurrent full gates.
 #
 # The local slot is only eligible when this worktree is already the thing a
 # local gate would test: HEAD at the requested commit and the tree clean.
@@ -206,7 +205,7 @@ local_eligible() {
 
 mkdir -p "$SLOT_ROOT" || die "could not create ${SLOT_ROOT}" "$EXIT_NO_VERDICT"
 
-printf 'gate-dispatch: %s, slots local(1) + %s(2), poll %ss, timeout %smin\n' \
+printf 'gate-dispatch: %s, slots %s(1) then local(1), poll %ss, timeout %smin\n' \
   "$OID" "$SERVER" "$POLL_SECONDS" "$TIMEOUT_MINUTES" >&2
 printf 'gate-dispatch: baseline %s%s\n' "$MASTER_OID" "${DEFAULT_REF:+ (${DEFAULT_REF})}" >&2
 
@@ -257,20 +256,19 @@ while :; do
   round_broken=""
   outcome=0
 
-  for slot in remote-1 remote-2; do
-    outcome=0
-    try_slot "$slot" || outcome=$?
-    case "$outcome" in
-      0) run_remote "$slot"; exit $? ;;
-      1) round_busy=$(( round_busy + 1 )) ;;
-      *) round_broken="${round_broken} ${slot}" ;;
-    esac
-  done
-  # Local capacity protects the production machine from agent-driven gate
-  # load. It is spillover only: both remote slots must be positively busy in
-  # this round. A broken remote lock is not "busy" and never unlocks local as a
-  # silent fallback.
-  if [ "$round_busy" -eq 2 ] && local_eligible; then
+  outcome=0
+  try_slot remote-1 || outcome=$?
+  case "$outcome" in
+    0) run_remote remote-1; exit $? ;;
+    1) round_busy=$(( round_busy + 1 )) ;;
+    *) round_broken="${round_broken} remote-1" ;;
+  esac
+
+  # Local capacity protects the user's machine from concurrent gate load. It
+  # is spillover only: the worker must be positively busy in this round. A
+  # broken remote lock is not "busy" and never unlocks local as a silent
+  # fallback.
+  if [ "$round_busy" -eq 1 ] && local_eligible; then
     outcome=0
     try_slot local || outcome=$?
     case "$outcome" in

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -3,7 +3,7 @@
 //
 // Two things are under test and both are mechanisms, not text.
 //
-// The first is the capacity invariant: three slots, and never a fourth. That is
+// The first is the capacity invariant: two slots, and never a third. That is
 // a concurrency property, so the cases here run real concurrent processes
 // against a real lock root. The bug they exist for is specific — a slot lock
 // that is created before it names its owner has a window in which a second
@@ -112,8 +112,8 @@ test("refuses a lock that names no pid rather than reclaiming it", (t) => {
 
 test("refuses a lock whose contents are not a pid", (t) => {
   const root = slotRoot(t);
-  writeFileSync(lockFile(root, "remote-2"), "held by somebody\n");
-  const result = runBash(`gate_slot_try "${root}" remote-2`);
+  writeFileSync(lockFile(root, "remote-1"), "held by somebody\n");
+  const result = runBash(`gate_slot_try "${root}" remote-1`);
   assert.equal(result.status, 2);
   assert.match(result.stderr, /names no pid/);
 });
@@ -235,12 +235,12 @@ test("sixteen concurrent claimers on one slot produce exactly one holder", (t) =
   assert.equal(held.length, 1, `expected one holder, got ${held.length}: ${held.join(",")}`);
 });
 
-test("nine concurrent claimers across three slots produce exactly three holders", (t) => {
+test("eight concurrent claimers across two slots produce exactly two holders", (t) => {
   const root = slotRoot(t);
   const winners = join(root, "winners");
   const claimer = `
     . "${libPath}"
-    for slot in local remote-1 remote-2; do
+    for slot in remote-1 local; do
       if gate_slot_try "${root}" "$slot"; then
         printf '%s %s\\n' "$slot" "$$" >> "${winners}"
         sleep 2
@@ -254,7 +254,7 @@ test("nine concurrent claimers across three slots produce exactly three holders"
       "-c",
       `set -uo pipefail
        : > "${winners}"
-       for i in $(seq 1 9); do
+       for i in $(seq 1 8); do
          bash -c '${claimer.replace(/'/g, "'\\''")}' &
        done
        wait`,
@@ -263,8 +263,8 @@ test("nine concurrent claimers across three slots produce exactly three holders"
   );
   assert.equal(result.status, 0, result.stderr);
   const held = readFileSync(winners, "utf8").trim().split("\n").filter(Boolean);
-  assert.equal(held.length, 3, `expected three holders, got ${held.length}: ${held.join(" | ")}`);
-  assert.equal(new Set(held.map((line) => line.split(" ")[0])).size, 3);
+  assert.equal(held.length, 2, `expected two holders, got ${held.length}: ${held.join(" | ")}`);
+  assert.equal(new Set(held.map((line) => line.split(" ")[0])).size, 2);
 });
 
 test("a killed holder's lock is released by the signal traps", (t) => {
@@ -344,7 +344,7 @@ const dispatch = (t, repo, args, env = {}, busySlots = []) => {
 
 test("a local PASS comes back as 0 with the gate's own verdict line", (t) => {
   const repo = fixtureRepo(t, {});
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1", "remote-2"]);
+  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /MERGE GATE: PASS/);
 });
@@ -353,7 +353,7 @@ test("a local FAIL comes back as 1, unchanged", (t) => {
   const repo = fixtureRepo(t, {
     mergeGate: 'printf "MERGE GATE: FAIL (stub)\\n"; exit 1',
   });
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1", "remote-2"]);
+  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
   assert.equal(result.status, 1);
   assert.match(result.stdout, /MERGE GATE: FAIL/);
 });
@@ -362,7 +362,7 @@ test("NOT AUTHORITATIVE keeps its own code", (t) => {
   const repo = fixtureRepo(t, {
     mergeGate: 'printf "MERGE GATE: NOT AUTHORITATIVE\\n"; exit 3',
   });
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1", "remote-2"]);
+  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
   assert.equal(result.status, 3);
 });
 
@@ -382,7 +382,7 @@ test("a failed mirror push is 76 and not a FAIL", (t) => {
   assert.doesNotMatch(result.stdout, /MERGE GATE: FAIL/);
 });
 
-test("dispatch tries a remote slot before an eligible local slot", (t) => {
+test("dispatch tries the remote slot before an eligible local slot", (t) => {
   const repo = fixtureRepo(t, {
     mergeGate: 'printf "LOCAL SHOULD NOT RUN\\n"; exit 1',
     remoteGate: 'printf "MERGE GATE: PASS remote-first\\n"; exit 0',
@@ -394,12 +394,12 @@ test("dispatch tries a remote slot before an eligible local slot", (t) => {
   assert.match(result.stderr, /remote-1/);
 });
 
-test("dispatch uses local only when both remote slots are busy", (t) => {
+test("dispatch uses local only when the remote slot is busy", (t) => {
   const repo = fixtureRepo(t, {
     mergeGate: 'printf "MERGE GATE: PASS local-spillover\\n"; exit 0',
     remoteGate: 'printf "REMOTE SHOULD NOT RUN\\n"; exit 1',
   });
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1", "remote-2"]);
+  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /local-spillover/);
   assert.doesNotMatch(result.stdout, /REMOTE SHOULD NOT RUN/);
@@ -440,7 +440,7 @@ test("every slot busy times out at 75 with no verdict", (t) => {
   const cache = join(scratch(t), "cache");
   const slots = join(cache, "gate-dispatch");
   mkdirSync(slots, { recursive: true });
-  for (const slot of ["local", "remote-1", "remote-2"]) {
+  for (const slot of ["local", "remote-1"]) {
     writeFileSync(join(slots, `${slot}.slot`), `${process.pid}\n`);
   }
   const result = spawnSync(
@@ -498,17 +498,12 @@ test("locks that cannot be operated are 76 at once, not 75 after the timeout", (
   assert.ok(Date.now() - started < 20_000, "it polled instead of answering at once");
 });
 
-test("one broken lock does not cost the dispatch a slot that is free", (t) => {
-  // The other half: a broken lock must not be contagious. remote-1 is
-  // unusable, the local slot is ineligible because the tree is dirty, and
-  // remote-2 is free — so the gate runs in remote-2 and comes back with a
-  // verdict rather than an errand.
+test("a busy remote slot spills an eligible gate onto the free local slot", (t) => {
   const repo = fixtureRepo(t, {});
-  writeFileSync(join(repo.root, "dirty.txt"), "dirty\n");
   const cache = join(scratch(t), "cache");
   const slots = join(cache, "gate-dispatch");
   mkdirSync(slots, { recursive: true });
-  mkdirSync(join(slots, "remote-1.lock"));
+  writeFileSync(join(slots, "remote-1.slot"), `${process.pid}\n`);
   const result = spawnSync(
     "bash",
     [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head],
@@ -520,22 +515,21 @@ test("one broken lock does not cost the dispatch a slot that is free", (t) => {
   );
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /MERGE GATE: PASS/);
-  assert.match(result.stderr, /remote-2/);
+  assert.match(result.stderr, /local slot/);
 });
 
 test("busy plus broken waits out the timeout and then reports 76, not 75", (t) => {
   // The mixed case. One slot is genuinely busy, so waiting is justified and the
   // dispatch must not give up early — but when the wait ends empty, the answer
-  // is not "the queue was full": two of the three slots were never available to
+  // is not "the queue was full": one of the two slots was never available to
   // anybody, and 75 would send the operator to re-dispatch into the same broken
   // locks. Nothing may be taken here either, so the capacity limit holds.
   const repo = fixtureRepo(t, {});
   const cache = join(scratch(t), "cache");
   const slots = join(cache, "gate-dispatch");
   mkdirSync(slots, { recursive: true });
-  writeFileSync(join(slots, "local.slot"), `${process.pid}\n`);
-  mkdirSync(join(slots, "remote-1.lock"));
-  mkdirSync(join(slots, "remote-2.lock"));
+  writeFileSync(join(slots, "remote-1.slot"), `${process.pid}\n`);
+  mkdirSync(join(slots, "local.lock"));
   const result = spawnSync(
     "bash",
     [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head, "--timeout-minutes", "0"],
@@ -548,7 +542,7 @@ test("busy plus broken waits out the timeout and then reports 76, not 75", (t) =
   assert.equal(result.status, 76, result.stderr);
   assert.match(result.stdout, /^GATE NOT RUN: /m);
   assert.doesNotMatch(result.stdout, /GATE DISPATCH: NO SLOT/);
-  assert.equal(readFileSync(join(slots, "local.slot"), "utf8").trim(), String(process.pid));
+  assert.equal(readFileSync(join(slots, "remote-1.slot"), "utf8").trim(), String(process.pid));
 });
 
 test("a gate killed by SIGKILL comes back as 137 with no verdict line", (t) => {
@@ -558,7 +552,7 @@ test("a gate killed by SIGKILL comes back as 137 with no verdict line", (t) => {
   // sees no MERGE GATE line and must read the silence as "no verdict", never as
   // a pass, and never as the FAIL that a rewritten code would have implied.
   const repo = fixtureRepo(t, { mergeGate: "kill -9 $$" });
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1", "remote-2"]);
+  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
   assert.equal(result.status, 137);
   assert.doesNotMatch(result.stdout, /MERGE GATE/);
 });

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -331,10 +331,10 @@ cp "$1" "$FAKE_SSH_HOME/$destination"
 
 // A gate home the way mirror-push.sh leaves one: run-gate.sh beside a bare
 // mirror, deriving its own GATE_HOME from where it was installed.
-const gateHome = (t, { verdict } = {}) => {
-  const root = scratch(t);
-  const work = join(root, "work");
-  const home = join(root, "home");
+const gateHome = (t, { verdict, workerRoot, name = "home" } = {}) => {
+  const root = workerRoot ?? scratch(t);
+  const work = join(root, `${name}-work`);
+  const home = join(root, name);
   mkdirSync(join(work, "scripts"), { recursive: true });
   writeFileSync(
     join(work, "scripts", "merge-gate.sh"),
@@ -414,6 +414,62 @@ test("a malformed STALE_WORKTREE_MINUTES is refused rather than passed to find",
   const result = runGate(fixture.home, [fixture.oid], { STALE_WORKTREE_MINUTES: "-1; id" });
   assert.equal(result.status, 2);
   assert.match(result.stderr, /STALE_WORKTREE_MINUTES/);
+});
+
+test("the worker lock serializes gates from different repositories", (t) => {
+  const workerRoot = scratch(t);
+  const starts = join(workerRoot, "starts");
+  const release = join(workerRoot, "release");
+  const verdict = `
+    printf '%s\\n' "$$" >> "$WORKER_LOCK_STARTS"
+    while [ ! -f "$WORKER_LOCK_RELEASE" ]; do sleep 0.05; done
+    printf 'MERGE GATE: PASS fixture\\n'
+  `;
+  const first = gateHome(t, { verdict, workerRoot, name: "repo-a" });
+  const second = gateHome(t, { verdict, workerRoot, name: "repo-b" });
+  const result = spawnSync(
+    "bash",
+    [
+      "-c",
+      `
+        set -uo pipefail
+        "$FIRST_HOME/run-gate.sh" "$FIRST_OID" > "$WORKER_ROOT/first.out" 2>&1 &
+        first_pid=$!
+        for _ in $(seq 1 100); do
+          [ -s "$WORKER_LOCK_STARTS" ] && break
+          sleep 0.05
+        done
+        [ -s "$WORKER_LOCK_STARTS" ] || exit 90
+
+        "$SECOND_HOME/run-gate.sh" "$SECOND_OID" > "$WORKER_ROOT/second.out" 2>&1 &
+        second_pid=$!
+        sleep 0.3
+        [ "$(wc -l < "$WORKER_LOCK_STARTS" | tr -d ' ')" = 1 ] || exit 91
+
+        : > "$WORKER_LOCK_RELEASE"
+        wait "$first_pid"
+        wait "$second_pid"
+        cat "$WORKER_ROOT/first.out" "$WORKER_ROOT/second.out"
+      `,
+    ],
+    {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: {
+        ...GIT_ENV,
+        FIRST_HOME: first.home,
+        FIRST_OID: first.oid,
+        SECOND_HOME: second.home,
+        SECOND_OID: second.oid,
+        WORKER_ROOT: workerRoot,
+        WORKER_LOCK_STARTS: starts,
+        WORKER_LOCK_RELEASE: release,
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.equal(readFileSync(starts, "utf8").trim().split("\n").length, 2);
+  assert.equal((result.stdout.match(/MERGE GATE: PASS/g) ?? []).length, 2);
 });
 
 // --- the stale-worktree sweep ------------------------------------------------

--- a/scripts/gate-worker/lib.sh
+++ b/scripts/gate-worker/lib.sh
@@ -157,7 +157,7 @@ gate_slot_try() {
   # A lock directory left by the pre-#132 dispatcher, which this shape cannot
   # see and which an older dispatcher may still be holding. Refusing is the only
   # safe reading: the two implementations do not exclude each other, so treating
-  # it as absent is how three slots become six.
+  # it as absent is how one physical slot becomes two concurrent gates.
   # Broken rather than busy: an old dispatcher may or may not be holding it, and
   # this implementation cannot tell which. "I cannot determine whether this slot
   # is occupied" is a mechanism failure that a person has to clear, not a queue

--- a/scripts/gate-worker/provision.sh
+++ b/scripts/gate-worker/provision.sh
@@ -178,7 +178,7 @@ done
 
 step "Base packages"
 missing_pkgs=""
-for pkg in git curl ca-certificates xz-utils; do
+for pkg in git curl ca-certificates xz-utils util-linux; do
   if dpkg -s "$pkg" >/dev/null 2>&1; then
     ok "$pkg"
   else

--- a/scripts/gate-worker/run-gate.sh
+++ b/scripts/gate-worker/run-gate.sh
@@ -43,11 +43,12 @@
 #      judgement about the commit exits 1, so a caller reading exit codes can
 #      tell a verdict from an errand.
 #
-# The worktree is per-run and unique, so two gates for different commits can run
-# concurrently and neither waits for the other. #131's per-worktree lock still
-# applies inside each one; because no two runs share a worktree, a live-lock FAIL
-# here means a previous run in the same directory was killed, which the sweep at
-# the top of this script is what clears.
+# The worktree is per-run and unique, but the worker is a whole-machine slot:
+# one worker-wide flock is held by the real process for its entire run. A second
+# invocation waits before creating a worktree. That lock is worker-wide rather
+# than repository-wide so two repositories cannot silently oversubscribe the
+# same four vCPUs, and it survives a dropped ssh connection for as long as the
+# remote gate process survives.
 #
 # Stateless: nothing is remembered between runs except the mirror and the logs.
 # Re-running the same oid after a dropped connection is the supported recovery,
@@ -177,6 +178,7 @@ no_verdict() {
 [ -d "$MIRROR_DIR" ] || no_verdict "no mirror at ${MIRROR_DIR}; run scripts/gate-worker/mirror-push.sh from the local machine first"
 command -v git >/dev/null 2>&1 || no_verdict "git is not installed on the worker"
 command -v node >/dev/null 2>&1 || no_verdict "node is not installed on the worker"
+command -v flock >/dev/null 2>&1 || no_verdict "flock is not installed on the worker"
 # Docker is deliberately not pre-checked here. merge-gate.sh requires it too, and
 # does so after the frozen-record rules, which need neither a daemon nor an
 # install: a documentation branch that rewrites history should be told that,
@@ -198,6 +200,17 @@ if [ -n "$MASTER_OID" ] && ! git -C "$MIRROR_DIR" cat-file -e "${MASTER_OID}^{co
 fi
 
 mkdir -p "$WORKTREES_DIR" "$LOGS_DIR" || no_verdict "could not create the gate directories under ${GATE_HOME}"
+
+# The repository directory is one level below the worker root installed by
+# mirror-push.sh. Keep the lock there so every repository on this machine
+# contends for the same physical capacity. flock owns the lifecycle correctly:
+# the kernel releases it only when the run and any surviving child holding the
+# descriptor are gone, not when the caller's ssh connection disappears.
+WORKER_LOCK="$(dirname "$GATE_HOME")/.full-gate.lock"
+exec 9>"$WORKER_LOCK" || no_verdict "could not open the worker lock at ${WORKER_LOCK}"
+printf 'run-gate: waiting for the worker slot\n' >&2
+flock 9 || no_verdict "could not acquire the worker lock at ${WORKER_LOCK}"
+printf 'run-gate: acquired the worker slot\n' >&2
 
 # --- reclaim what earlier runs abandoned ------------------------------------
 


### PR DESCRIPTION
Summary:
- reduce dispatch capacity to one remote slot plus one local spillover slot
- hold a worker-wide flock for the real remote gate lifetime
- update concurrency fixtures, provisioning, timing, and the worker runbook

Verification:
- npm run test:gate-worker (53 passed)
- MERGE GATE: PASS 6672a7689f01a8af18b1a6fbe4782c45386128b9