### PR TITLE
fix: isolate production checkout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,10 @@ acceptance criterion or caller requires it.
   `packages/api/src/test-startup-environment.ts`. The entrypoint loads the root
   `.env`, and dotenv restores omitted credentials unless the helper pins them
   from the test URL.
-- Treat a running installation's API, configuration, service definitions, and
-  built output as owned state. Work in a separate worktree. Bootstrap a fresh
-  worktree with `npm install`, `npm run db:generate`, and
-  `npm run build -w @agentos/db`.
+- **Appliance checkout:** before changing files or branches in a checkout named
+  by a loaded `com.agentos.*` service, read
+  [`docs/runbooks/quiet-window-auto-deploy.md`](docs/runbooks/quiet-window-auto-deploy.md).
+  Leave that checkout on clean `main`; do the work in a separate worktree.
 
 [`CONTRIBUTING.md`](CONTRIBUTING.md) owns the full test-safety rules, disposable
 development-database bootstrap, public-snapshot policy, and repository style.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,11 +66,12 @@ something outside the checkout.
   and give each worktree its own `?schema=` so parallel runs stay apart. Never
   point them at a database whose contents you would miss: `npm run test:db` drops
   and recreates what it is given.
-- A running installation's API, its configuration directory, its service
-  definitions and its built output belong to whoever is running it. Work in a
-  separate worktree, not in a checkout something is serving from. A fresh worktree
-  needs `npm install && npm run db:generate && npm run build -w @agentos/db`
-  before anything else works.
+- A checkout named by a loaded AgentOS service is an appliance checkout. Follow
+  its ownership and isolation contract in
+  [`docs/runbooks/quiet-window-auto-deploy.md`](docs/runbooks/quiet-window-auto-deploy.md);
+  use a separate worktree for development. A fresh worktree needs
+  `npm install && npm run db:generate && npm run build -w @agentos/db` before
+  anything else works.
 
 ### Development database bootstrap
 

--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -25,6 +25,43 @@ The checkout must have:
 The job reads `masterSha` and `controlPlaneASha` from the tracked
 `release-authority.json`; do not add those values to a plist or `.env`.
 
+## Appliance checkout
+
+The production checkout is a dedicated clone owned by the loaded AgentOS
+services and auto-deploy. Keep it on `main` with a clean tracked and untracked
+tree. Development happens in a different clone or worktree; no interactive
+agent task uses the production checkout as its working directory. A worktree of
+the development clone is not a production clone because it still shares branch
+and worktree administration with interactive work.
+
+Before installing or restoring auto-deploy, prove all three conditions:
+
+```sh
+test "$(git branch --show-current)" = main
+test -z "$(git status --porcelain)"
+git merge-base --is-ancestor HEAD origin/main
+```
+
+Relocating an existing installation is a controlled cutover:
+
+1. Prepare an independent clone at the target `main`, copy the existing mode-0600
+   `.env` without printing it, install dependencies, generate Prisma Client, and
+   build the exact stamped commit already running.
+2. Stage replacement LaunchAgent definitions from the loaded definitions,
+   preserving their environment and changing only paths rooted in the old
+   checkout. Validate every staged plist before touching launchd.
+3. At a quiet window, replace all nine service definitions and the auto-deploy
+   definition as one change. Restart the services from the dedicated clone.
+4. Require all labels to be running, `/health` to pass, `/version` to report the
+   prepared commit, every loaded program and working directory to resolve inside
+   the dedicated clone, and the clone to be clean `main`.
+5. Retain the old definitions and checkout until every criterion in step 4 has
+   passed. Restore the old definitions and services if any criterion fails.
+
+The cutover is complete only when the development checkout is absent from every
+loaded `com.agentos.*` definition. After that point it is ordinary development
+state and may use task worktrees without coordinating with auto-deploy.
+
 ## Read-only verification
 
 The production host has no host `pg_dump`. Define the exact container backup
@@ -114,8 +151,8 @@ recovery. The job does not stop runner processes while it waits.
 
 The job then performs exactly this sequence and stops at the first failure:
 
-1. refuse a dirty checkout; fetch `origin/main`; prove the current source is
-   its ancestor; fast-forward with `git merge --ff-only`;
+1. require branch `main`, refuse a dirty checkout, fetch `origin/main`, prove the
+   current source is its ancestor, and fast-forward with `git merge --ff-only`;
 2. create a detached staging worktree under `.agentos-deploy/`, run `npm ci`
    against the target lockfile, and run `npm run db:generate`;
 3. run `npm run build` in staging and verify its API build stamp;

--- a/scripts/deploy/quiet-window-adapters.mjs
+++ b/scripts/deploy/quiet-window-adapters.mjs
@@ -80,13 +80,15 @@ export const blockingRunsStatement = (statuses = BLOCKING_RUN_STATUSES) => {
 export const inspectGitPreflight = ({ git, root, target }) => {
   const text = (...args) => execFileSync(git, ["-C", root, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
   const head = text("rev-parse", "HEAD");
+  let branch = null;
+  try { branch = text("symbolic-ref", "--short", "HEAD"); } catch { /* detached HEAD is not the production main branch */ }
   const dirty = text("status", "--porcelain").length > 0;
   let fastForward = false;
   try {
     execFileSync(git, ["-C", root, "merge-base", "--is-ancestor", head, target], { stdio: "ignore" });
     fastForward = true;
   } catch { /* a non-zero merge-base verdict is the refusal */ }
-  return { head, target, dirty, fastForward, refusal: gitPreflightFailure({ dirty, head, target, fastForward }) };
+  return { branch, head, target, dirty, fastForward, refusal: gitPreflightFailure({ branch, dirty, head, target, fastForward }) };
 };
 
 export const processStartIdentity = (pid) => {

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -415,13 +415,15 @@ const serviceState = async () => {
 
 const repositoryState = async (target) => {
   const source = gitText("rev-parse", "HEAD");
+  let branch = null;
+  try { branch = gitText("symbolic-ref", "--short", "HEAD"); } catch { /* detached HEAD is reported by the dry-run */ }
   const dirty = gitText("status", "--porcelain").length > 0;
   let fastForward = "verify-after-fetch";
   try {
     execFileSync(loadBinaries().git, ["-C", REPOSITORY_ROOT, "cat-file", "-e", `${target}^{commit}`], { stdio: "ignore" });
     fastForward = commandSyncOk(loadBinaries().git, ["-C", REPOSITORY_ROOT, "merge-base", "--is-ancestor", source, target]) ? "yes" : "no";
   } catch { /* ls-remote can name an object this checkout has not fetched */ }
-  return { source, dirty, fastForward };
+  return { branch, source, dirty, fastForward };
 };
 
 const commandSyncOk = (program, args) => {
@@ -457,7 +459,7 @@ const dryRun = async () => {
     },
   });
   for (const line of result.lines) log(line);
-  return result.repository.dirty || result.repository.fastForward !== "yes" || !result.services.ok || !result.authority.ok || !result.backup.ok ? 1 : 0;
+  return result.repository.branch !== "main" || result.repository.dirty || result.repository.fastForward !== "yes" || !result.services.ok || !result.authority.ok || !result.backup.ok ? 1 : 0;
 };
 
 const main = async () => {
@@ -518,10 +520,12 @@ const main = async () => {
     }
     const host = createProductionHost({
       fastForward: async () => {
+        let branch = null;
+        try { branch = gitText("symbolic-ref", "--short", "HEAD"); } catch { /* detached HEAD is refused below */ }
         const dirty = gitText("status", "--porcelain").length > 0;
         const headBeforeFetch = gitText("rev-parse", "HEAD");
-        const preflight = gitPreflightFailure({ dirty, head: headBeforeFetch, target: headBeforeFetch, fastForward: true });
-        if (preflight) fail(preflight, "checkout-has-uncommitted-content");
+        const preflight = gitPreflightFailure({ branch, dirty, head: headBeforeFetch, target: headBeforeFetch, fastForward: true });
+        if (preflight) fail(preflight, preflight === "production-checkout-not-main" ? `branch-${branch ?? "detached"}` : "checkout-has-uncommitted-content");
         await checked("fetch-main-failed", loadBinaries().git, ["fetch", "origin", "main"]);
         to = gitText("rev-parse", "origin/main");
         const state = inspectGitPreflight({ git: loadBinaries().git, root: REPOSITORY_ROOT, target: to });

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -152,10 +152,11 @@ test("published artifacts derive every workspace dependency tree from the target
 });
 
 test("git preflight names dirty and non-fast-forward refusals", () => {
-  assert.equal(gitPreflightFailure({ dirty: true, head: "a", target: "b", fastForward: true }), "dirty-working-tree");
-  assert.equal(gitPreflightFailure({ dirty: false, head: "a", target: "b", fastForward: false }), "non-fast-forward-main");
-  assert.equal(gitPreflightFailure({ dirty: false, head: "a", target: "b", fastForward: true }), null);
-  assert.equal(gitPreflightFailure({ dirty: false, head: "b", target: "b", fastForward: false }), null);
+  assert.equal(gitPreflightFailure({ branch: "feature", dirty: false, head: "a", target: "b", fastForward: true }), "production-checkout-not-main");
+  assert.equal(gitPreflightFailure({ branch: "main", dirty: true, head: "a", target: "b", fastForward: true }), "dirty-working-tree");
+  assert.equal(gitPreflightFailure({ branch: "main", dirty: false, head: "a", target: "b", fastForward: false }), "non-fast-forward-main");
+  assert.equal(gitPreflightFailure({ branch: "main", dirty: false, head: "a", target: "b", fastForward: true }), null);
+  assert.equal(gitPreflightFailure({ branch: "main", dirty: false, head: "b", target: "b", fastForward: false }), null);
 });
 
 test("dry-run failures never persist escalation state", () => {
@@ -321,8 +322,11 @@ test("production Git preflight refuses real dirty and divergent repositories", (
   writeFileSync(join(root, "file"), "target");
   run("commit", "-am", "target");
   const target = run("rev-parse", "HEAD");
-  run("checkout", "--detach", base);
+  run("checkout", "main");
   assert.equal(inspectGitPreflight({ git, root, target }).refusal, null);
+  run("checkout", "-b", "feature");
+  assert.equal(inspectGitPreflight({ git, root, target }).refusal, "production-checkout-not-main");
+  run("checkout", "main");
   writeFileSync(join(root, "dirty"), "dirty");
   assert.equal(inspectGitPreflight({ git, root, target }).refusal, "dirty-working-tree");
   rmSync(join(root, "dirty"));
@@ -439,7 +443,7 @@ test("dry-run reads every decision surface and invokes no mutation", async () =>
   const result = await dryRunDecision({
     revisions: async () => { calls.push("revisions"); return { from: "a", source: "a", to: "b" }; },
     blockingRuns: async () => { calls.push("runs"); return [{ id: "r1", status: "waiting-inbox" }]; },
-    repositoryState: async () => { calls.push("repository"); return { dirty: false, fastForward: "yes" }; },
+    repositoryState: async () => { calls.push("repository"); return { branch: "main", dirty: false, fastForward: "yes" }; },
     serviceState: async () => { calls.push("services"); return { ok: true }; },
     authorityState: async () => { calls.push("authority"); return { ok: true }; },
     backupState: async () => { calls.push("backup"); return { ok: true, mode: "container" }; },
@@ -454,7 +458,7 @@ test("dry-run reports a refused container backup contract as a named decision", 
   const result = await dryRunDecision({
     revisions: async () => ({ from: "a", source: "a", to: "b" }),
     blockingRuns: async () => [],
-    repositoryState: async () => ({ dirty: false, fastForward: "yes" }),
+    repositoryState: async () => ({ branch: "main", dirty: false, fastForward: "yes" }),
     serviceState: async () => ({ ok: true }),
     authorityState: async () => ({ ok: true }),
     backupState: async () => ({

--- a/scripts/deploy/quiet-window-lib.mjs
+++ b/scripts/deploy/quiet-window-lib.mjs
@@ -38,7 +38,8 @@ export class DeployFailure extends Error {
 export const quietWindowIsOpen = (runs) =>
   runs.every((run) => !BLOCKING_RUN_STATUSES.includes(String(run.status).toLowerCase()));
 
-export const gitPreflightFailure = ({ dirty, head, target, fastForward }) => {
+export const gitPreflightFailure = ({ branch, dirty, head, target, fastForward }) => {
+  if (branch !== "main") return "production-checkout-not-main";
   if (dirty) return "dirty-working-tree";
   if (head !== target && !fastForward) return "non-fast-forward-main";
   return null;
@@ -135,7 +136,7 @@ export const dryRunDecision = async (host) => {
   const lines = [
     `DRY-RUN revisions from=${revisions.from} source=${revisions.source} target=${revisions.to}`,
     `DRY-RUN quiet-window=${quiet ? "open" : "holding"} blockers=${runs.length}`,
-    `DRY-RUN repository dirty=${repository.dirty} fast-forward=${repository.fastForward}`,
+    `DRY-RUN repository branch=${repository.branch} dirty=${repository.dirty} fast-forward=${repository.fastForward}`,
     `DRY-RUN services=${services.ok ? "ready" : "not-ready"} authority=${authority.ok ? "valid" : "invalid"}`,
     `DRY-RUN backup=${backup.ok ? "ready" : "not-ready"} mode=${backup.mode}${backup.reason ? ` reason=${backup.reason}` : ""}`,
   ];


### PR DESCRIPTION
## Summary
- require the auto-deploy appliance checkout to remain on clean main
- document dedicated-clone ownership and controlled relocation
- add a trigger-first AGENTS.md pointer for interactive work

## Verification
- npm run test:auto-deploy
- MERGE GATE: PASS 6de32cedb9996dbe11aecb690ac19edcfd04f897