### PR TITLE
fix: enforce deploy checkout guard before noop

### DIFF
--- a/scripts/deploy/quiet-window-adapters.mjs
+++ b/scripts/deploy/quiet-window-adapters.mjs
@@ -77,18 +77,36 @@ export const blockingRunsStatement = (statuses = BLOCKING_RUN_STATUSES) => {
   };
 };
 
-export const inspectGitPreflight = ({ git, root, target }) => {
+const inspectCheckout = ({ git, root }) => {
   const text = (...args) => execFileSync(git, ["-C", root, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
   const head = text("rev-parse", "HEAD");
   let branch = null;
   try { branch = text("symbolic-ref", "--short", "HEAD"); } catch { /* detached HEAD is not the production main branch */ }
   const dirty = text("status", "--porcelain").length > 0;
+  return { branch, head, dirty };
+};
+
+export const inspectProductionCheckout = ({ git, root }) => {
+  const state = inspectCheckout({ git, root });
+  return {
+    ...state,
+    refusal: gitPreflightFailure({ ...state, target: state.head, fastForward: true }),
+  };
+};
+
+export const inspectGitPreflight = ({ git, root, target }) => {
+  const state = inspectCheckout({ git, root });
   let fastForward = false;
   try {
-    execFileSync(git, ["-C", root, "merge-base", "--is-ancestor", head, target], { stdio: "ignore" });
+    execFileSync(git, ["-C", root, "merge-base", "--is-ancestor", state.head, target], { stdio: "ignore" });
     fastForward = true;
   } catch { /* a non-zero merge-base verdict is the refusal */ }
-  return { branch, head, target, dirty, fastForward, refusal: gitPreflightFailure({ branch, dirty, head, target, fastForward }) };
+  return {
+    ...state,
+    target,
+    fastForward,
+    refusal: gitPreflightFailure({ ...state, target, fastForward }),
+  };
 };
 
 export const processStartIdentity = (pid) => {

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -23,7 +23,6 @@ import {
   SERVICE_LABELS,
   dryRunDecision,
   executeUpgrade,
-  gitPreflightFailure,
   runLocked,
   shouldPersistFailure,
 } from "./quiet-window-lib.mjs";
@@ -34,6 +33,7 @@ import {
   DEPLOY_OPTIONAL_ARTIFACT_PATHS,
   DEPLOY_REQUIRED_ARTIFACT_PATHS,
   inspectGitPreflight,
+  inspectProductionCheckout,
   publishDirectories,
   workspaceDependencyPaths,
 } from "./quiet-window-adapters.mjs";
@@ -430,6 +430,19 @@ const commandSyncOk = (program, args) => {
   try { execFileSync(program, args, { stdio: "ignore" }); return true; } catch { return false; }
 };
 
+const assertProductionCheckout = () => {
+  const state = inspectProductionCheckout({ git: loadBinaries().git, root: REPOSITORY_ROOT });
+  if (state.refusal) {
+    fail(
+      state.refusal,
+      state.refusal === "production-checkout-not-main"
+        ? `branch-${state.branch ?? "detached"}`
+        : "checkout-has-uncommitted-content",
+    );
+  }
+  return state;
+};
+
 const dryRun = async () => {
   await loadEnvironment();
   loadBinaries();
@@ -486,6 +499,7 @@ const main = async () => {
     try {
       from = readDeployedRevision();
       to = await remoteMainRevision();
+      assertProductionCheckout();
     } catch (error) {
       const failure = error instanceof DeployFailure
         ? error
@@ -520,12 +534,7 @@ const main = async () => {
     }
     const host = createProductionHost({
       fastForward: async () => {
-        let branch = null;
-        try { branch = gitText("symbolic-ref", "--short", "HEAD"); } catch { /* detached HEAD is refused below */ }
-        const dirty = gitText("status", "--porcelain").length > 0;
-        const headBeforeFetch = gitText("rev-parse", "HEAD");
-        const preflight = gitPreflightFailure({ branch, dirty, head: headBeforeFetch, target: headBeforeFetch, fastForward: true });
-        if (preflight) fail(preflight, preflight === "production-checkout-not-main" ? `branch-${branch ?? "detached"}` : "checkout-has-uncommitted-content");
+        assertProductionCheckout();
         await checked("fetch-main-failed", loadBinaries().git, ["fetch", "origin", "main"]);
         to = gitText("rev-parse", "origin/main");
         const state = inspectGitPreflight({ git: loadBinaries().git, root: REPOSITORY_ROOT, target: to });

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -39,6 +39,7 @@ import {
   DEPLOY_OPTIONAL_ARTIFACT_PATHS,
   DEPLOY_REQUIRED_ARTIFACT_PATHS,
   inspectGitPreflight,
+  inspectProductionCheckout,
   publishDirectories,
   workspaceDependencyPaths,
 } from "./quiet-window-adapters.mjs";
@@ -157,6 +158,16 @@ test("git preflight names dirty and non-fast-forward refusals", () => {
   assert.equal(gitPreflightFailure({ branch: "main", dirty: false, head: "a", target: "b", fastForward: false }), "non-fast-forward-main");
   assert.equal(gitPreflightFailure({ branch: "main", dirty: false, head: "a", target: "b", fastForward: true }), null);
   assert.equal(gitPreflightFailure({ branch: "main", dirty: false, head: "b", target: "b", fastForward: false }), null);
+});
+
+test("the mutating entry checks checkout ownership before its already-deployed no-op", () => {
+  const source = readFileSync(new URL("./quiet-window-deploy.mjs", import.meta.url), "utf8");
+  const lockedEntry = source.indexOf("return runLocked(");
+  const checkoutPreflight = source.indexOf("assertProductionCheckout();", lockedEntry);
+  const alreadyDeployed = source.indexOf("if (from === to)", lockedEntry);
+  assert.ok(lockedEntry >= 0);
+  assert.ok(checkoutPreflight > lockedEntry);
+  assert.ok(alreadyDeployed > checkoutPreflight);
 });
 
 test("dry-run failures never persist escalation state", () => {
@@ -318,6 +329,7 @@ test("production Git preflight refuses real dirty and divergent repositories", (
   run("add", "file");
   run("commit", "-m", "base");
   const base = run("rev-parse", "HEAD");
+  assert.equal(inspectProductionCheckout({ git, root }).refusal, null);
   run("checkout", "-b", "target");
   writeFileSync(join(root, "file"), "target");
   run("commit", "-am", "target");
@@ -325,9 +337,11 @@ test("production Git preflight refuses real dirty and divergent repositories", (
   run("checkout", "main");
   assert.equal(inspectGitPreflight({ git, root, target }).refusal, null);
   run("checkout", "-b", "feature");
+  assert.equal(inspectProductionCheckout({ git, root }).refusal, "production-checkout-not-main");
   assert.equal(inspectGitPreflight({ git, root, target }).refusal, "production-checkout-not-main");
   run("checkout", "main");
   writeFileSync(join(root, "dirty"), "dirty");
+  assert.equal(inspectProductionCheckout({ git, root }).refusal, "dirty-working-tree");
   assert.equal(inspectGitPreflight({ git, root, target }).refusal, "dirty-working-tree");
   rmSync(join(root, "dirty"));
   writeFileSync(join(root, "file"), "divergent");


### PR DESCRIPTION
## Summary
- inspect production checkout ownership before the already-deployed early return
- repeat the ownership check before fetch after the quiet-window wait
- cover main, feature, dirty, non-fast-forward, and entry ordering regressions

## Review
- independent gpt-5.6-sol high review: no actionable findings
- closes the P2 finding that real deploy NOOP could bypass the main-only guard

## Verification
- npm run test:auto-deploy (33/33)
- MERGE GATE: PASS d43d34eeb865d0c9cf3889399a7c3a7d27bb2670