### PR TITLE
fix: close active run cancellation races

### DIFF
--- a/apps/web/src/pages/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail.tsx
@@ -315,7 +315,7 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
   const totalTokens = counted.length === 0 ? null : counted.reduce((sum, value) => sum + value, 0);
   // `app.ts` orders runs `runNumber desc`, so the newest run is the head.
   const newest = runs[0];
-  const newestIsActive = newest !== undefined
+  const newestIsActive = task.executionOwner === "agent" && newest !== undefined
     && ["QUEUED", "CLAIMED", "PROVISIONING", "RUNNING", "WAITING_INBOX"].includes(newest.status);
   const newestIsCancelling = newestIsActive && newest.cancelRequestedAt !== null && newest.cancelAcknowledgedAt === null;
   const newestBranch = newest?.branch ?? newest?.targetBranch ?? null;

--- a/apps/web/src/tests/task-detail.test.tsx
+++ b/apps/web/src/tests/task-detail.test.tsx
@@ -31,6 +31,7 @@ test("active Runs expose cancellation and an outstanding intent renders Cancelli
   assert.match(source, /newest\.cancelAcknowledgedAt === null/u);
   assert.match(source, /taskDetail\.cancel\.cancelling/u);
   assert.match(source, /\/runs\/\$\{newest\.id\}\/cancel/u);
+  assert.match(source, /task\.executionOwner === "agent"/u);
 });
 
 const output = (body: string): TaskStepOutput => ({

--- a/packages/api/src/active-run-cancellation.dbtest.ts
+++ b/packages/api/src/active-run-cancellation.dbtest.ts
@@ -99,6 +99,18 @@ test("every live provider status exposes one idempotent cancellation through hea
     assert.equal(duplicate.body.requestId, requestId);
     assert.equal((await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, { requestId: `${requestId}-other`, reason: "other" })).status, 409);
 
+    const lateEvents = await call("POST", `/runner/runs/${seeded.run.id}/events`, RUNNER, {
+      runnerId: RUNNER_ID,
+      fencingToken: seeded.run.fencingToken,
+      events: [{ seq: 0, source: "CLAUDE", type: "LATE", payload: { text: "must lose" } }],
+    });
+    assert.equal(lateEvents.status, 409);
+    const lateActivity = await call("POST", `/runner/runs/${seeded.run.id}/activity`, RUNNER, {
+      fencingToken: seeded.run.fencingToken,
+      body: "late activity must lose",
+    });
+    assert.equal(lateActivity.status, 409);
+
     const observed = await heartbeat(seeded.run.id, seeded.run.fencingToken!);
     assert.equal(observed.status, 200);
     assert.equal(observed.body.cancellation.requestId, requestId);
@@ -136,6 +148,159 @@ test("every live provider status exposes one idempotent cancellation through hea
   }
 });
 
+test("mechanical merge Runs refuse cancellation before recording an intent", async () => {
+  const seeded = await seed(RunStatus.RUNNING);
+  const template = await db.taskTemplate.create({ data: {
+    projectId: seeded.project.id,
+    name: "direct-engineer-workflow",
+    description: "mechanical tail",
+    variables: [],
+  } });
+  const step = await db.taskTemplateStep.create({ data: {
+    taskTemplateId: template.id,
+    stepIndex: 7,
+    name: "Merge execution",
+    prompt: "merge",
+    outputKind: "merge-result",
+    assigneeType: "AGENT",
+  } });
+  await db.task.update({ where: { id: seeded.task.id }, data: { templateId: template.id, templateStepId: step.id } });
+
+  const response = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+    requestId: "cancel-mechanical",
+    reason: "must be refused",
+  });
+  assert.equal(response.status, 409);
+  assert.match(response.body.error, /Mechanical merge Runs cannot be cancelled/u);
+  const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
+  assert.equal(run.cancelRequestId, null);
+  assert.equal(run.cancelRequestedAt, null);
+
+  await db.run.update({ where: { id: seeded.run.id }, data: {
+    cancelRequestId: "legacy-mechanical-cancel",
+    cancelReason: "persisted before upgrade",
+    cancelRequestedAt: new Date(),
+  } });
+  const replay = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+    requestId: "legacy-mechanical-cancel",
+    reason: "same request replay",
+  });
+  assert.equal(replay.status, 200);
+  assert.equal(replay.body.cancellationState, "requested");
+  assert.equal((await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+    requestId: "different-mechanical-cancel",
+    reason: "must conflict",
+  })).status, 409);
+});
+
+test("cancellation acknowledgement persists a provisioning workspace before terminalizing", async () => {
+  const seeded = await seed(RunStatus.PROVISIONING);
+  await db.run.update({ where: { id: seeded.run.id }, data: { workspacePath: null, branch: null, baseSha: null } });
+  const requestId = "cancel-with-workspace";
+  assert.equal((await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+    requestId,
+    reason: "retain provisioning evidence",
+  })).status, 200);
+  assert.equal((await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
+    runnerId: RUNNER_ID,
+    fencingToken: seeded.run.fencingToken,
+    requestId,
+    workspacePath: "/scratch/provisioning-evidence",
+    branch: "codex/provisioning-evidence",
+    baseSha: "a".repeat(40),
+  })).status, 200);
+  const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
+  assert.equal(run.status, RunStatus.CANCELLED);
+  assert.equal(run.workspacePath, "/scratch/provisioning-evidence");
+  assert.equal(run.branch, "codex/provisioning-evidence");
+  assert.equal(run.baseSha, "a".repeat(40));
+});
+
+test("start and cancellation acknowledgement serialize to one Run and Session outcome", { timeout: 20_000 }, async () => {
+  const seeded = await seed(RunStatus.PROVISIONING);
+  const startClient = new PrismaClient({ datasources: { db: { url: process.env.TEST_DATABASE_URL! } } });
+  let sessionWriteReached!: () => void;
+  let releaseSessionWrite!: () => void;
+  const reached = new Promise<void>((resolve) => { sessionWriteReached = resolve; });
+  const release = new Promise<void>((resolve) => { releaseSessionWrite = resolve; });
+  let intercepted = false;
+  const startDb = new Proxy(startClient, { get(target, property, receiver) {
+    if (property !== "$transaction") {
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    }
+    return (operation: (tx: any) => Promise<unknown>, options: unknown) => target.$transaction(async (tx) => {
+      const instrumentedTx = new Proxy(tx, { get(txTarget, txProperty, txReceiver) {
+        if (txProperty !== "session") return Reflect.get(txTarget, txProperty, txReceiver);
+        return new Proxy(txTarget.session, { get(sessionTarget, sessionProperty, sessionReceiver) {
+          if (sessionProperty !== "updateMany") return Reflect.get(sessionTarget, sessionProperty, sessionReceiver);
+          return async (...args: unknown[]) => {
+            if (!intercepted) {
+              intercepted = true;
+              sessionWriteReached();
+              await release;
+            }
+            return Reflect.apply(sessionTarget.updateMany, sessionTarget, args);
+          };
+        } });
+      } });
+      return operation(instrumentedTx);
+    }, options as any);
+  } }) as PrismaClient;
+  const priorOperator = process.env.OPERATOR_TOKEN;
+  const priorRunner = process.env.RUNNER_TOKEN;
+  process.env.OPERATOR_TOKEN = OPERATOR;
+  process.env.RUNNER_TOKEN = RUNNER;
+  try {
+    const start = createApp(startDb).request(`/runner/runs/${seeded.run.id}/start`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${RUNNER}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        runnerId: RUNNER_ID,
+        fencingToken: seeded.run.fencingToken,
+        adapterVersion: "test",
+        cliVersion: "test",
+        manifest: {},
+        workspacePath: "/scratch/start-cancel-race",
+        runtimeHandle: "test:123",
+      }),
+    });
+    await reached;
+    let cancellationSettled = false;
+    const cancellation = (async () => {
+      const requested = await createApp(db).request(`/runs/${seeded.run.id}/cancel`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${OPERATOR}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "cancel-start-race", reason: "operator stop" }),
+      });
+      assert.equal(requested.status, 200, await requested.text());
+      const acknowledged = await createApp(db).request(`/runner/runs/${seeded.run.id}/cancel/acknowledge`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${RUNNER}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken, requestId: "cancel-start-race" }),
+      });
+      assert.equal(acknowledged.status, 200, await acknowledged.text());
+      cancellationSettled = true;
+    })();
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    assert.equal(cancellationSettled, false, "cancellation must wait for the atomic start transaction");
+    releaseSessionWrite();
+    const started = await start;
+    assert.equal(started.status, 200, await started.text());
+    await cancellation;
+  } finally {
+    if (priorOperator === undefined) delete process.env.OPERATOR_TOKEN; else process.env.OPERATOR_TOKEN = priorOperator;
+    if (priorRunner === undefined) delete process.env.RUNNER_TOKEN; else process.env.RUNNER_TOKEN = priorRunner;
+    await startClient.$disconnect();
+  }
+  const [run, session] = await Promise.all([
+    db.run.findUniqueOrThrow({ where: { id: seeded.run.id } }),
+    db.session.findUniqueOrThrow({ where: { runId: seeded.run.id } }),
+  ]);
+  assert.equal(run.status, RunStatus.CANCELLED);
+  assert.equal(session.executionStatus, SessionExecutionStatus.CANCELLED);
+});
+
 test("QUEUED and WAITING_INBOX cancellation settle immediately without a provider acknowledgement", async () => {
   for (const status of [RunStatus.QUEUED, RunStatus.WAITING_INBOX]) {
     const seeded = await seed(status);
@@ -170,6 +335,103 @@ test("lease reconciliation settles an unacknowledged cancellation without retryi
   assert.equal(run.cancelAcknowledgedAt?.toISOString(), now.toISOString());
   assert.equal(count, 1);
   assert.equal(successor.status, TaskStatus.TODO);
+});
+
+test("a late runner acknowledgement backfills workspace evidence after reconciliation", async () => {
+  const now = new Date();
+  const seeded = await seed(RunStatus.PROVISIONING, new Date(now.getTime() - 1_000));
+  await db.run.update({ where: { id: seeded.run.id }, data: {
+    cancelRequestId: "cancel-reconciled-first",
+    cancelReason: "stop during provisioning",
+    cancelRequestedAt: new Date(now.getTime() - 2_000),
+    workspacePath: null,
+    branch: null,
+    baseSha: null,
+  } });
+  assert.equal(await reconcileDatabaseRuns(db, now), 1);
+  const response = await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
+    runnerId: RUNNER_ID,
+    fencingToken: seeded.run.fencingToken,
+    requestId: "cancel-reconciled-first",
+    workspacePath: "/scratch/reconciled-first",
+    branch: "codex/reconciled-first",
+    baseSha: "b".repeat(40),
+  });
+  assert.equal(response.status, 200);
+  const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
+  assert.equal(run.status, RunStatus.CANCELLED);
+  assert.equal(run.workspacePath, "/scratch/reconciled-first");
+  assert.equal(run.branch, "codex/reconciled-first");
+  assert.equal(run.baseSha, "b".repeat(40));
+
+  const conflicting = await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
+    runnerId: RUNNER_ID,
+    fencingToken: seeded.run.fencingToken,
+    requestId: "cancel-reconciled-first",
+    workspacePath: "/scratch/must-not-overwrite",
+    branch: "codex/must-not-overwrite",
+    baseSha: "c".repeat(40),
+  });
+  assert.equal(conflicting.status, 200);
+  const preserved = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
+  assert.equal(preserved.workspacePath, "/scratch/reconciled-first");
+  assert.equal(preserved.branch, "codex/reconciled-first");
+  assert.equal(preserved.baseSha, "b".repeat(40));
+});
+
+test("reconciliation re-reads cancellation after its stale candidate snapshot", { timeout: 20_000 }, async () => {
+  const now = new Date();
+  const seeded = await seed(RunStatus.RUNNING, new Date(now.getTime() - 1_000));
+  await db.run.update({ where: { id: seeded.run.id }, data: {
+    heartbeatAt: new Date(now.getTime() - 20 * 60_000),
+    stallTimeoutMin: 1,
+  } });
+  const reconcileClient = new PrismaClient({ datasources: { db: { url: process.env.TEST_DATABASE_URL! } } });
+  let snapshotRead!: () => void;
+  let releaseSnapshot!: () => void;
+  const reached = new Promise<void>((resolve) => { snapshotRead = resolve; });
+  const release = new Promise<void>((resolve) => { releaseSnapshot = resolve; });
+  let intercepted = false;
+  const reconcileDb = new Proxy(reconcileClient, { get(target, property, receiver) {
+    if (property !== "run") {
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    }
+    return new Proxy(target.run, { get(runTarget, runProperty, runReceiver) {
+      if (runProperty !== "findMany") return Reflect.get(runTarget, runProperty, runReceiver);
+      return async (...args: unknown[]) => {
+        const rows = await Reflect.apply(runTarget.findMany, runTarget, args);
+        const query = args[0] as { where?: { status?: unknown } } | undefined;
+        if (!intercepted && typeof query?.where?.status === "object") {
+          intercepted = true;
+          snapshotRead();
+          await release;
+        }
+        return rows;
+      };
+    } });
+  } }) as PrismaClient;
+  try {
+    const reconciliation = reconcileDatabaseRuns(reconcileDb, now);
+    await reached;
+    const cancellation = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+      requestId: "cancel-after-snapshot",
+      reason: "operator stop",
+    });
+    assert.equal(cancellation.status, 200);
+    assert.equal(cancellation.body.cancellationState, "requested");
+    releaseSnapshot();
+    assert.equal(await reconciliation, 1);
+  } finally {
+    await reconcileClient.$disconnect();
+  }
+  const [run, runCount] = await Promise.all([
+    db.run.findUniqueOrThrow({ where: { id: seeded.run.id } }),
+    db.run.count({ where: { taskId: seeded.task.id } }),
+  ]);
+  assert.equal(run.status, RunStatus.CANCELLED);
+  assert.equal(run.cancelRequestId, "cancel-after-snapshot");
+  assert.equal(runCount, 1);
 });
 
 test("a cancellation intent fences out a late Inbox suspension", async () => {

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -522,6 +522,7 @@ test("startup reconciliation spares a run whose runner is still heartbeating", a
     $transaction: async (operation: (value: unknown) => Promise<unknown>) => operation({
       $queryRaw: async () => [{ id: "task-2", archivedAt: null }],
       run: {
+        findFirst: async () => ({ cancelRequestId: null, cancelReason: null, cancelRequestedAt: null }),
         updateMany: async ({ where }: { where: { id: string } }) => { lost.push(where.id); return { count: 1 }; },
         create: async () => ({}),
       },
@@ -1561,6 +1562,7 @@ test("event ingestion makes literal NULs visible without changing seq order", as
     const visibleNul = "\\u0000";
     const stored: Array<Record<string, unknown>> = [];
     const database = {
+      $queryRaw: async () => [{ id: "run-1" }],
       run: {
         findFirst: async () => ({ session: { id: "ses-1", providerConversationId: null } }),
       },
@@ -1576,8 +1578,9 @@ test("event ingestion makes literal NULs visible without changing seq order", as
         },
         count: async () => stored.length,
       },
-    } as unknown as PrismaClient;
-    const app = createApp(database);
+    } as Record<string, unknown>;
+    database.$transaction = async (operation: (tx: unknown) => Promise<unknown>) => operation(database);
+    const app = createApp(database as unknown as PrismaClient);
     const response = await app.request("/runner/runs/run-1/events", {
       method: "POST",
       headers: { Authorization: "Bearer runner-unit-token", "Content-Type": "application/json" },

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -266,7 +266,7 @@ const stopBaseDriftRecoveryTail = async (
   ] });
 };
 
-const openMergeTailInbox = async (
+const openMergeTailReviewDecisionInbox = async (
   tx: DbTx,
   input: { taskId: string; agentId: string; sessionId?: string; reason: string },
 ): Promise<void> => {
@@ -285,6 +285,21 @@ const openMergeTailInbox = async (
       { id: "adopt-head", label: "Adopt current exact head and rerun Regression" },
       { id: "operator-takeover", label: "Park autonomous tail for operator takeover" },
     ],
+    dedupeKey: `merge-tail-review-rejection:${input.taskId}:${createHash("sha256").update(input.reason).digest("hex")}`,
+  } });
+};
+
+const openMergeTailStopNotice = async (
+  tx: DbTx,
+  input: { taskId: string; agentId: string; sessionId?: string; reason: string },
+): Promise<void> => {
+  await tx.inboxMessage.create({ data: {
+    from: "AGENT",
+    agentId: input.agentId,
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    taskId: input.taskId,
+    kind: "TEXT",
+    body: `Autonomous merge tail stopped: ${input.reason}`,
     dedupeKey: `merge-tail-stop:${input.taskId}:${createHash("sha256").update(input.reason).digest("hex")}`,
   } });
 };
@@ -390,7 +405,7 @@ const applyMergeTailOperatorDecision = async (
       task: { include: { templateStep: true, runs: { orderBy: { runNumber: "desc" }, take: 5 } } },
     },
   });
-  if (!card?.dedupeKey?.startsWith("merge-tail-stop:")) return null;
+  if (!card?.dedupeKey?.startsWith("merge-tail-review-rejection:")) return null;
   if (!card.task || !card.session?.run) return { duplicate: false, resumed: false, messageId: card.id, error: "Merge-tail decision is missing its Regression task or source Run" };
   if (!["create-repair", "adopt-head", "operator-takeover"].includes(input.decision)) {
     return { duplicate: false, resumed: false, messageId: card.id, error: "Unknown merge-tail operator decision" };
@@ -544,7 +559,7 @@ export const handleRegressionCompletion = async (
       body: `Regression did not advance: ${reason}`,
       metadata: { kind: MERGE_TAIL_KIND.regression, schemaVersion: 1, state: "stopped", reason },
     } });
-    await openMergeTailInbox(tx, { taskId: input.task.id, agentId: input.run.agentId, sessionId: input.run.sessionId, reason });
+    await openMergeTailStopNotice(tx, { taskId: input.task.id, agentId: input.run.agentId, sessionId: input.run.sessionId, reason });
     return "handled";
   };
   if (parsed.status === "invalid") return stop(parsed.reason);
@@ -947,6 +962,9 @@ const cancelAcknowledgeInput = z.object({
   runnerId: z.string().trim().min(1).max(120),
   fencingToken: fence,
   requestId: z.string().trim().min(1).max(160),
+  workspacePath: z.string().min(1).optional(),
+  branch: z.string().min(1).optional(),
+  baseSha: z.string().min(1).optional(),
 });
 const publicationInput = z.object({
   runnerId: z.string().trim().min(1).max(120),
@@ -1282,7 +1300,17 @@ type CancellationSettlement =
  * writer. No retry or successor is created on this path. */
 const settleCancellation = async (
   tx: Prisma.TransactionClient,
-  input: { runId: string; requestId: string; now: Date; runnerId?: string; fencingToken?: string; actorId?: string },
+  input: {
+    runId: string;
+    requestId: string;
+    now: Date;
+    runnerId?: string;
+    fencingToken?: string;
+    actorId?: string;
+    workspacePath?: string;
+    branch?: string;
+    baseSha?: string;
+  },
 ): Promise<CancellationSettlement> => {
   await tx.$queryRaw`SELECT "id" FROM "Run" WHERE "id" = ${input.runId} FOR UPDATE`;
   const run = await tx.run.findUnique({
@@ -1299,6 +1327,19 @@ const settleCancellation = async (
     return { error: "Cancellation acknowledgement is not owned by this runner", code: 409 };
   }
   if (run.status === RunStatus.CANCELLED && run.cancelAcknowledgedAt) {
+    // Reconciliation can settle an expired cancellation before the runner's
+    // final ACK arrives. That ACK is still the only durable account of a
+    // workspace provisioned before /start, so idempotence must backfill its
+    // evidence instead of discarding it.
+    if (input.workspacePath !== undefined) await tx.run.updateMany({
+      where: { id: run.id, workspacePath: null }, data: { workspacePath: input.workspacePath },
+    });
+    if (input.branch !== undefined) await tx.run.updateMany({
+      where: { id: run.id, branch: null }, data: { branch: input.branch },
+    });
+    if (input.baseSha !== undefined) await tx.run.updateMany({
+      where: { id: run.id, baseSha: null }, data: { baseSha: input.baseSha },
+    });
     return { runId: run.id, taskId: run.taskId, status: run.status, cancellationState: "acknowledged", requestId: input.requestId };
   }
   const settled = await tx.run.updateMany({
@@ -1320,6 +1361,9 @@ const settleCancellation = async (
       retryable: false,
       retryAt: null,
       workspaceRetained: true,
+      ...(input.workspacePath === undefined ? {} : { workspacePath: input.workspacePath }),
+      ...(input.branch === undefined ? {} : { branch: input.branch }),
+      ...(input.baseSha === undefined ? {} : { baseSha: input.baseSha }),
     },
   });
   if (settled.count !== 1) return { error: `Run is already ${run.status}`, code: 409 };
@@ -4421,7 +4465,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
               where: { runId: regressionRepairHandoff.previousRunId },
               select: { id: true },
             });
-            await openMergeTailInbox(tx, {
+            await openMergeTailStopNotice(tx, {
               taskId: candidate.task.id,
               agentId: candidate.agentId,
               ...(sourceSession ? { sessionId: sourceSession.id } : {}),
@@ -4605,39 +4649,44 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, startInput);
     const now = new Date();
-    const updated = await db.run.updateMany({
-      where: {
-        id: runId,
-        runnerId: body.runnerId,
-        fencingToken: body.fencingToken,
-        cancelRequestedAt: null,
-        leaseExpiresAt: { gt: now },
-        status: { in: [RunStatus.CLAIMED, RunStatus.PROVISIONING] },
-      },
-      data: {
-        status: RunStatus.RUNNING,
-        startedAt: now,
-        adapterVersion: body.adapterVersion,
-        cliVersion: body.cliVersion,
-        authMode: body.authMode ?? null,
-        manifest: jsonValue(body.manifest),
-        workspacePath: body.workspacePath,
-        branch: body.branch ?? null,
-        baseSha: body.baseSha ?? null,
-      },
+    const started = await db.$transaction(async (tx) => {
+      await tx.$queryRaw`SELECT "id" FROM "Run" WHERE "id" = ${runId} FOR UPDATE`;
+      const updated = await tx.run.updateMany({
+        where: {
+          id: runId,
+          runnerId: body.runnerId,
+          fencingToken: body.fencingToken,
+          cancelRequestedAt: null,
+          leaseExpiresAt: { gt: now },
+          status: { in: [RunStatus.CLAIMED, RunStatus.PROVISIONING] },
+        },
+        data: {
+          status: RunStatus.RUNNING,
+          startedAt: now,
+          adapterVersion: body.adapterVersion,
+          cliVersion: body.cliVersion,
+          authMode: body.authMode ?? null,
+          manifest: jsonValue(body.manifest),
+          workspacePath: body.workspacePath,
+          branch: body.branch ?? null,
+          baseSha: body.baseSha ?? null,
+        },
+      });
+      if (updated.count !== 1) return false;
+      const session = await tx.session.updateMany({
+        where: { runId, executionStatus: SessionExecutionStatus.PROVISIONING },
+        data: {
+          executionStatus: SessionExecutionStatus.RUNNING,
+          runtimeHandle: body.runtimeHandle ?? null,
+          resumeInput: null,
+          provisionedAt: now,
+          startedAt: now,
+        },
+      });
+      if (session.count !== 1) throw new Error(`Run ${runId} has no startable Session`);
+      return true;
     });
-    if (updated.count !== 1) return context.json({ error: "Stale fencing token" }, 409);
-    await db.session.update({
-      where: { runId },
-      data: {
-        executionStatus: SessionExecutionStatus.RUNNING,
-        runtimeHandle: body.runtimeHandle ?? null,
-        resumeInput: null,
-        provisionedAt: now,
-        startedAt: now,
-      },
-    });
-    return context.json({ ok: true });
+    return started ? context.json({ ok: true }) : context.json({ error: "Stale fencing token" }, 409);
   });
 
   app.post("/runner/runs/:runId/heartbeat", async (context) => {
@@ -4664,7 +4713,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         ...(body.inFlightTool !== undefined ? { inFlightTool: body.inFlightTool ? jsonValue(body.inFlightTool) : Prisma.JsonNull } : {}),
       },
     });
-    if (updated.count === 1) return context.json({ ok: true, cancellation: null });
+    if (updated.count === 1) return context.json({
+      ok: true,
+      cancellation: null,
+      mechanicalCancellationPolicy: "refused",
+    });
     const cancelling = await db.run.findFirst({
       where: {
         id: runId,
@@ -4678,6 +4731,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     if (cancelling?.cancelRequestId && cancelling.cancelReason && cancelling.cancelRequestedAt) {
       return context.json({
         ok: false,
+        mechanicalCancellationPolicy: "refused",
         cancellation: {
           requestId: cancelling.cancelRequestId,
           reason: cancelling.cancelReason,
@@ -4701,6 +4755,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       fencingToken: body.fencingToken,
       actorId: body.runnerId,
       now: new Date(),
+      ...(body.workspacePath === undefined ? {} : { workspacePath: body.workspacePath }),
+      ...(body.branch === undefined ? {} : { branch: body.branch }),
+      ...(body.baseSha === undefined ? {} : { baseSha: body.baseSha }),
     }));
     return "error" in result ? context.json({ error: result.error }, result.code) : context.json(result);
   });
@@ -4802,34 +4859,46 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/runner/runs/:runId/events", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, eventsInput);
-    const run = await db.run.findFirst({
-      where: { id: runId, runnerId: body.runnerId, fencingToken: body.fencingToken, cancelRequestedAt: null, leaseExpiresAt: { gt: new Date() }, status: { in: activeRunStatuses } },
-      include: { session: true },
+    const result = await db.$transaction(async (tx) => {
+      await tx.$queryRaw`SELECT "id" FROM "Run" WHERE "id" = ${runId} FOR UPDATE`;
+      const run = await tx.run.findFirst({
+        where: { id: runId, runnerId: body.runnerId, fencingToken: body.fencingToken, cancelRequestedAt: null, leaseExpiresAt: { gt: new Date() }, status: { in: activeRunStatuses } },
+        include: { session: true },
+      });
+      if (!run?.session) {
+        const waiting = await tx.run.findFirst({ where: { id: runId, status: RunStatus.WAITING_INBOX }, select: { id: true } });
+        return waiting
+          ? { error: "Run suspended for Inbox", code: "WAITING_INBOX" as const }
+          : { error: "Stale fencing token", code: "STALE" as const };
+      }
+      await tx.sessionEvent.createMany({
+        data: body.events.map((event) => ({
+          sessionId: run.session!.id,
+          runId,
+          seq: event.seq,
+          at: event.at ?? new Date(),
+          source: event.source,
+          type: normalizeSessionEventValue(event.type) as string,
+          providerEventId: event.providerEventId === undefined || event.providerEventId === null
+            ? null
+            : normalizeSessionEventValue(event.providerEventId) as string,
+          toolCallId: event.toolCallId === undefined || event.toolCallId === null
+            ? null
+            : normalizeSessionEventValue(event.toolCallId) as string,
+          payload: jsonValue(normalizeSessionEventValue(event.payload)),
+        })),
+        skipDuplicates: true,
+      });
+      if (body.providerConversationId && !run.session.providerConversationId) {
+        await tx.session.update({ where: { id: run.session.id }, data: { providerConversationId: body.providerConversationId } });
+      }
+      return { sessionId: run.session.id };
     });
-    if (!run?.session) {
-      const waiting = await db.run.findFirst({ where: { id: runId, status: RunStatus.WAITING_INBOX }, select: { id: true } });
-      return waiting
-        ? context.json({ error: "Run suspended for Inbox", code: "WAITING_INBOX" }, 409)
-        : context.json({ error: "Stale fencing token" }, 409);
+    if ("error" in result) {
+      return result.code === "WAITING_INBOX"
+        ? context.json({ error: result.error, code: result.code }, 409)
+        : context.json({ error: result.error }, 409);
     }
-    await db.sessionEvent.createMany({
-      data: body.events.map((event) => ({
-        sessionId: run.session!.id,
-        runId,
-        seq: event.seq,
-        at: event.at ?? new Date(),
-        source: event.source,
-        type: normalizeSessionEventValue(event.type) as string,
-        providerEventId: event.providerEventId === undefined || event.providerEventId === null
-          ? null
-          : normalizeSessionEventValue(event.providerEventId) as string,
-        toolCallId: event.toolCallId === undefined || event.toolCallId === null
-          ? null
-          : normalizeSessionEventValue(event.toolCallId) as string,
-        payload: jsonValue(normalizeSessionEventValue(event.payload)),
-      })),
-      skipDuplicates: true,
-    });
     // Recompute on "a FINAL_OUTPUT arrived", not "this payload had usage": a batch
     // whose event was already stored still recomputes, which is what self-heals a
     // write lost between createMany and here. The guard reads the request body
@@ -4844,13 +4913,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     // lock-wait timeout is one more throw this catch absorbs — same repair path.
     if (body.events.some((event) => event.type === "FINAL_OUTPUT")) {
       try {
-        await recomputeSessionUsage(db, run.session.id);
+        await recomputeSessionUsage(db, result.sessionId);
       } catch (error) {
-        console.error(`Session usage recompute failed for ${run.session.id}`, error);
+        console.error(`Session usage recompute failed for ${result.sessionId}`, error);
       }
-    }
-    if (body.providerConversationId && !run.session.providerConversationId) {
-      await db.session.update({ where: { id: run.session.id }, data: { providerConversationId: body.providerConversationId } });
     }
     return context.json({ accepted: body.events.length });
   });
@@ -4859,43 +4925,48 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, fencedActivityInput);
     const principal = context.get("principal");
-    const run = await db.run.findFirst({
-      where: {
-        id: runId,
-        fencingToken: body.fencingToken,
-        leaseExpiresAt: { gt: new Date() },
-        status: { in: activeRunStatuses },
-        ...(principal.kind === "runner" ? {} : { leaseGeneration: principal.kind === "session" ? principal.leaseGeneration : -1 }),
-      },
-      select: {
-        taskId: true,
-        task: { select: { templateStep: { select: {
-          stepIndex: true,
-          outputKind: true,
-          taskTemplate: { select: { name: true } },
-        } } } },
-      },
+    const result = await db.$transaction(async (tx) => {
+      await tx.$queryRaw`SELECT "id" FROM "Run" WHERE "id" = ${runId} FOR UPDATE`;
+      const run = await tx.run.findFirst({
+        where: {
+          id: runId,
+          fencingToken: body.fencingToken,
+          cancelRequestedAt: null,
+          leaseExpiresAt: { gt: new Date() },
+          status: { in: activeRunStatuses },
+          ...(principal.kind === "runner" ? {} : { leaseGeneration: principal.kind === "session" ? principal.leaseGeneration : -1 }),
+        },
+        select: {
+          taskId: true,
+          task: { select: { templateStep: { select: {
+            stepIndex: true,
+            outputKind: true,
+            taskTemplate: { select: { name: true } },
+          } } } },
+        },
+      });
+      if (!run?.taskId) return null;
+      const metadata = body.metadata
+        ? {
+            ...body.metadata,
+            ...(((body.metadata.kind === MERGE_INTEGRATOR_KIND.intent
+              || body.metadata.kind === MERGE_INTEGRATOR_KIND.result)
+              && executionModeFor(run.task?.templateStep ?? null) === "mechanical")
+              ? { sourceRunId: runId }
+              : {}),
+          }
+        : undefined;
+      return tx.taskActivity.create({
+        data: {
+          taskId: run.taskId,
+          actorType: principal.kind,
+          actorId: body.actorId ?? null,
+          body: body.body,
+          ...(metadata ? { metadata: jsonValue(metadata) } : {}),
+        },
+      });
     });
-    if (!run?.taskId) return context.json({ error: "Stale fencing token" }, 409);
-    const metadata = body.metadata
-      ? {
-          ...body.metadata,
-          ...(((body.metadata.kind === MERGE_INTEGRATOR_KIND.intent
-            || body.metadata.kind === MERGE_INTEGRATOR_KIND.result)
-            && executionModeFor(run.task?.templateStep ?? null) === "mechanical")
-            ? { sourceRunId: runId }
-            : {}),
-        }
-      : undefined;
-    return context.json(await db.taskActivity.create({
-      data: {
-        taskId: run.taskId,
-        actorType: principal.kind,
-        actorId: body.actorId ?? null,
-        body: body.body,
-        ...(metadata ? { metadata: jsonValue(metadata) } : {}),
-      },
-    }), 201);
+    return result ? context.json(result, 201) : context.json({ error: "Stale fencing token" }, 409);
   };
   app.post("/runner/runs/:runId/activity", appendFencedActivity);
   app.post("/session/runs/:runId/activity", appendFencedActivity);
@@ -5198,6 +5269,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       if (refusal) return context.json({ error: refusal }, 403);
     }
     const result = await db.$transaction(async (tx) => {
+      // Run owns fencing, cancellation, and terminalization. Take that mutex
+      // before Task so completion, cancellation, and canonical output writes
+      // cannot deadlock by entering the same two rows in opposite orders.
+      await tx.$queryRaw`SELECT "id" FROM "Run" WHERE "id" = ${runId} FOR UPDATE`;
       const run = await tx.run.findFirst({
         where: { id: runId, runnerId: body.runnerId, fencingToken: body.fencingToken, cancelRequestedAt: null, leaseExpiresAt: { gt: now }, status: { in: activeRunStatuses } },
         include: {
@@ -5459,14 +5534,14 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                 state: "failed",
               }),
             } });
-            await openMergeTailInbox(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+            await openMergeTailStopNotice(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
           } else if (reviewMarker
             && typeof reviewMarker.readinessTaskId === "string"
             && typeof reviewMarker.regressionTaskId === "string") {
             const reason = `independent review ${run.taskId} failed without an exact-head decision for ${String(reviewMarker.headSha)}`;
             await tx.task.update({ where: { id: reviewMarker.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
             await tx.task.update({ where: { id: reviewMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-            await openMergeTailInbox(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+            await openMergeTailStopNotice(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
           }
         }
         // §4.0 outcome branching. The executor's own fenced write is the only
@@ -5591,7 +5666,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
               const reason = `independent review returned missing, malformed, or stale decision for ${reviewMarker.headSha}`;
               await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: reason } });
               await tx.task.update({ where: { id: reviewMarker.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-              await openMergeTailInbox(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+              await openMergeTailStopNotice(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
             } else if (decision.outcome === "approved") {
               await tx.taskActivity.create({ data: {
                 taskId: reviewMarker.readinessTaskId,
@@ -5642,12 +5717,12 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
               } else if (alreadyRejected) {
                 const reason = `second independent review rejection at ${reviewMarker.headSha}: ${summary}`;
                 await tx.task.update({ where: { id: reviewMarker.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-                await openMergeTailInbox(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+                await openMergeTailReviewDecisionInbox(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
               } else {
                 const reason = `independent review rejected exact head ${reviewMarker.headSha}: ${summary}`;
                 await tx.task.update({ where: { id: reviewMarker.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
                 await tx.task.update({ where: { id: reviewMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-                await openMergeTailInbox(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+                await openMergeTailReviewDecisionInbox(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
               }
             }
           }
@@ -5687,7 +5762,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                     reason: bindingError,
                   }),
                 } });
-                await openMergeTailInbox(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+                await openMergeTailStopNotice(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
               } else if (parsedResolver.status === "ok") {
                 reportedUnable = parsedResolver.result.outcome === "unable";
                 resolvedHeadSha = parsedResolver.result.outcome === "resolved" ? parsedResolver.result.resolvedHeadSha : null;
@@ -5700,7 +5775,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
               const reason = `${String(repairMarker.repairKind)} repair ${run.taskId} reported unable at ${String(repairMarker.headSha)}`;
               await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: reason } });
               await tx.task.update({ where: { id: repairMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-              await openMergeTailInbox(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+              await openMergeTailStopNotice(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
             } else if (!repairUnable) {
               await tx.taskActivity.create({ data: {
                 taskId: repairMarker.regressionTaskId,
@@ -5911,6 +5986,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           cancelRequestedAt: true,
           cancelAcknowledgedAt: true,
           session: { select: { id: true } },
+          task: { select: { templateStep: { select: {
+            stepIndex: true,
+            outputKind: true,
+            taskTemplate: { select: { name: true } },
+          } } } },
         },
       });
       if (!run) return { error: "Run not found", code: 404 as const };
@@ -5926,6 +6006,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           requestId: run.cancelRequestId,
           reason: run.cancelReason,
         };
+      }
+      if (executionModeFor(run.task?.templateStep ?? null) === "mechanical") {
+        return { error: "Mechanical merge Runs cannot be cancelled after authorization", code: 409 as const };
       }
       if (!([RunStatus.QUEUED, ...activeRunStatuses] as RunStatus[]).includes(run.status)) {
         return {

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -224,6 +224,10 @@ export const persistSessionTaskOutput = async (
     metadata?: Prisma.InputJsonValue;
   },
 ): Promise<PersistOutputResult> => {
+  // Run is the cancellation authority. Take its row before Task so every
+  // output writer serializes with cancellation/completion and follows the
+  // same Run -> Task lock order as those terminal paths.
+  await tx.$queryRaw`SELECT "id" FROM "Run" WHERE "id" = ${input.runId} FOR UPDATE`;
   await lockTaskRow(tx, input.task.id);
   const authorized = await tx.run.findFirst({
     where: {

--- a/packages/api/src/chain.dbtest.ts
+++ b/packages/api/src/chain.dbtest.ts
@@ -166,7 +166,14 @@ test("runner completion and manual successor start serialize to one run without 
       const [completed, started] = await Promise.all([completion, manualStart]);
       assert.equal(completed.status, 200);
       assert.equal(started.status, 409);
-      assert.equal((await started.json() as { error: string }).error, "Task already has an active run");
+      // Completion now locks Run before Task so cancellation and completion
+      // share one global order. The manual start may therefore observe either
+      // side of the same safe boundary: the predecessor is not done yet, or
+      // completion has advanced it and already queued the successor Run.
+      assert.match(
+        (await started.json() as { error: string }).error,
+        /^(?:Cannot start Second; predecessor First is not done|Task already has an active run)$/,
+      );
     });
   } finally {
     if (priorOperator === undefined) delete process.env.OPERATOR_TOKEN; else process.env.OPERATOR_TOKEN = priorOperator;

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -350,6 +350,19 @@ test("a semantic FAIL skips the gate path and creates one review-fix task", asyn
   assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 1);
 });
 
+test("invalid Regression output opens a stop notice with no unusable operator choices", async () => {
+  const seeded = await seedRegression();
+  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, {
+    task: seeded.regression,
+    run: { id: seeded.run.id, agentId: seeded.regressionAgent.id, branch: BRANCH, headSha: HEAD, sessionId: seeded.session.id },
+    now: new Date(),
+  })), "handled");
+  const card = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
+  assert.equal(card.kind, "TEXT");
+  assert.equal(card.choices, null);
+  assert.match(card.dedupeKey ?? "", /^merge-tail-stop:/u);
+});
+
 test("a fresh Regression claim carries the prior verdict and exact published repair without resuming context", async () => {
   const seeded = await exercise("review-fail");
   const repair = await repairFor(seeded, "review-fix");

--- a/packages/api/src/reconcile.test.ts
+++ b/packages/api/src/reconcile.test.ts
@@ -185,6 +185,7 @@ test("lease-loss requeue for an archived agent becomes visible through the sweep
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
       $queryRaw: async () => [{ id: "task-1", archivedAt: null }],
       run: {
+        findFirst: async () => ({ cancelRequestId: null, cancelReason: null, cancelRequestedAt: null }),
         updateMany: async ({ data }: { data: Record<string, unknown> }) => { lostUpdate = data; return { count: 1 }; },
         create: async ({ data }: { data: Record<string, unknown> }) => { queued = data; return { id: "retry-2", ...data }; },
       },

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -138,15 +138,33 @@ export const reconcileDatabaseRuns = async (db: PrismaClient, now = new Date()):
         : run.heartbeatAt === null
           ? `Platform lease expired at ${run.leaseExpiresAt.toISOString()} without a recorded runner heartbeat`
           : `Runner heartbeat starved after ${run.heartbeatAt.toISOString()}; platform lease expired at ${run.leaseExpiresAt.toISOString()}`;
+      // Run is the authority for cancellation, fencing, and terminalization.
+      // Re-read it under its mutex before Task: the candidate list is only a
+      // hint and may predate a cancellation that committed while this sweep
+      // was starting.
+      await tx.$queryRaw`SELECT "id" FROM "Run" WHERE "id" = ${run.id} FOR UPDATE`;
+      const current = await tx.run.findFirst({
+        where: {
+          id: run.id,
+          status: { in: [...activeStatuses] },
+          OR: [{ leaseExpiresAt: { lt: now } }, { leaseExpiresAt: null }],
+        },
+        select: {
+          cancelRequestId: true,
+          cancelReason: true,
+          cancelRequestedAt: true,
+        },
+      });
+      if (!current) continue;
       // Order PATCH and retry creation through the same Task-row mutex. The
       // task is re-read after this lock before opensPullRequest is snapshotted.
       if (run.taskId) await lockTaskRow(tx, run.taskId);
-      if (run.cancelRequestId && run.cancelRequestedAt) {
-        const reason = run.cancelReason ?? "Cancelled by operator";
+      if (current.cancelRequestId && current.cancelRequestedAt) {
+        const reason = current.cancelReason ?? "Cancelled by operator";
         const cancelled = await tx.run.updateMany({
           where: {
             id: run.id,
-            cancelRequestId: run.cancelRequestId,
+            cancelRequestId: current.cancelRequestId,
             status: { in: [...activeStatuses] },
             OR: [{ leaseExpiresAt: { lt: now } }, { leaseExpiresAt: null }],
           },
@@ -185,7 +203,7 @@ export const reconcileDatabaseRuns = async (db: PrismaClient, now = new Date()):
             taskId: run.taskId,
             actorType: "control-plane",
             body: `Run ${run.runNumber} cancellation settled after its lease expired; evidence retained`,
-            metadata: { runId: run.id, requestId: run.cancelRequestId, status: RunStatus.CANCELLED },
+            metadata: { runId: run.id, requestId: current.cancelRequestId, status: RunStatus.CANCELLED },
           } });
         }
         continue;
@@ -197,7 +215,12 @@ export const reconcileDatabaseRuns = async (db: PrismaClient, now = new Date()):
       // after that budget changes. See `runBudgetCeiling`.
       const budgetGrants = run.budgetGrants + 1;
       const lost = await tx.run.updateMany({
-        where: { id: run.id, status: { in: [...activeStatuses] } },
+        where: {
+          id: run.id,
+          cancelRequestedAt: null,
+          status: { in: [...activeStatuses] },
+          OR: [{ leaseExpiresAt: { lt: now } }, { leaseExpiresAt: null }],
+        },
         data: {
           status: RunStatus.LOST,
           endedAt: now,

--- a/packages/api/src/run-output.dbtest.ts
+++ b/packages/api/src/run-output.dbtest.ts
@@ -635,6 +635,90 @@ test("completion makes an admitted replacement output lose atomically before suc
   assert.equal(await db.run.count({ where: { taskId: successor.id, status: "QUEUED" } }), 1);
 });
 
+test("cancellation holding the Run mutex makes an already-authenticated output lose", { timeout: 20_000 }, async () => {
+  const seed = await seedTask({
+    chained: true,
+    outputKind: "implementation",
+    templateName: DIRECT_TEMPLATE_NAME,
+    stepIndex: 1,
+  });
+  const runId = await enqueue(seed.task.id);
+  const claimed = await claimRun(runId, "output-cancellation-race");
+  const cancellationClient = new PrismaClient({ datasources: { db: { url: process.env.TEST_DATABASE_URL! } } });
+  const outputClient = new PrismaClient({ datasources: { db: { url: process.env.TEST_DATABASE_URL! } } });
+  let cancellationLocked!: () => void;
+  let outputWaiting!: () => void;
+  let releaseCancellation!: () => void;
+  const cancellationHasLock = new Promise<void>((resolve) => { cancellationLocked = resolve; });
+  const outputReachedLock = new Promise<void>((resolve) => { outputWaiting = resolve; });
+  const release = new Promise<void>((resolve) => { releaseCancellation = resolve; });
+  const instrumentTransactions = (
+    client: PrismaClient,
+    intercept: (pending: Promise<unknown>) => Promise<unknown>,
+  ): PrismaClient => new Proxy(client, { get(target, property, receiver) {
+    if (property !== "$transaction") {
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    }
+    return (operation: (tx: any) => Promise<unknown>, options: unknown) => target.$transaction(async (tx) => {
+      const instrumentedTx = new Proxy(tx, { get(txTarget, txProperty, txReceiver) {
+        if (txProperty !== "$queryRaw") return Reflect.get(txTarget, txProperty, txReceiver);
+        return (...args: unknown[]) => intercept(Reflect.apply(txTarget.$queryRaw, txTarget, args));
+      } });
+      return operation(instrumentedTx);
+    }, options as any);
+  } }) as PrismaClient;
+  let cancellationIntercepted = false;
+  let outputIntercepted = false;
+  const cancellationDb = instrumentTransactions(cancellationClient, async (pending) => {
+    const result = await pending;
+    if (!cancellationIntercepted) {
+      cancellationIntercepted = true;
+      cancellationLocked();
+      await release;
+    }
+    return result;
+  });
+  const outputDb = instrumentTransactions(outputClient, async (pending) => {
+    if (!outputIntercepted) {
+      outputIntercepted = true;
+      outputWaiting();
+    }
+    return pending;
+  });
+  try {
+    await withTokens(async () => {
+      const cancellation = createApp(cancellationDb).request(`/runs/${runId}/cancel`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${OPERATOR}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "cancel-output-race", reason: "operator stop" }),
+      });
+      await cancellationHasLock;
+      const output = createApp(outputDb).request(`/session/runs/${runId}/output`, {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${claimed.sessionToken}`, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fencingToken: claimed.fencingToken,
+          kind: "implementation",
+          body: implementationOutput("late output must lose"),
+          commitSha: SHA,
+        }),
+      });
+      await outputReachedLock;
+      releaseCancellation();
+      const [cancelled, written] = await Promise.all([cancellation, output]);
+      assert.equal(cancelled.status, 200, await cancelled.text());
+      assert.equal(written.status, 409);
+      assert.match((await written.json() as { error: string }).error, /Stale fencing token/u);
+    });
+  } finally {
+    await Promise.all([cancellationClient.$disconnect(), outputClient.$disconnect()]);
+  }
+  assert.equal(await db.taskStepOutput.count({ where: { taskId: seed.task.id } }), 0);
+  const run = await db.run.findUniqueOrThrow({ where: { id: runId } });
+  assert.equal(run.cancelRequestId, "cancel-output-race");
+});
+
 test("a canonical retry receives only the immediate prior Run output and retry reason", async () => {
   const { task } = await seedTask({
     chained: true,

--- a/packages/inbox/src/delivery.test.ts
+++ b/packages/inbox/src/delivery.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { InboxDeliveryStatus, InboxStatus, type PrismaClient } from "@agentos/db";
+
+import { deliverPending } from "./delivery.js";
+
+test("delivery requires an OPEN message both when selecting and when claiming it", async () => {
+  let sent = false;
+  const db = {
+    inboxMessage: {
+      findMany: async (query: { where: { status?: string } }) => {
+        assert.equal(query.where.status, InboxStatus.OPEN);
+        return [{
+          id: "message-1",
+          status: InboxStatus.CLOSED,
+          deliveryStatus: InboxDeliveryStatus.PENDING,
+          deliveryAttempts: 0,
+          body: "closed before delivery",
+          choices: [],
+          taskId: "task-1",
+          thread: { externalChatId: "chat-1" },
+        }];
+      },
+      updateMany: async (query: { where: { status?: string } }) => {
+        assert.equal(query.where.status, InboxStatus.OPEN);
+        return { count: 0 };
+      },
+    },
+  } as unknown as PrismaClient;
+
+  const result = await deliverPending(db, {
+    send: async () => {
+      sent = true;
+      return { messageId: "external-1" };
+    },
+  });
+
+  assert.deepEqual(result, { delivered: 0, failed: 0 });
+  assert.equal(sent, false);
+});

--- a/packages/inbox/src/delivery.ts
+++ b/packages/inbox/src/delivery.ts
@@ -1,4 +1,4 @@
-import { InboxDeliveryStatus, Prisma, type PrismaClient } from "@agentos/db";
+import { InboxDeliveryStatus, InboxStatus, Prisma, type PrismaClient } from "@agentos/db";
 
 import { questionCard, type Choice } from "./cards.js";
 
@@ -21,6 +21,7 @@ export const deliverPending = async (
   const messages = await db.inboxMessage.findMany({
     where: {
       from: "AGENT",
+      status: InboxStatus.OPEN,
       deliveryStatus: { in: [InboxDeliveryStatus.PENDING, InboxDeliveryStatus.FAILED] },
       nextDeliveryAt: { lte: now },
       thread: { isNot: null },
@@ -33,7 +34,7 @@ export const deliverPending = async (
   let failed = 0;
   for (const message of messages) {
     const won = await db.inboxMessage.updateMany({
-      where: { id: message.id, deliveryStatus: message.deliveryStatus },
+      where: { id: message.id, status: InboxStatus.OPEN, deliveryStatus: message.deliveryStatus },
       data: { deliveryStatus: InboxDeliveryStatus.SENDING, deliveryAttempts: { increment: 1 } },
     });
     if (won.count !== 1 || !message.thread) continue;

--- a/packages/merge-executor/src/agentos.ts
+++ b/packages/merge-executor/src/agentos.ts
@@ -24,6 +24,17 @@ export type MechanicalClaim = {
   sessionToken: string;
 };
 
+export type MechanicalCancellation = {
+  requestId: string;
+  reason: string;
+  requestedAt: string;
+};
+
+export type MechanicalHeartbeat = {
+  cancellation: MechanicalCancellation | null;
+  mechanicalCancellationPolicy: "refused" | null;
+};
+
 export type AgentOsClient = ReturnType<typeof makeAgentOsClient>;
 
 const jsonHeaders = (token: string): Record<string, string> => ({
@@ -73,8 +84,8 @@ export const makeAgentOsClient = (config: ExecutorConfig, fetchImpl: typeof fetc
     });
   };
 
-  const heartbeat = async (claimed: MechanicalClaim): Promise<void> => {
-    await request(`/runner/runs/${claimed.run.id}/heartbeat`, {
+  const heartbeat = async (claimed: MechanicalClaim): Promise<MechanicalHeartbeat> => {
+    const response = await request(`/runner/runs/${claimed.run.id}/heartbeat`, {
       method: "POST",
       token: config.executorToken,
       body: {
@@ -84,6 +95,30 @@ export const makeAgentOsClient = (config: ExecutorConfig, fetchImpl: typeof fetc
         processAlive: true,
         lastProgressEventAt: null,
         inFlightTool: null,
+      },
+    });
+    if (response.status === 204) return { cancellation: null, mechanicalCancellationPolicy: null };
+    const payload = await response.json() as {
+      cancellation?: MechanicalCancellation | null;
+      mechanicalCancellationPolicy?: string;
+    };
+    return {
+      cancellation: payload.cancellation ?? null,
+      mechanicalCancellationPolicy: payload.mechanicalCancellationPolicy === "refused" ? "refused" : null,
+    };
+  };
+
+  const acknowledgeCancellation = async (
+    claimed: MechanicalClaim,
+    cancellation: MechanicalCancellation,
+  ): Promise<void> => {
+    await request(`/runner/runs/${claimed.run.id}/cancel/acknowledge`, {
+      method: "POST",
+      token: config.executorToken,
+      body: {
+        runnerId: config.runnerId,
+        fencingToken: claimed.fencingToken,
+        requestId: cancellation.requestId,
       },
     });
   };
@@ -159,5 +194,5 @@ export const makeAgentOsClient = (config: ExecutorConfig, fetchImpl: typeof fetc
     });
   };
 
-  return { claim, start, heartbeat, readChain, readOwnIntents, writeActivity, writeOutput, complete };
+  return { claim, start, heartbeat, acknowledgeCancellation, readChain, readOwnIntents, writeActivity, writeOutput, complete };
 };

--- a/packages/merge-executor/src/index.test.ts
+++ b/packages/merge-executor/src/index.test.ts
@@ -38,6 +38,14 @@ const claimed = (id: string): MechanicalClaim => ({
 
 const log = makeLog(makeRedactor(), { log: () => {}, warn: () => {}, error: () => {} });
 
+const compatibleAgentOsResponse = (input: string | URL | Request): Response =>
+  String(input).endsWith("/heartbeat")
+    ? new Response(JSON.stringify({ ok: true, cancellation: null, mechanicalCancellationPolicy: "refused" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    : new Response(null, { status: 204 });
+
 test("an idle claim poll never enters the run-scoped mint path", async () => {
   let runCalls = 0;
   const fetchImpl: typeof fetch = async () => new Response(null, { status: 204 });
@@ -46,11 +54,73 @@ test("an idle claim poll never enters the run-scoped mint path", async () => {
   assert.equal(runCalls, 0);
 });
 
-test("each claimed Run mints once, immediately before constructing its GitHub surface", async () => {
+test("a persisted mechanical cancellation is acknowledged before GitHub authority is minted", async () => {
+  const requests: string[] = [];
+  const fetchImpl: typeof fetch = async (input) => {
+    const url = String(input);
+    requests.push(url);
+    if (url.endsWith("/heartbeat")) {
+      return new Response(JSON.stringify({
+        ok: false,
+        cancellation: { requestId: "legacy-cancel", reason: "operator stop", requestedAt: new Date(0).toISOString() },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return compatibleAgentOsResponse(input);
+  };
+  let mintCalls = 0;
+  let surfaceCalls = 0;
+  let executeCalls = 0;
+  await runClaim(config, "/private/app.pem", claimed("legacy-cancelled-run"), log, fetchImpl, {
+    mintToken: async () => {
+      mintCalls += 1;
+      return { ok: false, failure: "private-key-read-failed" };
+    },
+    makeGitHub: (() => { surfaceCalls += 1; return {}; }) as never,
+    executeDecision: (async () => { executeCalls += 1; return {}; }) as never,
+  });
+  assert.equal(mintCalls, 0);
+  assert.equal(surfaceCalls, 0);
+  assert.equal(executeCalls, 0);
+  assert.deepEqual(requests, [
+    "https://agentos.test/runner/runs/legacy-cancelled-run/start",
+    "https://agentos.test/runner/runs/legacy-cancelled-run/heartbeat",
+    "https://agentos.test/runner/runs/legacy-cancelled-run/cancel/acknowledge",
+  ]);
+});
+
+test("a control plane without the mechanical-cancellation policy cannot reach GitHub", async () => {
   const requests: Array<{ url: string; body: string }> = [];
   const fetchImpl: typeof fetch = async (input, init) => {
     requests.push({ url: String(input), body: typeof init?.body === "string" ? init.body : "" });
     return new Response(null, { status: 204 });
+  };
+  let mintCalls = 0;
+  let surfaceCalls = 0;
+  let executeCalls = 0;
+  await runClaim(config, "/private/app.pem", claimed("old-control-plane"), log, fetchImpl, {
+    mintToken: async () => {
+      mintCalls += 1;
+      return { ok: false, failure: "private-key-read-failed" };
+    },
+    makeGitHub: (() => { surfaceCalls += 1; return {}; }) as never,
+    executeDecision: (async () => { executeCalls += 1; return {}; }) as never,
+  });
+  assert.equal(mintCalls, 0);
+  assert.equal(surfaceCalls, 0);
+  assert.equal(executeCalls, 0);
+  assert.deepEqual(requests.map((request) => request.url), [
+    "https://agentos.test/runner/runs/old-control-plane/start",
+    "https://agentos.test/runner/runs/old-control-plane/heartbeat",
+    "https://agentos.test/runner/runs/old-control-plane/complete",
+  ]);
+  assert.match(requests[2]!.body, /does not enforce mechanical cancellation refusal/u);
+});
+
+test("each claimed Run mints once, immediately before constructing its GitHub surface", async () => {
+  const requests: Array<{ url: string; body: string }> = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    requests.push({ url: String(input), body: typeof init?.body === "string" ? init.body : "" });
+    return compatibleAgentOsResponse(input);
   };
   let mintCalls = 0;
   let surfaceCalls = 0;
@@ -82,7 +152,7 @@ test("any mint failure completes retryably before a GitHub surface or merge writ
   const requests: Array<{ url: string; body: string }> = [];
   const fetchImpl: typeof fetch = async (input, init) => {
     requests.push({ url: String(input), body: typeof init?.body === "string" ? init.body : "" });
-    return new Response(null, { status: 204 });
+    return compatibleAgentOsResponse(input);
   };
   let surfaceCalls = 0;
   let executeCalls = 0;
@@ -95,9 +165,10 @@ test("any mint failure completes retryably before a GitHub surface or merge writ
   assert.equal(executeCalls, 0);
   assert.deepEqual(requests.map((request) => request.url), [
     "https://agentos.test/runner/runs/failed-run/start",
+    "https://agentos.test/runner/runs/failed-run/heartbeat",
     "https://agentos.test/runner/runs/failed-run/complete",
   ]);
-  const completion = JSON.parse(requests[1]!.body) as Record<string, unknown>;
+  const completion = JSON.parse(requests[2]!.body) as Record<string, unknown>;
   assert.equal(completion.retryable, true);
   assert.match(String(completion.failureReason), /private-key-read-failed/u);
   assert.equal(requests.some((request) => request.body.includes(secret)), false);
@@ -107,7 +178,7 @@ test("a bounded non-settling key read cannot reach a GitHub surface, activity, o
   const requests: Array<{ url: string; body: string }> = [];
   const fetchImpl: typeof fetch = async (input, init) => {
     requests.push({ url: String(input), body: typeof init?.body === "string" ? init.body : "" });
-    return new Response(null, { status: 204 });
+    return compatibleAgentOsResponse(input);
   };
   let surfaceCalls = 0;
   let executeCalls = 0;
@@ -127,10 +198,11 @@ test("a bounded non-settling key read cannot reach a GitHub surface, activity, o
   assert.equal(executeCalls, 0);
   assert.deepEqual(requests.map((request) => request.url), [
     "https://agentos.test/runner/runs/stalled-key-run/start",
+    "https://agentos.test/runner/runs/stalled-key-run/heartbeat",
     "https://agentos.test/runner/runs/stalled-key-run/complete",
   ]);
   assert.equal(requests.some((request) => request.url.includes("/activity") || request.url.includes("/output")), false);
-  assert.match(requests[1]!.body, /private-key-read-failed/u);
+  assert.match(requests[2]!.body, /private-key-read-failed/u);
 });
 
 test("escaped malformed token responses cannot enter logs, completion, activity, or output", async () => {
@@ -144,7 +216,7 @@ test("escaped malformed token responses cannot enter logs, completion, activity,
     });
     const fetchImpl: typeof fetch = async (input, init) => {
       requests.push({ url: String(input), body: typeof init?.body === "string" ? init.body : "" });
-      return new Response(null, { status: 204 });
+      return compatibleAgentOsResponse(input);
     };
     let surfaceCalls = 0;
     await runClaim(config, "/private/app.pem", claimed(`malformed-${requests.length}`), capturedLog, fetchImpl, {
@@ -179,7 +251,7 @@ test("a minted installation token cannot escape through run evidence or completi
     if (url.startsWith("https://api.github.test")) {
       return new Response(JSON.stringify({ errors: [{ message: installationToken }] }), { status: 200 });
     }
-    return new Response(null, { status: 204 });
+    return compatibleAgentOsResponse(input);
   };
   await runClaim(config, "/private/app.pem", claimed("redacted-run"), log, fetchImpl, {
     mintToken: async () => ({ ok: true, token: installationToken, expiresAt: new Date(Date.now() + 60 * 60_000) }),

--- a/packages/merge-executor/src/index.ts
+++ b/packages/merge-executor/src/index.ts
@@ -14,7 +14,7 @@ import "dotenv/config";
 
 import { INTEGRATOR_OUTPUT_KIND, MERGE_INTEGRATOR_KIND, MERGE_INTEGRATOR_SCHEMA_VERSION, serializeMergeResult } from "@agentos/db/merge-integrator";
 
-import { makeAgentOsClient, type MechanicalClaim } from "./agentos.js";
+import { makeAgentOsClient, type MechanicalCancellation, type MechanicalClaim } from "./agentos.js";
 import { loadExecutorConfig, type ExecutorConfig } from "./config.js";
 import { execute, type Deps } from "./decision-table.js";
 import { mintInstallationToken } from "./github-app-auth.js";
@@ -23,6 +23,18 @@ import { evaluatePreconditions, liveDeps } from "./preconditions.js";
 import { makeLog, makeRedactor, type ExecutorLog } from "./redaction.js";
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+class MechanicalCancellationObserved extends Error {
+  constructor(readonly cancellation: MechanicalCancellation) {
+    super("persisted mechanical cancellation observed");
+  }
+}
+
+class MechanicalApiIncompatible extends Error {
+  constructor() {
+    super("control plane does not refuse mechanical cancellation");
+  }
+}
 
 export const runClaim = async (
   config: ExecutorConfig,
@@ -47,12 +59,31 @@ export const runClaim = async (
 
   const startedAt = new Date();
   let runLog = log;
+  let pendingCancellation: MechanicalCancellation | null = null;
+  const checkCancellation = async (): Promise<void> => {
+    if (pendingCancellation) throw new MechanicalCancellationObserved(pendingCancellation);
+    const heartbeat = await agentos.heartbeat(claimed);
+    if (heartbeat.cancellation) {
+      pendingCancellation = heartbeat.cancellation;
+      throw new MechanicalCancellationObserved(heartbeat.cancellation);
+    }
+    // A new executor must never run against an old API that can still accept a
+    // cancellation in the check-to-merge gap. The capability marker turns an
+    // unsafe inverse rollout into a fail-closed retry instead of a merge.
+    if (heartbeat.mechanicalCancellationPolicy !== "refused") throw new MechanicalApiIncompatible();
+  };
   const heartbeat = setInterval(() => {
-    void agentos.heartbeat(claimed).catch((error: unknown) => { runLog.warn("heartbeat failed", { error }); });
+    void agentos.heartbeat(claimed)
+      .then((observed) => { if (observed.cancellation) pendingCancellation = observed.cancellation; })
+      .catch((error: unknown) => { runLog.warn("heartbeat failed", { error }); });
   }, Math.max(5_000, config.leaseSeconds * 500));
 
   try {
     await agentos.start(claimed);
+    // Old control planes could persist a cancellation for an already-started
+    // mechanical Run. A rolling upgrade must consume that state before this
+    // process mints GitHub authority or reaches an irreversible merge.
+    await checkCancellation();
     const minted = await (overrides.mintToken ?? mintInstallationToken)({
       appId: config.githubAppId,
       installationId: config.githubAppInstallationId,
@@ -100,7 +131,13 @@ export const runClaim = async (
       readChain: () => agentos.readChain(claimed, chainIndex - 1),
       readOwnIntents: () => agentos.readOwnIntents(claimed, chainIndex),
       readPullRequest: (reference) => github.readPullRequest(reference),
-      merge: (reference, expectedHeadSha, expectedBase) => github.mergePullRequest(reference, expectedHeadSha, expectedBase),
+      merge: async (reference, expectedHeadSha, expectedBase) => {
+        // The current API refuses new mechanical cancellation, so this is an
+        // upgrade fence for persisted legacy intent. Keep it immediately in
+        // front of the only irreversible operation as defense in depth.
+        await checkCancellation();
+        return github.mergePullRequest(reference, expectedHeadSha, expectedBase);
+      },
       disableAutoMerge: (pullRequestId) => github.disableAutoMerge(pullRequestId),
       dequeuePullRequest: (entryId) => github.dequeuePullRequest(entryId),
       writeIntent: async (intent) => {
@@ -120,6 +157,7 @@ export const runClaim = async (
     };
 
     const outcome = await (overrides.executeDecision ?? execute)(deps);
+    await checkCancellation();
     // The output is the latest view and is replaceable; the activity is the
     // append-only history the stop guard keys on (Y1). Both are written, always.
     await agentos.writeOutput(claimed, INTEGRATOR_OUTPUT_KIND, serializeMergeResult(outcome));
@@ -135,6 +173,20 @@ export const runClaim = async (
     await agentos.complete(claimed, { succeeded: true, outcome });
     runLog.info("mechanical run completed", { runId: claimed.run.id, outcome: outcome.outcome });
   } catch (error: unknown) {
+    if (error instanceof MechanicalCancellationObserved) {
+      await agentos.acknowledgeCancellation(claimed, error.cancellation);
+      runLog.info("persisted mechanical cancellation acknowledged", { runId: claimed.run.id });
+      return;
+    }
+    if (error instanceof MechanicalApiIncompatible) {
+      runLog.error("mechanical run refused incompatible control plane", { runId: claimed.run.id });
+      await agentos.complete(claimed, {
+        succeeded: false,
+        outcome: null,
+        failureReason: "control plane does not enforce mechanical cancellation refusal",
+      });
+      return;
+    }
     runLog.error("mechanical run crashed", { runId: claimed.run.id, error });
     // Deep transport errors can contain request headers. The run record names
     // the failed phase without serialising the thrown value into control-plane

--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -238,6 +238,7 @@ export const acknowledgeCancellation = async (
   config: RunnerConfig,
   claim: ClaimedTask,
   cancellation: CancellationRequest,
+  workspace?: { path: string; branch: string; baseSha: string } | null,
 ): Promise<void> => {
   await request(config, `/runner/runs/${claim.run.id}/cancel/acknowledge`, {
     method: "POST",
@@ -245,6 +246,7 @@ export const acknowledgeCancellation = async (
       runnerId: config.runnerId,
       fencingToken: claim.fencingToken,
       requestId: cancellation.requestId,
+      ...(workspace ? { workspacePath: workspace.path, branch: workspace.branch, baseSha: workspace.baseSha } : {}),
     }),
   });
 };

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -10,7 +10,7 @@ import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { executeClaim, reportCliAvailabilityHeartbeat, runStartupPreflight } from "./runner.js";
 import {
-  cleanupAgentScratch, provisionSessionConfig, type AgentScratch,
+  cleanupAgentScratch, provisionSessionConfig, writeSessionCredentials, type AgentScratch,
 } from "./workspace.js";
 
 const config = (workspaceRoot: string): RunnerConfig => ({
@@ -1021,8 +1021,67 @@ test("a heartbeat cancellation kills the provider group, acknowledges once, and 
     const acknowledgements = posts.filter((post) => post.path.endsWith("/cancel/acknowledge"));
     assert.equal(acknowledgements.length, 1);
     assert.equal(acknowledgements[0]?.body.requestId, "cancel-1");
+    assert.equal(acknowledgements[0]?.body.workspacePath, join(workspaces, "run-10"));
+    assert.equal(acknowledgements[0]?.body.branch, "agentos/task-10/run-1");
     assert.equal(posts.some((post) => post.path.endsWith("/complete")), false);
     assert.equal(posts.some((post) => post.path.endsWith("/publication")), false);
+    await access(join(workspaces, "run-10"));
+  } finally {
+    await cleanupTestSession(root);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a provisioning cancellation is acknowledged only after provider launch is closed", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-prelaunch-cancellation-"));
+  try {
+    const workspaces = join(root, "workspaces");
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    await writeFile(binary, successfulCodexMutationStub(log, "sleep 30"));
+    await chmod(binary, 0o755);
+    const remote = await seedRemote(root);
+    await seedCodexAuth(root);
+    const posts: Array<{ path: string; body: Record<string, any> }> = [];
+    let credentialsWriting = false;
+    let cancellationSent = false;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
+      if (credentialsWriting && path.endsWith("/heartbeat") && !cancellationSent) {
+        cancellationSent = true;
+        return new Response(JSON.stringify({
+          ok: false,
+          cancellation: { requestId: "cancel-before-launch", reason: "operator stop", requestedAt: new Date(0).toISOString() },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ ok: true, cancellation: null }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+    const configured = { ...codexOnly(workspaces, root, binary), heartbeatIntervalMs: 20 };
+
+    await executeClaim(configured, {
+      ...mechanicalClaim,
+      executionMode: "agent",
+      runner: "CODEX",
+      session: testSession(root),
+      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
+      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
+      run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
+    }, {
+      writeSessionCredentials: async (...args) => {
+        const path = await writeSessionCredentials(...args);
+        credentialsWriting = true;
+        await new Promise<void>((resolve) => setTimeout(resolve, 80));
+        return path;
+      },
+    });
+
+    const acknowledgements = posts.filter((post) => post.path.endsWith("/cancel/acknowledge"));
+    assert.equal(cancellationSent, true);
+    assert.equal(acknowledgements.length, 1);
+    assert.equal(acknowledgements[0]?.body.workspacePath, join(workspaces, "run-10"));
+    assert.equal(posts.some((post) => post.path.endsWith("/start")), false);
+    assert.equal(posts.some((post) => post.path.endsWith("/complete")), false);
     await access(join(workspaces, "run-10"));
   } finally {
     await cleanupTestSession(root);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -168,6 +168,7 @@ const preflightEvidence = (message: string): ExitEvidence => ({
 export type ExecuteClaimDependencies = {
   provisionSessionConfig?: typeof provisionSessionConfig;
   cleanupAgentScratch?: typeof cleanupAgentScratch;
+  writeSessionCredentials?: typeof writeSessionCredentials;
 };
 
 export const executeClaim = async (
@@ -186,6 +187,15 @@ export const executeClaim = async (
   let waitingInbox = false;
   let cancellation: CancellationRequest | null = null;
   let cancellationPromise: Promise<void> | null = null;
+  let closeProviderLaunch!: () => void;
+  const providerLaunchSettled = new Promise<void>((resolve) => {
+    let closed = false;
+    closeProviderLaunch = () => {
+      if (closed) return;
+      closed = true;
+      resolve();
+    };
+  });
   let budgetReason: string | null = null;
   // A session CLI's root is retained until the run is known to have succeeded, so a
   // provisioning or execution failure can be inspected and resumed without
@@ -252,8 +262,12 @@ export const executeClaim = async (
     cancellation = request;
     fencingRejected = true;
     cancellationPromise ??= (async () => {
+      // ACK is proof that no provider group can still appear. Cancellation
+      // during credential preparation or adapter startup waits until launch is
+      // either abandoned or has produced the handle that must be killed.
+      await providerLaunchSettled;
       if (handle) await adapter.kill(handle, request.reason);
-      await acknowledgeCancellation(config, claim, request);
+      await acknowledgeCancellation(config, claim, request, workspace);
     })();
     await cancellationPromise;
   };
@@ -360,6 +374,7 @@ export const executeClaim = async (
     const preflight = await adapter.preflight({ config, runner: claim.runner, model: claim.run.model, env });
     if (fencingRejected) {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
+      closeProviderLaunch();
       if (cancellation) {
         await cancellationPromise;
         return;
@@ -397,11 +412,26 @@ export const executeClaim = async (
       return;
     }
 
-    const credentialsPath = await writeSessionCredentials(config, claim, workspace);
+    const credentialsPath = await (dependencies.writeSessionCredentials ?? writeSessionCredentials)(config, claim, workspace);
+    if (fencingRejected) {
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      closeProviderLaunch();
+      if (cancellation) await cancellationPromise;
+      return;
+    }
     const spec = { config, claim, workingDirectory: workspace.path, env, prompt, credentialsPath };
-    handle = claim.resume
-      ? await adapter.resume({ ...spec, ...claim.resume }, sink)
-      : await adapter.start(spec, sink);
+    try {
+      handle = claim.resume
+        ? await adapter.resume({ ...spec, ...claim.resume }, sink)
+        : await adapter.start(spec, sink);
+    } finally {
+      closeProviderLaunch();
+    }
+    if (fencingRejected) {
+      if (heartbeatTimer) clearInterval(heartbeatTimer);
+      if (cancellation) await cancellationPromise;
+      return;
+    }
     if (heartbeatTimer) clearInterval(heartbeatTimer);
     phase = "EXECUTE";
     await startRun(config, claim, {
@@ -625,6 +655,7 @@ export const executeClaim = async (
     });
     scratch = null;
   } catch (error: unknown) {
+    closeProviderLaunch();
     if (heartbeatTimer) clearInterval(heartbeatTimer);
     if ((error as { status?: number; code?: string }).status === 409 && (error as { code?: string }).code === "WAITING_INBOX") {
       waitingInbox = true;
@@ -705,6 +736,7 @@ export const executeClaim = async (
       } : {}),
     });
   } finally {
+    closeProviderLaunch();
     if (heartbeatTimer) clearInterval(heartbeatTimer);
     lease?.close();
     // Throwaway by construction, so losing it costs nothing and leaving it


### PR DESCRIPTION
## Summary
- serialize cancellation, completion, output, reconciliation, and event writes through the Run mutex
- fail closed for mechanical merge cancellation across rolling upgrades
- preserve provisioning evidence and prevent delivery of closed Inbox messages
- replace unusable merge-tail decision cards with explicit stop notices

## Verification
- Sol high independent review: PASS, no P0/P1/P2 findings
- API unit: 432 pass, 1 skip
- Runner unit: 204 pass, 1 skip
- Inbox unit: 6 pass
- Web unit: 388 pass
- Merge executor unit: 89 pass, 1 skip
- active cancellation DB regression: 10 pass
- run-output DB regression: 13 pass
- four affected package typechecks pass

Exact-head Merge Gate will be run on the final PR head before merge.