### PR TITLE
fix(gate): bound build cache retention

### DIFF
--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -82,8 +82,9 @@
 # copy-on-write primitive when available, and the two dated provenance files are
 # regenerated for this run. No test result or test verdict is cached: every
 # lint, database-CLI typecheck, unit test, migration and database test still
-# executes. Cache entries are write-once; a malformed entry falls back to the
-# original slow command rather than being repaired or guessed at.
+# executes. Cache entries are write-once, and at most 32 valid entries are
+# retained, including the entry serving the current run. A malformed entry
+# falls back to the original slow command rather than being repaired or guessed at.
 
 set -euo pipefail
 
@@ -92,6 +93,7 @@ EXPECT_HEAD=""
 MASTER_OID="${AGENTOS_MASTER_OID:-}"
 POSTGRES_IMAGE="${AGENTOS_GATE_POSTGRES_IMAGE:-postgres:16-alpine}"
 CACHE_ROOT="${XDG_CACHE_HOME:-${HOME}/.cache}/agentos-merge-gate"
+BUILD_CACHE_MAX_ENTRIES=32
 
 EXIT_FAIL=1
 EXIT_NOT_AUTHORITATIVE=3
@@ -433,6 +435,45 @@ build_cache_entry_valid() {
   done
 }
 
+prune_build_cache() {
+  local protected_key="${1:-}" builds="${CACHE_ROOT}/builds"
+  local candidate="" key="" keep_limit="${BUILD_CACHE_MAX_ENTRIES}"
+  local valid_count=0 removed=0
+  [ -d "${builds}" ] || return 0
+
+  if [ -n "${protected_key}" ] \
+    && build_cache_entry_valid "${builds}/${protected_key}" "${protected_key}"; then
+    keep_limit=$((BUILD_CACHE_MAX_ENTRIES - 1))
+  else
+    protected_key=""
+  fi
+
+  # Final entries are immutable, hash-named directories. Sort those candidates
+  # by publication mtime and leave writer locks, symlinks, and doubtful state
+  # untouched. A concurrent reader whose old entry is pruned either finishes
+  # its clone or takes the existing clean-build fallback.
+  while IFS= read -r candidate; do
+    [ -d "${candidate}" ] && [ ! -L "${candidate}" ] || continue
+    key="${candidate##*/}"
+    [ "${#key}" -eq 64 ] || continue
+    case "${key}" in *[!0-9a-f]*) continue ;; esac
+    [ "${key}" = "${protected_key}" ] && continue
+    build_cache_entry_valid "${candidate}" "${key}" || continue
+    valid_count=$((valid_count + 1))
+    [ "${valid_count}" -le "${keep_limit}" ] && continue
+    if chmod -R u+w "${candidate}" 2>/dev/null && rm -rf -- "${candidate}"; then
+      removed=$((removed + 1))
+    else
+      note "build cache pruning could not remove ${key}; leaving it unused"
+    fi
+  done < <(LC_ALL=C ls -1dt -- "${builds}/"* 2>/dev/null || true)
+
+  if [ "${removed}" -gt 0 ]; then
+    note "build cache pruned: ${removed} old entries; retaining at most ${BUILD_CACHE_MAX_ENTRIES}"
+  fi
+  return 0
+}
+
 clear_build_outputs() {
   local output=""
   for output in "${BUILD_OUTPUTS[@]}"; do rm -rf -- "${REPO_ROOT}/${output}" || return 1; done
@@ -498,6 +539,7 @@ publish_deferred_build_snapshot() {
   entry="${CACHE_ROOT}/builds/${key}"
   publish_build_snapshot "${entry}" "${key}" "${snapshot}/tree" \
     || note "build cache publication failed; this run keeps fresh build output"
+  prune_build_cache "${key}"
 }
 
 build_all() {
@@ -527,6 +569,7 @@ build_all() {
     (cd "${REPO_ROOT}/packages/api" && node ../build-info/stamp.mjs dist) || return 1
     (cd "${REPO_ROOT}/packages/runner" && node ../build-info/stamp.mjs dist) || return 1
     note "build cache hit: ${key} ($(cache_copy_description), provenance restamped)"
+    prune_build_cache "${key}"
     return 0
   fi
   note "build cache miss: ${key}"


### PR DESCRIPTION
## Summary

- retain at most 32 valid build-cache entries, including the key serving the current gate
- prune only immutable 64-hex cache directories with a valid READY contract
- preserve symlinks, malformed state, writer locks, and the current cache key

## Verification

- isolated 35-entry fixture retained exactly 32 valid entries and preserved the protected key, invalid directory, and symlink
- merge-gate profile fixtures: 5/5
- gate-worker harness: 53/53
- bash syntax and diff checks
- exact-head full gate PASS cf79caa93d840789ecd3c5dbefcb79448d11b8a9 against 753eed89d0c4553d7effdd71fc015da115efffb3
- remote cache publication completed; cache currently 7 entries / 61 MB