### PR TITLE
fix(runner): recover stale auth circuits

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1092,6 +1092,10 @@ const preflightInput = z.object({
   error: z.string().nullable().optional(),
 });
 const runnerAvailabilityInput = z.object({
+  // Optional only for the API-first half of a rolling deployment. A runner
+  // without an identity may still report binary health, but cannot receive a
+  // coordinated full-preflight retry directive.
+  runnerId: z.string().trim().min(1).max(120).optional(),
   runner: z.nativeEnum(RunnerKind),
   binary: z.string().trim().min(1).max(500),
   available: z.boolean(),
@@ -1571,6 +1575,13 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   const app = new Hono<AppEnvironment>();
   const noteArchivedQueuedRunsOnClaim = createArchivedRunNoticeScheduler(db);
   const runners = createRunnerRegistry();
+  // Authentication circuits are global backend state, so only one daemon must
+  // perform a recovery check. This short in-process lease prevents every idle
+  // daemon from invoking the same provider login command on each heartbeat.
+  // `lastPreflightAt` remains the durable retry clock, so an API restart may
+  // reassign an overdue check without changing what that timestamp means.
+  const preflightRecoveryLeases = new Map<RunnerKind, number>();
+  const preflightRecoveryIntervalMs = 5 * 60_000;
 
   // The supported browser path is same-origin through the Vite proxy, so this
   // allowlist is a boundary rather than a transport: it decides which *other*
@@ -4208,7 +4219,17 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       }
       return available;
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
-    return context.json(state);
+    const lastPreflightAt = state.lastPreflightAt?.getTime() ?? 0;
+    const currentLease = preflightRecoveryLeases.get(body.runner) ?? 0;
+    const revalidatePreflight = body.available
+      && body.runnerId !== undefined
+      && state.circuitOpen
+      && now.getTime() - lastPreflightAt >= preflightRecoveryIntervalMs
+      && currentLease <= now.getTime();
+    if (revalidatePreflight) {
+      preflightRecoveryLeases.set(body.runner, now.getTime() + preflightRecoveryIntervalMs);
+    }
+    return context.json({ ...state, revalidatePreflight });
   });
 
   app.post("/runner/preflight", async (context) => {
@@ -4239,6 +4260,24 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           : { circuitOpen: true, circuitReason: body.error ?? "Preflight failed", circuitOpenedAt: now }),
       },
     });
+    preflightRecoveryLeases.delete(body.runner);
+    const blockedReason = body.error ?? "Preflight failed";
+    if (body.ok) {
+      if (previous?.circuitReason) {
+        await db.task.updateMany({
+          where: { failureReason: previous.circuitReason },
+          data: { failureReason: null },
+        });
+      }
+    } else {
+      await db.task.updateMany({
+        where: {
+          status: { in: [TaskStatus.TODO, TaskStatus.DOING] },
+          runs: { some: { runner: body.runner, status: RunStatus.QUEUED } },
+        },
+        data: { failureReason: blockedReason },
+      });
+    }
     if (!body.ok && !previous?.circuitOpen) {
       // Attach the operator chat so the alert can actually leave the web Inbox;
       // threadless messages are skipped by the Feishu outbox forever.

--- a/packages/api/src/runner-cli-availability.dbtest.ts
+++ b/packages/api/src/runner-cli-availability.dbtest.ts
@@ -170,3 +170,65 @@ test("CLI availability reports preserve an independent authentication circuit", 
   assert.equal(state.circuitOpen, true);
   assert.equal(state.circuitReason, "not-authenticated: run codex login");
 });
+
+test("an overdue authentication circuit assigns one recovery preflight and surfaces its blocker", async () => {
+  const seeded = await seedTask(RunnerPreference.CODEX);
+  const openedAt = new Date(Date.now() - 10 * 60_000);
+  await db.runnerBackendState.create({ data: {
+    runner: "CODEX",
+    lastPreflightAt: openedAt,
+    lastPreflightOk: false,
+    circuitOpen: true,
+    circuitReason: "not-authenticated: run codex login",
+    circuitOpenedAt: openedAt,
+  } });
+  const app = createApp(db);
+  const report = async (runnerId: string) => {
+    const response = await app.request("/runner/availability", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${RUNNER_TOKEN}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        runnerId,
+        runner: "CODEX",
+        binary: "codex",
+        available: true,
+        resolvedPath: "/opt/runner/bin/codex",
+      }),
+    });
+    assert.equal(response.status, 200);
+    return await response.json() as { revalidatePreflight: boolean };
+  };
+
+  assert.equal((await report("runner-a")).revalidatePreflight, true);
+  assert.equal((await report("runner-b")).revalidatePreflight, false);
+
+  await app.request("/runner/preflight", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${RUNNER_TOKEN}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      runner: "CODEX",
+      ok: false,
+      cliVersion: "codex-cli test",
+      authMode: "chatgpt",
+      capabilities: {},
+      error: "not-authenticated: run codex login",
+    }),
+  });
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.task.id } })).failureReason,
+    "not-authenticated: run codex login");
+  assert.equal((await report("runner-b")).revalidatePreflight, false, "a fresh failure must back off");
+
+  await app.request("/runner/preflight", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${RUNNER_TOKEN}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      runner: "CODEX",
+      ok: true,
+      cliVersion: "codex-cli test",
+      authMode: "chatgpt",
+      capabilities: {},
+    }),
+  });
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.task.id } })).failureReason, null);
+  assert.equal((await report("runner-a")).revalidatePreflight, false);
+});

--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -457,6 +457,12 @@ export const reportCliAvailability = async (
     method: "POST",
     body: JSON.stringify({ runnerId: config.runnerId, ...availability }),
   });
-  const body = await response.json() as { revalidatePreflight?: boolean };
+  // The established endpoint contract did not require a response body. During
+  // rollout, an older control plane (and narrow protocol fixtures) may still
+  // acknowledge the report with an empty 2xx response. Only a non-empty body
+  // carries the additive recovery directive; malformed JSON still fails.
+  const responseBody = await response.text();
+  if (!responseBody.trim()) return { revalidatePreflight: false };
+  const body = JSON.parse(responseBody) as { revalidatePreflight?: boolean };
   return { revalidatePreflight: body.revalidatePreflight === true };
 };

--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -452,9 +452,11 @@ export const reportPreflight = async (
 export const reportCliAvailability = async (
   config: RunnerConfig,
   availability: { runner: RunnerKind; binary: string; available: boolean; resolvedPath: string | null },
-): Promise<void> => {
-  await request(config, "/runner/availability", {
+): Promise<{ revalidatePreflight: boolean }> => {
+  const response = await request(config, "/runner/availability", {
     method: "POST",
-    body: JSON.stringify(availability),
+    body: JSON.stringify({ runnerId: config.runnerId, ...availability }),
   });
+  const body = await response.json() as { revalidatePreflight?: boolean };
+  return { revalidatePreflight: body.revalidatePreflight === true };
 };

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -1489,3 +1489,39 @@ test("an availability heartbeat reports a CLI recovery without restarting the ru
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("an availability heartbeat runs one requested preflight and reports its recovery", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-auth-recovery-"));
+  try {
+    const log = join(root, "codex-argv.log");
+    const binary = join(root, "codex.sh");
+    await writeFile(binary, codexStub(log));
+    await chmod(binary, 0o755);
+    const configured = codexOnly(join(root, "workspaces"), root, binary);
+    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+      posts.push({ path, body });
+      const revalidatePreflight = path.endsWith("/runner/availability") && body.runner === "CODEX";
+      return new Response(JSON.stringify({ revalidatePreflight }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await reportCliAvailabilityHeartbeat(configured);
+
+    assert.ok(posts.filter((post) => post.path.endsWith("/runner/availability"))
+      .every((post) => post.body.runnerId === configured.runnerId));
+    const reports = posts.filter((post) => post.path.endsWith("/runner/preflight"));
+    assert.equal(reports.length, 1);
+    assert.equal(reports[0]?.body.runner, "CODEX");
+    assert.equal(reports[0]?.body.ok, true);
+    assert.deepEqual((await readFile(log, "utf8")).trim().split("\n"), [
+      "--version", "exec --help", "exec resume --help", "login status",
+    ]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -1473,7 +1473,7 @@ test("an availability heartbeat reports a CLI recovery without restarting the ru
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
     globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
-      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+      return new Response(null, { status: 200 });
     }) as typeof fetch;
 
     await reportCliAvailabilityHeartbeat(configured);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -817,7 +817,7 @@ const reportAvailabilityWithRetry = async (
   options: StartupReportRetryOptions,
 ): Promise<void> => reportStartupStateWithRetry(
   availability.runner,
-  () => reportCliAvailability(config, availability),
+  async () => { await reportCliAvailability(config, availability); },
   options,
 );
 
@@ -844,9 +844,7 @@ export const runStartupPreflight = async (
       results[runner] = false;
       continue;
     }
-    const model = runner === "PI" ? "openai-codex/gpt-5.6-luna"
-      : runner === "CODEX" ? CODEX_STARTER_MODEL : runner.toLowerCase();
-    const result = await adapters[runner].preflight({ config, runner, model, env });
+    const result = await runBackendPreflight(config, runner, env);
     results[runner] = result.ok;
     await reportPreflightWithRetry(config, runner, result, retryOptions);
   }
@@ -855,6 +853,17 @@ export const runStartupPreflight = async (
 
 export type AvailabilityHeartbeatOptions = {
   onReportError?: (availability: CliAvailability, error: unknown) => void;
+  onPreflightError?: (availability: CliAvailability, error: unknown) => void;
+};
+
+const runBackendPreflight = async (
+  config: RunnerConfig,
+  runner: RunnerKind,
+  env = workspaceEnvironment(config),
+) => {
+  const model = runner === "PI" ? "openai-codex/gpt-5.6-luna"
+    : runner === "CODEX" ? CODEX_STARTER_MODEL : runner.toLowerCase();
+  return adapters[runner].preflight({ config, runner, model, env });
 };
 
 /** One cheap daemon heartbeat. Every backend is attempted independently so a
@@ -867,11 +876,23 @@ export const reportCliAvailabilityHeartbeat = async (
   const onReportError = options.onReportError ?? ((probe: CliAvailability, error: unknown) => {
     console.error(`Failed to report ${probe.runner.toLowerCase()} runner CLI availability`, error);
   });
+  const onPreflightError = options.onPreflightError ?? ((probe: CliAvailability, error: unknown) => {
+    console.error(`Failed to revalidate ${probe.runner.toLowerCase()} runner preflight`, error);
+  });
   for (const runner of SUPPORTED_RUNNERS) {
+    let revalidatePreflight = false;
     try {
-      await reportCliAvailability(config, availability[runner]);
+      ({ revalidatePreflight } = await reportCliAvailability(config, availability[runner]));
     } catch (error: unknown) {
       onReportError(availability[runner], error);
+      continue;
+    }
+    if (revalidatePreflight && availability[runner].available) {
+      try {
+        await reportPreflight(config, runner, await runBackendPreflight(config, runner));
+      } catch (error: unknown) {
+        onPreflightError(availability[runner], error);
+      }
     }
   }
 };


### PR DESCRIPTION
Automatically revalidates overdue backend authentication circuits through one coordinated runner heartbeat. Preserves cheap CLI availability checks, backs off retries for five minutes, and surfaces or clears queued-task blockers with the circuit result.\n\nVerification:\n- MERGE GATE: PASS d725786430615c77bfce17581690ec6a01aab327\n- Runner regression tests: 28 passed\n- Service maintenance lock dbtest: 5 passed\n- Runner/API targeted tests and typecheck passed