### PR TITLE
fix(review): prevent blind review output stalls

### DIFF
--- a/agents/roles/review-coordinator-opus.md
+++ b/agents/roles/review-coordinator-opus.md
@@ -36,9 +36,11 @@ chain branch.
 - A finding reported only by the first reviewer enters the final list only
   after you verify it against the code and authority.
 - When one report identifies a defect and the other explicitly rejects it with
-  evidence, record both sides, stop in this step, and use Inbox to present both
-  bodies of evidence to the human. The contradiction does not become effective
-  automatically; continue adjudication only after the human decides it.
+  evidence, record both sides. Use Inbox only when the contradiction can change
+  a P0/P1 must-fix decision, security or data correctness, or whether the exact
+  head may advance. For a P2-only contradiction that cannot change must-fix or
+  merge eligibility, apply the governing specification and stronger verified
+  evidence, record the disposition and continue without interrupting the human.
 - P0 and P1 findings are must-fix. P2 findings remain recorded but do not block.
 
 Persist the closed adjudication and must-fix list as the task output, with a

--- a/packages/api/src/blind-claim.dbtest.ts
+++ b/packages/api/src/blind-claim.dbtest.ts
@@ -323,6 +323,89 @@ test("canonical blind review cannot complete from intermediate findings", async 
   assert.match(task.failureReason ?? "", /closed-must-fix phase/u);
 });
 
+test("canonical blind review refuses incomplete and internally inconsistent final artifacts", async () => {
+  const { template, repo } = await seedCanonicalTemplate();
+  const blind = await queueCanonicalStep(template, repo.id, 7);
+  const claimed = await claim();
+  const independentFinding = {
+    id: "OPUS-1",
+    severity: "P1",
+    file: "src/independent.ts",
+    line: 9,
+    title: "Independent defect",
+    evidence: "The blind review verified the defect independently.",
+    requiredFix: "Close the independent defect.",
+  } as const;
+  const independentBody = reviewBody(claimed.run.targetBranch, [independentFinding]);
+  for (const phase of ["independent-findings", "predecessor-evidence-unlocked"] as const) {
+    const response = await createApp(db).request(`/session/runs/${blind.run.id}/output`, {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${claimed.sessionToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fencingToken: claimed.fencingToken,
+        kind: "must-fix",
+        body: independentBody,
+        commitSha: claimed.run.targetBranch,
+        metadata: { phase },
+      }),
+    });
+    assert.equal(response.status, 200, await response.text());
+  }
+
+  const stub = JSON.stringify({
+    schemaVersion: 1,
+    headSha: claimed.run.targetBranch,
+    reviewedBase: "b".repeat(40),
+    reviewedHead: claimed.run.targetBranch,
+    findings: [],
+    dispositions: [{ id: "PROBE", disposition: "REJECTED", reason: "placeholder" }],
+    mustFixIds: [],
+  });
+  const incomplete = await createApp(db).request(`/session/runs/${blind.run.id}/output`, {
+    method: "PUT",
+    headers: { Authorization: `Bearer ${claimed.sessionToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      fencingToken: claimed.fencingToken,
+      kind: "must-fix",
+      body: stub,
+      commitSha: claimed.run.targetBranch,
+      metadata: { phase: "closed-must-fix" },
+    }),
+  });
+  assert.equal(incomplete.status, 409);
+  assert.match(await incomplete.text(), /missing: OPUS-1/u);
+  const stillUnlocked = await db.taskStepOutput.findUniqueOrThrow({ where: { taskId: blind.run.taskId! } });
+  assert.deepEqual(stillUnlocked.metadata, { phase: "predecessor-evidence-unlocked" });
+  assert.equal(stillUnlocked.body, independentBody);
+
+  const wrongMustFix = JSON.stringify({
+    schemaVersion: 1,
+    headSha: claimed.run.targetBranch,
+    reviewedBase: "b".repeat(40),
+    reviewedHead: claimed.run.targetBranch,
+    findings: [independentFinding],
+    dispositions: [{ id: independentFinding.id, disposition: "ADOPTED", reason: "verified" }],
+    mustFixIds: [],
+  });
+  const inconsistent = await createApp(db).request(`/session/runs/${blind.run.id}/output`, {
+    method: "PUT",
+    headers: { Authorization: `Bearer ${claimed.sessionToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      fencingToken: claimed.fencingToken,
+      kind: "must-fix",
+      body: wrongMustFix,
+      commitSha: claimed.run.targetBranch,
+      metadata: { phase: "closed-must-fix" },
+    }),
+  });
+  assert.equal(inconsistent.status, 409);
+  assert.match(await inconsistent.text(), /mustFixIds must exactly equal final P0\/P1 finding ids/u);
+  assert.deepEqual(
+    (await db.taskStepOutput.findUniqueOrThrow({ where: { taskId: blind.run.taskId! } })).metadata,
+    { phase: "predecessor-evidence-unlocked" },
+  );
+});
+
 test("operator retry re-resolves a pinned step to the recorded implementation commit", async () => {
   const { template, repo } = await seedCanonicalTemplate();
   const blind = await queueCanonicalStep(template, repo.id, 7);

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -91,6 +91,64 @@ const closedReviewArtifact = reviewArtifact.extend({
   mustFixIds: stringList,
 });
 
+type ReviewArtifact = z.infer<typeof reviewArtifact>;
+type ClosedReviewArtifact = z.infer<typeof closedReviewArtifact>;
+
+const duplicateValues = (values: string[]): string[] => {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates].sort();
+};
+
+const closedReviewSelfRefusal = (artifact: ClosedReviewArtifact): string | null => {
+  const duplicateFindings = duplicateValues(artifact.findings.map((finding) => finding.id));
+  if (duplicateFindings.length > 0) {
+    return `closed-must-fix findings contain duplicate ids: ${duplicateFindings.join(", ")}`;
+  }
+  const duplicateDispositions = duplicateValues(artifact.dispositions.map((disposition) => disposition.id));
+  if (duplicateDispositions.length > 0) {
+    return `closed-must-fix dispositions contain duplicate ids: ${duplicateDispositions.join(", ")}`;
+  }
+  const duplicateMustFixIds = duplicateValues(artifact.mustFixIds);
+  if (duplicateMustFixIds.length > 0) {
+    return `closed-must-fix mustFixIds contain duplicates: ${duplicateMustFixIds.join(", ")}`;
+  }
+  const expectedMustFixIds = new Set(
+    artifact.findings.filter((finding) => finding.severity === "P0" || finding.severity === "P1")
+      .map((finding) => finding.id),
+  );
+  const actualMustFixIds = new Set(artifact.mustFixIds);
+  const missing = [...expectedMustFixIds].filter((id) => !actualMustFixIds.has(id)).sort();
+  const unexpected = [...actualMustFixIds].filter((id) => !expectedMustFixIds.has(id)).sort();
+  if (missing.length > 0 || unexpected.length > 0) {
+    return `closed-must-fix mustFixIds must exactly equal final P0/P1 finding ids; missing: ${missing.join(", ") || "none"}; unexpected: ${unexpected.join(", ") || "none"}`;
+  }
+  return null;
+};
+
+const closedReviewRunRefusal = (
+  independent: ReviewArtifact,
+  closed: ClosedReviewArtifact,
+): string | null => {
+  if (closed.headSha !== independent.headSha
+    || closed.reviewedBase !== independent.reviewedBase
+    || closed.reviewedHead !== independent.reviewedHead) {
+    return "closed-must-fix review range must exactly match this Run's independent-findings range";
+  }
+  const dispositionIds = new Set(closed.dispositions.map((disposition) => disposition.id));
+  const missing = independent.findings.map((finding) => finding.id)
+    .filter((id) => !dispositionIds.has(id))
+    .sort();
+  if (missing.length > 0) {
+    return `closed-must-fix dispositions must cover every independent finding from this Run; missing: ${missing.join(", ")}`;
+  }
+  return null;
+};
+
 const canonicalOutputSchemas: Record<string, z.ZodType> = {
   spec: canonicalEnvelope.extend({ spec: nonEmptyString }),
   plan: canonicalEnvelope.extend({ summary: nonEmptyString, sliceIds: stringList }),
@@ -165,13 +223,18 @@ const canonicalBodyRefusal = (
   if (!schema) return `canonical output kind ${kind} has no versioned JSON contract`;
   const parsed = schema.safeParse(value);
   if (!parsed.success) {
-    const issue = parsed.error.issues[0];
-    const location = issue?.path.length ? issue.path.join(".") : "body";
-    return `${kind} task output body violates schemaVersion 1 at ${location}: ${issue?.message ?? "invalid value"}`;
+    const issues = parsed.error.issues.slice(0, 8).map((issue) => {
+      const location = issue.path.length ? issue.path.join(".") : "body";
+      return `${location}: ${issue.message}`;
+    });
+    return `${kind} task output body violates schemaVersion 1: ${issues.join("; ")}`;
   }
   const bodyHead = (parsed.data as { headSha: string }).headSha;
   if (bodyHead !== authoredHead) {
     return `${kind} task output body headSha ${bodyHead} does not match authored commit ${authoredHead ?? "none"}`;
+  }
+  if (kind === "must-fix" && phase === BLIND_REVIEW_PHASE.closed) {
+    return closedReviewSelfRefusal(parsed.data as ClosedReviewArtifact);
   }
   return null;
 };
@@ -282,6 +345,23 @@ export const persistSessionTaskOutput = async (
     if (phase === BLIND_REVIEW_PHASE.closed
       && (existing?.runId !== input.runId || metadataPhase(existing.metadata) !== BLIND_REVIEW_PHASE.evidenceUnlocked)) {
       return { ok: false, reason: `blind review must unlock predecessor evidence in this Run before ${BLIND_REVIEW_PHASE.closed}` };
+    }
+    if (phase === BLIND_REVIEW_PHASE.closed && existing) {
+      let independentValue: unknown;
+      let closedValue: unknown;
+      try {
+        independentValue = JSON.parse(existing.body);
+        closedValue = JSON.parse(input.body);
+      } catch {
+        return { ok: false, reason: "blind review output contract could not parse the persisted review sequence" };
+      }
+      const independent = reviewArtifact.safeParse(independentValue);
+      const closed = closedReviewArtifact.safeParse(closedValue);
+      if (!independent.success || !closed.success) {
+        return { ok: false, reason: "blind review output contract could not validate the persisted review sequence" };
+      }
+      const refusal = closedReviewRunRefusal(independent.data, closed.data);
+      if (refusal) return { ok: false, reason: refusal };
     }
     if (phase === BLIND_REVIEW_PHASE.independent
       && existing?.runId === input.runId && metadataPhase(existing.metadata) !== BLIND_REVIEW_PHASE.independent) {

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -225,9 +225,13 @@ const canonicalBodyRefusal = (
   if (!parsed.success) {
     const issues = parsed.error.issues.slice(0, 8).map((issue) => {
       const location = issue.path.length ? issue.path.join(".") : "body";
-      return `${location}: ${issue.message}`;
+      return { location, message: issue.message };
     });
-    return `${kind} task output body violates schemaVersion 1: ${issues.join("; ")}`;
+    const [first, ...remaining] = issues;
+    const additional = remaining.length > 0
+      ? `; additional violations: ${remaining.map((issue) => `${issue.location}: ${issue.message}`).join("; ")}`
+      : "";
+    return `${kind} task output body violates schemaVersion 1 at ${first?.location ?? "body"}: ${first?.message ?? "invalid value"}${additional}`;
   }
   const bodyHead = (parsed.data as { headSha: string }).headSha;
   if (bodyHead !== authoredHead) {

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -141,8 +141,8 @@ test("the split review prompts enforce persisted-range, blind-order, adjudicatio
   assert.match(finalReview, /reachable in the tree at `head`/u);
   assert.match(finalReview, /same defect reported by both is adopted at the higher severity/u);
   assert.equal(frontmatterValue(finalReview, "inboxAccess"), "true");
-  assert.match(finalReview, /stop in this step, and use Inbox to present both\s+bodies of evidence to the human/u);
-  assert.match(finalReview, /does not become effective\s+automatically/u);
+  assert.match(finalReview, /Use Inbox only when the contradiction can change\s+a P0\/P1 must-fix decision/u);
+  assert.match(finalReview, /P2-only contradiction[\s\S]*continue without interrupting the human/u);
   assert.match(finalReview, /entire fix diff as one\s+unit/u);
   assert.match(finalReview, /exact fixed head/u);
   assert.match(finalReview, /provider id in the platform output/u);

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -407,7 +407,7 @@ const main = async (): Promise<void> => {
         updatedSteps,
         updatedRoles,
       };
-    });
+    }, { timeout: 30_000 });
     const updated = result.createdAgents + result.createdAgentRepoGrants + result.adoptedAssignees + result.adoptedStepBases
       + result.renamedSteps + result.migratedTasks + result.migratedTaskPrompts + result.adoptedAgentDefaults + Object.values(result.updatedSteps)
       .flatMap((byStep) => Object.values(byStep))

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -5,6 +5,9 @@ import { loadAllTemplateStepSources, templateStepStructureDifferences } from "..
 
 const REGRESSION_AGENT_NAME = "regression-verifier";
 const REGRESSION_AGENT_SOURCE = "review-coordinator-sol";
+const LEGACY_BLIND_REVIEW_PROMPTS = [
+  "Blind-review the complete integrated implementation diff using the immutable implementationBaseSha and implementationHeadSha in the platform-pinned claim metadata; verify both endpoints resolve in this detached checkout. Persist your independent findings as an intermediate AgentOS task output before reading the first review. The successful task_output response unlocks predecessor step outputs; only then read them, apply the canonical merge matrix, and replace the intermediate output with the closed must-fix list. Do not write or commit any review report file.",
+] as const;
 type AssigneeTransition = { from: readonly string[]; to: string };
 const ASSIGNEE_TRANSITIONS = new Map<string, AssigneeTransition>([
   ["compound-engineer-workflow:9", { from: ["review-coordinator-opus", "review-coordinator-sol"], to: REGRESSION_AGENT_NAME }],
@@ -98,6 +101,7 @@ const main = async (): Promise<void> => {
       let renamedSteps = 0;
       let templateCount = 0;
       const regressionSteps: Array<{ id: string; projectId: string }> = [];
+      const blindReviewSteps: Array<{ id: string; prompt: string }> = [];
       for (const [templateName, steps] of templateSources) {
         const templates = await tx.taskTemplate.findMany({
           where: { name: templateName },
@@ -187,6 +191,9 @@ const main = async (): Promise<void> => {
               if (!projectId) throw new Error(`Template project was not found for regression step ${persisted.id}`);
               regressionSteps.push({ id: persisted.id, projectId });
             }
+            if (step.outputKind === "must-fix") {
+              blindReviewSteps.push({ id: persisted.id, prompt: step.prompt });
+            }
           }
           updated[step.stepIndex] = (await tx.taskTemplateStep.updateMany({
             where: { taskTemplateId: { in: templateIds }, stepIndex: step.stepIndex, prompt: { not: step.prompt } },
@@ -263,6 +270,69 @@ const main = async (): Promise<void> => {
         }
       }
 
+      let migratedTaskPrompts = 0;
+      const preservedBlindReviewPrompts = { archived: 0, nonTodo: 0, started: 0, output: 0, unrecognized: 0 };
+      for (const step of blindReviewSteps) {
+        const tasks = await tx.task.findMany({
+          where: { templateStepId: step.id },
+          select: {
+            id: true,
+            status: true,
+            archivedAt: true,
+            description: true,
+            _count: { select: { runs: true, sessions: true } },
+            stepOutput: { select: { id: true } },
+          },
+        });
+        for (const task of tasks) {
+          const legacyPrompt = LEGACY_BLIND_REVIEW_PROMPTS.find((prompt) => task.description.startsWith(prompt));
+          if (!legacyPrompt) {
+            if (!task.description.startsWith(step.prompt)) preservedBlindReviewPrompts.unrecognized += 1;
+            continue;
+          }
+          if (task.archivedAt) {
+            preservedBlindReviewPrompts.archived += 1;
+            continue;
+          }
+          if (task.status !== TaskStatus.TODO) {
+            preservedBlindReviewPrompts.nonTodo += 1;
+            continue;
+          }
+          if (task._count.runs > 0 || task._count.sessions > 0) {
+            preservedBlindReviewPrompts.started += 1;
+            continue;
+          }
+          if (task.stepOutput) {
+            preservedBlindReviewPrompts.output += 1;
+            continue;
+          }
+          const description = `${step.prompt}${task.description.slice(legacyPrompt.length)}`;
+          const adopted = await tx.task.updateMany({
+            where: {
+              id: task.id,
+              description: task.description,
+              status: TaskStatus.TODO,
+              archivedAt: null,
+              runs: { none: {} },
+              sessions: { none: {} },
+              stepOutput: { is: null },
+            },
+            data: { description },
+          });
+          if (adopted.count !== 1) throw new Error(`Blind-review task ${task.id} changed while its canonical prompt was being adopted`);
+          await tx.taskActivity.create({ data: {
+            taskId: task.id,
+            actorType: "control-plane",
+            body: "Canonical sync updated this unstarted blind-review step to the versioned output protocol",
+            metadata: {
+              kind: "canonicalTaskPrompt.blindReviewOutputV1",
+              schemaVersion: 1,
+            },
+          } });
+          migratedTaskPrompts += 1;
+        }
+      }
+
       const presentAgents = await tx.agent.findMany({
         where: { projectId: canonicalProject.id, archivedAt: null, name: { in: roleNames } },
         select: {
@@ -330,14 +400,16 @@ const main = async (): Promise<void> => {
         adoptedStepBases,
         renamedSteps,
         migratedTasks,
+        migratedTaskPrompts,
         preservedTaskAssignments,
+        preservedBlindReviewPrompts,
         adoptedAgentDefaults,
         updatedSteps,
         updatedRoles,
       };
     });
     const updated = result.createdAgents + result.createdAgentRepoGrants + result.adoptedAssignees + result.adoptedStepBases
-      + result.renamedSteps + result.migratedTasks + result.adoptedAgentDefaults + Object.values(result.updatedSteps)
+      + result.renamedSteps + result.migratedTasks + result.migratedTaskPrompts + result.adoptedAgentDefaults + Object.values(result.updatedSteps)
       .flatMap((byStep) => Object.values(byStep))
       .reduce((sum, count) => sum + count, 0)
       + Object.values(result.updatedRoles).reduce((sum, count) => sum + count, 0);

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -229,3 +229,64 @@ test("sync creates the narrow verifier and migrates only never-run TODO regressi
     where: { taskId: eligible.id, metadata: { path: ["kind"], equals: "canonicalRouting.regressionVerifier" } },
   }), 1);
 });
+
+test("sync upgrades only unstarted blind-review tasks with the exact legacy prompt", async () => {
+  const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
+  const template = await prisma.taskTemplate.findFirstOrThrow({
+    where: { projectId: project.id, name: "direct-engineer-workflow" },
+  });
+  const step = await prisma.taskTemplateStep.findFirstOrThrow({
+    where: { taskTemplateId: template.id, outputKind: "must-fix" },
+  });
+  const agent = await prisma.agent.findUniqueOrThrow({
+    where: { id: step.assigneeAgentId! },
+  });
+  const repo = await prisma.repo.findFirstOrThrow({ where: { projectId: project.id } });
+  const legacyPrompt = "Blind-review the complete integrated implementation diff using the immutable implementationBaseSha and implementationHeadSha in the platform-pinned claim metadata; verify both endpoints resolve in this detached checkout. Persist your independent findings as an intermediate AgentOS task output before reading the first review. The successful task_output response unlocks predecessor step outputs; only then read them, apply the canonical merge matrix, and replace the intermediate output with the closed must-fix list. Do not write or commit any review report file.";
+  const suffix = "\nFeature brief:\nKeep this exact feature brief.\nPersist the final must-fix output for this step through the AgentOS task output endpoint.";
+  const makeTask = (name: string, description = `${legacyPrompt}${suffix}`) => prisma.task.create({ data: {
+    projectId: project.id,
+    repoId: repo.id,
+    templateId: template.id,
+    templateStepId: step.id,
+    name,
+    description,
+    assigneeAgentId: agent.id,
+    assigneeType: "AGENT",
+    status: TaskStatus.TODO,
+  } });
+  const eligible = await makeTask("Eligible blind review");
+  const started = await makeTask("Started blind review");
+  await prisma.run.create({ data: {
+    projectId: project.id,
+    taskId: started.id,
+    agentId: agent.id,
+    repoId: repo.id,
+    runNumber: 1,
+    dedupeKey: `task:${started.id}:run:1`,
+    runner: "CLAUDE",
+    model: agent.model,
+    promptHash: "started-blind-review",
+  } });
+  const operatorEdited = await makeTask("Operator-edited blind review", `Operator-owned prefix${suffix}`);
+
+  const synced = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
+  assert.equal(synced.status, 0, synced.output);
+  assert.match(synced.output, /"migratedTaskPrompts":1/u);
+  assert.match(synced.output, /"preservedBlindReviewPrompts":\{[^}]*"started":1/u);
+
+  const migrated = await prisma.task.findUniqueOrThrow({ where: { id: eligible.id } });
+  assert.equal(migrated.description, `${step.prompt}${suffix}`);
+  assert.equal((await prisma.task.findUniqueOrThrow({ where: { id: started.id } })).description, `${legacyPrompt}${suffix}`);
+  assert.equal((await prisma.task.findUniqueOrThrow({ where: { id: operatorEdited.id } })).description, `Operator-owned prefix${suffix}`);
+  assert.equal(await prisma.taskActivity.count({
+    where: { taskId: eligible.id, metadata: { path: ["kind"], equals: "canonicalTaskPrompt.blindReviewOutputV1" } },
+  }), 1);
+
+  const second = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
+  assert.equal(second.status, 0, second.output);
+  assert.match(second.output, /"migratedTaskPrompts":0/u);
+  assert.equal(await prisma.taskActivity.count({
+    where: { taskId: eligible.id, metadata: { path: ["kind"], equals: "canonicalTaskPrompt.blindReviewOutputV1" } },
+  }), 1);
+});

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -19,7 +19,7 @@ const toolManifest = (claim: ClaimedTask): string[] => [
     ? "AgentOS tools attached to this session (pi extension tools):"
     : "AgentOS tools attached to this session (MCP server 'agentos'; your client may prefix them, e.g. mcp__agentos__task_output):",
   "- task_activity_log(body): record notable progress in the task activity log. Routine channel; never interrupts a human.",
-  "- task_output(kind, body, metadata?): persist this step's deliverable as the task output. Later steps and the approval gate read it.",
+  "- task_output(kind, body, metadata?): persist this step's deliverable using the task's exact output contract. Rejected writes change nothing; never submit placeholder probes. Closed final outputs may be immutable.",
   "- task_status(): read the current task and run status, budget, branch, and whether an output exists.",
   "- inbox_ask(body, choices?): ask the human. Suspends this session until they answer; you resume in place with the reply.",
   "- files_list(dir): list one Files Root directory non-recursively. Empty dir means the root.",

--- a/packages/runner/src/mcp-server.ts
+++ b/packages/runner/src/mcp-server.ts
@@ -107,7 +107,8 @@ export const TOOLS = [
     name: "task_output",
     title: "Persist the task output",
     description: "Persist this step's deliverable as the AgentOS task output. Later steps in the chain read it, and "
-      + "the approval gate shows it to the human. Call it once the deliverable is final; calling it again replaces the stored output.",
+      + "the approval gate shows it to the human. Canonical steps may require a phase-specific write sequence from the task contract. "
+      + "A rejected write changes nothing; never probe the contract with placeholder content. A closed final output may be immutable.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary
- make non-blocking P2 review disagreements auto-adjudicate instead of opening Inbox
- reject incomplete or contradictory blind-review final outputs before persistence
- migrate only exact legacy prompts on untouched Todo tasks
- clarify immutable per-Run task output behavior in runner tool manifests

## Verification
- MERGE GATE: PASS 4a893bf00188c15563024fcf1e4ad3c5921ce4fc
- targeted canonical prompt sync DB tests: 3/3 pass