### PR TITLE
perf: accelerate safe auto deploys

### DIFF
--- a/apps/web/src/tests/local-origin.test.ts
+++ b/apps/web/src/tests/local-origin.test.ts
@@ -344,3 +344,27 @@ test("the guard is installed inside configureServer, ahead of Vite's own middlew
   assert.equal(recorded.statusCode, 403);
   assert.deepEqual(attempts, []);
 });
+
+test("a production build does not read or embed the development proxy environment", async () => {
+  const priorTarget = process.env.WEB_API_URL;
+  const priorToken = process.env.OPERATOR_TOKEN;
+  process.env.WEB_API_URL = "https://not-loopback.example";
+  process.env.OPERATOR_TOKEN = "must-not-enter-build";
+  try {
+    const { default: configure } = await import("../../vite.config.js");
+    const resolved = typeof configure === "function"
+      ? await configure({ command: "build", mode: "production" })
+      : configure;
+    const config = resolved as {
+      server?: { proxy?: Record<string, unknown> };
+      preview?: { proxy?: Record<string, unknown> };
+    };
+    assert.deepEqual(config.server?.proxy, {});
+    assert.deepEqual(config.preview?.proxy, {});
+  } finally {
+    if (priorTarget === undefined) delete process.env.WEB_API_URL;
+    else process.env.WEB_API_URL = priorTarget;
+    if (priorToken === undefined) delete process.env.OPERATOR_TOKEN;
+    else process.env.OPERATOR_TOKEN = priorToken;
+  }
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -26,24 +26,25 @@ const sourceRoot = fileURLToPath(new URL("./src", import.meta.url));
  *  below decides, per request, that the caller is this server's own loopback
  *  origin. Both live in `src/lib/local-origin.ts`, which is unit-tested; the
  *  policy is not restated here. */
-export default defineConfig(({ mode }) => {
-  const environment = loadEnv(mode, repositoryRoot, "");
-  // First, and before anything is built: a refused destination throws here, so
-  // no proxy, no bearer header, no DNS lookup and no socket ever exists.
-  const target = resolveProxyTarget(environment);
-  const token = environment["OPERATOR_TOKEN"] ?? "";
-  if (token === "") {
-    console.warn("[agentos/web] OPERATOR_TOKEN is not set in the repository root .env; the control plane will answer 401.");
-  }
-
-  const proxy: Record<string, ProxyOptions> = {
-    "/api": {
+export default defineConfig(({ command, mode }) => {
+  const proxy: Record<string, ProxyOptions> = {};
+  if (command === "serve") {
+    const environment = loadEnv(mode, repositoryRoot, "");
+    // Refuse an unsafe destination before a proxy, bearer header, DNS lookup,
+    // or socket exists. Production builds contain no proxy and read no local
+    // credential-bearing environment, which makes their dist tree portable.
+    const target = resolveProxyTarget(environment);
+    const token = environment["OPERATOR_TOKEN"] ?? "";
+    if (token === "") {
+      console.warn("[agentos/web] OPERATOR_TOKEN is not set in the repository root .env; the control plane will answer 401.");
+    }
+    proxy["/api"] = {
       target,
       changeOrigin: false,
       headers: { Authorization: `Bearer ${token}` },
       rewrite: (path) => path.replace(/^\/api/, ""),
-    },
-  };
+    };
+  }
 
   /** Installed inside `configureServer`, which Vite calls *before* it adds its
    *  own middlewares — so `server.middlewares.use` here runs ahead of the proxy

--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -152,10 +152,18 @@ recovery. The job does not stop runner processes while it waits.
 The job then performs exactly this sequence and stops at the first failure:
 
 1. require branch `main`, refuse a dirty checkout, fetch `origin/main`, prove the
-   current source is its ancestor, and fast-forward with `git merge --ff-only`;
-2. create a detached staging worktree under `.agentos-deploy/`, run `npm ci`
-   against the target lockfile, and run `npm run db:generate`;
-3. run `npm run build` in staging and verify its API build stamp;
+   current source is its ancestor, and fast-forward with `git merge --ff-only`.
+   The remote revision read and fetch each make at most three attempts, waiting
+   two seconds and then five seconds; only the final failure escalates;
+2. create a detached staging worktree under `.agentos-deploy/` and run `npm ci`
+   against the target lockfile. The root `postinstall` generates Prisma Client,
+   so the deploy does not run the same generation a second time; the runtime
+   client is still verified before publication;
+3. materialize the exact target revision's local merge-gate `dist/` snapshot
+   when it is present and valid, otherwise run `npm run build` in staging, then
+   verify the API build stamp. A missing or cache-evicted snapshot is an explicit
+   source-build miss; a present malformed index, symlinked tree, wrong stamp, or
+   partial artifact is a terminal refusal rather than a silent fallback;
 4. run `/usr/local/bin/pg_dump -Fc` through `docker exec` in
    `agentos-postgres-1`; stream its stdout to a mode-0600 temporary file on the
    host under `.agentos-deploy/backups/`, fsync it, and rename it to `.dump`
@@ -185,6 +193,20 @@ The job then performs exactly this sequence and stops at the first failure:
    restart the services;
 8. require every launchd service to be running, `/health` to pass, and
    `/version` to report the exact target commit before reporting success.
+
+The release snapshot is only a local acceleration path. The exact-head merge
+gate publishes its revision index after the final clean-tree drift proof, and
+the index points at the gate's existing bounded, immutable build cache rather
+than creating a second artifact copy. A gate run on another host provides merge
+evidence but no local deployment artifact, so this host performs the normal
+source build. Deployment correctness never depends on cache availability.
+
+Runner lease heartbeats remain on `RUNNER_HEARTBEAT_INTERVAL_MS`. CLI
+availability reports use a separate one-minute interval, with a deterministic
+zero-to-fifteen-second initial offset derived from `runnerId`, so sibling runner
+services do not create a synchronized Serializable write burst. The API retries
+at most two `P2034` conflicts for this one global availability transaction and
+surfaces a third conflict normally.
 
 The old `dist/` trees and `node_modules` stay in a private `previous-*`
 transaction directory. A

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -115,6 +115,7 @@ import {
   readStoredCliAvailability,
   storeCliAvailability,
 } from "./runner-cli-availability.js";
+import { runRunnerAvailabilityTransaction } from "./runner-availability-transaction.js";
 import {
   chainKey,
   chainProgress,
@@ -4171,7 +4172,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/runner/availability", async (context) => {
     const body = await readJson(context.req.raw, runnerAvailabilityInput);
     const now = new Date();
-    const state = await db.$transaction(async (tx) => {
+    const state = await runRunnerAvailabilityTransaction(db, async (tx) => {
       const previous = await tx.runnerBackendState.findUnique({ where: { runner: body.runner } });
       const previousAvailability = readStoredCliAvailability(previous?.capabilities);
       const availability = nextStoredCliAvailability(body, previousAvailability, now);
@@ -4234,7 +4235,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         });
       }
       return available;
-    }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+    });
     const lastPreflightAt = state.lastPreflightAt?.getTime() ?? 0;
     const currentLease = preflightRecoveryLeases.get(body.runner) ?? 0;
     const revalidatePreflight = body.available

--- a/packages/api/src/runner-availability-transaction.test.ts
+++ b/packages/api/src/runner-availability-transaction.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Prisma, type PrismaClient } from "@agentos/db";
+
+import { runRunnerAvailabilityTransaction } from "./runner-availability-transaction.js";
+
+const conflict = (): Prisma.PrismaClientKnownRequestError => new Prisma.PrismaClientKnownRequestError(
+  "concurrent runner availability update",
+  { code: "P2034", clientVersion: "6.19.0" },
+);
+
+test("runner availability retries two Serializable conflicts with bounded backoff", async () => {
+  let attempts = 0;
+  const database = {
+    $transaction: async (operation: () => Promise<string>) => {
+      attempts += 1;
+      if (attempts < 3) throw conflict();
+      return operation();
+    },
+  } as unknown as PrismaClient;
+  const waits: number[] = [];
+  const result = await runRunnerAvailabilityTransaction(
+    database,
+    async () => "stored",
+    async (milliseconds) => { waits.push(milliseconds); },
+  );
+  assert.equal(result, "stored");
+  assert.equal(attempts, 3);
+  assert.deepEqual(waits, [25, 75]);
+});
+
+test("runner availability surfaces a third conflict and never retries other errors", async () => {
+  let conflicts = 0;
+  const database = {
+    $transaction: async () => { conflicts += 1; throw conflict(); },
+  } as unknown as PrismaClient;
+  await assert.rejects(
+    runRunnerAvailabilityTransaction(database, async () => "unreachable", async () => undefined),
+    (error) => error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034",
+  );
+  assert.equal(conflicts, 3);
+
+  let failures = 0;
+  const other = {
+    $transaction: async () => { failures += 1; throw new Error("not retryable"); },
+  } as unknown as PrismaClient;
+  await assert.rejects(
+    runRunnerAvailabilityTransaction(other, async () => "unreachable", async () => undefined),
+    /not retryable/u,
+  );
+  assert.equal(failures, 1);
+});

--- a/packages/api/src/runner-availability-transaction.ts
+++ b/packages/api/src/runner-availability-transaction.ts
@@ -1,0 +1,28 @@
+import { Prisma, type PrismaClient } from "@agentos/db";
+
+const RETRY_DELAYS_MS = [25, 75] as const;
+const wait = (milliseconds: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const isSerializationConflict = (error: unknown): boolean =>
+  error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2034";
+
+/** Runner availability is global backend state written by every daemon. Keep
+ * its Serializable guarantee, but absorb the short write conflicts that level
+ * reports can legitimately create. */
+export const runRunnerAvailabilityTransaction = async <T>(
+  db: PrismaClient,
+  operation: (tx: Prisma.TransactionClient) => Promise<T>,
+  sleep: (milliseconds: number) => Promise<void> = wait,
+): Promise<T> => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await db.$transaction(operation, {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      });
+    } catch (error: unknown) {
+      const waitMs = RETRY_DELAYS_MS[attempt];
+      if (!isSerializationConflict(error) || waitMs === undefined) throw error;
+      await sleep(waitMs);
+    }
+  }
+};

--- a/packages/api/src/workspace-reclaim.ts
+++ b/packages/api/src/workspace-reclaim.ts
@@ -208,7 +208,6 @@ export const publishReclaimIntents = async (
     }
     if (!ownedByCaller(run, inventory.runnerId)) {
       keep.push({ directory, reason: "foreign-runner" });
-      audit("keep-foreign-runner", { root, runId: run.id, owner: run.runnerId, caller: inventory.runnerId });
       continue;
     }
     // Only a terminal run's directory is disposable. The two lists partition

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -8,7 +8,12 @@ import { afterEach, test } from "node:test";
 import { adapters } from "./adapters.js";
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
-import { executeClaim, reportCliAvailabilityHeartbeat, runStartupPreflight } from "./runner.js";
+import {
+  cliAvailabilityHeartbeatSchedule,
+  executeClaim,
+  reportCliAvailabilityHeartbeat,
+  runStartupPreflight,
+} from "./runner.js";
 import {
   cleanupAgentScratch, provisionSessionConfig, writeSessionCredentials, type AgentScratch,
 } from "./workspace.js";
@@ -1488,6 +1493,16 @@ test("an availability heartbeat reports a CLI recovery without restarting the ru
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test("CLI availability uses an independent one-minute cadence with stable runner jitter", () => {
+  const first = cliAvailabilityHeartbeatSchedule("runner-1");
+  const same = cliAvailabilityHeartbeatSchedule("runner-1");
+  const other = cliAvailabilityHeartbeatSchedule("runner-2");
+  assert.deepEqual(first, same);
+  assert.equal(first.intervalMs, 60_000);
+  assert.ok(first.initialDelayMs >= 60_000 && first.initialDelayMs < 75_000);
+  assert.notEqual(first.initialDelayMs, other.initialDelayMs);
 });
 
 test("an availability heartbeat runs one requested preflight and reports its recovery", async () => {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -902,10 +902,37 @@ export const startCliAvailabilityMonitor = (
   options: AvailabilityHeartbeatOptions = {},
 ): { stop: () => void } => {
   let busy = false;
-  const timer = setInterval(() => {
+  let interval: ReturnType<typeof setInterval> | null = null;
+  const tick = (): void => {
     if (busy) return;
     busy = true;
     void reportCliAvailabilityHeartbeat(config, options).finally(() => { busy = false; });
-  }, config.heartbeatIntervalMs);
-  return { stop: () => clearInterval(timer) };
+  };
+  const schedule = cliAvailabilityHeartbeatSchedule(config.runnerId);
+  const initial = setTimeout(() => {
+    tick();
+    interval = setInterval(tick, schedule.intervalMs);
+  }, schedule.initialDelayMs);
+  return { stop: () => {
+    clearTimeout(initial);
+    if (interval !== null) clearInterval(interval);
+  } };
+};
+
+const CLI_AVAILABILITY_INTERVAL_MS = 60_000;
+const CLI_AVAILABILITY_JITTER_MS = 15_000;
+
+export const cliAvailabilityHeartbeatSchedule = (runnerId: string): {
+  initialDelayMs: number;
+  intervalMs: number;
+} => {
+  let hash = 2_166_136_261;
+  for (const character of runnerId) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16_777_619) >>> 0;
+  }
+  return {
+    initialDelayMs: CLI_AVAILABILITY_INTERVAL_MS + (hash % CLI_AVAILABILITY_JITTER_MS),
+    intervalMs: CLI_AVAILABILITY_INTERVAL_MS,
+  };
 };

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -38,6 +38,8 @@ import {
   workspaceDependencyPaths,
 } from "./quiet-window-adapters.mjs";
 import { createProductionHost } from "./quiet-window-host.mjs";
+import { materializeReleaseSnapshot } from "./release-snapshot.mjs";
+import { runCommandWithRetry } from "./quiet-window-retry.mjs";
 import { verifyBackupConfiguration } from "./install-launchd.mjs";
 import { backupConfigurationFromEnvironment, writePgDumpBackup } from "./quiet-window-backup.mjs";
 import { createDeployInterruption } from "./quiet-window-interrupt.mjs";
@@ -54,6 +56,10 @@ const POLL_MS = POLL_SECONDS * 1_000;
 const SHA = /^[0-9a-f]{40}$/u;
 const DEPLOY_BARRIER_CLASS = 0x41_47_44_50; // Must match @agentos/db deploy-barrier.ts ("AGDP").
 const DEPLOY_BARRIER_KEY = 1;
+
+const generatedPrismaClientIsComplete = (root) =>
+  existsSync(join(root, "node_modules/.prisma/client/index.js"))
+  && existsSync(join(root, "node_modules/.prisma/client/schema.prisma"));
 
 const log = (line) => process.stdout.write(`${new Date().toISOString()} ${line}\n`);
 const fail = (reason, detail = "") => { throw new DeployFailure(reason, detail); };
@@ -117,9 +123,9 @@ const command = (program, args, {
   });
 };
 
-const checked = async (reason, program, args, options) => {
+const checkedResult = async (reason, run) => {
   log(`START ${reason}`);
-  const result = await command(program, args, options).catch((error) => {
+  const result = await run().catch((error) => {
     if (error instanceof DeployFailure) throw error;
     return { code: 1, stderr: String(error), stdout: "" };
   });
@@ -130,6 +136,28 @@ const checked = async (reason, program, args, options) => {
   log(`PASS ${reason}`);
   return result;
 };
+
+const checked = (reason, program, args, options) => checkedResult(
+  reason,
+  () => command(program, args, options),
+);
+
+const retryingGitCommand = (operation, args, options) => runCommandWithRetry(
+  () => command(loadBinaries().git, args, options).catch((error) => {
+    if (error instanceof DeployFailure) throw error;
+    return { code: 1, stderr: String(error), stdout: "" };
+  }),
+  {
+    onRetry: ({ attempt, nextAttempt, waitMs }) => log(
+      `RETRY git-network operation=${operation} attempt=${attempt} next-attempt=${nextAttempt} wait-ms=${waitMs}`,
+    ),
+  },
+);
+
+const checkedGitNetwork = (reason, operation, args, options) => checkedResult(
+  reason,
+  () => retryingGitCommand(operation, args, options),
+);
 
 const gitText = (...args) => execFileSync(loadBinaries().git, ["-C", REPOSITORY_ROOT, ...args], {
   encoding: "utf8",
@@ -155,7 +183,11 @@ const readDeployedRevision = () => {
 };
 
 const remoteMainRevision = async () => {
-  const result = await command(loadBinaries().git, ["ls-remote", "--exit-code", "origin", "refs/heads/main"], { capture: true });
+  const result = await retryingGitCommand(
+    "ls-remote-main",
+    ["ls-remote", "--exit-code", "origin", "refs/heads/main"],
+    { capture: true },
+  );
   const revision = result.stdout.trim().split(/\s+/u)[0] ?? "";
   if (result.code !== 0 || !SHA.test(revision)) fail("remote-main-unreadable", `exit-${result.code}`);
   return revision;
@@ -535,7 +567,7 @@ const main = async () => {
     const host = createProductionHost({
       fastForward: async () => {
         assertProductionCheckout();
-        await checked("fetch-main-failed", loadBinaries().git, ["fetch", "origin", "main"]);
+        await checkedGitNetwork("fetch-main-failed", "fetch-main", ["fetch", "origin", "main"]);
         to = gitText("rev-parse", "origin/main");
         const state = inspectGitPreflight({ git: loadBinaries().git, root: REPOSITORY_ROOT, target: to });
         const { head } = state;
@@ -547,10 +579,19 @@ const main = async () => {
         stage = join(STATE_DIR, `stage-${transactionId}`);
         await checked("staging-worktree-failed", loadBinaries().git, ["worktree", "add", "--detach", stage, "HEAD"]);
       },
-      installDependencies: () => checked("staging-dependencies-failed", loadBinaries().node, [loadBinaries().npm, "ci"], { cwd: stage }),
-      prismaGenerate: () => checked("prisma-generate-failed", loadBinaries().node, [loadBinaries().npm, "run", "db:generate"], { cwd: stage }),
+      installDependencies: async () => {
+        await checked("staging-dependencies-failed", loadBinaries().node, [loadBinaries().npm, "ci"], { cwd: stage });
+        if (!generatedPrismaClientIsComplete(stage)) {
+          fail("staging-dependencies-failed", "npm-ci-did-not-produce-generated-prisma-client");
+        }
+      },
       build: async () => {
-        await checked("build-failed", loadBinaries().node, [loadBinaries().npm, "run", "build"], { cwd: stage });
+        const snapshot = materializeReleaseSnapshot({ stageRoot: stage, revision: to });
+        if (snapshot.hit) log(`PASS release-snapshot-hit build-key=${snapshot.buildKey}`);
+        else {
+          log(`MISS release-snapshot reason=${snapshot.reason}; building-from-source`);
+          await checked("build-failed", loadBinaries().node, [loadBinaries().npm, "run", "build"], { cwd: stage });
+        }
         const stamp = readJson(join(stage, "packages/api/dist/build-info.json"), "build-stamp-invalid");
         if (stamp.commit !== to || stamp.dirty !== false) fail("build-stamp-invalid", "staged-api-dist-does-not-match-target");
         optionalArtifacts = [...DEPLOY_OPTIONAL_ARTIFACT_PATHS, ...workspaceDependencyPaths(stage)];
@@ -587,7 +628,7 @@ const main = async () => {
       },
       syncCanonicalPrompts: () => checked("canonical-prompt-sync-refused", loadBinaries().node, [loadBinaries().npm, "run", "db:sync-canonical-prompts"], { cwd: stage }),
       verifyRuntimePrismaClient: async () => {
-        if (!existsSync(join(stage, "node_modules/.prisma/client/index.js"))) {
+        if (!generatedPrismaClientIsComplete(stage)) {
           fail("runtime-prisma-client-missing", "staged-generated-client-is-absent");
         }
       },

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -10,6 +10,7 @@ import {
   realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -49,6 +50,12 @@ import {
 } from "./quiet-window-backup.mjs";
 import { createProductionHost } from "./quiet-window-host.mjs";
 import { createDeployInterruption } from "./quiet-window-interrupt.mjs";
+import {
+  materializeReleaseSnapshot,
+  publishReleaseSnapshot,
+  RELEASE_SNAPSHOT_OUTPUTS,
+} from "./release-snapshot.mjs";
+import { runCommandWithRetry } from "./quiet-window-retry.mjs";
 
 const revisions = { from: "a".repeat(40), to: "b".repeat(40) };
 
@@ -86,7 +93,6 @@ const fixture = (failure = null) => {
     fastForward: step("fast-forward", async () => revisions.to),
     createStage: step("create-stage"),
     installDependencies: step("install-dependencies"),
-    prismaGenerate: step("prisma-generate"),
     build: step("build"),
     backup: step("backup"),
     guardedMigration: step("guarded-migration"),
@@ -194,7 +200,7 @@ test("successful upgrade runs the safety sequence in order", async () => {
   const { host, calls, state } = fixture();
   assert.deepEqual(await executeUpgrade(host, revisions), { ok: true });
   assert.deepEqual(calls, [
-    "fast-forward", "create-stage", "install-dependencies", "prisma-generate", "build", "backup",
+    "fast-forward", "create-stage", "install-dependencies", "build", "backup",
     "guarded-migration", "canonical-prompt-sync", "verify-runtime-prisma-client", "quiet-recheck",
     "publish-build", "restart-services", "verify-services", "notify-success", "commit-build", "cleanup-stage",
   ]);
@@ -209,7 +215,7 @@ test("the first failing step stops the pipeline and keeps the previous build ser
   assert.equal(result.ok, false);
   assert.equal(result.failure.reason, "build-failed");
   assert.deepEqual(calls, [
-    "fast-forward", "create-stage", "install-dependencies", "prisma-generate", "build",
+    "fast-forward", "create-stage", "install-dependencies", "build",
     "escalate", "notify-failure", "cleanup-stage",
   ]);
   assert.equal(state.serving, "previous");
@@ -465,7 +471,112 @@ test("dry-run reads every decision surface and invokes no mutation", async () =>
   assert.equal(result.quiet, true);
   assert.deepEqual(new Set(calls), new Set(["revisions", "runs", "repository", "services", "authority", "backup"]));
   assert.ok(result.lines.includes("DRY-RUN backup=ready mode=container"));
-  assert.equal(result.lines.filter((line) => line.includes("mutation=skipped")).length, 11);
+  assert.equal(result.lines.filter((line) => line.includes("mutation=skipped")).length, 10);
+});
+
+const buildCacheFixture = (root, revision, buildKey) => {
+  const tree = join(root, "builds", buildKey, "tree");
+  for (const output of RELEASE_SNAPSHOT_OUTPUTS) {
+    mkdirSync(join(tree, output), { recursive: true });
+    writeFileSync(join(tree, output, "artifact.txt"), output);
+  }
+  writeFileSync(join(root, "builds", buildKey, "READY"), `${buildKey}\n`);
+  writeFileSync(join(tree, "packages/api/dist/build-info.json"), JSON.stringify({
+    packageName: "@agentos/api", commit: revision, dirty: false,
+  }));
+  writeFileSync(join(tree, "packages/runner/dist/build-info.json"), JSON.stringify({
+    packageName: "@agentos/runner", commit: revision, dirty: false,
+  }));
+};
+
+test("an exact merge-gate snapshot materializes every deploy output without a source build", () => {
+  const root = mkdtempSync(join(tmpdir(), "agentos-release-snapshot-"));
+  const cacheRoot = join(root, "cache");
+  const stageRoot = join(root, "stage");
+  const revision = "c".repeat(40);
+  const buildKey = "d".repeat(64);
+  mkdirSync(stageRoot);
+  buildCacheFixture(cacheRoot, revision, buildKey);
+  assert.deepEqual(publishReleaseSnapshot({ revision, buildKey, cacheRoot }), { published: true, buildKey });
+  assert.deepEqual(materializeReleaseSnapshot({ revision, stageRoot, cacheRoot }), { hit: true, buildKey });
+  for (const output of RELEASE_SNAPSHOT_OUTPUTS) {
+    assert.equal(readFileSync(join(stageRoot, output, "artifact.txt"), "utf8"), output);
+  }
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("a missing or evicted release snapshot explicitly falls back to a source build", () => {
+  const root = mkdtempSync(join(tmpdir(), "agentos-release-miss-"));
+  const cacheRoot = join(root, "cache");
+  const stageRoot = join(root, "stage");
+  const revision = "e".repeat(40);
+  const buildKey = "f".repeat(64);
+  mkdirSync(stageRoot);
+  assert.deepEqual(materializeReleaseSnapshot({ revision, stageRoot, cacheRoot }), { hit: false, reason: "missing" });
+  buildCacheFixture(cacheRoot, revision, buildKey);
+  publishReleaseSnapshot({ revision, buildKey, cacheRoot });
+  rmSync(join(cacheRoot, "builds", buildKey), { recursive: true });
+  assert.deepEqual(materializeReleaseSnapshot({ revision, stageRoot, cacheRoot }), { hit: false, reason: "evicted" });
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("a present but corrupted or symlinked release snapshot fails loudly", () => {
+  const root = mkdtempSync(join(tmpdir(), "agentos-release-invalid-"));
+  const cacheRoot = join(root, "cache");
+  const stageRoot = join(root, "stage");
+  const revision = "1".repeat(40);
+  const buildKey = "2".repeat(64);
+  mkdirSync(stageRoot);
+  buildCacheFixture(cacheRoot, revision, buildKey);
+  publishReleaseSnapshot({ revision, buildKey, cacheRoot });
+  rmSync(join(cacheRoot, "builds", buildKey, "tree", "apps/web/dist/artifact.txt"));
+  assert.throws(
+    () => materializeReleaseSnapshot({ revision, stageRoot, cacheRoot }),
+    (error) => error instanceof DeployFailure && error.reason === "release-snapshot-invalid",
+  );
+  writeFileSync(join(cacheRoot, "builds", buildKey, "tree", "apps/web/dist/artifact.txt"), "apps/web/dist");
+  symlinkSync("/tmp", join(cacheRoot, "builds", buildKey, "tree", "apps/web/dist/unsafe"));
+  assert.throws(
+    () => materializeReleaseSnapshot({ revision, stageRoot, cacheRoot }),
+    (error) => error instanceof DeployFailure && error.reason === "release-snapshot-invalid",
+  );
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("Git network commands retry twice with bounded delays before succeeding or surfacing failure", async () => {
+  const waits = [];
+  let attempts = 0;
+  const recovered = await runCommandWithRetry(async () => ({
+    code: ++attempts === 3 ? 0 : 128, stdout: "", stderr: "transient",
+  }), { wait: async (milliseconds) => { waits.push(milliseconds); } });
+  assert.equal(recovered.code, 0);
+  assert.equal(attempts, 3);
+  assert.deepEqual(waits, [2_000, 5_000]);
+
+  attempts = 0;
+  const failed = await runCommandWithRetry(async () => {
+    attempts += 1;
+    return { code: 128, stdout: "", stderr: "still unavailable" };
+  }, { wait: async () => undefined });
+  assert.equal(failed.code, 128);
+  assert.equal(attempts, 3);
+});
+
+test("the merge gate publishes deploy acceleration only after its final drift proof", () => {
+  const repositoryRoot = realpathSync(new URL("../../", import.meta.url));
+  const source = readFileSync(join(repositoryRoot, "scripts/merge-gate.sh"), "utf8");
+  const drift = source.lastIndexOf('step "verify the gated commit did not drift"');
+  const buildPublication = source.lastIndexOf("publish_deferred_build_snapshot");
+  const releasePublication = source.lastIndexOf("publish_release_snapshot");
+  assert.ok(drift >= 0 && drift < buildPublication && buildPublication < releasePublication);
+});
+
+test("deployment relies on npm ci postinstall once and verifies the generated Prisma client", () => {
+  const repositoryRoot = realpathSync(new URL("../../", import.meta.url));
+  const source = readFileSync(join(repositoryRoot, "scripts/deploy/quiet-window-deploy.mjs"), "utf8");
+  assert.doesNotMatch(source, /\[loadBinaries\(\)\.npm, "run", "db:generate"\]/u);
+  assert.match(source, /npm-ci-did-not-produce-generated-prisma-client/u);
+  assert.match(source, /node_modules\/\.prisma\/client\/schema\.prisma/u);
 });
 
 test("dry-run reports a refused container backup contract as a named decision", async () => {

--- a/scripts/deploy/quiet-window-host.mjs
+++ b/scripts/deploy/quiet-window-host.mjs
@@ -1,5 +1,5 @@
 const METHODS = Object.freeze([
-  "fastForward", "createStage", "installDependencies", "prismaGenerate", "build", "backup",
+  "fastForward", "createStage", "installDependencies", "build", "backup",
   "guardedMigration", "syncCanonicalPrompts", "verifyRuntimePrismaClient",
   "assertQuietBeforeRestart", "publishBuild", "restartServices", "verifyServices",
   "restorePreviousServices", "escalate", "notify", "cleanupStage",

--- a/scripts/deploy/quiet-window-lib.mjs
+++ b/scripts/deploy/quiet-window-lib.mjs
@@ -3,7 +3,6 @@ export const BLOCKING_RUN_STATUSES = Object.freeze(["claimed", "provisioning", "
 export const DEPLOY_STEPS = Object.freeze([
   "fast-forward",
   "install-dependencies",
-  "prisma-generate",
   "build",
   "backup",
   "guarded-migration",
@@ -65,7 +64,6 @@ export const executeUpgrade = async (host, initialRevisions) => {
     revisions = Object.freeze({ from: initialRevisions.from, to });
     await host.createStage();
     await host.installDependencies();
-    await host.prismaGenerate();
     await host.build();
     await host.backup();
     await host.guardedMigration();

--- a/scripts/deploy/quiet-window-retry.mjs
+++ b/scripts/deploy/quiet-window-retry.mjs
@@ -1,0 +1,21 @@
+const DEFAULT_DELAYS_MS = Object.freeze([2_000, 5_000]);
+
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+/** Runs a read-only or idempotent command up to three times. A caller remains
+ * responsible for classifying the final non-zero result. */
+export const runCommandWithRetry = async (
+  run,
+  { delaysMs = DEFAULT_DELAYS_MS, wait = delay, onRetry = () => undefined } = {},
+) => {
+  let result;
+  for (let attempt = 1; attempt <= delaysMs.length + 1; attempt += 1) {
+    result = await run(attempt);
+    if (result.code === 0) return result;
+    const waitMs = delaysMs[attempt - 1];
+    if (waitMs === undefined) return result;
+    onRetry({ attempt, nextAttempt: attempt + 1, waitMs, result });
+    await wait(waitMs);
+  }
+  return result;
+};

--- a/scripts/deploy/release-snapshot.mjs
+++ b/scripts/deploy/release-snapshot.mjs
@@ -1,0 +1,246 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  constants as fsConstants,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { DeployFailure } from "./quiet-window-lib.mjs";
+
+const RELEASE_INDEX_VERSION = 1;
+const REVISION = /^[0-9a-f]{40}$/u;
+const BUILD_KEY = /^[0-9a-f]{64}$/u;
+const CONTENT_HASH = /^[0-9a-f]{64}$/u;
+
+export const RELEASE_SNAPSHOT_OUTPUTS = Object.freeze([
+  "packages/github-client/dist",
+  "packages/db/dist",
+  "packages/api/dist",
+  "packages/runner/dist",
+  "packages/inbox/dist",
+  "packages/merge-executor/dist",
+  "apps/web/dist",
+]);
+
+export const defaultReleaseSnapshotCacheRoot = () => join(
+  process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache"),
+  "agentos-merge-gate",
+);
+
+const invalid = (detail) => { throw new DeployFailure("release-snapshot-invalid", detail); };
+
+const assertDirectory = (path, label) => {
+  let status;
+  try { status = lstatSync(path); } catch { invalid(`${label}-missing`); }
+  if (status.isSymbolicLink() || !status.isDirectory()) invalid(`${label}-not-a-directory`);
+};
+
+const assertRegularFile = (path, label) => {
+  let status;
+  try { status = lstatSync(path); } catch { invalid(`${label}-missing`); }
+  if (status.isSymbolicLink() || !status.isFile()) invalid(`${label}-not-a-regular-file`);
+};
+
+const inventoryDirectory = (path, relativePath, files) => {
+  const label = `build-output:${relativePath}`;
+  assertDirectory(path, label);
+  for (const entry of readdirSync(path, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name))) {
+    const child = join(path, entry.name);
+    if (entry.isSymbolicLink()) invalid(`${label}-contains-symlink:${entry.name}`);
+    const relativeChild = `${relativePath}/${entry.name}`;
+    if (entry.isDirectory()) inventoryDirectory(child, relativeChild, files);
+    else if (entry.isFile()) {
+      const contents = readFileSync(child);
+      files.push({
+        path: relativeChild,
+        size: contents.byteLength,
+        sha256: createHash("sha256").update(contents).digest("hex"),
+      });
+    } else invalid(`${label}-contains-non-file:${entry.name}`);
+  }
+};
+
+const inventoryBuildOutputs = (tree) => {
+  const files = [];
+  for (const output of RELEASE_SNAPSHOT_OUTPUTS) inventoryDirectory(join(tree, output), output, files);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+};
+
+const readJsonObject = (path, label) => {
+  assertRegularFile(path, label);
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8"));
+    if (typeof value !== "object" || value === null || Array.isArray(value)) invalid(`${label}-root-not-object`);
+    return value;
+  } catch (error) {
+    if (error instanceof DeployFailure) throw error;
+    invalid(`${label}-unreadable`);
+  }
+};
+
+const readReleaseIndex = (path, revision) => {
+  const value = readJsonObject(path, "release-index");
+  if (value.schemaVersion !== RELEASE_INDEX_VERSION) invalid("release-index-version");
+  if (value.revision !== revision) invalid("release-index-revision");
+  if (!BUILD_KEY.test(value.buildKey ?? "")) invalid("release-index-build-key");
+  if (JSON.stringify(value.outputs) !== JSON.stringify(RELEASE_SNAPSHOT_OUTPUTS)) invalid("release-index-outputs");
+  if (!Array.isArray(value.files) || value.files.length > 50_000) invalid("release-index-files");
+  let previousPath = "";
+  for (const file of value.files) {
+    if (typeof file !== "object" || file === null || Array.isArray(file)
+      || typeof file.path !== "string" || file.path <= previousPath
+      || !RELEASE_SNAPSHOT_OUTPUTS.some((output) => file.path.startsWith(`${output}/`))
+      || !Number.isSafeInteger(file.size) || file.size < 0
+      || !CONTENT_HASH.test(file.sha256 ?? "")) invalid("release-index-file-entry");
+    previousPath = file.path;
+  }
+  return value;
+};
+
+const assertBuildStamp = (tree, path, revision, packageName) => {
+  const stamp = readJsonObject(join(tree, path), `${packageName}-build-stamp`);
+  if (stamp.commit !== revision || stamp.dirty !== false || stamp.packageName !== packageName) {
+    invalid(`${packageName}-build-stamp-mismatch`);
+  }
+};
+
+const validateBuildEntry = (cacheRoot, revision, buildKey, expectedFiles = null) => {
+  const entry = join(cacheRoot, "builds", buildKey);
+  if (!existsSync(entry)) return null;
+  assertDirectory(entry, "build-entry");
+  const ready = join(entry, "READY");
+  assertRegularFile(ready, "build-entry-ready");
+  if (readFileSync(ready, "utf8").trim() !== buildKey) invalid("build-entry-ready-mismatch");
+  const tree = join(entry, "tree");
+  assertDirectory(tree, "build-entry-tree");
+  assertBuildStamp(tree, "packages/api/dist/build-info.json", revision, "@agentos/api");
+  assertBuildStamp(tree, "packages/runner/dist/build-info.json", revision, "@agentos/runner");
+  const files = inventoryBuildOutputs(tree);
+  if (expectedFiles !== null && JSON.stringify(files) !== JSON.stringify(expectedFiles)) {
+    invalid("build-entry-content-mismatch");
+  }
+  return { tree, files };
+};
+
+const releaseIndexPath = (cacheRoot, revision) => join(cacheRoot, "releases", `${revision}.json`);
+
+export const publishReleaseSnapshot = ({
+  revision,
+  buildKey,
+  cacheRoot = defaultReleaseSnapshotCacheRoot(),
+}) => {
+  if (!REVISION.test(revision ?? "")) invalid("revision");
+  if (!BUILD_KEY.test(buildKey ?? "")) invalid("build-key");
+  if (existsSync(cacheRoot)) assertDirectory(cacheRoot, "cache-root");
+  else mkdirSync(cacheRoot, { recursive: true, mode: 0o700 });
+  const proposed = validateBuildEntry(cacheRoot, revision, buildKey);
+  if (proposed === null) invalid("build-entry-missing");
+
+  const releases = join(cacheRoot, "releases");
+  if (existsSync(releases)) assertDirectory(releases, "release-index-directory");
+  else mkdirSync(releases, { mode: 0o700 });
+  const path = releaseIndexPath(cacheRoot, revision);
+  if (existsSync(path)) {
+    const current = readReleaseIndex(path, revision);
+    if (validateBuildEntry(cacheRoot, revision, current.buildKey, current.files) !== null) {
+      return Object.freeze({ published: false, buildKey: current.buildKey });
+    }
+  }
+
+  const temporary = join(releases, `.${revision}.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    writeFileSync(temporary, `${JSON.stringify({
+      schemaVersion: RELEASE_INDEX_VERSION,
+      revision,
+      buildKey,
+      outputs: RELEASE_SNAPSHOT_OUTPUTS,
+      files: proposed.files,
+    })}\n`, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    chmodSync(temporary, 0o444);
+    renameSync(temporary, path);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+  return Object.freeze({ published: true, buildKey });
+};
+
+const makeWritable = (path) => {
+  const status = lstatSync(path);
+  if (status.isDirectory()) {
+    chmodSync(path, status.mode | 0o700);
+    for (const entry of readdirSync(path)) makeWritable(join(path, entry));
+  } else {
+    chmodSync(path, status.mode | 0o200);
+  }
+};
+
+export const materializeReleaseSnapshot = ({
+  stageRoot,
+  revision,
+  cacheRoot = defaultReleaseSnapshotCacheRoot(),
+}) => {
+  if (!REVISION.test(revision ?? "")) invalid("revision");
+  if (!existsSync(cacheRoot)) return Object.freeze({ hit: false, reason: "missing" });
+  assertDirectory(cacheRoot, "cache-root");
+  const releases = join(cacheRoot, "releases");
+  if (!existsSync(releases)) return Object.freeze({ hit: false, reason: "missing" });
+  assertDirectory(releases, "release-index-directory");
+  const path = releaseIndexPath(cacheRoot, revision);
+  if (!existsSync(path)) return Object.freeze({ hit: false, reason: "missing" });
+  const index = readReleaseIndex(path, revision);
+  const entry = validateBuildEntry(cacheRoot, revision, index.buildKey, index.files);
+  if (entry === null) return Object.freeze({ hit: false, reason: "evicted" });
+
+  const copied = [];
+  try {
+    for (const output of RELEASE_SNAPSHOT_OUTPUTS) {
+      const destination = join(stageRoot, output);
+      if (existsSync(destination)) invalid(`staged-output-already-exists:${output}`);
+      mkdirSync(dirname(destination), { recursive: true });
+      cpSync(join(entry.tree, output), destination, {
+        recursive: true,
+        force: false,
+        errorOnExist: true,
+        mode: fsConstants.COPYFILE_FICLONE,
+      });
+      copied.push(destination);
+      makeWritable(destination);
+    }
+  } catch (error) {
+    for (const destination of copied.reverse()) rmSync(destination, { recursive: true, force: true });
+    if (error instanceof DeployFailure) throw error;
+    throw new DeployFailure(
+      "release-snapshot-materialization-failed",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+  return Object.freeze({ hit: true, buildKey: index.buildKey });
+};
+
+const entrypoint = process.argv[1] ? resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
+if (entrypoint) {
+  const [action, revision, cacheRoot, buildKey] = process.argv.slice(2);
+  if (action !== "publish" || !revision || !cacheRoot || !buildKey) {
+    process.stderr.write("usage: release-snapshot.mjs publish <revision> <cache-root> <build-key>\n");
+    process.exitCode = 64;
+  } else {
+    try {
+      const result = publishReleaseSnapshot({ revision, cacheRoot, buildKey });
+      process.stdout.write(`release snapshot ${result.published ? "published" : "reused"}: ${revision} ${result.buildKey}\n`);
+    } catch (error) {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 1;
+    }
+  }
+}

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -525,6 +525,10 @@ prepare_deferred_build_snapshot() {
   printf '%s\n' "${key}" > "${GATE_TMP}/deferred-build-key" || return 1
 }
 
+record_release_build_key() {
+  printf '%s\n' "$1" > "${GATE_TMP}/release-build-key"
+}
+
 # This is called only after verify_tree_did_not_drift succeeds. Until then the
 # completed build exists solely under this gate run's private temporary root and
 # no later run can observe it under the pinned-OID cache key.
@@ -540,6 +544,21 @@ publish_deferred_build_snapshot() {
   publish_build_snapshot "${entry}" "${key}" "${snapshot}/tree" \
     || note "build cache publication failed; this run keeps fresh build output"
   prune_build_cache "${key}"
+}
+
+# The revision index is deployment acceleration, never merge authority. It is
+# published only after the final drift proof and points at the bounded immutable
+# build cache above, so it adds no second artifact copy or unbounded cache.
+publish_release_snapshot() {
+  local key=""
+  [ -f "${GATE_TMP}/release-build-key" ] && [ ! -L "${GATE_TMP}/release-build-key" ] || return 0
+  key="$(cat "${GATE_TMP}/release-build-key" 2>/dev/null || true)"
+  [ -n "${key}" ] || return 0
+  if node "${REPO_ROOT}/scripts/deploy/release-snapshot.mjs" publish "${GATED_HEAD}" "${CACHE_ROOT}" "${key}"; then
+    note "release snapshot indexed: ${GATED_HEAD}"
+  else
+    note "release snapshot publication failed; deployment will build from source"
+  fi
 }
 
 build_all() {
@@ -569,14 +588,18 @@ build_all() {
     (cd "${REPO_ROOT}/packages/api" && node ../build-info/stamp.mjs dist) || return 1
     (cd "${REPO_ROOT}/packages/runner" && node ../build-info/stamp.mjs dist) || return 1
     note "build cache hit: ${key} ($(cache_copy_description), provenance restamped)"
+    record_release_build_key "${key}" || return 1
     prune_build_cache "${key}"
     return 0
   fi
   note "build cache miss: ${key}"
   clear_build_outputs || return 1
   npm run build || return 1
-  prepare_deferred_build_snapshot "${key}" \
-    || note "build snapshot could not be staged; this run keeps fresh build output"
+  if prepare_deferred_build_snapshot "${key}"; then
+    record_release_build_key "${key}" || return 1
+  else
+    note "build snapshot could not be staged; this run keeps fresh build output"
+  fi
   return 0
 }
 
@@ -1063,3 +1086,4 @@ step "database preflight tests" run_database_preflight_tests
 step "api database tests" run_api_database_tests
 step "verify the gated commit did not drift" verify_tree_did_not_drift
 publish_deferred_build_snapshot
+publish_release_snapshot


### PR DESCRIPTION
## Summary
- reuse exact local merge-gate dist snapshots with verified file hashes, and build from source on an explicit cache miss
- remove duplicate Prisma generation while retaining generated-client verification and retry transient Git reads/fetches
- reduce runner availability write contention with a separate jittered cadence and bounded P2034 retries

## Verification
- npm run test:auto-deploy
- npm run test -w @agentos/api
- npm run test -w @agentos/runner
- npm run test -w @agentos/web
- npm run lint
- npm run typecheck
- npm run build
- npm run test:dependency-gate
- npm run verify:compose-binding