### PR TITLE
fix: harden runtime recovery paths

### DIFF
--- a/packages/api/src/execution.test.ts
+++ b/packages/api/src/execution.test.ts
@@ -245,6 +245,7 @@ test("the envelope a real hung push produces is classified as retryable transien
  * vocabulary would have quietly made these failures final.
  */
 const TRANSIENT_PHRASES = [
+  "fetch failed",
   "SSL_ERROR_SYSCALL: connection failed",
   "fatal: the remote end hung up unexpectedly: unexpected EOF",
   "connection reset by peer",

--- a/packages/api/src/execution.ts
+++ b/packages/api/src/execution.ts
@@ -164,6 +164,7 @@ const PROVIDER_OUTAGE_PATTERN = /provider outage|\b5\d\d\b/iu;
  * retry loop has every one of these tokens in its stdout.
  */
 const TRANSIENT_NETWORK_PATTERNS = [
+  /fetch failed/i,
   /SSL_ERROR_SYSCALL/i,
   /unexpected EOF/i,
   /connection (?:reset|closed|timed out|lost)/i,

--- a/packages/api/src/github-read.test.ts
+++ b/packages/api/src/github-read.test.ts
@@ -28,3 +28,40 @@ test("compare refuses an unknown ancestry status", async () => {
     (error: unknown) => error instanceof GitHubReadError && /invalid status/u.test(error.message),
   );
 });
+
+test("transport failures retry with bounded exponential delays", async () => {
+  let calls = 0;
+  const waits: number[] = [];
+  const reader = createGitHubReader("read-token", async () => {
+    calls += 1;
+    if (calls < 3) throw new TypeError("fetch failed");
+    return new Response(JSON.stringify({ status: "ahead", behind_by: 0, files: [] }), { status: 200 });
+  }, { wait: async (delayMs) => { waits.push(delayMs); } })!;
+
+  const compared = await reader.compareCommits!(
+    "owner/repo",
+    "a".repeat(40),
+    "b".repeat(40),
+    new AbortController().signal,
+  );
+
+  assert.equal(compared.status, "ahead");
+  assert.equal(calls, 3);
+  assert.deepEqual(waits, [250, 1_000]);
+});
+
+test("permission failures never retry", async () => {
+  let calls = 0;
+  const waits: number[] = [];
+  const reader = createGitHubReader("read-token", async () => {
+    calls += 1;
+    return new Response("forbidden", { status: 403 });
+  }, { wait: async (delayMs) => { waits.push(delayMs); } })!;
+
+  await assert.rejects(
+    reader.compareCommits!("owner/repo", "a".repeat(40), "b".repeat(40), new AbortController().signal),
+    (error: unknown) => error instanceof GitHubReadError && error.kind === "permission",
+  );
+  assert.equal(calls, 1);
+  assert.deepEqual(waits, []);
+});

--- a/packages/api/src/github-read.ts
+++ b/packages/api/src/github-read.ts
@@ -106,6 +106,13 @@ export type GitHubReader = {
   }>;
 };
 
+type GitHubReadRetryOptions = {
+  wait?: (delayMs: number) => Promise<void>;
+};
+
+const GITHUB_READ_RETRY_DELAYS_MS = [250, 1_000] as const;
+const waitForRetry = (delayMs: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, delayMs));
+
 const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
 const asObject = (value: unknown): Record<string, unknown> | null =>
   typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null;
@@ -234,54 +241,56 @@ export const checkConclusionFor = (snapshot: PullRequestSnapshot, name: string):
 export const createGitHubReader = (
   token: string | undefined = process.env.GITHUB_READ_TOKEN,
   fetchImpl: typeof fetch = fetch,
+  retryOptions: GitHubReadRetryOptions = {},
 ): GitHubReader | null => {
   if (!token) return null;
+  const wait = retryOptions.wait ?? waitForRetry;
   const request = async (url: string, init: RequestInit): Promise<Response> => {
-    let response: Response;
-    try {
-      response = await fetchImpl(url, init);
-    } catch (error: unknown) {
-      if (error instanceof Error && error.name === "AbortError") throw new GitHubReadError("GitHub read aborted at its deadline", "timeout");
-      const message = error instanceof Error ? error.message : "unknown";
-      throw new GitHubReadError(`GitHub read failed: ${message}`, isDeterministicRefusal(error) ? "permission" : "transport");
-    }
-    if (response.status === 401 || response.status === 403) throw new GitHubReadError(`GitHub read refused with ${response.status}`, "permission");
-    if (!response.ok) throw new GitHubReadError(`GitHub read returned ${response.status}`, "transport");
-    return response;
-  };
-  return {
-    readPullRequest: async (repository, prNumber, baseRef, signal) => {
-      const [owner, name] = repository.split("/");
-      if (!owner || !name) throw new GitHubReadError(`malformed repository ${repository}`, "response");
+    for (let attempt = 0; ; attempt += 1) {
       let response: Response;
       try {
-        response = await fetchImpl(GITHUB_GRAPHQL_URL, {
-          method: "POST",
-          signal,
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-            Accept: "application/vnd.github+json",
-          },
-          body: JSON.stringify({ query: PULL_REQUEST_QUERY, variables: { owner, name, number: prNumber, base: baseRef } }),
-        });
+        response = await fetchImpl(url, init);
       } catch (error: unknown) {
         if (error instanceof Error && error.name === "AbortError") {
           throw new GitHubReadError("GitHub read aborted at its deadline", "timeout");
         }
         const message = error instanceof Error ? error.message : "unknown";
-        // A credential failure raised at the transport layer rather than as a
-        // status is still a credential failure. Calling it `transport` invites
-        // the reader to treat a permanently broken token as a network blip.
-        throw new GitHubReadError(
-          `GitHub read failed: ${message}`,
-          isDeterministicRefusal(error) ? "permission" : "transport",
-        );
+        if (isDeterministicRefusal(error)) throw new GitHubReadError(`GitHub read failed: ${message}`, "permission");
+        const delay = GITHUB_READ_RETRY_DELAYS_MS[attempt];
+        if (delay === undefined) throw new GitHubReadError(`GitHub read failed: ${message}`, "transport");
+        await wait(delay);
+        continue;
       }
       if (response.status === 401 || response.status === 403) {
         throw new GitHubReadError(`GitHub read refused with ${response.status}`, "permission");
       }
-      if (!response.ok) throw new GitHubReadError(`GitHub read returned ${response.status}`, "transport");
+      if (response.ok) return response;
+      const delay = GITHUB_READ_RETRY_DELAYS_MS[attempt];
+      const transientStatus = response.status === 429 || response.status >= 500;
+      if (transientStatus && delay !== undefined) {
+        await wait(delay);
+        continue;
+      }
+      throw new GitHubReadError(
+        `GitHub read returned ${response.status}`,
+        transientStatus ? "transport" : "response",
+      );
+    }
+  };
+  return {
+    readPullRequest: async (repository, prNumber, baseRef, signal) => {
+      const [owner, name] = repository.split("/");
+      if (!owner || !name) throw new GitHubReadError(`malformed repository ${repository}`, "response");
+      const response = await request(GITHUB_GRAPHQL_URL, {
+        method: "POST",
+        signal,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          Accept: "application/vnd.github+json",
+        },
+        body: JSON.stringify({ query: PULL_REQUEST_QUERY, variables: { owner, name, number: prNumber, base: baseRef } }),
+      });
       return parsePullRequestResponse(repository, baseRef, await response.json(), new Date().toISOString());
     },
     compareCommits: async (repository, baseSha, headSha, signal) => {

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -541,6 +541,7 @@ export const readinessTick = async (
           update: { kind: "merge-authorization", body: JSON.stringify({ authorizationActivityId: activity.id, headSha: evidence.headSha }), commitSha: evidence.headSha },
         });
         await tx.task.update({ where: { id: readiness.id }, data: { status: TaskStatus.DONE, failureReason: null } });
+        await tx.task.update({ where: { id: regression.id }, data: { failureReason: null } });
         await tx.taskActivity.create({ data: {
           taskId: readiness.id,
           actorType: "control-plane",

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -149,8 +149,13 @@ const seedReadiness = async () => {
 
 test("clean exact-head readiness authorizes and queues mechanical merge", async () => {
   const seeded = await seedReadiness();
+  await db.task.update({
+    where: { id: seeded.regression.id },
+    data: { failureReason: "readiness evaluation failed: GitHub read failed: fetch failed" },
+  });
   assert.deepEqual(await readinessTick(db, reader()), { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 });
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.DONE);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } })).failureReason, null);
   const output = await db.taskStepOutput.findUniqueOrThrow({ where: { taskId: seeded.readiness.id } });
   assert.equal(output.commitSha, HEAD);
   assert.equal((await db.run.count({ where: { taskId: seeded.integrator.id } })), 1);

--- a/packages/api/src/testdb.test.ts
+++ b/packages/api/src/testdb.test.ts
@@ -1,18 +1,36 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 
-import {
+const unitTestDatabaseUrl = "postgresql://scratch_role:secret@127.0.0.1:55432/agentos_test_control?schema=isolated";
+const previousTestDatabaseUrl = process.env.TEST_DATABASE_URL;
+process.env.TEST_DATABASE_URL = unitTestDatabaseUrl;
+const {
   awaitNoConnections,
   ScratchDatabaseManager,
   scratchNameOwnerPid,
   validateScratchDatabaseEnvironment,
-} from "./testdb.js";
+} = await import("./testdb.js");
+if (previousTestDatabaseUrl === undefined) delete process.env.TEST_DATABASE_URL;
+else process.env.TEST_DATABASE_URL = previousTestDatabaseUrl;
 
 const safeEnvironment = {
   AGENTOS_ALLOW_SCRATCH_DATABASES: "1",
-  TEST_DATABASE_URL: "postgresql://scratch_role:secret@127.0.0.1:55432/agentos_test_control?schema=isolated",
+  TEST_DATABASE_URL: unitTestDatabaseUrl,
   TEST_DATABASE_MAINTENANCE_URL: "postgresql://scratch_role:secret@127.0.0.1:55432/postgres_maintenance?schema=isolated",
 } satisfies NodeJS.ProcessEnv;
+
+test("DB-HARNESS-GUARD refuses to load without an explicit test database URL", () => {
+  const environment = { ...process.env };
+  delete environment.TEST_DATABASE_URL;
+  const imported = spawnSync(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "-e", `await import(${JSON.stringify(new URL("./testdb.ts", import.meta.url).href)})`],
+    { encoding: "utf8", env: environment },
+  );
+  assert.notEqual(imported.status, 0);
+  assert.match(imported.stderr, /scratch-test-database-url-required/u);
+});
 
 test("DB-HARNESS-GUARD requires explicit opt-in and both explicit URLs", () => {
   assert.throws(() => validateScratchDatabaseEnvironment({}), /opt-in-required/u);

--- a/packages/api/src/testdb.ts
+++ b/packages/api/src/testdb.ts
@@ -1,5 +1,5 @@
 import { execFileSync, execSync } from "node:child_process";
-import { createHash, randomBytes } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
@@ -306,16 +306,8 @@ export class ScratchDatabaseManager {
   }
 }
 
-const defaultTestDatabaseUrl = new URL("postgresql://agentos:agentos@localhost:5432/agentos?schema=agentos_test");
-// Every AgentOS workspace used to drop the same host-wide schema. The package's
-// concurrency=1 flag serializes files only inside one workspace, so a sibling
-// test process could still drop our tables mid-suite. Derive a stable,
-// PostgreSQL-safe private schema unless the caller explicitly supplies one.
-defaultTestDatabaseUrl.searchParams.set(
-  "schema",
-  `agentos_test_${createHash("sha256").update(process.cwd()).digest("hex").slice(0, 16)}`,
-);
-export const testDatabaseUrl = process.env.TEST_DATABASE_URL ?? defaultTestDatabaseUrl.toString();
+if (!process.env.TEST_DATABASE_URL) throw new Error("scratch-test-database-url-required");
+export const testDatabaseUrl = process.env.TEST_DATABASE_URL;
 
 const parsedTestDatabaseUrl = new URL(testDatabaseUrl);
 export const testDatabaseSchema = parsedTestDatabaseUrl.searchParams.get("schema") ?? "public";

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -892,6 +892,54 @@ test("Codex structured errors take precedence over stderr warnings", async () =>
   assert.equal(failureReasonFromEvidence({ ...evidence, stderr: "models cache warning" }), "policy denied");
 });
 
+test("PI terminal success follows the final provider attempt after an internal retry", async () => {
+  const script = [
+    "const emit = (value) => process.stdout.write(JSON.stringify(value) + '\\n');",
+    "emit({type:'turn_end',message:{role:'assistant',content:[],stopReason:'error',errorMessage:'fetch failed'}});",
+    "emit({type:'agent_end',messages:[{role:'assistant',stopReason:'error',errorMessage:'fetch failed'}],willRetry:true});",
+    "emit({type:'turn_end',message:{role:'assistant',content:[{type:'text',text:'final PASS'}],stopReason:'stop'}});",
+    "emit({type:'agent_end',messages:[{role:'assistant',stopReason:'stop'}],willRetry:false});",
+    "emit({type:'agent_settled'});",
+  ].join("");
+  const config = {
+    binaries: { CLAUDE: "claude", CODEX: "codex", PI: "pi" },
+    runAsPrefix: [process.execPath, "-e", script],
+  } as unknown as RunnerConfig;
+  const handle = await adapters.PI.start({
+    config, claim, workingDirectory: process.cwd(), env: process.env, prompt: "prompt",
+    credentialsPath: "/tmp/session.json",
+  }, () => undefined);
+
+  const evidence = await handle.exit;
+  assert.equal(evidence.terminalSuccess, true);
+  assert.equal(evidence.providerError, null);
+  assert.equal(evidence.finalOutput, "final PASS");
+  assert.equal(adapterExecutionSucceeded(evidence), true);
+});
+
+test("PI exposes the exhausted provider error instead of a generic protocol failure", async () => {
+  const script = [
+    "const emit = (value) => process.stdout.write(JSON.stringify(value) + '\\n');",
+    "emit({type:'turn_end',message:{role:'assistant',content:[],stopReason:'error',errorMessage:'fetch failed'}});",
+    "emit({type:'agent_end',messages:[{role:'assistant',stopReason:'error',errorMessage:'fetch failed'}],willRetry:false});",
+    "emit({type:'agent_settled'});",
+  ].join("");
+  const config = {
+    binaries: { CLAUDE: "claude", CODEX: "codex", PI: "pi" },
+    runAsPrefix: [process.execPath, "-e", script],
+  } as unknown as RunnerConfig;
+  const handle = await adapters.PI.start({
+    config, claim, workingDirectory: process.cwd(), env: process.env, prompt: "prompt",
+    credentialsPath: "/tmp/session.json",
+  }, () => undefined);
+
+  const evidence = await handle.exit;
+  assert.equal(evidence.terminalEventSeen, true);
+  assert.equal(evidence.terminalSuccess, false);
+  assert.equal(evidence.providerError, "fetch failed");
+  assert.deepEqual(adapters.PI.classifyError(evidence), { failureClass: "TRANSIENT_PROVIDER", retryable: true });
+});
+
 test("Codex agent progress renews an open command deadline while stderr does not", async () => {
   const script = [
     "const emit = (value) => process.stdout.write(JSON.stringify(value) + '\\n');",

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -378,6 +378,7 @@ export type RuntimeHandle = {
   sawError: boolean;
   providerError: string | null;
   piTurnCompleted: boolean;
+  piFinalAttemptFailed: boolean;
   finalOutput: string | null;
   stdout: string;
   stderr: string;
@@ -564,11 +565,18 @@ const parsePi = (handle: RuntimeHandle, event: Record<string, unknown>, sink: Se
     }
     emit(handle, sink, "MODEL_COMPLETED", event);
   } else if (type === "agent_end") {
-    if (event.willRetry === true) handle.sawError = true;
+    const messages = Array.isArray(event.messages) ? event.messages : [];
+    const finalMessage = asRecord(messages.at(-1));
+    const stopReason = stringField(finalMessage, "stopReason");
+    const errorMessage = stringField(finalMessage, "errorMessage");
+    handle.piFinalAttemptFailed = event.willRetry === true || stopReason === "error" || errorMessage !== null;
+    handle.providerError = handle.piFinalAttemptFailed
+      ? errorMessage ?? (stopReason ? `PI stopped with ${stopReason}` : "PI provider retry failed")
+      : null;
     emit(handle, sink, "PROVIDER_STATUS", event);
   } else if (type === "agent_settled") {
     handle.terminalEventSeen = true;
-    handle.terminalSuccess = handle.piTurnCompleted && !handle.sawError;
+    handle.terminalSuccess = handle.piTurnCompleted && !handle.piFinalAttemptFailed && !handle.sawError;
     emit(handle, sink, "FINAL_OUTPUT", event);
   } else {
     if (type?.includes("error")) handle.sawError = true;
@@ -728,6 +736,7 @@ const spawnRuntime = (runner: RunnerKind, spec: RunSpec, sink: SessionEventSink,
     sawError: false,
     providerError: null,
     piTurnCompleted: false,
+    piFinalAttemptFailed: false,
     finalOutput: null,
     stdout: "",
     stderr: "",

--- a/packages/runner/src/dependency-cache.test.ts
+++ b/packages/runner/src/dependency-cache.test.ts
@@ -217,6 +217,51 @@ test("a miss publishes complete root and workspace targets, then a hit restores 
   }
 });
 
+test("a cache hit rebuilds binding.gyp workspaces whose install artifacts live outside node_modules", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-native-"));
+  try {
+    const workspace = join(root, "workspace");
+    await createFixture(workspace);
+    await writeFile(join(workspace, "apps/web/binding.gyp"), '{"targets":[]}\n');
+    const nativeOutput = join(workspace, "apps/web/build/Release/control_plane_directory.node");
+    const fake = fakeInstallExecutor(async (cwd) => {
+      await mkdir(join(cwd, "node_modules/fake-package"), { recursive: true });
+      await writeFile(join(cwd, "node_modules/fake-package/index.js"), "cached root\n");
+      await mkdir(dirname(nativeOutput), { recursive: true });
+      await writeFile(nativeOutput, "installed native addon\n");
+    });
+    const rebuilds: string[][] = [];
+    const execute: DependencyCommandExecutor = async (runnerConfig, executable, args, cwd, env, options) => {
+      if (executable === "npm" && args[0] === "rebuild") {
+        rebuilds.push([...args]);
+        await mkdir(dirname(nativeOutput), { recursive: true });
+        await writeFile(nativeOutput, "rebuilt native addon\n");
+        return "";
+      }
+      return fake.execute(runnerConfig, executable, args, cwd, env, options);
+    };
+    const configured = config(root);
+
+    const first = await materializeWorkspaceDependencies(
+      configured, workspace, workspaceEnvironment(configured), execute,
+      { toolchain: TOOLCHAIN, report: () => undefined },
+    );
+    assert.equal(first.status, "installed");
+    assert.deepEqual(rebuilds, []);
+    await rm(join(workspace, "apps/web/build"), { recursive: true });
+
+    const second = await materializeWorkspaceDependencies(
+      configured, workspace, workspaceEnvironment(configured), execute,
+      { toolchain: TOOLCHAIN, report: () => undefined },
+    );
+    assert.equal(second.status, "restored");
+    assert.deepEqual(rebuilds, [["rebuild", "-w", "fixture-web", "--no-audit", "--no-fund"]]);
+    assert.equal(await readFile(nativeOutput, "utf8"), "rebuilt native addon\n");
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
 test("every dependency input and toolchain coordinate changes the cache key", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-key-"));
   try {

--- a/packages/runner/src/dependency-cache.ts
+++ b/packages/runner/src/dependency-cache.ts
@@ -52,6 +52,7 @@ type CacheMetadata = {
 type DependencyProject = {
   inputs: CacheInput[];
   targets: string[];
+  nativeWorkspaces: string[];
   inputMissCondition?: string;
 };
 
@@ -334,6 +335,15 @@ const inspectDependencyProject = async (workspacePath: string): Promise<Dependen
   const requiredPaths = ["package.json", "package-lock.json", ...packageDirectories.map((path) => `${path}/package.json`)];
   const optionalPaths = [".npmrc", ...packageDirectories.map((path) => `${path}/.npmrc`)];
   const schemaInputs = await lifecycleSchemaInputs(workspace, packages);
+  const nativeWorkspaces: string[] = [];
+  for (const pkg of packages) {
+    const bindingPath = posix.join(pkg.directory, "binding.gyp");
+    const kind = await pathKind(resolve(workspace, bindingPath));
+    if (kind === "missing") continue;
+    if (kind !== "file") throw new Error(`Ambiguous native workspace input: ${bindingPath} is ${kind}`);
+    if (!pkg.name) throw new Error(`Native workspace ${pkg.manifestPath} has no package name`);
+    nativeWorkspaces.push(pkg.name);
+  }
   const inputs: CacheInput[] = [];
   let inputMissCondition: string | undefined;
   for (const { path, required } of [
@@ -356,6 +366,7 @@ const inspectDependencyProject = async (workspacePath: string): Promise<Dependen
   return {
     inputs,
     targets: ["node_modules", ...packageDirectories.map((path) => `${path}/node_modules`)],
+    nativeWorkspaces,
     ...(inputMissCondition ? { inputMissCondition } : {}),
   };
 };
@@ -793,6 +804,25 @@ const installDependencies = async (
   }
 };
 
+const rebuildNativeWorkspaces = async (
+  config: RunnerConfig,
+  workspace: string,
+  nativeWorkspaces: string[],
+  env: NodeJS.ProcessEnv,
+  execute: DependencyCommandExecutor,
+): Promise<void> => {
+  for (const name of nativeWorkspaces) {
+    await execute(
+      config,
+      "npm",
+      ["rebuild", "-w", name, "--no-audit", "--no-fund"],
+      workspace,
+      env,
+      { timeoutMs: NPM_INSTALL_COMMAND_TIMEOUT_MS },
+    );
+  }
+};
+
 export const materializeWorkspaceDependencies = async (
   config: RunnerConfig,
   workspacePath: string,
@@ -834,6 +864,7 @@ export const materializeWorkspaceDependencies = async (
       try {
         const metadata = await validateEntry(entry, expected, workspace);
         await restoreEntry(config, metadata, entry, workspace, env, execute);
+        await rebuildNativeWorkspaces(config, workspace, project.nativeWorkspaces, env, execute);
         report({ event: "hit", key: key.slice(0, 16) });
         return { status: "restored", key };
       } catch (error: unknown) {

--- a/packages/runner/src/exec.test.ts
+++ b/packages/runner/src/exec.test.ts
@@ -117,3 +117,7 @@ test("the runner's own CLI preflight timeout is not mistaken for a network timeo
   // Ours is recognised by type, not by wording.
   assert.equal(isTransientNetworkError(new CommandTimeoutError("git", ["push"], 20_000)), true);
 });
+
+test("fetch transport failures are classified as transient", () => {
+  assert.equal(isTransientNetworkError(new TypeError("fetch failed")), true);
+});

--- a/packages/runner/src/network-retry.ts
+++ b/packages/runner/src/network-retry.ts
@@ -1,6 +1,7 @@
 import { isCommandTimeout, KILL_OVERHEAD_MS } from "./exec.js";
 
 const TRANSIENT_NETWORK_PATTERNS = [
+  /fetch failed/i,
   /SSL_ERROR_SYSCALL/i,
   /unexpected EOF/i,
   /connection (?:reset|closed|timed out|lost)/i,


### PR DESCRIPTION
## Summary

- retry transient GitHub reads within a fixed three-attempt budget
- parse PI terminal state from the final provider attempt and classify fetch failures as transient
- clear stale readiness failure reasons after successful authorization
- rebuild binding.gyp workspaces after dependency-cache restores
- require an explicit test database URL

## Verification

- MERGE GATE: PASS e8ee65b3aa7ff35718ff1d56d28277390cd834b6