### PR TITLE
fix(runtime): verify task stop cleanup

### DIFF
--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -786,6 +786,8 @@ export const en = {
   "taskDetail.stats.stall": "{n}m stall",
   "taskDetail.stats.tokens": "{n} tokens",
   "taskDetail.stats.wallClock": "{n}m wall-clock",
+  "taskDetail.stop.action": "Stop and park Task",
+  "taskDetail.stop.prompt": "Why should this Task be stopped and parked in Backlog?",
 
   "tasks.announcement.moved": "Moved {name} to {status}",
   "tasks.archiveAll": "Archive All",

--- a/apps/web/src/locales/zh.ts
+++ b/apps/web/src/locales/zh.ts
@@ -779,6 +779,8 @@ export const zh = {
   "taskDetail.stats.stall": "{n} 分钟停滞",
   "taskDetail.stats.tokens": "{n} token",
   "taskDetail.stats.wallClock": "{n} 分钟总时长",
+  "taskDetail.stop.action": "停止并暂停 Task",
+  "taskDetail.stop.prompt": "请输入停止此 Task 并将其暂停在 Backlog 的原因",
 
   "tasks.announcement.moved": "已将 {name} 移至{status}",
   "tasks.archiveAll": "全部归档",

--- a/apps/web/src/pages/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail.tsx
@@ -289,12 +289,16 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
   const retry = (): void => {
     void run(async () => { await api.post(`/tasks/${taskId}/retry`, {}); reload(); });
   };
-  const cancelCurrentRun = (): void => {
+  const cancelCurrentRun = (parkTask: boolean): void => {
     if (!newest) return;
-    const reason = window.prompt(t("taskDetail.cancel.prompt"));
+    const reason = window.prompt(t(parkTask ? "taskDetail.stop.prompt" : "taskDetail.cancel.prompt"));
     if (!reason?.trim()) return;
     void run(async () => {
-      await api.post(`/runs/${newest.id}/cancel`, { requestId: crypto.randomUUID(), reason: reason.trim() });
+      await api.post(`/runs/${newest.id}/cancel`, {
+        requestId: crypto.randomUUID(),
+        reason: reason.trim(),
+        parkTask,
+      });
       reload();
     });
   };
@@ -354,8 +358,13 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
           <Button type="button" variant="legacy" size="legacy" disabled={pending} onClick={retry}><IconRefresh />{t("common.retry")}</Button>
         ) : null}
         {newestIsActive ? (
-          <Button type="button" variant="legacy" size="legacy" disabled={pending || newestIsCancelling} onClick={cancelCurrentRun}>
+          <Button type="button" variant="legacy" size="legacy" disabled={pending || newestIsCancelling} onClick={() => cancelCurrentRun(false)}>
             {t(newestIsCancelling ? "taskDetail.cancel.cancelling" : "taskDetail.cancel.action")}
+          </Button>
+        ) : null}
+        {newestIsActive ? (
+          <Button type="button" variant="legacy" size="legacy" disabled={pending || newestIsCancelling} onClick={() => cancelCurrentRun(true)}>
+            {t("taskDetail.stop.action")}
           </Button>
         ) : null}
         <Button type="button" variant="legacy" size="legacy" disabled={pending} onClick={() => setArchived(task.archivedAt === null)}>

--- a/apps/web/src/tests/task-detail.test.tsx
+++ b/apps/web/src/tests/task-detail.test.tsx
@@ -31,6 +31,8 @@ test("active Runs expose cancellation and an outstanding intent renders Cancelli
   assert.match(source, /newest\.cancelAcknowledgedAt === null/u);
   assert.match(source, /taskDetail\.cancel\.cancelling/u);
   assert.match(source, /\/runs\/\$\{newest\.id\}\/cancel/u);
+  assert.match(source, /parkTask/u);
+  assert.match(source, /taskDetail\.stop\.action/u);
   assert.match(source, /task\.executionOwner === "agent"/u);
 });
 

--- a/packages/api/src/active-run-cancellation.dbtest.ts
+++ b/packages/api/src/active-run-cancellation.dbtest.ts
@@ -301,22 +301,49 @@ test("start and cancellation acknowledgement serialize to one Run and Session ou
   assert.equal(session.executionStatus, SessionExecutionStatus.CANCELLED);
 });
 
-test("QUEUED and WAITING_INBOX cancellation settle immediately without a provider acknowledgement", async () => {
-  for (const status of [RunStatus.QUEUED, RunStatus.WAITING_INBOX]) {
-    const seeded = await seed(status);
-    const response = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
-      requestId: `cancel-immediate-${status.toLowerCase()}`, reason: "operator stop",
-    });
-    assert.equal(response.status, 200);
-    assert.equal(response.body.cancellationState, "acknowledged");
-    const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
-    assert.equal(run.status, RunStatus.CANCELLED);
-    assert.ok(run.cancelAcknowledgedAt);
-    if (seeded.session) {
-      const session = await db.session.findUniqueOrThrow({ where: { id: seeded.session.id } });
-      assert.equal(session.executionStatus, SessionExecutionStatus.CANCELLED);
-    }
-  }
+test("only an unclaimed QUEUED cancellation settles without runner acknowledgement", async () => {
+  const queued = await seed(RunStatus.QUEUED);
+  const queuedResponse = await call("POST", `/runs/${queued.run.id}/cancel`, OPERATOR, {
+    requestId: "cancel-immediate-queued", reason: "operator stop",
+  });
+  assert.equal(queuedResponse.status, 200);
+  assert.equal(queuedResponse.body.cancellationState, "acknowledged");
+  assert.ok((await db.run.findUniqueOrThrow({ where: { id: queued.run.id } })).cancelAcknowledgedAt);
+
+  const waiting = await seed(RunStatus.WAITING_INBOX);
+  const requestId = "cancel-waiting-provider-cleanup";
+  const waitingResponse = await call("POST", `/runs/${waiting.run.id}/cancel`, OPERATOR, {
+    requestId, reason: "operator stop",
+  });
+  assert.equal(waitingResponse.status, 200);
+  assert.equal(waitingResponse.body.cancellationState, "requested");
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: waiting.run.id } })).status, RunStatus.WAITING_INBOX);
+  const acknowledged = await call("POST", `/runner/runs/${waiting.run.id}/cancel/acknowledge`, RUNNER, {
+    runnerId: RUNNER_ID, fencingToken: waiting.run.fencingToken, requestId,
+  });
+  assert.equal(acknowledged.status, 200);
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: waiting.run.id } })).status, RunStatus.CANCELLED);
+});
+
+test("stop-and-park records cancellation intent and keeps the Task in Backlog after acknowledgement", async () => {
+  const seeded = await seed(RunStatus.RUNNING);
+  const requestId = "cancel-and-park";
+  const requested = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+    requestId, reason: "pause implementation", parkTask: true,
+  });
+  assert.equal(requested.status, 200);
+  assert.equal(requested.body.cancellationState, "requested");
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.task.id } })).status, TaskStatus.BACKLOG);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.successor.id } })).status, TaskStatus.TODO);
+
+  const acknowledged = await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
+    runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken, requestId,
+  });
+  assert.equal(acknowledged.status, 200);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.task.id } })).status, TaskStatus.BACKLOG);
+  assert.equal(await db.run.count({ where: { taskId: seeded.task.id, status: { in: [
+    RunStatus.QUEUED, RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING, RunStatus.WAITING_INBOX,
+  ] } } }), 0);
 });
 
 test("lease reconciliation settles an unacknowledged cancellation without retrying", async () => {
@@ -332,7 +359,7 @@ test("lease reconciliation settles an unacknowledged cancellation without retryi
     db.task.findUniqueOrThrow({ where: { id: seeded.successor.id } }),
   ]);
   assert.equal(run.status, RunStatus.CANCELLED);
-  assert.equal(run.cancelAcknowledgedAt?.toISOString(), now.toISOString());
+  assert.equal(run.cancelAcknowledgedAt, null);
   assert.equal(count, 1);
   assert.equal(successor.status, TaskStatus.TODO);
 });
@@ -360,6 +387,7 @@ test("a late runner acknowledgement backfills workspace evidence after reconcili
   assert.equal(response.status, 200);
   const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
   assert.equal(run.status, RunStatus.CANCELLED);
+  assert.ok(run.cancelAcknowledgedAt);
   assert.equal(run.workspacePath, "/scratch/reconciled-first");
   assert.equal(run.branch, "codex/reconciled-first");
   assert.equal(run.baseSha, "b".repeat(40));

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -978,6 +978,7 @@ const heartbeatInput = z.object({
 const cancelRunInput = z.object({
   requestId: z.string().trim().min(1).max(160),
   reason: z.string().trim().min(1).max(2000),
+  parkTask: z.boolean().default(false),
 });
 const cancelAcknowledgeInput = z.object({
   runnerId: z.string().trim().min(1).max(120),
@@ -1351,7 +1352,7 @@ const settleCancellation = async (
   if (input.runnerId !== undefined && (run.runnerId !== input.runnerId || run.fencingToken !== input.fencingToken)) {
     return { error: "Cancellation acknowledgement is not owned by this runner", code: 409 };
   }
-  if (run.status === RunStatus.CANCELLED && run.cancelAcknowledgedAt) {
+  if (run.status === RunStatus.CANCELLED) {
     // Reconciliation can settle an expired cancellation before the runner's
     // final ACK arrives. That ACK is still the only durable account of a
     // workspace provisioned before /start, so idempotence must backfill its
@@ -1365,6 +1366,21 @@ const settleCancellation = async (
     if (input.baseSha !== undefined) await tx.run.updateMany({
       where: { id: run.id, baseSha: null }, data: { baseSha: input.baseSha },
     });
+    if (!run.cancelAcknowledgedAt && input.runnerId !== undefined) {
+      await tx.run.update({
+        where: { id: run.id },
+        data: { cancelAcknowledgedAt: input.now },
+      });
+      if (run.taskId) await tx.taskActivity.create({ data: {
+        taskId: run.taskId,
+        actorType: "runner",
+        actorId: input.actorId ?? null,
+        body: `Run ${run.runNumber} cancellation cleanup confirmed after terminalization`,
+        metadata: { runId: run.id, requestId: input.requestId, status: RunStatus.CANCELLED },
+      } });
+    } else if (!run.cancelAcknowledgedAt) {
+      return { error: "Cancellation cleanup has not been acknowledged by the runner", code: 409 };
+    }
     return { runId: run.id, taskId: run.taskId, status: run.status, cancellationState: "acknowledged", requestId: input.requestId };
   }
   const settled = await tx.run.updateMany({
@@ -6183,15 +6199,41 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         },
       });
       if (!run) return { error: "Run not found", code: 404 as const };
+      if (body.parkTask && !run.taskId) return { error: "Run has no Task to park", code: 409 as const };
+      const parkTarget = body.parkTask && run.taskId ? await lockTask(tx, run.taskId) : null;
+      if (body.parkTask && run.taskId && !parkTarget) return { error: "Task not found", code: 404 as const };
+      if (parkTarget && parkTarget.archivedAt !== null) {
+        return { error: "Cannot park an archived task", code: 409 as const };
+      }
+      if (parkTarget?.status === TaskStatus.DONE) return { error: "Cannot park a completed task", code: 409 as const };
+      const parkTask = async () => {
+        const task = parkTarget;
+        if (!task) return;
+        if (task.status === TaskStatus.BACKLOG) return null;
+        const reason = run.cancelRequestId ? run.cancelReason ?? body.reason : body.reason;
+        await tx.task.update({
+          where: { id: task.id },
+          data: { status: TaskStatus.BACKLOG, failureReason: reason },
+        });
+        await tx.taskActivity.create({ data: {
+          taskId: task.id,
+          actorType: "operator",
+          body: `Status changed: ${task.status} → ${TaskStatus.BACKLOG}`,
+          metadata: { runId: run.id, requestId: body.requestId, reason: "stop-and-park" },
+        } });
+      };
       if (run.cancelRequestId) {
         if (run.cancelRequestId !== body.requestId) {
           return { error: `Run already has cancellation request ${run.cancelRequestId}`, code: 409 as const };
         }
+        await parkTask();
         return {
           runId: run.id,
           taskId: run.taskId,
           status: run.status,
-          cancellationState: run.cancelAcknowledgedAt ? "acknowledged" as const : "requested" as const,
+          cancellationState: run.cancelAcknowledgedAt
+            ? "acknowledged" as const
+            : run.status === RunStatus.CANCELLED ? "unconfirmed" as const : "requested" as const,
           requestId: run.cancelRequestId,
           reason: run.cancelReason,
         };
@@ -6220,16 +6262,17 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         },
       });
       if (requested.count !== 1) return { error: "Run changed while cancellation was being requested", code: 409 as const };
+      await parkTask();
       if (run.taskId) await tx.taskActivity.create({ data: {
         taskId: run.taskId,
         actorType: "operator",
         body: `Cancellation requested for Run ${run.runNumber}: ${body.reason}`,
         metadata: { runId: run.id, requestId: body.requestId, priorStatus: run.status, state: "requested" },
       } });
-      // No provider process exists before claim or while suspended for Inbox,
-      // so the control plane can acknowledge these states immediately. Claimed,
-      // provisioning, and running owners must first kill their process group.
-      if (run.status === RunStatus.QUEUED || run.status === RunStatus.WAITING_INBOX) {
+      // An unclaimed Run has never had a provider process. Every claimed state,
+      // including WAITING_INBOX, requires runner-owned process cleanup or an
+      // explicitly unconfirmed terminalization after runner loss.
+      if (run.status === RunStatus.QUEUED) {
         return settleCancellation(tx, { runId: run.id, requestId: body.requestId, now });
       }
       return {

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -173,7 +173,6 @@ export const reconcileDatabaseRuns = async (db: PrismaClient, now = new Date()):
             endedAt: now,
             leaseExpiresAt: null,
             sessionTokenRevokedAt: now,
-            cancelAcknowledgedAt: now,
             failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
             failureReason: reason,
             retryable: false,
@@ -202,8 +201,13 @@ export const reconcileDatabaseRuns = async (db: PrismaClient, now = new Date()):
           await tx.taskActivity.create({ data: {
             taskId: run.taskId,
             actorType: "control-plane",
-            body: `Run ${run.runNumber} cancellation settled after its lease expired; evidence retained`,
-            metadata: { runId: run.id, requestId: current.cancelRequestId, status: RunStatus.CANCELLED },
+            body: `Run ${run.runNumber} cancellation terminalized after runner loss; process cleanup unconfirmed`,
+            metadata: {
+              runId: run.id,
+              requestId: current.cancelRequestId,
+              status: RunStatus.CANCELLED,
+              cleanupConfirmed: false,
+            },
           } });
         }
         continue;

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -88,6 +88,60 @@ const stableArgv = (args: string[]): string[] => args.map((arg) => arg
   .replaceAll(piExtensionPath(), "<PI_EXTENSION>")
   .replaceAll(claudePlatformSettingsPath(), "<CLAUDE_SETTINGS>"));
 
+const processAlive = (pid: number): boolean => {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+};
+
+const waitForProcessExit = async (pid: number): Promise<boolean> => {
+  for (let waited = 0; waited < 3_000; waited += 25) {
+    if (!processAlive(pid)) return true;
+    await new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 25));
+  }
+  return false;
+};
+
+test("cancellation drains a Run-owned descendant that starts a separate process group", { timeout: 20_000 }, async () => {
+  const fixture = await mkdtemp(join(tmpdir(), "agentos-run-drain-"));
+  const binary = join(fixture, "provider.mjs");
+  const pidFile = join(fixture, "descendant.pid");
+  await writeFile(binary, [
+    "#!/usr/bin/env node",
+    'import { spawn } from "node:child_process";',
+    'import { writeFileSync } from "node:fs";',
+    `const descendant = spawn(process.execPath, ["-e", "setInterval(() => undefined, 1000)"], { detached: true, stdio: "ignore", env: process.env });`,
+    "descendant.unref();",
+    `writeFileSync(${JSON.stringify(pidFile)}, String(descendant.pid));`,
+    "setInterval(() => undefined, 1000);",
+    "",
+  ].join("\n"));
+  await chmod(binary, 0o755);
+  let descendantPid: number | null = null;
+  try {
+    const spec = runSpec();
+    spec.config = { ...spec.config, binaries: { CLAUDE: binary, CODEX: binary, PI: binary } };
+    spec.claim = { ...spec.claim, run: { ...spec.claim.run, id: `run-drain-${process.pid}` } };
+    spec.workingDirectory = fixture;
+    spec.env = { PATH: process.env.PATH ?? "/usr/bin:/bin", AGENTOS_RUN_ID: spec.claim.run.id };
+    const handle = await adapters.CODEX.start(spec, () => undefined);
+    for (let waited = 0; waited < 3_000; waited += 25) {
+      try {
+        descendantPid = Number.parseInt((await readFile(pidFile, "utf8")).trim(), 10);
+        break;
+      } catch {
+        await new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 25));
+      }
+    }
+    assert.ok(descendantPid && Number.isInteger(descendantPid));
+    assert.equal(processAlive(descendantPid), true);
+    const result = await adapters.CODEX.kill(handle, "operator stop");
+    assert.equal(result.processAlive, false);
+    assert.equal(await waitForProcessExit(descendantPid), true, "detached Run-owned descendant survived cancellation");
+  } finally {
+    if (descendantPid && processAlive(descendantPid)) process.kill(descendantPid, "SIGKILL");
+    await rm(fixture, { recursive: true, force: true });
+  }
+});
+
 test("buildPrompt combines foundational, role, and task context", () => {
   assert.match(buildPrompt(claim), /Foundation[\s\S]*Role \(senior-dev\): Implement[\s\S]*Task: Ship it[\s\S]*Do the work/);
 });

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -364,6 +364,7 @@ export type HeartbeatSnapshot = {
 };
 
 export type RuntimeHandle = {
+  runId: string;
   runner: RunnerKind;
   child: ChildProcess;
   pid: number | null;
@@ -722,6 +723,7 @@ const spawnRuntime = (runner: RunnerKind, spec: RunSpec, sink: SessionEventSink,
     stdio: ["pipe", "pipe", "pipe"],
   });
   const handle: RuntimeHandle = {
+    runId: spec.claim.run.id,
     runner,
     child,
     pid: child.pid ?? null,
@@ -1020,17 +1022,60 @@ const classifyError = (evidence: ExitEvidence): ClassifiedFailure => {
   return { failureClass: "TASK_FAILED", retryable: false };
 };
 
+const ownedRunProcesses = async (runId: string): Promise<number[]> => new Promise((resolvePromise, rejectPromise) => {
+  execFile("ps", ["eww", "-axo", "pid=,ppid=,pgid=,command="], { maxBuffer: 64 * 1024 * 1024 }, (error, stdout) => {
+    if (error) {
+      rejectPromise(new Error(`Unable to inspect Run-owned processes: ${error.message}`));
+      return;
+    }
+    const marker = ` AGENTOS_RUN_ID=${runId}`;
+    const pids = stdout.split("\n").flatMap((line) => {
+      if (!line.includes(marker)) return [];
+      const match = /^\s*(\d+)\s+/u.exec(line);
+      return match ? [Number.parseInt(match[1]!, 10)] : [];
+    });
+    resolvePromise(pids.filter((pid) => pid !== process.pid));
+  });
+});
+
+const signalProcesses = (pids: number[], signal: NodeJS.Signals): void => {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+    }
+  }
+};
+
+const waitForRunDrain = async (runId: string, timeoutMs: number): Promise<number[]> => {
+  const deadline = Date.now() + timeoutMs;
+  let remaining = await ownedRunProcesses(runId);
+  while (remaining.length > 0 && Date.now() < deadline) {
+    await new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 50));
+    remaining = await ownedRunProcesses(runId);
+  }
+  return remaining;
+};
+
 const kill = async (handle: RuntimeHandle, reason: string): Promise<KillResult> => {
   handle.terminationReason = reason;
   const pid = handle.pid;
-  if (!pid || handle.child.exitCode !== null || handle.child.signalCode !== null) return { signal: null, processAlive: false };
-  try { process.kill(-pid, "SIGTERM"); } catch { return { signal: null, processAlive: false }; }
-  const closed = await Promise.race([
-    handle.exit.then(() => true),
-    new Promise<false>((resolvePromise) => setTimeout(() => resolvePromise(false), 5_000)),
-  ]);
-  if (closed) return { signal: "SIGTERM", processAlive: false };
-  try { process.kill(-pid, "SIGKILL"); } catch { return { signal: "SIGTERM", processAlive: false }; }
+  if (pid && handle.child.exitCode === null && handle.child.signalCode === null) {
+    try { process.kill(-pid, "SIGTERM"); } catch { /* the ownership scan below is authoritative */ }
+  }
+  let remaining = await ownedRunProcesses(handle.runId);
+  signalProcesses(remaining, "SIGTERM");
+  remaining = await waitForRunDrain(handle.runId, 5_000);
+  if (remaining.length === 0) {
+    await handle.exit;
+    return { signal: pid ? "SIGTERM" : null, processAlive: false };
+  }
+  signalProcesses(remaining, "SIGKILL");
+  remaining = await waitForRunDrain(handle.runId, 5_000);
+  if (remaining.length > 0) {
+    throw new Error(`Unable to terminate ${remaining.length} process(es) owned by Run ${handle.runId}`);
+  }
   await handle.exit;
   return { signal: "SIGKILL", processAlive: false };
 };

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -254,7 +254,14 @@ export const executeClaim = async (
     if (!isFencingError(error)) return;
     waitingInbox = (error as { code?: string }).code === "WAITING_INBOX";
     fencingRejected = true;
-    if (handle) await adapter.kill(handle, waitingInbox ? "waiting for Inbox reply" : "fencing token rejected").catch(() => undefined);
+    if (handle) {
+      try {
+        const killed = await adapter.kill(handle, waitingInbox ? "waiting for Inbox reply" : "fencing token rejected");
+        if (killed.processAlive) throw new Error(`Run ${claim.run.id} still owns a live provider process`);
+      } catch (killError: unknown) {
+        console.error(`Unable to drain fenced Run ${claim.run.id}: ${errorMessage(killError)}`);
+      }
+    }
   };
 
   const acceptCancellation = async (request: CancellationRequest | null): Promise<void> => {
@@ -266,7 +273,10 @@ export const executeClaim = async (
       // during credential preparation or adapter startup waits until launch is
       // either abandoned or has produced the handle that must be killed.
       await providerLaunchSettled;
-      if (handle) await adapter.kill(handle, request.reason);
+      if (handle) {
+        const killed = await adapter.kill(handle, request.reason);
+        if (killed.processAlive) throw new Error(`Run ${claim.run.id} still owns a live provider process`);
+      }
       await acknowledgeCancellation(config, claim, request, workspace);
     })();
     await cancellationPromise;


### PR DESCRIPTION
## Summary
- drain every process owned by a Run before cancellation acknowledgement
- add a stop-and-park action that returns the Task to Backlog
- keep lost-run reconciliation terminal but explicitly unconfirmed until a late runner acknowledgement

## Verification
- MERGE GATE: PASS 0983b904055920c2e57ca04c590cc42de8350c28