### PR TITLE
Fix blind review range after implementation recovery

### DIFF
--- a/packages/api/src/blind-claim.dbtest.ts
+++ b/packages/api/src/blind-claim.dbtest.ts
@@ -125,16 +125,31 @@ const queueCanonicalStep = async (
   if (sourceRun) {
     await db.run.update({
       where: { id: sourceRun.id },
-      data: { status: "SUCCEEDED", baseSha: "b".repeat(40) },
+      // Model the exact-head recovery publisher: its workspace starts at the
+      // already-implemented head, while the canonical output retains the
+      // original implementation base.
+      data: { status: "SUCCEEDED", baseSha: "5".padStart(40, "0") },
     });
   }
-  await db.taskStepOutput.createMany({ data: priorTasks.map((task) => ({
-    taskId: task.id,
-    ...(task.id === sourceTask?.id && sourceRun ? { runId: sourceRun.id } : {}),
-    kind: `step-${task.chainIndex}`,
-    body: `persisted output from step ${task.chainIndex}`,
-    commitSha: String(task.chainIndex).padStart(40, "0"),
-  })) });
+  await db.taskStepOutput.createMany({ data: priorTasks.map((task) => {
+    const headSha = String(task.chainIndex).padStart(40, "0");
+    const implementationSource = task.id === sourceTask?.id && sourceRun;
+    return {
+      taskId: task.id,
+      ...(implementationSource ? { runId: sourceRun.id } : {}),
+      kind: implementationSource ? "implementation" : `step-${task.chainIndex}`,
+      body: implementationSource
+        ? JSON.stringify({
+          schemaVersion: 1,
+          baseSha: "b".repeat(40),
+          headSha,
+          summary: "implemented before exact-head recovery",
+          testsRun: ["focused"],
+        })
+        : `persisted output from step ${task.chainIndex}`,
+      commitSha: headSha,
+    };
+  }) });
   const run = await db.$transaction((tx) => enqueueTaskRun(tx as never, target.id));
   return { run, expectedPriorOutputs: priorTasks.length };
 };
@@ -167,7 +182,7 @@ test("canonical blind-review claims omit prior outputs while attached steps reta
   const attachedClaim = await claim();
   assert.equal(attachedClaim.run.id, attached.run.id);
   assert.equal(attachedClaim.priorOutputs.length, attached.expectedPriorOutputs);
-  assert.ok(attachedClaim.priorOutputs.some((output) => output.body === "persisted output from step 5"));
+  assert.ok(attachedClaim.priorOutputs.some((output) => output.body.includes("implemented before exact-head recovery")));
 
   const blind = await queueCanonicalStep(template, repo.id, 7);
   const blindClaim = await claim();

--- a/packages/api/src/chain.dbtest.ts
+++ b/packages/api/src/chain.dbtest.ts
@@ -1205,7 +1205,7 @@ const seedTemplateChain = async (label: string, stepCount = 3) => {
   return { project, agent, repo, template, chain };
 };
 
-test("a pinned successor fails explicitly without its source commit and advances linearly once recorded", async () => {
+test("a pinned successor fails explicitly without canonical source output and advances once recorded", async () => {
   const { template, chain } = await seedTemplateChain("pinned-base", 3);
   const pinnedStep = await db.taskTemplateStep.findFirstOrThrow({
     where: { taskTemplateId: template.id, stepIndex: 2 },
@@ -1225,7 +1225,7 @@ test("a pinned successor fails explicitly without its source commit and advances
 
   await assert.rejects(
     () => db.$transaction((tx) => activateChainSuccessor(tx, predecessor)),
-    /Pinned task .* cannot activate from step 1: referenced step has no recorded commitSha/u,
+    /Pinned task .* cannot activate from step 1: referenced step has no canonical implementation output/u,
   );
   assert.equal(await db.run.count({ where: { taskId: chain.tasks[1]!.id } }), 0);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: chain.tasks[1]!.id } })).status, "TODO");
@@ -1235,19 +1235,15 @@ test("a pinned successor fails explicitly without its source commit and advances
     taskId: predecessor.id,
     runId: predecessorRun.id,
     kind: "implementation",
-    body: "implemented",
+    body: JSON.stringify({
+      schemaVersion: 1,
+      baseSha: implementationBaseSha,
+      headSha: commitSha,
+      summary: "implemented",
+      testsRun: ["focused"],
+    }),
     commitSha,
   } });
-  await assert.rejects(
-    () => db.$transaction((tx) => activateChainSuccessor(tx, predecessor)),
-    /Pinned task .* cannot activate from step 1: referenced step has no recorded implementation baseSha/u,
-  );
-  assert.equal(await db.run.count({ where: { taskId: chain.tasks[1]!.id } }), 0);
-
-  await db.run.update({
-    where: { id: predecessorRun.id },
-    data: { baseSha: implementationBaseSha },
-  });
   const advanced = await db.$transaction((tx) => activateChainSuccessor(tx, predecessor));
   assert.equal(advanced.nextTaskId, chain.tasks[1]!.id);
   const pinnedRun = await db.run.findFirstOrThrow({ where: { taskId: chain.tasks[1]!.id } });

--- a/packages/api/src/claim-activation-isolation.dbtest.ts
+++ b/packages/api/src/claim-activation-isolation.dbtest.ts
@@ -15,6 +15,15 @@ import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
 const RUNNER_TOKEN = "claim-activation-isolation-runner";
+const IMPLEMENTATION_BASE = "b".repeat(40);
+const IMPLEMENTATION_HEAD = "a".repeat(40);
+const implementationBody = (headSha = IMPLEMENTATION_HEAD) => JSON.stringify({
+  schemaVersion: 1,
+  baseSha: IMPLEMENTATION_BASE,
+  headSha,
+  summary: "preserved implementation evidence",
+  testsRun: ["focused"],
+});
 const priorRunnerToken = process.env.RUNNER_TOKEN;
 let db: PrismaClient;
 
@@ -105,15 +114,16 @@ const seedCandidates = async (options: { valid?: boolean; inconsistent?: boolean
   const sourceRun = await db.$transaction((tx) => enqueueTaskRun(tx as never, sourceTask.id));
   await db.run.update({
     where: { id: sourceRun.id },
-    data: { status: RunStatus.SUCCEEDED, baseSha: "b".repeat(40), endedAt: new Date() },
+    data: { status: RunStatus.SUCCEEDED, baseSha: IMPLEMENTATION_BASE, endedAt: new Date() },
   });
   await db.task.update({ where: { id: sourceTask.id }, data: { status: TaskStatus.DONE } });
+  const originalSourceBody = implementationBody();
   const sourceOutput = await db.taskStepOutput.create({ data: {
     taskId: sourceTask.id,
     runId: sourceRun.id,
     kind: "implementation",
-    body: "preserved implementation evidence",
-    commitSha: "a".repeat(40),
+    body: originalSourceBody,
+    commitSha: IMPLEMENTATION_HEAD,
   } });
   const poisonTask = await db.task.create({ data: {
     projectId: project.id,
@@ -133,7 +143,9 @@ const seedCandidates = async (options: { valid?: boolean; inconsistent?: boolean
   ));
   await db.taskStepOutput.update({
     where: { id: sourceOutput.id },
-    data: { commitSha: options.inconsistent ? "c".repeat(40) : null },
+    data: options.inconsistent
+      ? { commitSha: "c".repeat(40), body: implementationBody("c".repeat(40)) }
+      : { commitSha: null },
   });
 
   let validTask: Awaited<ReturnType<typeof db.task.create>> | null = null;
@@ -152,7 +164,20 @@ const seedCandidates = async (options: { valid?: boolean; inconsistent?: boolean
       new Date("2026-01-01T00:00:01.000Z"),
     ));
   }
-  return { project, environment, agent, repo, sourceTask, sourceRun, sourceOutput, poisonTask, poisonRun, validTask, validRun };
+  return {
+    project,
+    environment,
+    agent,
+    repo,
+    sourceTask,
+    sourceRun,
+    sourceOutput,
+    expectedSourceBody: options.inconsistent ? implementationBody("c".repeat(40)) : originalSourceBody,
+    poisonTask,
+    poisonRun,
+    validTask,
+    validRun,
+  };
 };
 
 const assertPoisonIsolated = async (
@@ -189,7 +214,7 @@ const assertPoisonIsolated = async (
   assert.equal(notifications.length, 1);
   assert.equal(notifications[0]!.dedupeKey, `candidate-activation-failed:${seeded.poisonRun.id}`);
   assert.match(notifications[0]!.body, new RegExp(`${failureType}:`, "u"));
-  assert.equal(output.body, "preserved implementation evidence");
+  assert.equal(output.body, seeded.expectedSourceBody);
 };
 
 test("one claim isolates a poisoned pinned candidate and returns the next valid run", async () => {

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -202,6 +202,47 @@ export class PinnedBaseCommitError extends Error {
 export const isPinnedBaseCommitError = (error: unknown): error is PinnedBaseCommitError =>
   error instanceof Error && error.name === "PinnedBaseCommitError";
 
+const IMPLEMENTATION_SHA = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u;
+
+const implementationRangeFromOutput = (
+  taskId: string,
+  baseFromStepIndex: number,
+  source: { kind: string; body: string; commitSha: string | null },
+): { implementationBaseSha: string; implementationHeadSha: string } => {
+  if (!source.commitSha) {
+    throw new PinnedBaseCommitError(taskId, baseFromStepIndex, "referenced step has no recorded commitSha");
+  }
+  if (!IMPLEMENTATION_SHA.test(source.commitSha)) {
+    throw new PinnedBaseCommitError(taskId, baseFromStepIndex, "referenced step has invalid commitSha");
+  }
+  if (source.kind !== "implementation") {
+    throw new PinnedBaseCommitError(taskId, baseFromStepIndex, "referenced step has no canonical implementation output");
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(source.body);
+  } catch {
+    throw new PinnedBaseCommitError(taskId, baseFromStepIndex, "referenced implementation output is not valid JSON");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new PinnedBaseCommitError(taskId, baseFromStepIndex, "referenced implementation output is not a JSON object");
+  }
+  const output = value as Record<string, unknown>;
+  if (output.schemaVersion !== 1) {
+    throw new PinnedBaseCommitError(taskId, baseFromStepIndex, "referenced implementation output has unsupported schemaVersion");
+  }
+  if (typeof output.baseSha !== "string" || !IMPLEMENTATION_SHA.test(output.baseSha)) {
+    throw new PinnedBaseCommitError(taskId, baseFromStepIndex, "referenced implementation output has invalid baseSha");
+  }
+  if (typeof output.headSha !== "string" || !IMPLEMENTATION_SHA.test(output.headSha)) {
+    throw new PinnedBaseCommitError(taskId, baseFromStepIndex, "referenced implementation output has invalid headSha");
+  }
+  if (output.headSha !== source.commitSha) {
+    throw new PinnedBaseCommitError(taskId, baseFromStepIndex, "referenced implementation output headSha does not match commitSha");
+  }
+  return { implementationBaseSha: output.baseSha, implementationHeadSha: output.headSha };
+};
+
 export const pinnedImplementationRange = async (
   tx: Tx,
   task: {
@@ -226,21 +267,16 @@ export const pinnedImplementationRange = async (
         chainIndex: baseFromStepIndex,
       },
     },
-    select: { commitSha: true, run: { select: { baseSha: true } } },
+    select: { kind: true, body: true, commitSha: true },
   });
-  if (!source?.commitSha) {
-    throw new PinnedBaseCommitError(task.id, baseFromStepIndex, "referenced step has no recorded commitSha");
+  if (!source) {
+    throw new PinnedBaseCommitError(task.id, baseFromStepIndex, "referenced step has no canonical implementation output");
   }
-  if (!/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u.test(source.commitSha)) {
-    throw new PinnedBaseCommitError(task.id, baseFromStepIndex, "referenced step has invalid commitSha");
-  }
-  if (!source.run?.baseSha) {
-    throw new PinnedBaseCommitError(task.id, baseFromStepIndex, "referenced step has no recorded implementation baseSha");
-  }
-  if (!/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u.test(source.run.baseSha)) {
-    throw new PinnedBaseCommitError(task.id, baseFromStepIndex, "referenced step has invalid implementation baseSha");
-  }
-  return { implementationBaseSha: source.run.baseSha, implementationHeadSha: source.commitSha };
+  // A recovery Run republishes an already-complete head, so its workspace
+  // base legitimately equals that head. The canonical implementation output
+  // preserves the original reviewed range and is the authority for every
+  // later blind-review claim.
+  return implementationRangeFromOutput(task.id, baseFromStepIndex, source);
 };
 
 /**

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -1008,7 +1008,10 @@ const classifyError = (evidence: ExitEvidence): ClassifiedFailure => {
 };
 
 const ownedRunProcesses = async (runId: string): Promise<number[]> => new Promise((resolvePromise, rejectPromise) => {
-  execFile("ps", ["eww", "-axo", "pid=,ppid=,pgid=,command="], { maxBuffer: 64 * 1024 * 1024 }, (error, stdout) => {
+  const args = process.platform === "darwin"
+    ? ["-Eww", "-axo", "pid=,ppid=,pgid=,command="]
+    : ["-axeww", "-o", "pid=,ppid=,pgid=,command="];
+  execFile("ps", args, { maxBuffer: 64 * 1024 * 1024 }, (error, stdout) => {
     if (error) {
       rejectPromise(new Error(`Unable to inspect Run-owned processes: ${error.message}`));
       return;

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -200,6 +200,16 @@
       "reason": "internal planning state is not needed to build or run the product"
     },
     {
+      "glob": "pelican-bike.html",
+      "disposition": "later-release-follow-up",
+      "reason": "standalone animation demo is not AgentOS product source and requires a separate publication and license decision"
+    },
+    {
+      "glob": "pelican-bike-2.html",
+      "disposition": "later-release-follow-up",
+      "reason": "standalone animation demo is not AgentOS product source and requires a separate publication and license decision"
+    },
+    {
       "glob": "deploy/**",
       "disposition": "later-release-follow-up",
       "reason": "host-specific deployment material requires environment and path review"


### PR DESCRIPTION
## Summary

- derive immutable blind-review range from the canonical Implementation output
- fail loudly on malformed or inconsistent range authority
- cover exact-head recovery where the republisher Run has base equal to head
- classify the two standalone animation demos already added to main as outside the AgentOS public snapshot
- make Runner process ownership scans portable across macOS and Linux
- migrate stale pinned-authority test fixtures to the canonical Implementation JSON contract

## Focused verification

- @agentos/db typecheck
- @agentos/api typecheck
- blind-claim, chain, and claim-activation-isolation DB suites: 54/54 pass
- cancellation process-drain tests: 2/2 pass
- public snapshot scanner: 20/20 pass

## Exact-head Gate

MERGE GATE: PASS cb5544643e51a9ebe1dd24039ec62d571c634e5a