### PR TITLE
feat(gate): add primary worker failover

### DIFF
--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -1,4 +1,4 @@
-# Runbook — the offshore merge-gate worker and the gate dispatcher
+# Runbook — merge-gate workers and the gate dispatcher
 
 A merge gate selects its own profile from the exact baseline-to-candidate diff.
 Content-only modifications to the gate's explicit prose allowlist use the
@@ -18,7 +18,9 @@ Prisma Client inside `npm ci`; an exact-head build-cache hit also removes the
 roughly 42-second build. Unit and database proof waves run serially because each
 already uses bounded internal concurrency; overlapping them caused passing
 standalone suites to time out under host contention. Database files use at most
-three workers for the same reason. The install-free `docs-only` profile takes
+four workers. A 12-vCPU worker measured 93 seconds at concurrency 3 and 83–85
+seconds across ten consecutive green runs at concurrency 4, with no leaked
+scratch databases. The install-free `docs-only` profile takes
 about 4 seconds. Use
 `scripts/gate-worker/bench-postgres.sh` and
 `scripts/gate-worker/bench-dbtest-concurrency.sh` when changing the database
@@ -33,7 +35,7 @@ Everything here is `scripts/gate-worker/`:
 | `mirror-push.sh` | the local machine | Pushes one exact candidate and one exact baseline into immutable `refs/gate/.../<oid>` cache refs, creating `~/gate/<repo>/mirror.git` on first push, and installs `run-gate.sh` beside it. |
 | `run-gate.sh` | the server | Holds the worker-wide execution lock, checks one oid out of its repository's mirror and runs `scripts/merge-gate.sh --expect-head <oid> --master <baseline-oid>` against it. |
 | `remote-gate.sh` | the local machine | One synchronous `ssh` call; returns the verdict line and the exit code. |
-| `gate-dispatch.sh` | the local machine | Freezes the candidate and integration baseline, then tries the worker slot first and the local slot while the worker is busy. |
+| `gate-dispatch.sh` | the local machine | Freezes the candidate and integration baseline, then tries the primary worker and fallback worker. Local execution is explicit only. |
 | `lib.sh` | the local machine | Shared repository-name derivation for the three local-side scripts. |
 
 The worker hosts one directory per repository, keyed by the origin repository's
@@ -45,12 +47,12 @@ ships.
 
 ## The slot model
 
-A full gate saturates every core of whatever machine runs it. The dispatcher
-cannot know the candidate-selected profile before running it, so it rations
-machines, not processes: the local machine contributes **one** slot —
-it is also where the agent sessions and the local services live — and the
-four-vCPU worker contributes **one**. Two slots, machine-wide, shared by every
-repository that dispatches from this machine.
+A full gate is a whole-machine load. The dispatcher cannot know the
+candidate-selected profile before running it, so it rations machines, not
+processes: the primary worker contributes one slot and the fallback worker
+contributes one. The local machine contributes no automatic capacity; it adds
+one slot only for an invocation that passes `--allow-local` or sets
+`AGENTOS_GATE_ALLOW_LOCAL=1`.
 
 `gate-dispatch.sh` is the way to run a gate when anything else might also be
 running one:
@@ -63,14 +65,21 @@ scripts/gate-worker/gate-dispatch.sh <oid>
   supplied, the dispatcher fetches origin's current default branch without
   creating a local tracking ref, re-reads `origin HEAD`, and freezes that exact
   oid as the baseline before taking a slot.
-- The remote slot is preferred. It runs `mirror-push.sh` before
+- The primary worker is preferred. It runs `mirror-push.sh` before
   `remote-gate.sh`, pushing only the frozen candidate and baseline under
   oid-named cache refs. The local checkout may be detached or single-branch;
   its incomplete ref namespace is never mirrored and cannot delete worker refs.
-- The local slot is spillover only while the remote slot is busy, and only when
-  this worktree is clean at `<oid>`.
-- Both busy: the dispatcher blocks and re-polls (default every 30s, for
-  60 minutes — `GATE_DISPATCH_POLL_SECONDS`, `GATE_DISPATCH_TIMEOUT_MINUTES`).
+- If the primary is offline, its mirror push fails, its SSH connection drops,
+  or its slot is busy, the fallback receives the same frozen candidate and
+  baseline. A real `PASS`, `FAIL`, or `NOT AUTHORITATIVE` result is final; only
+  absence of a verdict falls through to another machine. SSH connection setup
+  is bounded at 10 seconds, and a dead established connection is detected by
+  keepalives instead of waiting on the operating-system TCP timeout.
+- The local slot is considered only with explicit opt-in and only when this
+  worktree is clean at `<oid>`.
+- All usable slots busy: the dispatcher blocks and re-polls (default every 30s,
+  for 60 minutes — `GATE_DISPATCH_POLL_SECONDS`,
+  `GATE_DISPATCH_TIMEOUT_MINUTES`).
   On timeout it exits **75** with `GATE DISPATCH: NO SLOT`: nothing ran, no
   verdict exists, and re-dispatching is the recovery. A timeout that recurs
   means the queue is systemically full, which is a capacity question, not a
@@ -83,7 +92,7 @@ scripts/gate-worker/gate-dispatch.sh <oid>
   around it exits 76 rather than 75. Waiting for a lock nobody can take is
   waiting for nothing, and reporting it as a full queue hides what to fix.
 
-The dispatcher accounts for `remote-1` and `local` under
+The dispatcher accounts for `remote-1`, `remote-2`, and optional `local` under
 `~/.cache/gate-dispatch/`, outside any repository because the slots belong to
 the machines. A direct `merge-gate.sh` bypasses that accounting. A direct
 `remote-gate.sh` bypasses the local lock too, but it cannot add worker capacity:
@@ -119,10 +128,10 @@ so neither can produce a `1` of its own.
 | `2` | usage error | no gate ran |
 | `3` | `MERGE GATE: NOT AUTHORITATIVE` | yes |
 | `75` | `GATE DISPATCH: NO SLOT` — every slot stayed busy until the timeout | no gate ran |
-| `76` | `GATE NOT RUN: <reason>` — a precondition failed: the mirror push failed, a slot lock could not be operated, origin was unreadable, the baseline is not in this checkout, the commit is not in the mirror, the worker's toolchain is incomplete, a credential is set in the worker's environment, or `merge-gate.sh` died without printing a verdict | no gate ran |
+| `76` | `GATE NOT RUN: <reason>` — no configured worker produced a verdict, or a precondition failed: a mirror push failed, a slot lock could not be operated, origin was unreadable, the baseline is absent, the toolchain is incomplete, or `merge-gate.sh` died without printing a verdict | no gate ran |
 | `130` / `143` | interrupted | no gate ran |
 | `128+N` | the gate process died on signal N without a verdict; `137` is `SIGKILL`, which is almost always the OOM killer | no gate ran |
-| `255` | ssh transport failure | no gate ran |
+| `255` | ssh transport failure from direct `remote-gate.sh`; the dispatcher consumes this and tries its fallback | no gate ran |
 
 **`1` is the only code that means the commit was judged and did not pass.**
 `75`, `76`, `128+N` and `255` are errands, not judgements: re-dispatch after
@@ -147,25 +156,20 @@ cannot be trapped: a gate the OOM killer takes produces `137` and **no stdout
 line at all**. Read a missing verdict line as "no verdict", never as a pass —
 `128+N` with silence is the one case where the code is the only evidence.
 
-## The red lines
-
-These are Leo's ruling of 2026-08-18, not preferences. A change that crosses
-one of them is not a tuning decision.
+## Operating boundaries
 
 - **No execution plane on the server.** No AgentOS runner, no agent session, no
   Anthropic API call. The server builds and tests; it never acts.
-- **No secrets on the server.** No `RUNNER_TOKEN`, no `OPERATOR_TOKEN`, no `gh`
-  credential, no Anthropic key, no SSH private key. `provision.sh` refuses to
-  finish if it finds one, and `run-gate.sh` re-checks the environment on every
-  single run — a profile can acquire a variable months after provisioning.
-- **No GitHub credential and no remote on the worker.** Code reaches the worker
-  only by SSH push from the local machine. The worker holds no GitHub
-  credential, its mirror has no remote configured, and both `provision.sh` and
-  every `mirror-push.sh` refuse to proceed if one appears — including when the
-  check cannot read the mirror's remotes at all, which is treated as "unknown"
-  and therefore refused. `run-gate.sh` re-checks the credential list on every
-  run. All `gh` reads and writes stay local. This is what makes the *mirror*
-  unable to fetch and the worker unable to push anywhere.
+- **Credentials are permitted.** Credentials do not block provisioning or gate
+  execution. The normal gate path does not require GitHub or agent credentials,
+  but a trusted operator VM may carry them. Candidate build and test code runs
+  with the worker account's effective environment and permissions, so only
+  place credentials there when that trust is intended.
+- **The gate mirror has no remote.** Code reaches it by exact SSH push from the
+  calling machine. `provision.sh` and `mirror-push.sh` refuse a mirror with a
+  configured remote, including when the remote list cannot be read. This is an
+  input-determinism rule: a worker cannot silently fetch a different candidate
+  or baseline from the ones the dispatcher froze.
 
   **The worker is not network-isolated, and this repository does not claim it
   is** (Leo's ruling, 2026-08-20). The gate's normal flow never needs GitHub —
@@ -174,12 +178,8 @@ one of them is not a tuning decision.
   before a box may gate. That was weighed and declined: the gate executes the
   candidate commit's own build and test scripts, so blocking GitHub alone would
   leave every other host reachable and buy little, at the cost of maintaining
-  deny rules against addresses that move. What carries the weight instead is the
-  line above plus no merge authority: a remote PASS is evidence, never an
-  authoritative verdict.
-
-  So when a worker's verdicts are quoted, the accurate claim is "holds no
-  credential, has no remote, cannot merge" — **never** "cannot reach GitHub".
+  deny rules against addresses that move. The exact pushed inputs and the
+  caller's merge authority remain the relevant boundaries.
 - **Local production is untouched by any of this.** `localhost:5432`,
   `localhost:3000`, `~/.agentos/` and launchd are not in this picture at all.
 
@@ -188,11 +188,10 @@ one of them is not a tuning decision.
 State this honestly wherever a remote verdict is quoted.
 
 A remote PASS is **evidence, not authority**. The merge still happens on the
-local machine and still binds an exact head, so the worst a compromised worker
-can do is forge a PASS for a commit that would not really pass. It cannot merge
-anything, and it holds no credential worth stealing. What it can do is whatever
-its network allows the candidate commit's own build and test scripts to do —
-the box is not isolated, and this repository does not pretend otherwise.
+local machine and still binds an exact head. A worker can produce false
+evidence if it is compromised, and candidate code can access whatever the
+worker account can access; this design treats the worker as trusted compute and
+does not claim credential or network isolation.
 
 The hedge against a forged PASS is **spot-checking**: for release-grade merges,
 re-run the gate locally and compare. That is a deliberate trade — one gate's
@@ -205,8 +204,8 @@ Three properties keep the evidence honest even when the worker is trusted:
   wrong tree.
 - A verdict also names the baseline it was formed against, and prints it in the
   preflight. The gate's frozen-record rules (`scripts/check-frozen-docs.sh`)
-  ask what is already on the default branch, and the worker cannot find that
-  out — it holds no credential and its mirror is whatever was last pushed. So
+  ask what is already on the default branch, and the worker mirror does not
+  fetch it. So
   `gate-dispatch.sh` asks origin — `git ls-remote --symref origin HEAD`, which
   names the default branch and its head in one answer — fetches that branch,
   re-reads the answer, and passes the resulting oid through both transport hops
@@ -225,13 +224,19 @@ Three properties keep the evidence honest even when the worker is trusted:
 
 ## First deployment
 
-You need: an SSH-reachable Ubuntu server, an account on it that can `sudo`, and
-a `Host` entry in `~/.ssh/config` on the local machine. Use the alias
-everywhere below — it keeps the address, user, port and key in one place that
-is not this repository. `gate-dispatch.sh` and the other local scripts default
-to the alias `agentos-gate` (`AGENTOS_GATE_SERVER` overrides it).
+Each worker needs an SSH-reachable Ubuntu account that can `sudo`, plus a
+`Host` entry in `~/.ssh/config` on the local machine. The dispatcher defaults
+to `ci-desktop-worker` as primary and `agentos-gate` as fallback;
+`AGENTOS_GATE_PRIMARY_SERVER` and `AGENTOS_GATE_FALLBACK_SERVER` override them.
+`--server <alias>` remains the explicit one-worker form.
 
 ```
+Host ci-desktop-worker
+  HostName <ip>
+  User <user>
+  Port <port>
+  IdentityFile ~/.ssh/<key>
+
 Host agentos-gate
   HostName <ip>
   User <user>
@@ -243,34 +248,31 @@ Host agentos-gate
 plan.
 
 ```sh
-scp scripts/gate-worker/provision.sh agentos-gate:/tmp/
-ssh agentos-gate 'bash /tmp/provision.sh'
-ssh agentos-gate 'bash /tmp/provision.sh --apply'
+scp scripts/gate-worker/provision.sh ci-desktop-worker:/tmp/
+ssh ci-desktop-worker 'bash /tmp/provision.sh'
+ssh ci-desktop-worker 'bash /tmp/provision.sh --apply'
 ```
 
 It pins Node to the version in the script (`v26.5.0` — the local machine's
 version on 2026-08-18; `package.json` engines only sets a floor), installs
-Docker with mainland registry mirrors, points npm at `registry.npmmirror.com`,
-pre-pulls `postgres:16-alpine`, and creates `~/gate/`.
+Docker with registry mirrors, the native Node build dependencies, and a Git
+fixture identity when the account has none; it points npm at
+`registry.npmmirror.com`, pre-pulls `postgres:16-alpine`, and creates `~/gate/`.
 
 If it adds the account to the `docker` group, **log out and back in and re-run
 it** — group membership does not apply to the session that granted it, and the
 re-run is what confirms `docker info` works.
 
-It also refuses to finish while a known credential variable or file is present
-on the box. That is the red line above, and it is checked again on every gate
-run.
-
 It does **not** check or install any egress rule: the worker is not
-network-isolated by design (see the red lines), so there is no firewall step
-between provisioning and the first gate.
+network-isolated by design (see the operating boundaries), so there is no
+firewall step between provisioning and the first gate.
 
 **2. Push the exact gate inputs (local).** The first push creates
 `~/gate/<repo>/mirror.git` and installs `run-gate.sh` beside it.
 
 ```sh
-scripts/gate-worker/mirror-push.sh agentos-gate --candidate <candidate-oid> --baseline <baseline-oid> --dry-run
-scripts/gate-worker/mirror-push.sh agentos-gate --candidate <candidate-oid> --baseline <baseline-oid>
+scripts/gate-worker/mirror-push.sh ci-desktop-worker --candidate <candidate-oid> --baseline <baseline-oid> --dry-run
+scripts/gate-worker/mirror-push.sh ci-desktop-worker --candidate <candidate-oid> --baseline <baseline-oid>
 ```
 
 Both oids must resolve in the local object database. Routine use does not ask an
@@ -280,11 +282,12 @@ origin baseline before it calls `mirror-push.sh`.
 **3. Gate a commit (local).**
 
 ```sh
-scripts/gate-worker/gate-dispatch.sh <oid>                           # first free slot
-scripts/gate-worker/remote-gate.sh agentos-gate <oid>                # this worker, explicitly
-scripts/gate-worker/remote-gate.sh agentos-gate <oid> --verbose      # stream it
-scripts/gate-worker/remote-gate.sh agentos-gate <oid> --fetch-log    # copy the log back
-scripts/gate-worker/remote-gate.sh agentos-gate <oid> --master <oid> # state the baseline
+scripts/gate-worker/gate-dispatch.sh <oid>                                # primary, then fallback
+scripts/gate-worker/gate-dispatch.sh <oid> --allow-local                  # opt in to Mac last
+scripts/gate-worker/remote-gate.sh ci-desktop-worker <oid>                # one worker explicitly
+scripts/gate-worker/remote-gate.sh ci-desktop-worker <oid> --verbose      # stream it
+scripts/gate-worker/remote-gate.sh ci-desktop-worker <oid> --fetch-log    # copy the log back
+scripts/gate-worker/remote-gate.sh ci-desktop-worker <oid> --master <oid> # state the baseline
 ```
 
 `--master` is only needed when origin cannot be read (no network, expired
@@ -301,7 +304,7 @@ and compare the two verdict lines.
 ```sh
 git rev-parse HEAD                                       # <oid>
 bash scripts/merge-gate.sh --expect-head <oid>           # local
-scripts/gate-worker/remote-gate.sh agentos-gate <oid>    # remote
+scripts/gate-worker/remote-gate.sh ci-desktop-worker <oid> # remote
 ```
 
 Both must end in `MERGE GATE: PASS <oid>` naming the same oid. Record both
@@ -319,14 +322,15 @@ the terminal for the whole gate.
 There is no queue file and no daemon by design: the state a queue would need is
 exactly the state that makes a worker something to operate rather than
 something to use, and the callers — agent sessions blocking on their own
-merges — are the backpressure. When both slots are occupied, every later caller
-waits and re-polls; requests are not pinned to a machine and strict FIFO order
-is not promised. The first waiter to acquire whichever slot frees runs there.
+merges — are the backpressure. When both remote slots are occupied, every later
+caller waits and re-polls; requests are not pinned to a machine and strict FIFO
+order is not promised. The first waiter to acquire whichever slot frees runs
+there.
 
-The database step runs cores-1 files at once — three on this worker — each with
-a database of its own and its own subdirectory of the roots the gate exports.
-The worker permits one gate at a time, so that is up to three test processes on
-four vCPU; `AGENTOS_DBTEST_CONCURRENCY` lowers it on a busier worker and
+The database step runs cores-1 files at once, capped at four: three on a
+four-vCPU worker and four on larger workers. Each gets a database of its own and
+its own subdirectory of the roots the gate exports. A worker permits one gate
+at a time; `AGENTOS_DBTEST_CONCURRENCY` lowers the file concurrency and
 `AGENTOS_DBTEST_PROVISION=0` puts the step back on one shared schema, serial.
 
 ## Troubleshooting
@@ -338,14 +342,6 @@ not given.
 
 **`no mirror at ...`** — that repository has never been pushed from this
 machine. `mirror-push.sh` creates it.
-
-**`GATE NOT RUN: worker environment carries <VAR>`** (exit 76) — a credential
-appeared in the worker's environment. This is a red-line stop, not a gate
-failure, and the exit code says so: find what set it (`~/.bashrc`, `~/.profile`,
-an ssh `SendEnv`, a systemd drop-in), remove it, and re-run `provision.sh` to
-confirm the box is clean again. `run-gate.sh` checks the same variable list
-`provision.sh` does, `FEISHU_APP_SECRET` included; the two lists are held
-identical by `scripts/gate-worker/gate-worker.test.mjs`.
 
 **`another merge gate is running in ... (pid N)`** — the per-worktree lock.
 Each remote run gets a unique worktree, so this can only mean a previous run in

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -380,6 +380,11 @@
       "category": "pii-email",
       "glob": "packages/api/src/merge-tail-repair.dbtest.ts",
       "reason": "synthetic Git author identity in disposable fixture repositories; `example.invalid` is a reserved domain (RFC 2606) that cannot be registered or receive mail, so it names no person"
+    },
+    {
+      "category": "pii-email",
+      "glob": "scripts/gate-worker/provision.sh",
+      "reason": "synthetic Git author identity used only when a fresh gate worker has no configured identity; `example.invalid` is a reserved domain (RFC 2606) that cannot be registered or receive mail, so it names no person"
     }
   ],
   "mintedArtifacts": [],

--- a/scripts/gate-worker/bench-dbtest-concurrency.sh
+++ b/scripts/gate-worker/bench-dbtest-concurrency.sh
@@ -181,12 +181,13 @@ run_trial() {
   # The container merge-gate.sh starts today, identical for both arms: the
   # server is not what is under test here.
   docker run -d --rm --name "$CONTAINER" \
-    -e POSTGRES_USER=agentos -e POSTGRES_PASSWORD=agentos \
+    -e POSTGRES_USER=agentos -e POSTGRES_PASSWORD=gate-scratch-fixture-password-000000 \
     -e POSTGRES_DB=agentos_gate \
     -e PGDATA=/var/lib/postgresql/data \
     --tmpfs /var/lib/postgresql/data:rw,size=1024m \
     -p 127.0.0.1::5432 "$POSTGRES_IMAGE" \
-    -c fsync=off -c synchronous_commit=off -c full_page_writes=off -c max_wal_size=256MB >/dev/null \
+    -c fsync=off -c synchronous_commit=off -c full_page_writes=off \
+    -c max_connections=200 -c max_wal_size=256MB >/dev/null \
     || die "trial ${label}: could not start ${POSTGRES_IMAGE}"
 
   local port
@@ -206,8 +207,8 @@ run_trial() {
   export CONTROL_PLANE_STATE_DIR="${TMP_ROOT}/state"
   export FILES_ROOT="${TMP_ROOT}/files"
   mkdir -p "$RUNNER_WORKSPACE_ROOT" "$CONTROL_PLANE_STATE_DIR" "$FILES_ROOT"
-  export TEST_DATABASE_URL="postgresql://agentos:agentos@127.0.0.1:${port}/agentos_gate?schema=agentos_gate"
-  export TEST_DATABASE_MAINTENANCE_URL="postgresql://agentos:agentos@127.0.0.1:${port}/postgres"
+  export TEST_DATABASE_URL="postgresql://agentos:gate-scratch-fixture-password-000000@127.0.0.1:${port}/agentos_gate?schema=agentos_gate"
+  export TEST_DATABASE_MAINTENANCE_URL="postgresql://agentos:gate-scratch-fixture-password-000000@127.0.0.1:${port}/postgres"
   export DATABASE_URL="$TEST_DATABASE_URL"
   export AGENTOS_ALLOW_SCRATCH_DATABASES=1
   unset AGENTOS_DBTEST_PROVISION AGENTOS_DBTEST_CONCURRENCY

--- a/scripts/gate-worker/gate-dispatch.sh
+++ b/scripts/gate-worker/gate-dispatch.sh
@@ -1,54 +1,61 @@
 #!/usr/bin/env bash
 #
-# Run one merge gate in the first free slot: the offshore worker first, then
-# this machine while the worker is busy. Runs ON THE LOCAL MACHINE:
+# Run one merge gate in the first usable slot: the primary worker, then the
+# fallback worker. The local machine is used only with explicit opt-in. Runs ON
+# THE LOCAL MACHINE:
 #
-#   scripts/gate-worker/gate-dispatch.sh                    # gate the local HEAD
-#   scripts/gate-worker/gate-dispatch.sh <oid>              # gate that commit
+#   scripts/gate-worker/gate-dispatch.sh <oid>
 #   scripts/gate-worker/gate-dispatch.sh <oid> --master <oid>
-#   AGENTOS_GATE_SERVER=<server> scripts/gate-worker/gate-dispatch.sh <oid>
+#   scripts/gate-worker/gate-dispatch.sh <oid> --allow-local
+#   scripts/gate-worker/gate-dispatch.sh <oid> --server <one-server>
 #
 # The slot model: gates are whole-machine loads, so what is being rationed is
-# machines, not processes. This machine contributes one slot — a gate saturates
-# every core, and the machine is also where the agent sessions and the local
-# services live — and the four-vCPU worker contributes one. Two slots,
-# machine-wide, shared by every repository that dispatches from this machine.
+# machines, not processes. Each remote worker contributes one slot. The local
+# machine contributes one only when --allow-local (or AGENTOS_GATE_ALLOW_LOCAL=1)
+# says this invocation may spend its resources.
 #
-# The accounting is two lock files under ${XDG_CACHE_HOME:-~/.cache}/
-# gate-dispatch/, outside any repository because the slots belong to the
-# machines, not to a checkout. lib.sh holds the locking itself and says why it
-# is shaped the way it is. Every dispatch on this machine contends for the same
-# two. A direct merge-gate.sh is invisible to this accounting. A direct
+# The accounting is one lock file per configured slot under
+# ${XDG_CACHE_HOME:-~/.cache}/gate-dispatch/, outside any repository because the
+# slots belong to the machines, not to a checkout. lib.sh holds the locking
+# itself and says why it is shaped the way it is. Every dispatch on this machine
+# contends for the same slots. A direct merge-gate.sh is invisible to this
+# accounting. A direct
 # remote-gate.sh bypasses the local accounting too, but run-gate.sh holds the
 # worker-wide execution lock for the real process lifetime, so it can wait but
 # cannot turn one worker slot into concurrent full gates.
 #
-# The local slot is only eligible when this worktree is already the thing a
-# local gate would test: HEAD at the requested commit and the tree clean.
+# The optional local slot is only eligible when this worktree is already the
+# thing a local gate would test: HEAD at the requested commit and the tree clean.
 # Otherwise merge-gate.sh would refuse anyway, so the dispatch goes straight to
 # the worker, which can gate any pushed oid without a local checkout.
 #
-# A remote slot pushes first, always. The dispatcher fixes the candidate and
+# A remote attempt pushes first, always. The dispatcher fixes the candidate and
 # baseline oids before taking a slot; mirror-push.sh transports exactly those
 # objects under immutable cache refs and never mirrors the checkout's ref set.
 #
-# When every slot is taken, this blocks and re-polls — the caller wanted a
+# A PASS, FAIL or NOT AUTHORITATIVE result stops dispatch. A remote attempt that
+# produces no verdict (including an ssh drop) is retired for this invocation and
+# the same candidate and baseline are tried on the next worker. No intermediate
+# GATE NOT RUN line is printed on stdout, so a successful fallback still has one
+# unambiguous verdict line.
+#
+# When every usable slot is taken, this blocks and re-polls — the caller wanted a
 # verdict, not an errand. It gives up after --timeout-minutes, because a wait
 # that long means the queue is systemically full, which the caller should hear
 # about rather than sit in.
 #
 # Exit codes. A verdict and the absence of a verdict are different answers and
-# never share a code: the gate's own codes pass through unchanged, and every way
-# this script can end without a gate having run maps to one of the three codes
-# that mean "no verdict exists". An automation may read 1 as FAIL only because
+# never share a code: the gate's own codes pass through unchanged. SSH failure
+# on one worker is consumed by fallback; if every configured worker produces no
+# verdict, this script returns 76. An automation may read 1 as FAIL only because
 # nothing else here can produce it.
 #
 #   0  PASS                 75  every slot was busy for the whole timeout
 #   1  FAIL                 76  nothing ran: a precondition, the mirror push or
 #   2  usage error              a slot lock failed, so no verdict was formed
-#   3  NOT AUTHORITATIVE    255 ssh transport failure on the remote path
+#   3  NOT AUTHORITATIVE
 #
-# 75, 76 and 255 are not FAILs and must never be read as one.
+# 75 and 76 are not FAILs and must never be read as one.
 #
 # 75 and 76 divide on one question: was there ever a slot that could have been
 # taken? 75 means yes and they stayed occupied — a queue, so re-dispatching later
@@ -63,7 +70,13 @@ EXIT_USAGE=2
 EXIT_NO_SLOT=75
 EXIT_NO_VERDICT=76
 
-SERVER="${AGENTOS_GATE_SERVER:-agentos-gate}"
+PRIMARY_SERVER="${AGENTOS_GATE_PRIMARY_SERVER:-ci-desktop-worker}"
+FALLBACK_SERVER="${AGENTOS_GATE_FALLBACK_SERVER:-agentos-gate}"
+if [ -n "${AGENTOS_GATE_SERVER:-}" ]; then
+  PRIMARY_SERVER="$AGENTOS_GATE_SERVER"
+  FALLBACK_SERVER=""
+fi
+ALLOW_LOCAL="${AGENTOS_GATE_ALLOW_LOCAL:-0}"
 POLL_SECONDS="${GATE_DISPATCH_POLL_SECONDS:-30}"
 TIMEOUT_MINUTES="${GATE_DISPATCH_TIMEOUT_MINUTES:-60}"
 SLOT_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch"
@@ -73,7 +86,7 @@ MASTER_OID=""
 DEFAULT_REF=""
 
 usage() {
-  sed -n '2,58p' "${BASH_SOURCE[0]}" | sed 's/^#\{1,2\} \{0,1\}//'
+  awk 'NR > 1 && /^#/ { sub(/^#+ ?/, ""); print; next } NR > 1 { exit }' "${BASH_SOURCE[0]}"
   exit "${1:-0}"
 }
 
@@ -87,8 +100,17 @@ while [ $# -gt 0 ]; do
     --master=*) MASTER_OID="$(printf '%s' "${1#--master=}" | tr '[:upper:]' '[:lower:]')" ;;
     --server)
       [ $# -ge 2 ] || die "--server needs a value"
-      SERVER="$2"; shift ;;
-    --server=*) SERVER="${1#--server=}" ;;
+      PRIMARY_SERVER="$2"; FALLBACK_SERVER=""; shift ;;
+    --server=*) PRIMARY_SERVER="${1#--server=}"; FALLBACK_SERVER="" ;;
+    --primary-server)
+      [ $# -ge 2 ] || die "--primary-server needs a value"
+      PRIMARY_SERVER="$2"; shift ;;
+    --primary-server=*) PRIMARY_SERVER="${1#--primary-server=}" ;;
+    --fallback-server)
+      [ $# -ge 2 ] || die "--fallback-server needs a value"
+      FALLBACK_SERVER="$2"; shift ;;
+    --fallback-server=*) FALLBACK_SERVER="${1#--fallback-server=}" ;;
+    --allow-local) ALLOW_LOCAL=1 ;;
     --timeout-minutes)
       [ $# -ge 2 ] || die "--timeout-minutes needs a number"
       TIMEOUT_MINUTES="$2"; shift ;;
@@ -104,6 +126,7 @@ done
 
 case "$TIMEOUT_MINUTES" in ''|*[!0-9]*) die "--timeout-minutes needs a number, got: $TIMEOUT_MINUTES" ;; esac
 case "$POLL_SECONDS" in ''|*[!0-9]*|0) die "GATE_DISPATCH_POLL_SECONDS needs a positive number, got: $POLL_SECONDS" ;; esac
+case "$ALLOW_LOCAL" in 0|1) ;; *) die "AGENTOS_GATE_ALLOW_LOCAL must be 0 or 1, got: $ALLOW_LOCAL" ;; esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
@@ -116,8 +139,14 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
 # Validated here as well as inside the scripts that send it: this one decides
 # which of them to call, and a destination it cannot vouch for is a dispatch
 # that should not start rather than one that fails halfway through a push.
-gate_valid_server "$SERVER" >/dev/null \
-  || die "not a usable ssh destination: ${SERVER}" "$EXIT_USAGE"
+gate_valid_server "$PRIMARY_SERVER" >/dev/null \
+  || die "not a usable primary ssh destination: ${PRIMARY_SERVER}" "$EXIT_USAGE"
+if [ -n "$FALLBACK_SERVER" ]; then
+  gate_valid_server "$FALLBACK_SERVER" >/dev/null \
+    || die "not a usable fallback ssh destination: ${FALLBACK_SERVER}" "$EXIT_USAGE"
+  [ "$PRIMARY_SERVER" != "$FALLBACK_SERVER" ] \
+    || die "primary and fallback name the same ssh destination: ${PRIMARY_SERVER}" "$EXIT_USAGE"
+fi
 
 if [ -z "$OID" ]; then
   OID="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || true)"
@@ -205,8 +234,10 @@ local_eligible() {
 
 mkdir -p "$SLOT_ROOT" || die "could not create ${SLOT_ROOT}" "$EXIT_NO_VERDICT"
 
-printf 'gate-dispatch: %s, slots %s(1) then local(1), poll %ss, timeout %smin\n' \
-  "$OID" "$SERVER" "$POLL_SECONDS" "$TIMEOUT_MINUTES" >&2
+printf 'gate-dispatch: %s, primary %s(1)' "$OID" "$PRIMARY_SERVER" >&2
+[ -n "$FALLBACK_SERVER" ] && printf ', fallback %s(1)' "$FALLBACK_SERVER" >&2
+[ "$ALLOW_LOCAL" -eq 1 ] && printf ', local(1, explicit)' >&2
+printf ', poll %ss, timeout %smin\n' "$POLL_SECONDS" "$TIMEOUT_MINUTES" >&2
 printf 'gate-dispatch: baseline %s%s\n' "$MASTER_OID" "${DEFAULT_REF:+ (${DEFAULT_REF})}" >&2
 
 # --- dispatch ----------------------------------------------------------------
@@ -216,8 +247,11 @@ run_local() {
   ( cd "$REPO_ROOT" && bash scripts/merge-gate.sh --expect-head "$OID" --master "$MASTER_OID" )
 }
 
+REMOTE_OUTPUT=""
+REMOTE_STATUS="$EXIT_NO_VERDICT"
 run_remote() {
-  printf 'gate-dispatch: running in %s (%s)\n' "$1" "$SERVER" >&2
+  local label="$1" server="$2"
+  printf 'gate-dispatch: running on %s (%s)\n' "$label" "$server" >&2
   # The push and the gate share the slot: a push racing another dispatch's gate
   # is safe (the worker's worktrees are per-run and detached), but the slot is
   # what meters how much of the worker one dispatch may occupy, and the push is
@@ -227,13 +261,15 @@ run_remote() {
   # so there is no verdict to report and 76 says exactly that; returning the
   # gate's FAIL code here would have dressed a transport or mirror problem up as
   # a judgement about the commit.
-  bash "${SCRIPT_DIR}/mirror-push.sh" "$SERVER" \
+  bash "${SCRIPT_DIR}/mirror-push.sh" "$server" \
     --candidate "$OID" --baseline "$MASTER_OID" >&2 || {
     printf 'gate-dispatch: mirror-push failed; no gate was run and no verdict exists\n' >&2
-    printf 'GATE NOT RUN: the mirror push failed, so nothing was gated\n'
-    return "$EXIT_NO_VERDICT"
+    REMOTE_OUTPUT=""
+    REMOTE_STATUS="$EXIT_NO_VERDICT"
+    return 0
   }
-  bash "${SCRIPT_DIR}/remote-gate.sh" "$SERVER" "$OID" --master "$MASTER_OID"
+  REMOTE_OUTPUT="$(bash "${SCRIPT_DIR}/remote-gate.sh" "$server" "$OID" --master "$MASTER_OID")"
+  REMOTE_STATUS=$?
 }
 
 no_verdict() {
@@ -247,6 +283,9 @@ FIRST=1
 # Survives the rounds: once a slot's lock has been seen broken, a later 75 would
 # be a lie even if that round happened to find only busy slots.
 BROKEN_EVER=""
+UNAVAILABLE_EVER=""
+PRIMARY_DISABLED=0
+FALLBACK_DISABLED=0
 while :; do
   # Per round, because "busy" is a fact with a shelf life. round_busy counts the
   # slots that could have been taken and were not; round_broken the ones whose
@@ -256,19 +295,52 @@ while :; do
   round_broken=""
   outcome=0
 
-  outcome=0
-  try_slot remote-1 || outcome=$?
-  case "$outcome" in
-    0) run_remote remote-1; exit $? ;;
-    1) round_busy=$(( round_busy + 1 )) ;;
-    *) round_broken="${round_broken} remote-1" ;;
-  esac
+  if [ "$PRIMARY_DISABLED" -eq 0 ]; then
+    try_slot remote-1 || outcome=$?
+    case "$outcome" in
+      0)
+        run_remote primary "$PRIMARY_SERVER"
+        case "$REMOTE_STATUS" in
+          0|1|3) [ -n "$REMOTE_OUTPUT" ] && printf '%s\n' "$REMOTE_OUTPUT"; exit "$REMOTE_STATUS" ;;
+          *)
+            printf 'gate-dispatch: primary produced no verdict (exit %s); trying fallback capacity\n' "$REMOTE_STATUS" >&2
+            [ -n "$REMOTE_OUTPUT" ] && printf 'gate-dispatch: primary said: %s\n' "$REMOTE_OUTPUT" >&2
+            release_slot
+            PRIMARY_DISABLED=1
+            UNAVAILABLE_EVER="${UNAVAILABLE_EVER} remote-1"
+            ;;
+        esac
+        ;;
+      1) round_busy=$(( round_busy + 1 )) ;;
+      *) round_broken="${round_broken} remote-1" ;;
+    esac
+  fi
 
-  # Local capacity protects the user's machine from concurrent gate load. It
-  # is spillover only: the worker must be positively busy in this round. A
-  # broken remote lock is not "busy" and never unlocks local as a silent
-  # fallback.
-  if [ "$round_busy" -eq 1 ] && local_eligible; then
+  outcome=0
+  if [ -n "$FALLBACK_SERVER" ] && [ "$FALLBACK_DISABLED" -eq 0 ]; then
+    try_slot remote-2 || outcome=$?
+    case "$outcome" in
+      0)
+        run_remote fallback "$FALLBACK_SERVER"
+        case "$REMOTE_STATUS" in
+          0|1|3) [ -n "$REMOTE_OUTPUT" ] && printf '%s\n' "$REMOTE_OUTPUT"; exit "$REMOTE_STATUS" ;;
+          *)
+            printf 'gate-dispatch: fallback produced no verdict (exit %s)\n' "$REMOTE_STATUS" >&2
+            [ -n "$REMOTE_OUTPUT" ] && printf 'gate-dispatch: fallback said: %s\n' "$REMOTE_OUTPUT" >&2
+            release_slot
+            FALLBACK_DISABLED=1
+            UNAVAILABLE_EVER="${UNAVAILABLE_EVER} remote-2"
+            ;;
+        esac
+        ;;
+      1) round_busy=$(( round_busy + 1 )) ;;
+      *) round_broken="${round_broken} remote-2" ;;
+    esac
+  fi
+
+  # The local machine is never an automatic fallback. Opting in makes it the
+  # last slot after both remote workers for this invocation only.
+  if [ "$ALLOW_LOCAL" -eq 1 ] && local_eligible; then
     outcome=0
     try_slot local || outcome=$?
     case "$outcome" in
@@ -289,10 +361,10 @@ while :; do
   # Nothing to wait for: every slot this dispatch could have used has a lock that
   # does not work. Polling would only repeat the same failure until the timeout
   # and then report a full queue that never existed.
-  if [ "$round_busy" -eq 0 ] && [ -n "$round_broken" ]; then
+  if [ "$round_busy" -eq 0 ] && { [ -n "$round_broken" ] || [ -n "$UNAVAILABLE_EVER" ]; }; then
     no_verdict \
-      "no slot could be locked (${round_broken# }); nothing ran and no verdict exists" \
-      "the slot locks are unusable (${round_broken# }), so nothing was gated"
+      "no remaining worker could produce a verdict; unavailable:${UNAVAILABLE_EVER:- none}; broken:${round_broken:- none}" \
+      "no configured worker produced a verdict"
   fi
 
   now="$(date +%s)"
@@ -300,10 +372,10 @@ while :; do
     # A slot seen broken at any point during the wait means the timeout is not
     # the whole story, and 75 — "the queue stayed full" — would send the caller
     # to re-dispatch into the same broken lock.
-    if [ -n "$BROKEN_EVER" ]; then
+    if [ -n "$BROKEN_EVER$UNAVAILABLE_EVER" ]; then
       no_verdict \
-        "waited ${TIMEOUT_MINUTES} minutes with slots busy and the locks of${BROKEN_EVER} unusable; nothing ran" \
-        "some slots stayed busy and${BROKEN_EVER} could not be locked, so nothing was gated"
+        "waited ${TIMEOUT_MINUTES} minutes with slots busy; unavailable:${UNAVAILABLE_EVER:- none}; broken:${BROKEN_EVER:- none}" \
+        "no configured worker produced a verdict"
     fi
     printf 'gate-dispatch: no slot freed up in %s minutes; nothing ran and no verdict exists\n' \
       "$TIMEOUT_MINUTES" >&2
@@ -312,8 +384,8 @@ while :; do
   fi
   if [ "$FIRST" -eq 1 ]; then
     FIRST=0
-    if ! local_eligible; then
-      printf 'gate-dispatch: local slot ineligible (worktree not clean at %s); remote only\n' "${OID:0:12}" >&2
+    if [ "$ALLOW_LOCAL" -eq 1 ] && ! local_eligible; then
+      printf 'gate-dispatch: explicitly enabled local slot is ineligible (worktree not clean at %s)\n' "${OID:0:12}" >&2
     fi
     if [ -n "$round_broken" ]; then
       printf 'gate-dispatch: the locks of%s are unusable; waiting on the %s slot(s) that are merely busy\n' \

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -342,18 +342,18 @@ const dispatch = (t, repo, args, env = {}, busySlots = []) => {
   });
 };
 
-test("a local PASS comes back as 0 with the gate's own verdict line", (t) => {
+test("an explicitly enabled local PASS comes back as 0 with the gate's own verdict line", (t) => {
   const repo = fixtureRepo(t, {});
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
+  const result = dispatch(t, repo, [repo.head, "--server", "primary", "--allow-local"], {}, ["remote-1"]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /MERGE GATE: PASS/);
 });
 
-test("a local FAIL comes back as 1, unchanged", (t) => {
+test("an explicitly enabled local FAIL comes back as 1, unchanged", (t) => {
   const repo = fixtureRepo(t, {
     mergeGate: 'printf "MERGE GATE: FAIL (stub)\\n"; exit 1',
   });
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
+  const result = dispatch(t, repo, [repo.head, "--server", "primary", "--allow-local"], {}, ["remote-1"]);
   assert.equal(result.status, 1);
   assert.match(result.stdout, /MERGE GATE: FAIL/);
 });
@@ -362,7 +362,7 @@ test("NOT AUTHORITATIVE keeps its own code", (t) => {
   const repo = fixtureRepo(t, {
     mergeGate: 'printf "MERGE GATE: NOT AUTHORITATIVE\\n"; exit 3',
   });
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
+  const result = dispatch(t, repo, [repo.head, "--server", "primary", "--allow-local"], {}, ["remote-1"]);
   assert.equal(result.status, 3);
 });
 
@@ -391,15 +391,15 @@ test("dispatch tries the remote slot before an eligible local slot", (t) => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /remote-first/);
   assert.doesNotMatch(result.stdout, /LOCAL SHOULD NOT RUN/);
-  assert.match(result.stderr, /remote-1/);
+  assert.match(result.stderr, /running on primary/);
 });
 
-test("dispatch uses local only when the remote slot is busy", (t) => {
+test("dispatch uses local only when it is explicit and the selected remote is busy", (t) => {
   const repo = fixtureRepo(t, {
     mergeGate: 'printf "MERGE GATE: PASS local-spillover\\n"; exit 0',
     remoteGate: 'printf "REMOTE SHOULD NOT RUN\\n"; exit 1',
   });
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
+  const result = dispatch(t, repo, [repo.head, "--server", "primary", "--allow-local"], {}, ["remote-1"]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /local-spillover/);
   assert.doesNotMatch(result.stdout, /REMOTE SHOULD NOT RUN/);
@@ -411,7 +411,7 @@ test("the remote path's exit code is passed through unchanged", (t) => {
     remoteGate: 'printf "GATE NOT RUN: stub precondition\\n"; exit 76',
   });
   writeFileSync(join(repo.root, "dirty.txt"), "dirty\n");
-  const result = dispatch(t, repo, [repo.head]);
+  const result = dispatch(t, repo, [repo.head, "--server", "primary"]);
   assert.equal(result.status, 76, result.stderr);
   assert.match(result.stdout, /GATE NOT RUN/);
 });
@@ -428,11 +428,29 @@ test("the remote path receives the exact candidate and frozen baseline", (t) => 
   assert.match(result.stderr, new RegExp(`remote args: .*${repo.head} --master ${repo.head}`));
 });
 
-test("an ssh transport failure stays 255", (t) => {
-  const repo = fixtureRepo(t, { remoteGate: "exit 255" });
+test("an ssh transport failure retries the exact gate on the fallback", (t) => {
+  const repo = fixtureRepo(t, {
+    remoteGate:
+      'if [ "$1" = ci-desktop-worker ]; then printf "GATE NOT RUN: ssh dropped\\n"; exit 255; fi; printf "MERGE GATE: PASS fallback\\n"',
+  });
   writeFileSync(join(repo.root, "dirty.txt"), "dirty\n");
   const result = dispatch(t, repo, [repo.head]);
-  assert.equal(result.status, 255);
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /^MERGE GATE: PASS fallback$/m);
+  assert.doesNotMatch(result.stdout, /GATE NOT RUN/);
+  assert.match(result.stderr, /trying fallback capacity/);
+  assert.match(result.stderr, /running on fallback/);
+});
+
+test("a primary FAIL is final and never falls back", (t) => {
+  const repo = fixtureRepo(t, {
+    remoteGate:
+      'if [ "$1" = ci-desktop-worker ]; then printf "MERGE GATE: FAIL (candidate)\\n"; exit 1; fi; printf "FALLBACK SHOULD NOT RUN\\n"',
+  });
+  const result = dispatch(t, repo, [repo.head]);
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /MERGE GATE: FAIL/);
+  assert.doesNotMatch(result.stdout + result.stderr, /FALLBACK SHOULD NOT RUN/);
 });
 
 test("every slot busy times out at 75 with no verdict", (t) => {
@@ -440,7 +458,7 @@ test("every slot busy times out at 75 with no verdict", (t) => {
   const cache = join(scratch(t), "cache");
   const slots = join(cache, "gate-dispatch");
   mkdirSync(slots, { recursive: true });
-  for (const slot of ["local", "remote-1"]) {
+  for (const slot of ["remote-1", "remote-2"]) {
     writeFileSync(join(slots, `${slot}.slot`), `${process.pid}\n`);
   }
   const result = spawnSync(
@@ -498,7 +516,7 @@ test("locks that cannot be operated are 76 at once, not 75 after the timeout", (
   assert.ok(Date.now() - started < 20_000, "it polled instead of answering at once");
 });
 
-test("a busy remote slot spills an eligible gate onto the free local slot", (t) => {
+test("a busy primary spills onto the fallback without using the Mac", (t) => {
   const repo = fixtureRepo(t, {});
   const cache = join(scratch(t), "cache");
   const slots = join(cache, "gate-dispatch");
@@ -515,7 +533,8 @@ test("a busy remote slot spills an eligible gate onto the free local slot", (t) 
   );
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /MERGE GATE: PASS/);
-  assert.match(result.stderr, /local slot/);
+  assert.match(result.stderr, /running on fallback/);
+  assert.doesNotMatch(result.stderr, /local slot/);
 });
 
 test("busy plus broken waits out the timeout and then reports 76, not 75", (t) => {
@@ -529,7 +548,7 @@ test("busy plus broken waits out the timeout and then reports 76, not 75", (t) =
   const slots = join(cache, "gate-dispatch");
   mkdirSync(slots, { recursive: true });
   writeFileSync(join(slots, "remote-1.slot"), `${process.pid}\n`);
-  mkdirSync(join(slots, "local.lock"));
+  mkdirSync(join(slots, "remote-2.lock"));
   const result = spawnSync(
     "bash",
     [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head, "--timeout-minutes", "0"],
@@ -545,16 +564,12 @@ test("busy plus broken waits out the timeout and then reports 76, not 75", (t) =
   assert.equal(readFileSync(join(slots, "remote-1.slot"), "utf8").trim(), String(process.pid));
 });
 
-test("a gate killed by SIGKILL comes back as 137 with no verdict line", (t) => {
-  // 137 is not in the table's named codes and is not supposed to be: SIGKILL
-  // cannot be trapped, so merge-gate.sh prints nothing and the death shows up
-  // as 128+9. What matters is that it is passed through as itself — a reader
-  // sees no MERGE GATE line and must read the silence as "no verdict", never as
-  // a pass, and never as the FAIL that a rewritten code would have implied.
-  const repo = fixtureRepo(t, { mergeGate: "kill -9 $$" });
-  const result = dispatch(t, repo, [repo.head], {}, ["remote-1"]);
-  assert.equal(result.status, 137);
+test("remote processes that die without a verdict exhaust fallback as 76", (t) => {
+  const repo = fixtureRepo(t, { remoteGate: "exit 137" });
+  const result = dispatch(t, repo, [repo.head]);
+  assert.equal(result.status, 76);
   assert.doesNotMatch(result.stdout, /MERGE GATE/);
+  assert.match(result.stdout, /^GATE NOT RUN:/m);
 });
 
 test("the dispatcher releases its slot when the gate ends", (t) => {
@@ -575,5 +590,5 @@ test("a destination that is not an ssh destination is refused before anything is
   const repo = fixtureRepo(t, {});
   const result = dispatch(t, repo, [repo.head, "--server", "host; rm -rf /"]);
   assert.equal(result.status, 2);
-  assert.match(result.stderr, /not a usable ssh destination/);
+  assert.match(result.stderr, /not a usable primary ssh destination/);
 });

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -4,12 +4,8 @@
 // Three things are proved here, and each is something that has already been
 // wrong once.
 //
-// 1. The credential red line is one rule stated in two files. `provision.sh`
-//    refuses to finish provisioning a box that carries any of a list of
-//    variables, and `run-gate.sh` refuses to gate on one. The lists drifted
-//    apart — `FEISHU_APP_SECRET` was in the first and not the second — which
-//    turned "re-checked on every single run" into a claim the code did not
-//    keep. They are compared here rather than trusted.
+// 1. Credentials are not a worker precondition. Provisioning and gate execution
+//    must not fail merely because the trusted operator VM carries credentials.
 //
 // 2. Repository names, gate homes, ssh destinations and ref names become part
 //    of a command string a remote login shell parses. `.` and `..` were
@@ -18,14 +14,14 @@
 //    than what is accepted.
 //
 // 3. `run-gate.sh` must not report the worker's own state as a verdict about a
-//    commit. A missing mirror, a commit that was never pushed, a credential in
-//    the environment — none of those are things the gate decided, and each is
+//    commit. A missing mirror or a commit that was never pushed is not something
+//    the gate decided, and each is
 //    checked to exit 76 with a GATE NOT RUN line rather than 1 with a
 //    MERGE GATE: FAIL line.
 //
 // 4. What the worker's isolation is claimed to be. Leo's ruling of 2026-08-20
-//    is that no network egress control is required: the containment is no
-//    credential, no remote and no merge authority, and the box is NOT
+//    is that no network egress control is required: the deterministic boundary
+//    is the exact pushed objects, no mirror remote and no merge authority; the box is NOT
 //    network-isolated. The failure mode this guards is a document drifting back
 //    into "the worker cannot reach GitHub", which would be an isolation claim
 //    nothing enforces.
@@ -51,6 +47,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const libPath = join(here, "lib.sh");
 const runGatePath = join(here, "run-gate.sh");
 const dispatchPath = join(here, "gate-dispatch.sh");
+const mirrorPushPath = join(here, "mirror-push.sh");
 const provisionPath = join(here, "provision.sh");
 const runbookPath = join(here, "..", "..", "docs", "runbooks", "gate-worker.md");
 
@@ -77,42 +74,17 @@ const scratch = (t) => {
 const git = (cwd, ...args) =>
   execFileSync("git", args, { cwd, encoding: "utf8", env: GIT_ENV }).trim();
 
-// --- the credential red line -------------------------------------------------
+// --- worker provisioning contract -------------------------------------------
 
-// Both files declare the list under the same name, on one line, so one reader
-// serves both. A change that splits the list across lines will fail here rather
-// than pass by reading half of it.
-const secretVars = (path) => {
-  const source = readFileSync(path, "utf8");
-  const match = source.match(/^SECRET_VARS="([^"]*)"$/m);
-  assert.ok(match, `${path} has no single-line SECRET_VARS= declaration`);
-  return match[1].split(/\s+/).filter(Boolean);
-};
-
-test("provision.sh and run-gate.sh refuse the same credential variables", () => {
-  const provisioning = secretVars(provisionPath);
-  const runtime = secretVars(runGatePath);
-  assert.deepEqual(
-    [...runtime].sort(),
-    [...provisioning].sort(),
-    "the provisioning red line and the per-run red line have drifted apart",
-  );
-  assert.ok(provisioning.length > 0);
-});
-
-test("the credential list still carries the variables the red line names", () => {
-  const declared = new Set(secretVars(runGatePath));
-  for (const name of [
-    "OPERATOR_TOKEN",
-    "RUNNER_TOKEN",
-    "ANTHROPIC_API_KEY",
-    "GH_TOKEN",
-    "GITHUB_TOKEN",
-    // The one that was missing at runtime while provisioning called it a secret.
-    "FEISHU_APP_SECRET",
-  ]) {
-    assert.ok(declared.has(name), `${name} is not in the runtime red line`);
+test("provisioning includes the native Node build/runtime dependencies and Git identity", () => {
+  const source = readFileSync(provisionPath, "utf8");
+  for (const pkg of ["python3", "build-essential", "libatomic1"]) {
+    assert.match(source, new RegExp(`for pkg in [^\\n]*\\b${pkg}\\b`), `${pkg} is not provisioned`);
   }
+  assert.match(source, /git config --global user\.name/);
+  assert.match(source, /git config --global user\.email/);
+  assert.doesNotMatch(source, /SECRET_VARS=/);
+  assert.doesNotMatch(readFileSync(runGatePath, "utf8"), /SECRET_VARS=/);
 });
 
 // --- what may reach a remote shell -------------------------------------------
@@ -214,6 +186,63 @@ test("gate_repo_name refuses a name carrying remote shell syntax", (t) => {
   }
 });
 
+test("a first-deployment mirror dry-run describes creation without pushing into an absent mirror", (t) => {
+  const root = scratch(t);
+  const repo = join(root, "source");
+  mkdirSync(join(repo, "scripts", "gate-worker"), { recursive: true });
+  writeFileSync(join(repo, "scripts", "merge-gate.sh"), "#!/usr/bin/env bash\nexit 0\n");
+  cpSync(mirrorPushPath, join(repo, "scripts", "gate-worker", "mirror-push.sh"));
+  cpSync(libPath, join(repo, "scripts", "gate-worker", "lib.sh"));
+  git(repo, "init", "-q", "-b", "main");
+  git(repo, "remote", "add", "origin", "https://example.invalid/mosonlab/agentos-public.git");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-q", "-m", "fixture");
+  const oid = git(repo, "rev-parse", "HEAD");
+
+  const fakeHome = join(root, "worker-home");
+  const fakeBin = join(root, "fake-bin");
+  mkdirSync(fakeHome, { recursive: true });
+  mkdirSync(fakeBin, { recursive: true });
+  writeFileSync(
+    join(fakeBin, "ssh"),
+    `#!/usr/bin/env bash
+set -uo pipefail
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -p|-o|-i|-F) shift 2 ;;
+    -n|-T|-x) shift ;;
+    --) shift; break ;;
+    -*) shift ;;
+    *) break ;;
+  esac
+done
+[ $# -ge 1 ] || exit 2
+shift
+cd "$FAKE_SSH_HOME"
+exec bash -c "$*"
+`,
+  );
+  chmodSync(join(fakeBin, "ssh"), 0o755);
+
+  const result = spawnSync(
+    "bash",
+    [join(repo, "scripts", "gate-worker", "mirror-push.sh"), "fake", "--candidate", oid, "--baseline", oid, "--dry-run"],
+    {
+      cwd: repo,
+      encoding: "utf8",
+      env: {
+        ...GIT_ENV,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        FAKE_SSH_HOME: fakeHome,
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /would create the bare mirror/);
+  assert.match(result.stdout, /MIRROR PUSH: DRY RUN OK/);
+  assert.equal(existsSync(join(fakeHome, "gate", "agentos-public", "mirror.git")), false);
+});
+
 // --- exact-ref transport -----------------------------------------------------
 
 test("dispatch transports a detached candidate and current baseline without mirroring an incomplete ref namespace", (t) => {
@@ -290,7 +319,7 @@ exec bash -c "$*"
 set -uo pipefail
 while [ $# -gt 0 ]; do
   case "$1" in
-    -P) shift 2 ;;
+    -P|-o) shift 2 ;;
     -q) shift ;;
     *) break ;;
   esac
@@ -373,14 +402,11 @@ test("a gate that fails is 1 and says MERGE GATE: FAIL", (t) => {
   assert.match(result.stdout, /MERGE GATE: FAIL/);
 });
 
-test("a credential in the worker's environment stops the run without a verdict", (t) => {
-  // The regression for the missing entry: FEISHU_APP_SECRET must stop a gate,
-  // and stopping it is not a FAIL — the runbook calls this a red-line stop.
+test("a credential in the trusted worker environment does not block the gate", (t) => {
   const fixture = gateHome(t);
   const result = runGate(fixture.home, [fixture.oid], { FEISHU_APP_SECRET: "x" });
-  assert.equal(result.status, 76, result.stdout + result.stderr);
-  assert.match(result.stdout, /^GATE NOT RUN: worker environment carries FEISHU_APP_SECRET$/m);
-  assert.doesNotMatch(result.stdout, /MERGE GATE/);
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /MERGE GATE: PASS/);
 });
 
 test("a commit the mirror does not have is not a FAIL", (t) => {
@@ -556,8 +582,8 @@ test("the runbook and the scripts agree on the no-verdict exit code", () => {
 test("the isolation claim stays the one that is actually enforced", () => {
   // Leo's ruling, 2026-08-20: no egress control, so nothing here may probe a
   // route or make provisioning depend on one, and the runbook has to say plainly
-  // that the box is not isolated. The enforced half — no credential, no remote —
-  // stays fail-closed and is checked above and on every run.
+  // that the box is not isolated. Exact inputs and the mirror's lack of a
+  // remote stay fail-closed.
   const provision = readFileSync(provisionPath, "utf8");
   assert.doesNotMatch(provision, /\/dev\/tcp/, "provision.sh probes a route again");
   assert.doesNotMatch(provision, /GATE_GITHUB_HOSTS/, "the egress host list is back");
@@ -566,9 +592,12 @@ test("the isolation claim stays the one that is actually enforced", () => {
   assert.match(runbook, /not network-isolated/);
   assert.doesNotMatch(runbook, /^\s*ssh [^\n]*nft /m, "the runbook asks for a firewall rule again");
 
-  // The half that is enforced, in both places that enforce it.
-  assert.match(provision, /no AgentOS credentials on this host/);
-  assert.match(readFileSync(runGatePath, "utf8"), /the gate worker holds no credentials/);
+  // Credential presence is deliberately not a provisioning or runtime stop.
+  assert.doesNotMatch(provision, /SECRET_VARS=/);
+  assert.doesNotMatch(readFileSync(runGatePath, "utf8"), /SECRET_VARS=/);
+  assert.match(runbook, /credentials do not block provisioning or gate\s+execution/i);
+
+  // Exact pushed inputs and a mirror with no remote remain enforced.
   assert.match(
     readFileSync(join(here, "mirror-push.sh"), "utf8"),
     /refusing to push into a mirror this check could not inspect/,

--- a/scripts/gate-worker/mirror-push.sh
+++ b/scripts/gate-worker/mirror-push.sh
@@ -17,9 +17,9 @@
 # lives under its own directory, so a second project can be gated on the same
 # worker without either seeing the other.
 #
-# This is the only path by which code reaches the worker. The worker holds no
-# GitHub credential and its mirror has no remote configured, so no repository
-# content arrives there except by this push, and the mirror cannot fetch. That
+# This is the only path by which code reaches the worker's gate mirror. The
+# mirror has no remote configured, so no repository content arrives there
+# except by this push, and the mirror cannot fetch. That
 # is a statement about how code gets in, not about what the worker's network can
 # reach: the gate executes the candidate commit's own code, and nothing here
 # constrains what that code connects to. docs/runbooks/gate-worker.md states the
@@ -41,8 +41,8 @@
 # is therefore a complete transport source as long as it contains the requested
 # candidate and the caller refreshed the requested baseline object.
 #
-# Sends no credential of any kind. The push is git-over-ssh; the ssh key stays on
-# this machine and is used for authentication, never copied.
+# The transport copies no credential. The push is git-over-ssh; the ssh key stays
+# on this machine and is used for authentication, never copied.
 #
 # <server>, --gate-home and the repository name all become part of a command
 # string a remote login shell parses. Each is validated against an allowlist in
@@ -139,16 +139,19 @@ REPO_HOME="${GATE_HOME}/${REPO_NAME}"
 # Expanded as ${arr[@]+"${arr[@]}"} at every use site: bash 3.2, which is what
 # /bin/bash still is on macOS, treats an empty array as unset under `set -u`
 # and aborts. The + form expands to nothing when the array is empty.
-SSH_OPTS=()
-SCP_OPTS=()
+SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
+SCP_OPTS=(-o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
 if [ -n "$SSH_PORT" ]; then
   SSH_OPTS+=(-p "$SSH_PORT")
   SCP_OPTS+=(-P "$SSH_PORT")
-  # git has no --port: the scp-style address form used below cannot carry one, and
-  # the ssh:// form that can does not expand ~ in the path. Passing the port
-  # through GIT_SSH_COMMAND keeps the address form that works and adds the port.
-  export GIT_SSH_COMMAND="ssh -p ${SSH_PORT}"
 fi
+# git has no --port: the scp-style address form used below cannot carry one, and
+# the ssh:// form that can does not expand ~ in the path. Passing the port and
+# fixed liveness options through GIT_SSH_COMMAND keeps the address form that
+# works.
+GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+[ -n "$SSH_PORT" ] && GIT_SSH_COMMAND="${GIT_SSH_COMMAND} -p ${SSH_PORT}"
+export GIT_SSH_COMMAND
 
 # A path relative to the remote $HOME, expanded by the remote login shell rather
 # than written as ~ inside a URL: git's ssh:// URLs do not expand a tilde, and
@@ -171,7 +174,9 @@ printf '   baseline:   %s\n' "$BASELINE_OID"
 # path is refused rather than pushed into. `git init` on an existing bare
 # repository is a no-op, so this is convergent, but a non-bare directory there
 # is somebody's working state and not this script's to overwrite.
+MIRROR_EXISTS=0
 if ssh ${SSH_OPTS[@]+"${SSH_OPTS[@]}"} "$SERVER" "test -e ${REPO_HOME}/mirror.git" 2>/dev/null; then
+  MIRROR_EXISTS=1
   ssh ${SSH_OPTS[@]+"${SSH_OPTS[@]}"} "$SERVER" \
       "test \"\$(git -C ${REPO_HOME}/mirror.git rev-parse --is-bare-repository 2>/dev/null)\" = true" 2>/dev/null \
     || die "${REPO_HOME}/mirror.git on ${SERVER} exists but is not a bare repository; refusing to push into it"
@@ -206,9 +211,14 @@ fi
 
 if [ "$DRY_RUN" -eq 1 ]; then
   printf '\n== Dry run: exact cache refs that would be pushed\n'
-  git -C "$REPO_ROOT" push --atomic --dry-run "$REMOTE_MIRROR" \
-    "${CANDIDATE_OID}:${CANDIDATE_REF}" \
-    "${BASELINE_OID}:${BASELINE_REF}" || die "dry-run push failed"
+  if [ "$MIRROR_EXISTS" -eq 1 ]; then
+    git -C "$REPO_ROOT" push --atomic --dry-run "$REMOTE_MIRROR" \
+      "${CANDIDATE_OID}:${CANDIDATE_REF}" \
+      "${BASELINE_OID}:${BASELINE_REF}" || die "dry-run push failed"
+  else
+    printf '   would push %s to %s\n' "$CANDIDATE_REF" "$REMOTE_MIRROR"
+    printf '   would push %s to %s\n' "$BASELINE_REF" "$REMOTE_MIRROR"
+  fi
   printf '\n   would also install scripts/gate-worker/run-gate.sh at %s (copy to a\n   temporary name in the same directory, then rename into place)\n' "$REMOTE_HARNESS"
   printf '\nMIRROR PUSH: DRY RUN OK\n'
   exit 0

--- a/scripts/gate-worker/provision.sh
+++ b/scripts/gate-worker/provision.sh
@@ -1,30 +1,28 @@
 #!/usr/bin/env bash
 #
-# Provision an offshore merge-gate worker (issue #132). Runs ON THE SERVER.
+# Provision a merge-gate worker (issue #132). Runs ON THE SERVER.
 #
 #   scp scripts/gate-worker/provision.sh <server>:/tmp/
 #   ssh <server> 'bash /tmp/provision.sh'            # dry run, prints the plan
 #   ssh <server> 'bash /tmp/provision.sh --apply'    # do it
 #
-# What this machine is allowed to be: a stateless compute worker that checks a
-# commit out of a bare mirror and runs scripts/merge-gate.sh against it. That is
-# all. It holds no credential, has no remote configured on its mirror, and never
-# runs an AgentOS runner or an agent session — the execution plane stays on the
-# local machine (Leo's ruling, 2026-08-18). This script therefore installs a
-# toolchain and a directory layout and nothing else: no service, no queue, no
-# daemon, no token file, no clone of a GitHub remote.
+# What this machine is: a compute worker that checks a commit out of a bare
+# mirror and runs scripts/merge-gate.sh against it. It never runs an AgentOS
+# runner or an agent session — the execution plane stays on the local machine.
+# This script installs a toolchain and a directory layout and nothing else: no
+# service, no queue, no daemon and no clone of a GitHub remote.
 #
-# Both of those are enforced, here and in mirror-push.sh, and both are checked
-# again on every run. What is deliberately NOT claimed: this box is not made
+# The mirror's lack of a remote is enforced here and in mirror-push.sh. What is
+# deliberately NOT claimed: this box is not made
 # network-isolated. Nothing here denies it a route to GitHub or anywhere else,
 # and the repository does not guarantee one is denied (Leo's ruling,
 # 2026-08-20). The gate's own flow never needs GitHub — the mirror arrives over
 # ssh from the local machine and nothing fetches from a remote — but a candidate
 # commit's build and test scripts run on this box, so what they can reach is
 # whatever this box's network policy allows. Blocking GitHub alone would not
-# change that, since every other host would remain reachable; the boundary that
-# does the work is the one above — no credential, no remote, no merge authority,
-# and a remote PASS that is evidence rather than an authoritative verdict.
+# change that, since every other host would remain reachable. Deterministic
+# inputs come from the exact pushed objects and a mirror with no remote; merge
+# authority remains on the calling machine.
 #
 # Idempotent by construction: every step reads the current state first and prints
 # "ok" for what already matches, so re-running after a partial failure is safe
@@ -150,35 +148,11 @@ else
   note "dry run — nothing below will be changed; re-run with --apply"
 fi
 
-# --- red line: this box holds no secrets ------------------------------------
-
-# Checked before anything is installed, and checked again by run-gate.sh on every
-# gate run. The worst case this design accepts is a compromised worker forging a
-# PASS; it must not be able to escalate that into a leaked credential, so a box
-# that already carries one is not a box this script will finish provisioning.
-step "Red line: no AgentOS credentials on this host"
-
-SECRET_VARS="OPERATOR_TOKEN RUNNER_TOKEN AGENTOS_API_TOKEN AGENTOS_SESSION_TOKEN AGENTOS_FENCING_TOKEN VITE_API_TOKEN ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN GH_TOKEN GITHUB_TOKEN FEISHU_APP_SECRET"
-for var in $SECRET_VARS; do
-  eval "value=\${$var:-}"
-  # shellcheck disable=SC2154
-  if [ -n "$value" ]; then
-    fail "$var is set in this environment; unset it and remove it from the shell profile before provisioning"
-  fi
-done
-
-for path in "$HOME/.config/gh/hosts.yml" "$HOME/.claude/.credentials.json" "$HOME/.agentos" "$HOME/.netrc"; do
-  if [ -e "$path" ]; then
-    fail "$path exists on this host; the worker holds no credentials — remove it"
-  fi
-done
-[ "$failures" = 0 ] && ok "no known credential variable or file present"
-
 # --- packages ---------------------------------------------------------------
 
 step "Base packages"
 missing_pkgs=""
-for pkg in git curl ca-certificates xz-utils util-linux; do
+for pkg in git curl ca-certificates xz-utils util-linux python3 build-essential libatomic1; do
   if dpkg -s "$pkg" >/dev/null 2>&1; then
     ok "$pkg"
   else
@@ -191,6 +165,21 @@ if [ -n "$missing_pkgs" ]; then
   sudo_run apt-get update || fail "apt-get update failed"
   # shellcheck disable=SC2086
   sudo_run apt-get install -y $missing_pkgs || fail "could not install:${missing_pkgs}"
+fi
+
+# Several gate fixtures create commits in temporary repositories. A fresh cloud
+# image has no Git identity, so those fixtures fail before testing anything. Do
+# not overwrite an operator identity that is already complete; provide a stable
+# synthetic one only when either half is absent.
+step "Git fixture identity"
+if command -v git >/dev/null 2>&1 \
+  && [ -n "$(git config --global user.name 2>/dev/null)" ] \
+  && [ -n "$(git config --global user.email 2>/dev/null)" ]; then
+  ok "$(git config --global user.name) <$(git config --global user.email)>"
+else
+  run git config --global user.name "AgentOS Gate Worker"
+  run git config --global user.email "gate-worker@example.invalid"
+  did "configured the synthetic Git fixture identity"
 fi
 
 step "Docker"
@@ -284,19 +273,14 @@ else
 fi
 
 step "npm registry"
-# A user-level .npmrc rather than a global one: it carries no auth token (there
-# is nothing private to fetch) and keeping it in $HOME makes "what does this box
-# talk to" answerable by reading one file.
+# A user-level .npmrc rather than a global one keeps the worker's registry
+# selection visible and easy to change without rewriting system configuration.
 if [ -f "$HOME/.npmrc" ] && grep -q "registry=${NPM_REGISTRY}" "$HOME/.npmrc" 2>/dev/null; then
   ok "~/.npmrc points at ${NPM_REGISTRY}"
 else
   run_sh "printf 'registry=%s\n' '${NPM_REGISTRY}' >> \"\$HOME/.npmrc\""
   did "appended registry=${NPM_REGISTRY} to ~/.npmrc"
 fi
-if [ -f "$HOME/.npmrc" ] && grep -qE '_authToken|_auth=' "$HOME/.npmrc" 2>/dev/null; then
-  fail "~/.npmrc carries an auth token; this host holds no credentials — remove that line"
-fi
-
 # --- layout -----------------------------------------------------------------
 
 # Only the root. Each repository's mirror, worktrees, logs and run-gate.sh live

--- a/scripts/gate-worker/remote-gate.sh
+++ b/scripts/gate-worker/remote-gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Gate a commit on the offshore worker and bring the verdict home. Runs ON THE
+# Gate a commit on one remote worker and bring the verdict home. Runs ON THE
 # LOCAL MACHINE (issue #132):
 #
 #   scripts/gate-worker/remote-gate.sh <server>                  # gate local HEAD
@@ -14,9 +14,9 @@
 # default branch, so a verdict has to name the baseline it was formed against.
 # That oid is resolved here, on the machine that can actually ask — `git
 # ls-remote --symref origin HEAD`, which names origin's default branch and its
-# head in one answer, or --master to state it — and passed to the worker, which
-# holds no credential and could otherwise only offer a mirror ref of unknown
-# age. If this repository cannot resolve the oid origin just named, neither can
+# head in one answer, or --master to state it — and passed to the worker, whose
+# mirror does not fetch and could otherwise only offer a ref of unknown age. If
+# this repository cannot resolve the oid origin just named, neither can
 # the mirror, and the fix is an exact candidate/baseline mirror-push.
 #
 # The worker hosts one directory per repository under ~/gate/<repo>, keyed by
@@ -49,17 +49,12 @@
 #
 #   It is evidence, not authority. The merge still happens on the local machine
 #   and still binds an exact head. A worker that has been tampered with can forge
-#   a PASS; it cannot forge a merge, and it holds no GitHub credential to steal
-#   or to push with. What it does have is a working network: the worker runs the
-#   gate the candidate commit ships, so the candidate's own code executes there,
-#   and nothing in this repository makes that box network-isolated. The gate's
-#   own flow needs no GitHub access — the mirror arrives by ssh and never fetches
-#   — but the repository does not guarantee the route is unreachable, and does
-#   not ask an operator to block it (Leo's ruling, 2026-08-20): denying GitHub
-#   alone would leave every other host open, so the containment that carries the
-#   weight is no credential, no remote, no merge authority. Release-grade merges
-#   are spot-checked by re-running the gate locally, which is the hedge against a
-#   forged PASS. docs/runbooks/gate-worker.md states the boundary.
+#   a PASS but cannot perform the caller's merge. The worker is trusted compute:
+#   candidate code can reach its network and anything available to its account,
+#   including credentials if the operator placed them there. The gate mirror has
+#   no remote and receives exact objects from the caller; this repository claims
+#   neither credential nor network isolation. Release-grade merges are
+#   spot-checked locally. docs/runbooks/gate-worker.md states the boundary.
 #
 # The commit must already be in the worker's mirror. The worker never fetches, so
 # push first: scripts/gate-worker/mirror-push.sh <server> --candidate <oid>
@@ -216,9 +211,9 @@ fi
 # Expanded as ${arr[@]+"${arr[@]}"} at every use site: bash 3.2, which is what
 # /bin/bash still is on macOS, treats an empty array as unset under `set -u`
 # and aborts. The + form expands to nothing when the array is empty.
-SSH_OPTS=()
+SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
 [ -n "$SSH_PORT" ] && SSH_OPTS+=(-p "$SSH_PORT")
-SCP_OPTS=()
+SCP_OPTS=(-o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
 [ -n "$SSH_PORT" ] && SCP_OPTS+=(-P "$SSH_PORT")
 
 printf 'remote-gate: %s on %s%s\n' "$OID" "$SERVER" "${SSH_PORT:+ (port ${SSH_PORT})}" >&2

--- a/scripts/gate-worker/run-gate.sh
+++ b/scripts/gate-worker/run-gate.sh
@@ -11,8 +11,8 @@
 #
 # --master carries the authoritative master oid, which the frozen-record rules
 # are evaluated against. remote-gate.sh reads it from origin on the local
-# machine and passes it here, because this box cannot ask: it holds no GitHub
-# credential and its mirror has no remote to fetch through. When it is given, it
+# machine and passes it here, because this box's mirror has no remote to fetch
+# through. When it is given, it
 # is verified to be resolvable in the mirror before the gate starts.
 #
 # The supported remote path always supplies it: gate-dispatch.sh freezes the
@@ -37,8 +37,8 @@
 #
 #   0  PASS               2  usage error (this script or merge-gate.sh)
 #   1  FAIL               3  NOT AUTHORITATIVE
-#   76 nothing ran — no mirror, the commit is not in the mirror, a missing tool,
-#      a credential in this box's environment. The line on stdout is
+#   76 nothing ran — no mirror, the commit is not in the mirror or a missing
+#      tool. The line on stdout is
 #      GATE NOT RUN: <reason>, and it is not a FAIL. Only merge-gate.sh's own
 #      judgement about the commit exits 1, so a caller reading exit codes can
 #      tell a verdict from an errand.
@@ -129,33 +129,6 @@ if [ -n "$MASTER_OID" ]; then
   [ "${#MASTER_OID}" -eq 40 ] || die_usage "not a full 40-character object id: $MASTER_OID"
 fi
 
-# --- red line: this box holds no secrets ------------------------------------
-
-# Re-checked on every run, not just at provisioning time. ssh can carry variables
-# across with SendEnv/PermitUserEnvironment, and a shell profile can acquire one
-# months after provisioning; a worker that runs with a token in its environment is
-# outside the boundary this design was approved under, so it refuses rather than
-# produces a verdict.
-# The same list provision.sh checks, under the same variable name, because the
-# two are one red line stated twice: a variable that provisioning refuses to
-# finish with must also be a variable a gate refuses to run with, and the pair
-# has drifted apart before. scripts/gate-worker/gate-worker.test.mjs fails if
-# they stop matching.
-SECRET_VARS="OPERATOR_TOKEN RUNNER_TOKEN AGENTOS_API_TOKEN AGENTOS_SESSION_TOKEN AGENTOS_FENCING_TOKEN VITE_API_TOKEN ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN GH_TOKEN GITHUB_TOKEN FEISHU_APP_SECRET"
-
-for var in $SECRET_VARS; do
-  eval "value=\${$var:-}"
-  # shellcheck disable=SC2154
-  if [ -n "$value" ]; then
-    # Not a FAIL: the gate never ran. This box being outside the boundary it was
-    # approved under is a stop, and calling it a verdict about the commit would
-    # be a lie in both directions.
-    printf 'run-gate: %s is set in this environment; the gate worker holds no credentials\n' "$var" >&2
-    printf 'GATE NOT RUN: worker environment carries %s\n' "$var"
-    exit "$EXIT_NO_VERDICT"
-  fi
-done
-
 # --- preconditions ----------------------------------------------------------
 
 # A verdict about the commit. Reserved for the one precondition that is a
@@ -184,8 +157,8 @@ command -v flock >/dev/null 2>&1 || no_verdict "flock is not installed on the wo
 # install: a documentation branch that rewrites history should be told that,
 # not told about a daemon it never needed. One ordering, defined in one place.
 
-# The commit has to already be in the mirror. The worker never fetches — it has no
-# GitHub credential and its mirror has no remote — so "unknown commit" always
+# The commit has to already be in the mirror. The worker never fetches because
+# its mirror has no remote, so "unknown commit" always
 # means the local machine has not pushed it yet, and saying so precisely is the
 # difference between a one-command fix and a debugging session.
 if ! git -C "$MIRROR_DIR" cat-file -e "${OID}^{commit}" 2>/dev/null; then

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -992,7 +992,7 @@ fi
 # one way a data directory in RAM could run the machine out of it. Checkpoints
 # are cheap here precisely because fsync is off.
 say "Starting a throwaway PostgreSQL (${POSTGRES_IMAGE}, tmpfs data directory, durability off)"
-DBTEST_CONCURRENCY="$(node -e 'const { availableParallelism } = require("node:os"); process.stdout.write(String(Math.max(1, Math.min(availableParallelism() - 1, 3))))')"
+DBTEST_CONCURRENCY="$(node -e 'const { availableParallelism } = require("node:os"); process.stdout.write(String(Math.max(1, Math.min(availableParallelism() - 1, 4))))')"
 export AGENTOS_DBTEST_CONCURRENCY="${DBTEST_CONCURRENCY}"
 docker run -d --rm --name "${CONTAINER}" \
   -e POSTGRES_USER=agentos -e POSTGRES_PASSWORD=gate-scratch-fixture-password-000000 \
@@ -1020,7 +1020,7 @@ for _ in $(seq 1 90); do
 done
 [ "${ready}" -eq 1 ] || die "PostgreSQL did not become ready"
 note "127.0.0.1:${PGPORT}, database agentos_gate, deleted when this script exits"
-note "dbtest concurrency: ${AGENTOS_DBTEST_CONCURRENCY} (min(available cores minus one, stable ceiling 3), via the per-file DBTEST plan)"
+note "dbtest concurrency: ${AGENTOS_DBTEST_CONCURRENCY} (min(available cores minus one, stable ceiling 4), via the per-file DBTEST plan)"
 
 # The database is called agentos_gate rather than agentos, and the schema is a
 # dedicated non-public one: the dbtest harness drops and re-applies whatever


### PR DESCRIPTION
## Summary
- prefer the desktop gate worker and fall back to the VPS without using the Mac automatically
- provision native Node build dependencies and permit credentials on trusted workers
- raise DB test concurrency to four after ten consecutive green desktop trials
- fix first-deployment mirror dry-run and bound SSH failure detection

## Verification
- `node --test scripts/gate-worker/gate-dispatch.test.mjs scripts/gate-worker/gate-worker.test.mjs` (54/54)
- public snapshot scanner tests (20/20)
- `MERGE GATE: PASS d81137bfca8714a2b6524d52d8eaff684ac51859` on `ci-desktop-worker`
- DB concurrency 4: ten consecutive green benchmark trials; median 83-84s versus 93s at concurrency 3