### PR TITLE
feat(gate): add measured desktop worker capacity

### DIFF
--- a/apps/web/src/tests/proxy-boundary.e2e.test.ts
+++ b/apps/web/src/tests/proxy-boundary.e2e.test.ts
@@ -59,7 +59,10 @@ before(async () => {
     configFile: fileURLToPath(new URL("../../vite.config.ts", import.meta.url)),
     root: fileURLToPath(new URL("../../", import.meta.url)),
     logLevel: "silent",
-    server: { port: 0, host: "127.0.0.1" },
+    // Vite normalises port 0 back to its development default. Let this test
+    // advance to the next loopback port when another isolated GATE already owns
+    // 5173; the assertions read the address it actually bound below.
+    server: { port: 0, host: "127.0.0.1", strictPort: false },
     // Nothing here asks for a module, so the dependency scanner would only cost
     // seconds and leave work in flight at `close()`. The transport boundary is
     // what is under test; the bundler is not.

--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -12,16 +12,16 @@ PostgreSQL, database preflight tests and the API dbtests. The pre-optimization
 worker baseline measured on 2026-08-23 was about 6 minutes 7 seconds with the
 worker to themselves. Two
 overlapping full gates took 8 minutes 14 seconds and 8 minutes 42 seconds on the
-same four vCPUs, which is why the worker now exposes one execution slot. The
-current gate removes the redundant whole-workspace typecheck and generates
-Prisma Client inside `npm ci`; an exact-head build-cache hit also removes the
-roughly 42-second build. Unit and database proof waves run serially because each
-already uses bounded internal concurrency; overlapping them caused passing
-standalone suites to time out under host contention. Database files use at most
-four workers. A 12-vCPU worker measured 93 seconds at concurrency 3 and 83–85
-seconds across ten consecutive green runs at concurrency 4, with no leaked
-scratch databases. The install-free `docs-only` profile takes
-about 4 seconds. Use
+same four vCPUs, which is why a worker exposes one execution slot unless that
+exact host has been accepted for two. The current gate removes the redundant
+whole-workspace typecheck and generates Prisma Client inside `npm ci`; an
+exact-head build-cache hit also removes the roughly 42-second build. Unit and
+database proof waves run serially because each already uses bounded internal
+concurrency; overlapping them caused passing standalone suites to time out
+under host contention. Database files use at most four workers. A 12-vCPU
+worker measured 93 seconds at concurrency 3 and 83–85 seconds across ten
+consecutive green runs at concurrency 4, with no leaked scratch databases. The
+install-free `docs-only` profile takes about 4 seconds. Use
 `scripts/gate-worker/bench-postgres.sh` and
 `scripts/gate-worker/bench-dbtest-concurrency.sh` when changing the database
 runner itself; each alternates its arms over one fixed commit so a tuning claim
@@ -33,10 +33,10 @@ Everything here is `scripts/gate-worker/`:
 | --- | --- | --- |
 | `provision.sh` | the server | Installs the pinned toolchain and creates `~/gate/`. Idempotent, dry-run by default. |
 | `mirror-push.sh` | the local machine | Pushes one exact candidate and one exact baseline into immutable `refs/gate/.../<oid>` cache refs, creating `~/gate/<repo>/mirror.git` on first push, and installs `run-gate.sh` beside it. |
-| `run-gate.sh` | the server | Holds the worker-wide execution lock, checks one oid out of its repository's mirror and runs `scripts/merge-gate.sh --expect-head <oid> --master <baseline-oid>` against it. |
+| `run-gate.sh` | the server | Holds one configured worker-wide execution slot, checks one oid out of its repository's mirror and runs `scripts/merge-gate.sh --expect-head <oid> --master <baseline-oid>` against it. |
 | `remote-gate.sh` | the local machine | One synchronous `ssh` call; returns the verdict line and the exit code. |
 | `gate-dispatch.sh` | the local machine | Freezes the candidate and integration baseline, then tries the primary worker and fallback worker. Local execution is explicit only. |
-| `lib.sh` | the local machine | Shared repository-name derivation for the three local-side scripts. |
+| `lib.sh` | both | Shared input validation and atomic pid-slot locking. |
 
 The worker hosts one directory per repository, keyed by the origin repository's
 name: `~/gate/<repo>/{mirror.git,worktrees,logs,run-gate.sh}`. The toolchain is
@@ -47,12 +47,13 @@ ships.
 
 ## The slot model
 
-A full gate is a whole-machine load. The dispatcher cannot know the
-candidate-selected profile before running it, so it rations machines, not
-processes: the primary worker contributes one slot and the fallback worker
-contributes one. The local machine contributes no automatic capacity; it adds
-one slot only for an invocation that passes `--allow-local` or sets
-`AGENTOS_GATE_ALLOW_LOCAL=1`.
+A full gate can consume a host. The dispatcher cannot know the
+candidate-selected profile before running it, so it rations fixed, measured
+host capacity rather than trying to resize from live CPU or memory readings.
+The default topology is two slots on the primary desktop worker and one on the
+fallback worker. The explicit `--server` form contributes one dispatcher slot.
+The local machine contributes no automatic capacity; it adds one slot only for
+an invocation that passes `--allow-local` or sets `AGENTOS_GATE_ALLOW_LOCAL=1`.
 
 `gate-dispatch.sh` is the way to run a gate when anything else might also be
 running one:
@@ -70,7 +71,7 @@ scripts/gate-worker/gate-dispatch.sh <oid>
   oid-named cache refs. The local checkout may be detached or single-branch;
   its incomplete ref namespace is never mirrored and cannot delete worker refs.
 - If the primary is offline, its mirror push fails, its SSH connection drops,
-  or its slot is busy, the fallback receives the same frozen candidate and
+  or both of its slots are busy, the fallback receives the same frozen candidate and
   baseline. A real `PASS`, `FAIL`, or `NOT AUTHORITATIVE` result is final; only
   absence of a verdict falls through to another machine. SSH connection setup
   is bounded at 10 seconds, and a dead established connection is detected by
@@ -92,14 +93,16 @@ scripts/gate-worker/gate-dispatch.sh <oid>
   around it exits 76 rather than 75. Waiting for a lock nobody can take is
   waiting for nothing, and reporting it as a full queue hides what to fix.
 
-The dispatcher accounts for `remote-1`, `remote-2`, and optional `local` under
-`~/.cache/gate-dispatch/`, outside any repository because the slots belong to
-the machines. A direct `merge-gate.sh` bypasses that accounting. A direct
-`remote-gate.sh` bypasses the local lock too, but it cannot add worker capacity:
-every installed `run-gate.sh` contends for the worker-wide
-`~/gate/.full-gate.lock`, held with `flock` for the real process lifetime. If an
-SSH connection drops while its remote process survives, that process keeps the
-worker lock and a later invocation waits instead of running beside it.
+The dispatcher accounts for `remote-1`, `remote-1-2`, `remote-2`, and optional
+`local` under `~/.cache/gate-dispatch/`, outside any repository because the
+slots belong to the machines. A direct `merge-gate.sh` bypasses that accounting. A direct
+`remote-gate.sh` bypasses the local lock too, but it cannot exceed worker
+capacity: every installed `run-gate.sh` contends for the worker-wide
+`~/gate/.full-gate.lock` and, only on a capacity-two host,
+`~/gate/.full-gate-2.lock`. Each is held with `flock` for the real process
+lifetime. If an SSH connection drops while its remote process survives, that
+process keeps its worker slot and a later invocation waits instead of exceeding
+the configured capacity.
 
 A lock is a file created with `ln`, holding the pid of the dispatcher that owns
 it. That shape is deliberate and `scripts/gate-worker/lib.sh` explains it:
@@ -267,6 +270,12 @@ It does **not** check or install any egress rule: the worker is not
 network-isolated by design (see the operating boundaries), so there is no
 firewall step between provisioning and the first gate.
 
+An absent `~/gate/worker-capacity` means one whole-GATE slot. Capacity two is a
+deliberate host acceptance, not an automatic core-count rule. Temporarily set
+the file to the exact value `2` for step 5 and retain it only if that acceptance
+passes. `run-gate.sh` refuses every other value and never creates a third slot.
+Removing the file returns the worker to one slot.
+
 **2. Push the exact gate inputs (local).** The first push creates
 `~/gate/<repo>/mirror.git` and installs `run-gate.sh` beside it.
 
@@ -310,6 +319,16 @@ scripts/gate-worker/remote-gate.sh ci-desktop-worker <oid> # remote
 Both must end in `MERGE GATE: PASS <oid>` naming the same oid. Record both
 lines in the PR.
 
+**5. Capacity-two acceptance.** This is required only for a host proposed for
+two slots. Use one fixed full-profile commit and a warm build cache. Record
+three single runs, then five rounds with two `remote-gate.sh` processes started
+together. Sample host CPU, memory availability and memory pressure during each
+round. Keep `worker-capacity=2` only when all ten overlapping gates pass, none
+times out or leaks a database/worktree, there is no OOM or sustained memory
+pressure, and the median two-gate batch finishes at least 15 percent sooner
+than running two median single gates serially. Otherwise remove the capacity
+file; one slot remains the supported result rather than a degraded fallback.
+
 ## Routine use
 
 ```sh
@@ -322,15 +341,16 @@ the terminal for the whole gate.
 There is no queue file and no daemon by design: the state a queue would need is
 exactly the state that makes a worker something to operate rather than
 something to use, and the callers — agent sessions blocking on their own
-merges — are the backpressure. When both remote slots are occupied, every later
-caller waits and re-polls; requests are not pinned to a machine and strict FIFO
-order is not promised. The first waiter to acquire whichever slot frees runs
-there.
+merges — are the backpressure. When all three automatic remote slots are
+occupied, every later caller waits and re-polls; requests are not pinned to a
+machine and strict FIFO order is not promised. The first waiter to acquire
+whichever slot frees runs there.
 
 The database step runs cores-1 files at once, capped at four: three on a
 four-vCPU worker and four on larger workers. Each gets a database of its own and
 its own subdirectory of the roots the gate exports. A worker permits one gate
-at a time; `AGENTOS_DBTEST_CONCURRENCY` lowers the file concurrency and
+by default or two only when `~/gate/worker-capacity` contains `2`;
+`AGENTOS_DBTEST_CONCURRENCY` lowers the file concurrency and
 `AGENTOS_DBTEST_PROVISION=0` puts the step back on one shared schema, serial.
 
 ## Troubleshooting
@@ -359,9 +379,10 @@ ssh agentos-gate 'ls -la ~/gate/<repo>/worktrees'
 ssh agentos-gate 'rm -rf ~/gate/<repo>/worktrees/gate-<oid>-<stamp>-<pid> && git -C ~/gate/<repo>/mirror.git worktree prune'
 ```
 
-**`GATE DISPATCH: NO SLOT` keeps recurring** — the two slots are systemically
-full. That is a capacity signal, not an error to retry harder: either stagger
-the merges, or revisit the worker's sizing with the bench scripts.
+**`GATE DISPATCH: NO SLOT` keeps recurring** — the configured slots are
+systemically full. That is a capacity signal, not an error to retry harder:
+either stagger the merges, or repeat the same-commit overlap acceptance before
+changing host capacity.
 
 **`GATE NOT RUN: the slot locks are unusable (...)`** — the named slots have a
 lock this dispatcher cannot operate, so nothing was gated and nothing will be
@@ -415,7 +436,7 @@ minor difference, a timing-sensitive dbtest), and a divergence here is exactly
 what a second machine is for.
 
 **Reading logs.** They stay on the worker at
-`~/gate/<repo>/logs/<stamp>-<oid>.log`, one per run, and are never pruned
+`~/gate/<repo>/logs/<stamp>-<oid>-<pid>.log`, one per run, and are never pruned
 automatically — a log is small and the reason a verdict happened is worth
 keeping. Trim them by hand when the disk asks:
 
@@ -434,6 +455,8 @@ interpreter than the local one is weaker evidence than it looks.
 ## Undoing it
 
 The local machine carries only the slot lock files under
-`~/.cache/gate-dispatch/`, which are inert when nothing runs. To retire one repository from the worker,
-delete `~/gate/<repo>` on it; to decommission the worker, delete `~/gate`.
+`~/.cache/gate-dispatch/`, which are inert when nothing runs. To return a
+capacity-two worker to one slot, remove `~/gate/worker-capacity` after its gates
+finish. To retire one repository from the worker, delete `~/gate/<repo>` on it;
+to decommission the worker, delete `~/gate`.
 Gating locally is, and remains, `bash scripts/merge-gate.sh`.

--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -16,9 +16,10 @@ same four vCPUs, which is why a worker exposes one execution slot unless that
 exact host has been accepted for two. The current gate removes the redundant
 whole-workspace typecheck and generates Prisma Client inside `npm ci`; an
 exact-head build-cache hit also removes the roughly 42-second build. Unit and
-database proof waves run serially because each already uses bounded internal
-concurrency; overlapping them caused passing standalone suites to time out
-under host contention. Database files use at most four workers. A 12-vCPU
+database proof waves run serially inside each gate because each already uses
+bounded internal concurrency. Database files use at most four workers in a
+single-slot worker; a capacity-two worker automatically uses two per gate so
+the host-wide database fan-out remains four. A 12-vCPU
 worker measured 93 seconds at concurrency 3 and 83–85 seconds across ten
 consecutive green runs at concurrency 4, with no leaked scratch databases. The
 install-free `docs-only` profile takes about 4 seconds. Use
@@ -261,6 +262,10 @@ version on 2026-08-18; `package.json` engines only sets a floor), installs
 Docker with registry mirrors, the native Node build dependencies, and a Git
 fixture identity when the account has none; it points npm at
 `registry.npmmirror.com`, pre-pulls `postgres:16-alpine`, and creates `~/gate/`.
+On a VMware guest it also disables VMware's time synchronization and enables
+Ubuntu NTP. Two independent time disciplines caused the guest wall clock to
+step backwards under sustained load; database ordering and ready-time tests
+then failed even with only one gate running.
 
 If it adds the account to the `docker` group, **log out and back in and re-run
 it** — group membership does not apply to the session that granted it, and the
@@ -329,6 +334,18 @@ pressure, and the median two-gate batch finishes at least 15 percent sooner
 than running two median single gates serially. Otherwise remove the capacity
 file; one slot remains the supported result rather than a degraded fallback.
 
+The 12-vCPU, 20-GiB desktop VM passed this acceptance on 2026-08-24 at commit
+`7886fad3ee03380672832166337c804726b5aec9`, after VMware time synchronization
+was disabled and Ubuntu NTP was the sole time discipline. Three warm single
+runs took 241, 240 and 240 seconds (median 240). Five two-gate batches took
+270, 270, 270, 271 and 270 seconds (median 270); all ten overlapping gates
+passed. The median batch was 43.8 percent faster than two median single gates
+run serially. Peak CPU reached 100 percent, peak used memory was 5.50 GiB, at
+least 13.37 GiB remained available, and there was no OOM, sustained memory
+pressure, leaked container, database, worktree or held slot. The retained
+desktop setting is therefore `worker-capacity=2`; the four-vCPU fallback stays
+at its default capacity of one.
+
 ## Routine use
 
 ```sh
@@ -346,11 +363,13 @@ occupied, every later caller waits and re-polls; requests are not pinned to a
 machine and strict FIFO order is not promised. The first waiter to acquire
 whichever slot frees runs there.
 
-The database step runs cores-1 files at once, capped at four: three on a
-four-vCPU worker and four on larger workers. Each gets a database of its own and
-its own subdirectory of the roots the gate exports. A worker permits one gate
-by default or two only when `~/gate/worker-capacity` contains `2`;
-`AGENTOS_DBTEST_CONCURRENCY` lowers the file concurrency and
+The database step normally runs cores-1 files at once, capped at four: three on
+a four-vCPU worker and four on larger single-slot workers. Each gets a database
+of its own and its own subdirectory of the roots the gate exports. A worker
+permits one gate by default or two only when `~/gate/worker-capacity` contains
+`2`; in capacity-two mode `run-gate.sh` fixes each gate's database concurrency
+at two, keeping the host-wide maximum at four. `AGENTOS_DBTEST_CONCURRENCY`
+lowers the file concurrency on other paths and
 `AGENTOS_DBTEST_PROVISION=0` puts the step back on one shared schema, serial.
 
 ## Troubleshooting
@@ -434,6 +453,12 @@ local PASS alone. Fetch the remote log (`--fetch-log`) and read the failing
 step first; the interesting cases are real (a platform-dependent test, a Node
 minor difference, a timing-sensitive dbtest), and a divergence here is exactly
 what a second machine is for.
+
+**Timing assertions fail intermittently on a VMware guest** — check both time
+disciplines before changing tests. `vmware-toolbox-cmd timesync status` must say
+`Disabled`, while `timedatectl show -p NTP -p NTPSynchronized` must report both
+as `yes`. Re-run `provision.sh --apply` to converge that state. Do not leave
+VMware periodic synchronization and Ubuntu NTP enabled together.
 
 **Reading logs.** They stay on the worker at
 `~/gate/<repo>/logs/<stamp>-<oid>-<pid>.log`, one per run, and are never pruned

--- a/packages/runner/src/exec.test.ts
+++ b/packages/runner/src/exec.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import test from "node:test";
 
 import { CommandTimeoutError, KILL_GRACE_MS, runCommand } from "./exec.js";
@@ -49,10 +50,13 @@ test("a command that ignores SIGTERM is escalated to SIGKILL", async () => {
   try {
     // `exec` keeps the ignored SIGTERM disposition across the exec, so the
     // entire group survives the polite signal and only SIGKILL ends it.
-    const started = Date.now();
+    // The timeout implementation uses Node's monotonic timers. Measure it with
+    // the same kind of clock: VM wall-clock synchronisation may move Date.now()
+    // backwards while the SIGTERM grace is elapsing.
+    const started = performance.now();
     const error = await runCommand([], "/bin/sh", ["-c", "trap '' TERM; exec sleep 30"], directory, env, { timeoutMs: 300 })
       .then(() => null, (reason: unknown) => reason);
-    const elapsed = Date.now() - started;
+    const elapsed = performance.now() - started;
     assert.ok(error instanceof Error);
     assert.match(error.message, /timed out after 300ms/);
     assert.ok(elapsed >= 300 + KILL_GRACE_MS, `expected the SIGTERM grace to elapse, took ${elapsed}ms`);

--- a/scripts/gate-worker/gate-dispatch.sh
+++ b/scripts/gate-worker/gate-dispatch.sh
@@ -9,8 +9,9 @@
 #   scripts/gate-worker/gate-dispatch.sh <oid> --allow-local
 #   scripts/gate-worker/gate-dispatch.sh <oid> --server <one-server>
 #
-# The slot model: gates are whole-machine loads, so what is being rationed is
-# machines, not processes. Each remote worker contributes one slot. The local
+# The slot model rations measured host capacity, not arbitrary processes. The
+# default desktop worker contributes two fixed slots and the fallback worker
+# contributes one. The explicit --server form remains one slot. The local
 # machine contributes one only when --allow-local (or AGENTOS_GATE_ALLOW_LOCAL=1)
 # says this invocation may spend its resources.
 #
@@ -20,9 +21,9 @@
 # itself and says why it is shaped the way it is. Every dispatch on this machine
 # contends for the same slots. A direct merge-gate.sh is invisible to this
 # accounting. A direct
-# remote-gate.sh bypasses the local accounting too, but run-gate.sh holds the
-# worker-wide execution lock for the real process lifetime, so it can wait but
-# cannot turn one worker slot into concurrent full gates.
+# remote-gate.sh bypasses the local accounting too, but run-gate.sh enforces the
+# worker's configured capacity with worker-wide execution locks held for the
+# real process lifetime.
 #
 # The optional local slot is only eligible when this worktree is already the
 # thing a local gate would test: HEAD at the requested commit and the tree clean.
@@ -72,9 +73,11 @@ EXIT_NO_VERDICT=76
 
 PRIMARY_SERVER="${AGENTOS_GATE_PRIMARY_SERVER:-ci-desktop-worker}"
 FALLBACK_SERVER="${AGENTOS_GATE_FALLBACK_SERVER:-agentos-gate}"
+SINGLE_SERVER=0
 if [ -n "${AGENTOS_GATE_SERVER:-}" ]; then
   PRIMARY_SERVER="$AGENTOS_GATE_SERVER"
   FALLBACK_SERVER=""
+  SINGLE_SERVER=1
 fi
 ALLOW_LOCAL="${AGENTOS_GATE_ALLOW_LOCAL:-0}"
 POLL_SECONDS="${GATE_DISPATCH_POLL_SECONDS:-30}"
@@ -100,8 +103,8 @@ while [ $# -gt 0 ]; do
     --master=*) MASTER_OID="$(printf '%s' "${1#--master=}" | tr '[:upper:]' '[:lower:]')" ;;
     --server)
       [ $# -ge 2 ] || die "--server needs a value"
-      PRIMARY_SERVER="$2"; FALLBACK_SERVER=""; shift ;;
-    --server=*) PRIMARY_SERVER="${1#--server=}"; FALLBACK_SERVER="" ;;
+      PRIMARY_SERVER="$2"; FALLBACK_SERVER=""; SINGLE_SERVER=1; shift ;;
+    --server=*) PRIMARY_SERVER="${1#--server=}"; FALLBACK_SERVER=""; SINGLE_SERVER=1 ;;
     --primary-server)
       [ $# -ge 2 ] || die "--primary-server needs a value"
       PRIMARY_SERVER="$2"; shift ;;
@@ -123,6 +126,12 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$SINGLE_SERVER" -eq 1 ]; then
+  PRIMARY_SLOTS=(remote-1)
+else
+  PRIMARY_SLOTS=(remote-1 remote-1-2)
+fi
 
 case "$TIMEOUT_MINUTES" in ''|*[!0-9]*) die "--timeout-minutes needs a number, got: $TIMEOUT_MINUTES" ;; esac
 case "$POLL_SECONDS" in ''|*[!0-9]*|0) die "GATE_DISPATCH_POLL_SECONDS needs a positive number, got: $POLL_SECONDS" ;; esac
@@ -234,7 +243,7 @@ local_eligible() {
 
 mkdir -p "$SLOT_ROOT" || die "could not create ${SLOT_ROOT}" "$EXIT_NO_VERDICT"
 
-printf 'gate-dispatch: %s, primary %s(1)' "$OID" "$PRIMARY_SERVER" >&2
+printf 'gate-dispatch: %s, primary %s(%s)' "$OID" "$PRIMARY_SERVER" "${#PRIMARY_SLOTS[@]}" >&2
 [ -n "$FALLBACK_SERVER" ] && printf ', fallback %s(1)' "$FALLBACK_SERVER" >&2
 [ "$ALLOW_LOCAL" -eq 1 ] && printf ', local(1, explicit)' >&2
 printf ', poll %ss, timeout %smin\n' "$POLL_SECONDS" "$TIMEOUT_MINUTES" >&2
@@ -293,27 +302,29 @@ while :; do
   # a busy slot frees when its gate ends, a broken one does not free at all.
   round_busy=0
   round_broken=""
-  outcome=0
-
   if [ "$PRIMARY_DISABLED" -eq 0 ]; then
-    try_slot remote-1 || outcome=$?
-    case "$outcome" in
-      0)
-        run_remote primary "$PRIMARY_SERVER"
-        case "$REMOTE_STATUS" in
-          0|1|3) [ -n "$REMOTE_OUTPUT" ] && printf '%s\n' "$REMOTE_OUTPUT"; exit "$REMOTE_STATUS" ;;
-          *)
-            printf 'gate-dispatch: primary produced no verdict (exit %s); trying fallback capacity\n' "$REMOTE_STATUS" >&2
-            [ -n "$REMOTE_OUTPUT" ] && printf 'gate-dispatch: primary said: %s\n' "$REMOTE_OUTPUT" >&2
-            release_slot
-            PRIMARY_DISABLED=1
-            UNAVAILABLE_EVER="${UNAVAILABLE_EVER} remote-1"
-            ;;
-        esac
-        ;;
-      1) round_busy=$(( round_busy + 1 )) ;;
-      *) round_broken="${round_broken} remote-1" ;;
-    esac
+    for primary_slot in "${PRIMARY_SLOTS[@]}"; do
+      outcome=0
+      try_slot "$primary_slot" || outcome=$?
+      case "$outcome" in
+        0)
+          run_remote primary "$PRIMARY_SERVER"
+          case "$REMOTE_STATUS" in
+            0|1|3) [ -n "$REMOTE_OUTPUT" ] && printf '%s\n' "$REMOTE_OUTPUT"; exit "$REMOTE_STATUS" ;;
+            *)
+              printf 'gate-dispatch: primary produced no verdict (exit %s); trying fallback capacity\n' "$REMOTE_STATUS" >&2
+              [ -n "$REMOTE_OUTPUT" ] && printf 'gate-dispatch: primary said: %s\n' "$REMOTE_OUTPUT" >&2
+              release_slot
+              PRIMARY_DISABLED=1
+              UNAVAILABLE_EVER="${UNAVAILABLE_EVER} primary"
+              break
+              ;;
+          esac
+          ;;
+        1) round_busy=$(( round_busy + 1 )) ;;
+        *) round_broken="${round_broken} ${primary_slot}" ;;
+      esac
+    done
   fi
 
   outcome=0

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -3,9 +3,10 @@
 //
 // Two things are under test and both are mechanisms, not text.
 //
-// The first is the capacity invariant: two slots, and never a third. That is
-// a concurrency property, so the cases here run real concurrent processes
-// against a real lock root. The bug they exist for is specific — a slot lock
+// The first is the per-slot capacity invariant: one holder for each named slot,
+// never two holders in one slot. That is a concurrency property, so the cases
+// here run real concurrent processes against a real lock root. The bug they
+// exist for is specific — a slot lock
 // that is created before it names its owner has a window in which a second
 // dispatcher reads "no owner", calls the lock abandoned and takes the slot its
 // owner is gating in — and `refuses a lock that names no pid` reproduces
@@ -458,7 +459,7 @@ test("every slot busy times out at 75 with no verdict", (t) => {
   const cache = join(scratch(t), "cache");
   const slots = join(cache, "gate-dispatch");
   mkdirSync(slots, { recursive: true });
-  for (const slot of ["remote-1", "remote-2"]) {
+  for (const slot of ["remote-1", "remote-1-2", "remote-2"]) {
     writeFileSync(join(slots, `${slot}.slot`), `${process.pid}\n`);
   }
   const result = spawnSync(
@@ -516,12 +517,35 @@ test("locks that cannot be operated are 76 at once, not 75 after the timeout", (
   assert.ok(Date.now() - started < 20_000, "it polled instead of answering at once");
 });
 
-test("a busy primary spills onto the fallback without using the Mac", (t) => {
+test("one busy desktop slot uses the second desktop slot before fallback", (t) => {
   const repo = fixtureRepo(t, {});
   const cache = join(scratch(t), "cache");
   const slots = join(cache, "gate-dispatch");
   mkdirSync(slots, { recursive: true });
   writeFileSync(join(slots, "remote-1.slot"), `${process.pid}\n`);
+  const result = spawnSync(
+    "bash",
+    [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head],
+    {
+      cwd: repo.root,
+      encoding: "utf8",
+      env: { ...GIT_ENV, XDG_CACHE_HOME: cache, GATE_DISPATCH_POLL_SECONDS: "1" },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /MERGE GATE: PASS/);
+  assert.match(result.stderr, /running on primary/);
+  assert.doesNotMatch(result.stderr, /running on fallback/);
+});
+
+test("two busy desktop slots spill onto the fallback without using the Mac", (t) => {
+  const repo = fixtureRepo(t, {});
+  const cache = join(scratch(t), "cache");
+  const slots = join(cache, "gate-dispatch");
+  mkdirSync(slots, { recursive: true });
+  for (const slot of ["remote-1", "remote-1-2"]) {
+    writeFileSync(join(slots, `${slot}.slot`), `${process.pid}\n`);
+  }
   const result = spawnSync(
     "bash",
     [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head],
@@ -540,7 +564,7 @@ test("a busy primary spills onto the fallback without using the Mac", (t) => {
 test("busy plus broken waits out the timeout and then reports 76, not 75", (t) => {
   // The mixed case. One slot is genuinely busy, so waiting is justified and the
   // dispatch must not give up early — but when the wait ends empty, the answer
-  // is not "the queue was full": one of the two slots was never available to
+  // is not "the queue was full": one of the three slots was never available to
   // anybody, and 75 would send the operator to re-dispatch into the same broken
   // locks. Nothing may be taken here either, so the capacity limit holds.
   const repo = fixtureRepo(t, {});
@@ -548,6 +572,7 @@ test("busy plus broken waits out the timeout and then reports 76, not 75", (t) =
   const slots = join(cache, "gate-dispatch");
   mkdirSync(slots, { recursive: true });
   writeFileSync(join(slots, "remote-1.slot"), `${process.pid}\n`);
+  writeFileSync(join(slots, "remote-1-2.slot"), `${process.pid}\n`);
   mkdirSync(join(slots, "remote-2.lock"));
   const result = spawnSync(
     "bash",

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -502,9 +502,11 @@ test("the default worker capacity serializes gates from different repositories",
 test("worker capacity two admits exactly two gates and keeps concurrent logs distinct", (t) => {
   const workerRoot = scratch(t);
   const starts = join(workerRoot, "starts");
+  const dbtestConcurrency = join(workerRoot, "dbtest-concurrency");
   const release = join(workerRoot, "release");
   const verdict = `
     printf '%s\n' "$$" >> "$WORKER_LOCK_STARTS"
+    printf '%s\n' "\${AGENTOS_DBTEST_CONCURRENCY:-unset}" >> "$WORKER_DBTEST_CONCURRENCY"
     while [ ! -f "$WORKER_LOCK_RELEASE" ]; do sleep 0.05; done
     printf 'MERGE GATE: PASS fixture\n'
   `;
@@ -546,12 +548,14 @@ test("worker capacity two admits exactly two gates and keeps concurrent logs dis
         GATE_OID: fixture.oid,
         WORKER_ROOT: workerRoot,
         WORKER_LOCK_STARTS: starts,
+        WORKER_DBTEST_CONCURRENCY: dbtestConcurrency,
         WORKER_LOCK_RELEASE: release,
       },
     },
   );
   assert.equal(result.status, 0, result.stdout + result.stderr);
   assert.equal(readFileSync(starts, "utf8").trim().split("\n").length, 3);
+  assert.deepEqual(readFileSync(dbtestConcurrency, "utf8").trim().split("\n"), ["2", "2", "2"]);
   assert.equal((result.stdout.match(/MERGE GATE: PASS/g) ?? []).length, 3);
   const logs = readdirSync(join(fixture.home, "logs")).filter((name) => name.endsWith(".log"));
   assert.equal(logs.length, 3, `concurrent runs shared a log: ${logs.join(", ")}`);

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -84,6 +84,8 @@ test("provisioning includes the native Node build/runtime dependencies and Git i
   }
   assert.match(source, /git config --global user\.name/);
   assert.match(source, /git config --global user\.email/);
+  assert.match(source, /vmware-toolbox-cmd timesync disable/);
+  assert.match(source, /timedatectl set-ntp true/);
   assert.doesNotMatch(source, /SECRET_VARS=/);
   assert.doesNotMatch(readFileSync(runGatePath, "utf8"), /SECRET_VARS=/);
 });

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -33,6 +33,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   utimesSync,
@@ -442,7 +443,7 @@ test("a malformed STALE_WORKTREE_MINUTES is refused rather than passed to find",
   assert.match(result.stderr, /STALE_WORKTREE_MINUTES/);
 });
 
-test("the worker lock serializes gates from different repositories", (t) => {
+test("the default worker capacity serializes gates from different repositories", (t) => {
   const workerRoot = scratch(t);
   const starts = join(workerRoot, "starts");
   const release = join(workerRoot, "release");
@@ -496,6 +497,73 @@ test("the worker lock serializes gates from different repositories", (t) => {
   assert.equal(result.status, 0, result.stdout + result.stderr);
   assert.equal(readFileSync(starts, "utf8").trim().split("\n").length, 2);
   assert.equal((result.stdout.match(/MERGE GATE: PASS/g) ?? []).length, 2);
+});
+
+test("worker capacity two admits exactly two gates and keeps concurrent logs distinct", (t) => {
+  const workerRoot = scratch(t);
+  const starts = join(workerRoot, "starts");
+  const release = join(workerRoot, "release");
+  const verdict = `
+    printf '%s\n' "$$" >> "$WORKER_LOCK_STARTS"
+    while [ ! -f "$WORKER_LOCK_RELEASE" ]; do sleep 0.05; done
+    printf 'MERGE GATE: PASS fixture\n'
+  `;
+  const fixture = gateHome(t, { verdict, workerRoot });
+  writeFileSync(join(workerRoot, "worker-capacity"), "2\n");
+  const result = spawnSync(
+    "bash",
+    [
+      "-c",
+      `
+        set -uo pipefail
+        for run in 1 2 3; do
+          "$GATE_HOME/run-gate.sh" "$GATE_OID" > "$WORKER_ROOT/$run.out" 2>&1 &
+          eval "pid_$run=$!"
+        done
+        for _ in $(seq 1 100); do
+          [ -s "$WORKER_LOCK_STARTS" ] \
+            && [ "$(wc -l < "$WORKER_LOCK_STARTS" | tr -d ' ')" -ge 2 ] \
+            && break
+          sleep 0.05
+        done
+        [ "$(wc -l < "$WORKER_LOCK_STARTS" | tr -d ' ')" = 2 ] || exit 90
+        sleep 0.3
+        [ "$(wc -l < "$WORKER_LOCK_STARTS" | tr -d ' ')" = 2 ] || exit 91
+
+        : > "$WORKER_LOCK_RELEASE"
+        wait "$pid_1"
+        wait "$pid_2"
+        wait "$pid_3"
+        cat "$WORKER_ROOT/1.out" "$WORKER_ROOT/2.out" "$WORKER_ROOT/3.out"
+      `,
+    ],
+    {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: {
+        ...GIT_ENV,
+        GATE_HOME: fixture.home,
+        GATE_OID: fixture.oid,
+        WORKER_ROOT: workerRoot,
+        WORKER_LOCK_STARTS: starts,
+        WORKER_LOCK_RELEASE: release,
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.equal(readFileSync(starts, "utf8").trim().split("\n").length, 3);
+  assert.equal((result.stdout.match(/MERGE GATE: PASS/g) ?? []).length, 3);
+  const logs = readdirSync(join(fixture.home, "logs")).filter((name) => name.endsWith(".log"));
+  assert.equal(logs.length, 3, `concurrent runs shared a log: ${logs.join(", ")}`);
+});
+
+test("a worker capacity other than one or two is refused without a verdict", (t) => {
+  const fixture = gateHome(t);
+  writeFileSync(join(fixture.root, "worker-capacity"), "3\n");
+  const result = runGate(fixture.home, [fixture.oid]);
+  assert.equal(result.status, 76, result.stdout + result.stderr);
+  assert.match(result.stdout, /^GATE NOT RUN: worker capacity .* must be exactly 1 or 2/m);
+  assert.doesNotMatch(result.stdout, /MERGE GATE/);
 });
 
 // --- the stale-worktree sweep ------------------------------------------------

--- a/scripts/gate-worker/lib.sh
+++ b/scripts/gate-worker/lib.sh
@@ -1,5 +1,6 @@
 # Shared by the local-side gate-worker scripts (mirror-push.sh, remote-gate.sh,
-# gate-dispatch.sh). Not executable on its own; source it.
+# gate-dispatch.sh) and merge-gate.sh's build-cache publisher. Not executable
+# on its own; source it.
 #
 # Two things live here: the values that travel into a remote shell command
 # string, and the slot locks that ration how many gates run at once. Both are

--- a/scripts/gate-worker/provision.sh
+++ b/scripts/gate-worker/provision.sh
@@ -167,6 +167,30 @@ if [ -n "$missing_pkgs" ]; then
   sudo_run apt-get install -y $missing_pkgs || fail "could not install:${missing_pkgs}"
 fi
 
+# VMware's guest time plugin and Ubuntu's NTP service must not both discipline
+# CLOCK_REALTIME. Under sustained gate load the two sources can step the clock
+# backwards, making freshly-created database rows appear to come from the
+# future. Keep VMware's periodic synchronization off and let Ubuntu own the
+# clock. This is a no-op on physical, cloud and non-VMware workers.
+step "Clock discipline"
+if command -v vmware-toolbox-cmd >/dev/null 2>&1; then
+  vmware_timesync="$(vmware-toolbox-cmd timesync status 2>&1 || true)"
+  if [ "$vmware_timesync" = "Disabled" ]; then
+    ok "VMware time synchronization disabled"
+  else
+    sudo_run vmware-toolbox-cmd timesync disable || fail "could not disable VMware time synchronization"
+    did "disabled VMware time synchronization"
+  fi
+  if [ "$(timedatectl show -p NTP --value 2>/dev/null)" = "yes" ]; then
+    ok "Ubuntu NTP enabled"
+  else
+    sudo_run timedatectl set-ntp true || fail "could not enable Ubuntu NTP"
+    did "enabled Ubuntu NTP"
+  fi
+else
+  ok "not a VMware guest"
+fi
+
 # Several gate fixtures create commits in temporary repositories. A fresh cloud
 # image has no Git identity, so those fixtures fail before testing anything. Do
 # not overwrite an operator identity that is already complete; provide a stable

--- a/scripts/gate-worker/run-gate.sh
+++ b/scripts/gate-worker/run-gate.sh
@@ -191,6 +191,15 @@ if [ -e "$WORKER_CAPACITY_FILE" ] || [ -L "$WORKER_CAPACITY_FILE" ]; then
   esac
 fi
 
+# Each full gate normally lets the database harness run four test files at
+# once. Two gates would therefore turn the measured two-slot desktop into an
+# eight-file database host, which is exactly the oversubscription the harness's
+# stable ceiling avoids. Keep the host-wide database fan-out at four when the
+# worker has two slots; every other gate phase remains free to use all CPUs.
+if [ "$WORKER_CAPACITY" -eq 2 ]; then
+  export AGENTOS_DBTEST_CONCURRENCY=2
+fi
+
 # Slot one retains the original lock path, so a rollout beside an older
 # run-gate.sh still counts the old process. Slot two has one additional lock
 # file. Polling both non-blockingly is what lets whichever slot frees first run
@@ -295,6 +304,8 @@ printf 'run-gate: %s\n' "$OID" > "$LOG" 2>/dev/null \
   printf 'run-gate: worker %s\n' "$(uname -srm)"
   printf 'run-gate: node %s, npm %s\n' "$(node -v 2>/dev/null)" "$(npm -v 2>/dev/null)"
   printf 'run-gate: started %s\n' "$STAMP"
+  printf 'run-gate: capacity %s, dbtest concurrency %s\n' \
+    "$WORKER_CAPACITY" "${AGENTOS_DBTEST_CONCURRENCY:-default}"
   printf 'run-gate: worktree %s\n\n' "$WORKTREE"
 } >> "$LOG"
 

--- a/scripts/gate-worker/run-gate.sh
+++ b/scripts/gate-worker/run-gate.sh
@@ -43,12 +43,11 @@
 #      judgement about the commit exits 1, so a caller reading exit codes can
 #      tell a verdict from an errand.
 #
-# The worktree is per-run and unique, but the worker is a whole-machine slot:
-# one worker-wide flock is held by the real process for its entire run. A second
-# invocation waits before creating a worktree. That lock is worker-wide rather
-# than repository-wide so two repositories cannot silently oversubscribe the
-# same four vCPUs, and it survives a dropped ssh connection for as long as the
-# remote gate process survives.
+# The worktree is per-run and unique. The worker contributes one execution slot
+# by default, or two when its worker-capacity file contains 2. Each slot is a
+# worker-wide flock held by the real process for its entire run, so repositories
+# share the same fixed capacity and a dropped ssh connection cannot release a
+# slot while its remote gate process survives.
 #
 # Stateless: nothing is remembered between runs except the mirror and the logs.
 # Re-running the same oid after a dropped connection is the supported recovery,
@@ -175,15 +174,47 @@ fi
 mkdir -p "$WORKTREES_DIR" "$LOGS_DIR" || no_verdict "could not create the gate directories under ${GATE_HOME}"
 
 # The repository directory is one level below the worker root installed by
-# mirror-push.sh. Keep the lock there so every repository on this machine
-# contends for the same physical capacity. flock owns the lifecycle correctly:
-# the kernel releases it only when the run and any surviving child holding the
-# descriptor are gone, not when the caller's ssh connection disappears.
-WORKER_LOCK="$(dirname "$GATE_HOME")/.full-gate.lock"
-exec 9>"$WORKER_LOCK" || no_verdict "could not open the worker lock at ${WORKER_LOCK}"
-printf 'run-gate: waiting for the worker slot\n' >&2
-flock 9 || no_verdict "could not acquire the worker lock at ${WORKER_LOCK}"
-printf 'run-gate: acquired the worker slot\n' >&2
+# mirror-push.sh. Capacity is host state, not repository state: an absent file
+# means one slot, while the only larger supported value is the measured desktop
+# capacity of two. There is no load-sensitive resizing and no third slot.
+WORKER_ROOT="$(dirname "$GATE_HOME")"
+WORKER_CAPACITY_FILE="${WORKER_ROOT}/worker-capacity"
+WORKER_CAPACITY=1
+if [ -e "$WORKER_CAPACITY_FILE" ] || [ -L "$WORKER_CAPACITY_FILE" ]; then
+  [ -f "$WORKER_CAPACITY_FILE" ] && [ ! -L "$WORKER_CAPACITY_FILE" ] \
+    || no_verdict "worker capacity at ${WORKER_CAPACITY_FILE} is not a regular file"
+  WORKER_CAPACITY="$(cat "$WORKER_CAPACITY_FILE" 2>/dev/null)" \
+    || no_verdict "could not read worker capacity at ${WORKER_CAPACITY_FILE}"
+  case "$WORKER_CAPACITY" in
+    1|2) ;;
+    *) no_verdict "worker capacity at ${WORKER_CAPACITY_FILE} must be exactly 1 or 2" ;;
+  esac
+fi
+
+# Slot one retains the original lock path, so a rollout beside an older
+# run-gate.sh still counts the old process. Slot two has one additional lock
+# file. Polling both non-blockingly is what lets whichever slot frees first run
+# the waiter without a queue daemon or mutable scheduler state.
+WORKER_SLOT=""
+printf 'run-gate: waiting for one of %s worker slot(s)\n' "$WORKER_CAPACITY" >&2
+while [ -z "$WORKER_SLOT" ]; do
+  for slot in $(seq 1 "$WORKER_CAPACITY"); do
+    if [ "$slot" -eq 1 ]; then
+      candidate_lock="${WORKER_ROOT}/.full-gate.lock"
+    else
+      candidate_lock="${WORKER_ROOT}/.full-gate-${slot}.lock"
+    fi
+    exec 9>"$candidate_lock" \
+      || no_verdict "could not open worker slot ${slot} at ${candidate_lock}"
+    if flock -n 9; then
+      WORKER_SLOT="$slot"
+      break
+    fi
+    exec 9>&-
+  done
+  [ -n "$WORKER_SLOT" ] || sleep 1
+done
+printf 'run-gate: acquired worker slot %s/%s\n' "$WORKER_SLOT" "$WORKER_CAPACITY" >&2
 
 # --- reclaim what earlier runs abandoned ------------------------------------
 
@@ -228,7 +259,7 @@ sweep_stale_worktrees
 
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 WORKTREE="${WORKTREES_DIR}/gate-${OID}-${STAMP}-$$"
-LOG="${LOGS_DIR}/${STAMP}-${OID}.log"
+LOG="${LOGS_DIR}/${STAMP}-${OID}-$$.log"
 WORKTREE_CREATED=0
 
 # Only ever removes the directory this run created, matched against the name it

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -132,6 +132,11 @@ done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+# Build-cache publication is shared by distinct worktrees on one host. Reuse
+# the tested atomic pid-lock primitive instead of a mkdir-then-pid lock whose
+# empty-owner window lets two concurrent gates both become the writer.
+# shellcheck source=scripts/gate-worker/lib.sh
+. "${SCRIPT_DIR}/gate-worker/lib.sh"
 CONTAINER="agentos-merge-gate-$$"
 # The lock lives in the worktree because the worktree is what is being contended:
 # two checkouts of the same repository may gate at the same time, two gates in one
@@ -331,17 +336,26 @@ dependency_state_key() {
   } | sha256
 }
 
+CACHE_WRITER_ROOT=""
+CACHE_WRITER_SLOT=""
+
 take_cache_writer_lock() {
-  local lock="$1" holder=""
-  if mkdir "${lock}" 2>/dev/null; then
-    printf '%s\n' "$$" > "${lock}/pid"
+  local entry="$1"
+  CACHE_WRITER_ROOT="$(dirname "${entry}")"
+  CACHE_WRITER_SLOT="$(basename "${entry}").writer"
+  if gate_slot_try "${CACHE_WRITER_ROOT}" "${CACHE_WRITER_SLOT}"; then
     return 0
   fi
-  holder="$(cat "${lock}/pid" 2>/dev/null || true)"
-  if [ -n "${holder}" ] && kill -0 "${holder}" 2>/dev/null; then return 1; fi
-  rm -rf -- "${lock}"
-  mkdir "${lock}" 2>/dev/null || return 1
-  printf '%s\n' "$$" > "${lock}/pid"
+  CACHE_WRITER_ROOT=""
+  CACHE_WRITER_SLOT=""
+  return 1
+}
+
+release_cache_writer_lock() {
+  [ -n "${CACHE_WRITER_ROOT}" ] && [ -n "${CACHE_WRITER_SLOT}" ] || return 0
+  gate_slot_release "${CACHE_WRITER_ROOT}" "${CACHE_WRITER_SLOT}" || true
+  CACHE_WRITER_ROOT=""
+  CACHE_WRITER_SLOT=""
 }
 
 install_dependencies() {
@@ -480,10 +494,10 @@ clear_build_outputs() {
 }
 
 publish_build_snapshot() {
-  local entry="$1" key="$2" source_tree="$3" lock="${entry}.writer" staging="" output=""
-  take_cache_writer_lock "${lock}" || return 0
+  local entry="$1" key="$2" source_tree="$3" staging="" output=""
+  take_cache_writer_lock "${entry}" || return 0
   if build_cache_entry_valid "${entry}" "${key}" || [ -e "${entry}" ]; then
-    rm -rf -- "${lock}"
+    release_cache_writer_lock
     return 0
   fi
   staging="$(mktemp -d "${CACHE_ROOT}/.build.${key}.XXXXXXXX")"
@@ -491,7 +505,8 @@ publish_build_snapshot() {
   for output in "${BUILD_OUTPUTS[@]}"; do
     mkdir -p "${staging}/tree/$(dirname "${output}")"
     copy_cache_tree "${source_tree}/${output}" "${staging}/tree/${output}" || {
-      rm -rf -- "${staging}" "${lock}"
+      rm -rf -- "${staging}"
+      release_cache_writer_lock
       note "build snapshot could not be cloned; this run keeps fresh build output"
       return 0
     }
@@ -502,11 +517,12 @@ publish_build_snapshot() {
     || ! chmod a-w "${entry}"; then
     chmod -R u+w "${staging}" 2>/dev/null || true
     chmod -R u+w "${entry}" 2>/dev/null || true
-    rm -rf -- "${staging}" "${entry}" "${lock}"
+    rm -rf -- "${staging}" "${entry}"
+    release_cache_writer_lock
     note "build snapshot could not be published; this run keeps fresh build output"
     return 0
   fi
-  rm -rf -- "${lock}"
+  release_cache_writer_lock
   note "build cache stored: ${key}"
 }
 


### PR DESCRIPTION
## Summary

- add a measured second whole-GATE slot on the primary desktop worker while retaining the VPS as a one-slot fallback
- keep database-test fan-out bounded at four across both desktop slots and isolate concurrent test ports/build-cache publication
- make VMware provisioning use Ubuntu NTP as the sole time discipline
- document the fixed topology, rollback, and capacity-two acceptance evidence

## Validation

- 57 gate-worker/dispatcher tests pass
- 47 profile, snapshot, compose, and dependency contract tests pass
- lint and public snapshot scan pass
- exact commit `7886fad3ee03380672832166337c804726b5aec9`: 3/3 warm single GATEs pass (median 240s)
- same exact commit: 10/10 overlapping GATEs pass (five batches, median 270s; 43.8% faster than serial)
- no OOM, sustained memory pressure, leaked container/database/worktree, or held slot

The exact-head merge gate for the final PR head will be attached before merge.