### PR TITLE
fix(api): extend merge readiness read budget

### DIFF
--- a/packages/api/src/merge-readiness-worker.test.ts
+++ b/packages/api/src/merge-readiness-worker.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  READINESS_CLAIM_LEASE_MS,
+  READINESS_READ_BUDGET_MS,
+} from "./merge-readiness-worker.js";
+
+test("readiness GitHub reads have a 20-second budget within the claim lease", () => {
+  assert.equal(READINESS_READ_BUDGET_MS, 20_000);
+  assert.ok(READINESS_READ_BUDGET_MS < READINESS_CLAIM_LEASE_MS);
+});

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -31,7 +31,8 @@ export const readinessPollIntervalMs = (): number => {
 };
 
 const READINESS_CLAIM_PREFIX = "merge-readiness-claim:";
-const READINESS_LEASE_MS = 30_000;
+export const READINESS_READ_BUDGET_MS = 20_000;
+export const READINESS_CLAIM_LEASE_MS = 30_000;
 
 type RecoveryContext = {
   aggregateId: string;
@@ -94,7 +95,7 @@ const recoveryContextFor = async (
 };
 
 const readinessClaim = (now: Date): string => (
-  `${READINESS_CLAIM_PREFIX}${randomUUID()}|${new Date(now.getTime() + READINESS_LEASE_MS).toISOString()}`
+  `${READINESS_CLAIM_PREFIX}${randomUUID()}|${new Date(now.getTime() + READINESS_CLAIM_LEASE_MS).toISOString()}`
 );
 
 const expiredReadinessClaim = (reason: string | null, now: Date): boolean => {
@@ -400,7 +401,7 @@ export const readinessTick = async (
       continue;
     }
       const controller = new AbortController();
-      timer = setTimeout(() => controller.abort(), 8_000);
+      timer = setTimeout(() => controller.abort(), READINESS_READ_BUDGET_MS);
       const snapshot = await reader.readPullRequest(target.repository, target.prNumber, readiness.repo?.defaultBranch ?? "main", controller.signal);
       if (snapshot.headRefOid !== verdict.verdict.headSha) {
         await requeueRegression(db, {


### PR DESCRIPTION
## Summary

- extend the aggregate GitHub read budget for server-owned merge readiness from 8 seconds to 20 seconds
- keep the budget below the 30-second readiness claim lease
- add a focused timing-policy regression test

## Verification

- focused unit test: pass
- API typecheck: pass
- onboarding timing test after an unrelated first gate failure: 3/3 local pass
- MERGE GATE: PASS 4a1f6ed2fb7cfa543a485ea4ba4a1e647f7461f0