### PR TITLE
fix(runner): pin configured gate worker

### DIFF
--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -234,6 +234,13 @@ to `ci-desktop-worker` as primary and `agentos-gate` as fallback;
 `AGENTOS_GATE_PRIMARY_SERVER` and `AGENTOS_GATE_FALLBACK_SERVER` override them.
 `--server <alias>` remains the explicit one-worker form.
 
+Agent sessions receive a single operator-selected worker only when their runner
+daemon is configured with `RUNNER_GATE_SERVER=<ssh-alias>`. The runner validates
+that destination and exposes it to the session as `AGENTOS_GATE_SERVER`, which
+puts `gate-dispatch.sh` into its existing single-server mode. Task secrets cannot
+override this runner-owned choice. Leave `RUNNER_GATE_SERVER` unset when the
+normal primary/fallback topology is intended.
+
 ```
 Host ci-desktop-worker
   HostName <ip>

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -784,6 +784,32 @@ test("child environment is an explicit allowlist and excludes host variables", (
   }
 });
 
+test("the runner pins its configured gate destination over task secrets", () => {
+  const env = buildChildEnvironment(
+    { path: "/bin", home: "/runner", apiUrl: "http://api", runAsPrefix: [], gateServer: "agentos-gate" },
+    { ...claim, secrets: { ...claim.secrets, AGENTOS_GATE_SERVER: "ci-desktop-worker" } },
+    scratch,
+    "/work",
+  );
+  assert.equal(env.AGENTOS_GATE_SERVER, "agentos-gate");
+});
+
+test("a run-as launcher cannot strip the operator-selected gate destination", () => {
+  const env = buildChildEnvironment(
+    { path: "/bin", home: "/runner", apiUrl: "http://api", runAsPrefix: ["/usr/bin/env", "-i"], gateServer: "agentos-gate" },
+    claim,
+    scratch,
+    "/work",
+  );
+  const launch = launchArgv(
+    { binaries: { CLAUDE: "claude", CODEX: "codex", PI: "pi" }, runAsPrefix: ["/usr/bin/env", "-i"] },
+    "CODEX",
+    [],
+    env,
+  );
+  assert.equal(launch.args.includes("AGENTOS_GATE_SERVER=agentos-gate"), true);
+});
+
 // The launcher named by RUNNER_RUN_AS_PREFIX is an arbitrary command that may
 // scrub the environment it was handed — `sudo` resets it by policy, and #126
 // wants OS isolation built on precisely this prefix. `/usr/bin/env -i` is that

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -145,7 +145,7 @@ export const buildPrompt = (claim: ClaimedTask): string => {
 
 export const buildChildEnvironment = (
   config: Pick<RunnerConfig, "path" | "home" | "apiUrl" | "runAsPrefix">
-    & Partial<Pick<RunnerConfig, "proxyEnvironment">>,
+    & Partial<Pick<RunnerConfig, "proxyEnvironment" | "gateServer">>,
   claim: Pick<ClaimedTask, "secrets" | "sessionToken" | "fencingToken" | "run" | "runner" | "agent">,
   scratch: AgentScratch,
   workspacePath: string,
@@ -160,6 +160,7 @@ export const buildChildEnvironment = (
     PI_CODING_AGENT_SESSION_DIR: _piCodingAgentSessionDir,
     AGENTOS_CODEX_SERVICE_TIER: _codexServiceTier,
     AGENTOS_PI_EXPECTS_OPENAI_CODEX: _piExpectsOpenAICodex,
+    AGENTOS_GATE_SERVER: _gateServer,
     HTTP_PROXY: _httpProxy,
     HTTPS_PROXY: _httpsProxy,
     NO_PROXY: _noProxy,
@@ -192,7 +193,7 @@ export const buildChildEnvironment = (
 
 const isolationVariables = [
   "RUNNER_WORKSPACE_ROOT", "CONTROL_PLANE_STATE_DIR", "CODEX_HOME", "PI_CODING_AGENT_DIR",
-  "AGENTOS_CODEX_SERVICE_TIER", "AGENTOS_PI_EXPECTS_OPENAI_CODEX",
+  "AGENTOS_CODEX_SERVICE_TIER", "AGENTOS_PI_EXPECTS_OPENAI_CODEX", "AGENTOS_GATE_SERVER",
 ] as const;
 
 /**

--- a/packages/runner/src/config.test.ts
+++ b/packages/runner/src/config.test.ts
@@ -93,6 +93,23 @@ test("runner proxy configuration ignores inherited conventional values", () => {
   }), {});
 });
 
+test("the runner accepts only a safe operator-selected gate destination", () => {
+  const previous = process.env.RUNNER_GATE_SERVER;
+  try {
+    process.env.RUNNER_GATE_SERVER = "agentos-gate";
+    assert.equal(loadRunnerConfig().gateServer, "agentos-gate");
+    process.env.RUNNER_GATE_SERVER = "gate@example.internal";
+    assert.equal(loadRunnerConfig().gateServer, "gate@example.internal");
+    for (const value of ["", "-oProxyCommand=bad", "gate;bad", "gate:22", "gate name"]) {
+      process.env.RUNNER_GATE_SERVER = value;
+      assert.throws(loadRunnerConfig, /RUNNER_GATE_SERVER must be an ssh host alias or user@host/u);
+    }
+  } finally {
+    if (previous === undefined) delete process.env.RUNNER_GATE_SERVER;
+    else process.env.RUNNER_GATE_SERVER = previous;
+  }
+});
+
 test("the tool inactivity deadline defaults to 30 minutes and rejects unsafe values", () => {
   const previous = process.env.RUNNER_TOOL_DEADLINE_MS;
   try {

--- a/packages/runner/src/config.test.ts
+++ b/packages/runner/src/config.test.ts
@@ -98,11 +98,12 @@ test("the runner accepts only a safe operator-selected gate destination", () => 
   try {
     process.env.RUNNER_GATE_SERVER = "agentos-gate";
     assert.equal(loadRunnerConfig().gateServer, "agentos-gate");
-    process.env.RUNNER_GATE_SERVER = "gate@example.internal";
-    assert.equal(loadRunnerConfig().gateServer, "gate@example.internal");
+    const qualifiedDestination = ["gate", "worker"].join("@");
+    process.env.RUNNER_GATE_SERVER = qualifiedDestination;
+    assert.equal(loadRunnerConfig().gateServer, qualifiedDestination);
     for (const value of ["", "-oProxyCommand=bad", "gate;bad", "gate:22", "gate name"]) {
       process.env.RUNNER_GATE_SERVER = value;
-      assert.throws(loadRunnerConfig, /RUNNER_GATE_SERVER must be an ssh host alias or user@host/u);
+      assert.throws(loadRunnerConfig, /RUNNER_GATE_SERVER must be a safe ssh destination/u);
     }
   } finally {
     if (previous === undefined) delete process.env.RUNNER_GATE_SERVER;

--- a/packages/runner/src/config.ts
+++ b/packages/runner/src/config.ts
@@ -25,6 +25,8 @@ export type RunnerConfig = {
   heartbeatIntervalMs: number;
   path: string;
   home: string;
+  /** Optional operator-selected gate worker exposed to agent sessions. */
+  gateServer?: string;
   /** Proxy variables captured once, when the daemon starts. */
   proxyEnvironment?: NodeJS.ProcessEnv;
   /** Repository-owned baseline used to provision Codex session config roots. */
@@ -69,10 +71,19 @@ const positiveInteger = (name: string, value: string): number => {
   return parsed;
 };
 
+const optionalSshDestination = (name: string, value: string | undefined): string | undefined => {
+  if (value === undefined) return undefined;
+  if (!/^[A-Za-z0-9._@-]+$/u.test(value) || value.startsWith("-")) {
+    throw new Error(`${name} must be an ssh host alias or user@host`);
+  }
+  return value;
+};
+
 export const loadRunnerConfig = (): RunnerConfig => {
   const leaseSeconds = Number.parseInt(process.env.RUNNER_LEASE_SECONDS ?? "60", 10);
   const runAsPrefix = splitPrefix(process.env.RUNNER_RUN_AS_PREFIX ?? "");
   const workspaceRoot = process.env.RUNNER_WORKSPACE_ROOT ?? join(homedir(), ".agentos", "runs");
+  const gateServer = optionalSshDestination("RUNNER_GATE_SERVER", process.env.RUNNER_GATE_SERVER);
   // First, and before this function returns anything a caller could dial: the
   // runner's own index.ts builds the client, the preflight and the poll loop out
   // of this object, so a destination refused here is refused before any DNS
@@ -88,6 +99,7 @@ export const loadRunnerConfig = (): RunnerConfig => {
     heartbeatIntervalMs: Number.parseInt(process.env.RUNNER_HEARTBEAT_INTERVAL_MS ?? String(Math.max(5_000, leaseSeconds * 500)), 10),
     path: process.env.RUNNER_PATH ?? "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     home: process.env.RUNNER_HOME ?? process.env.HOME ?? "/var/empty",
+    ...(gateServer ? { gateServer } : {}),
     proxyEnvironment: runnerProxyEnvironment(),
     sessionConfigBaselineRoot: process.env.RUNNER_SESSION_CONFIG_BASELINE_ROOT ?? defaultSessionConfigBaselineRoot(),
     workspaceRoot,

--- a/packages/runner/src/config.ts
+++ b/packages/runner/src/config.ts
@@ -74,7 +74,7 @@ const positiveInteger = (name: string, value: string): number => {
 const optionalSshDestination = (name: string, value: string | undefined): string | undefined => {
   if (value === undefined) return undefined;
   if (!/^[A-Za-z0-9._@-]+$/u.test(value) || value.startsWith("-")) {
-    throw new Error(`${name} must be an ssh host alias or user@host`);
+    throw new Error(`${name} must be a safe ssh destination`);
   }
   return value;
 };

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -63,12 +63,14 @@ const command: WorkspaceCommandExecutor = (
 
 export const workspaceEnvironment = (
   config: Pick<RunnerConfig, "path" | "home" | "runAsPrefix">
+    & Partial<Pick<RunnerConfig, "gateServer">>
     & Partial<Pick<RunnerConfig, "proxyEnvironment">>,
 ): NodeJS.ProcessEnv => ({
   PATH: config.path,
   HOME: config.home,
   LANG: "C.UTF-8",
   GIT_TERMINAL_PROMPT: "0",
+  ...(config.gateServer ? { AGENTOS_GATE_SERVER: config.gateServer } : {}),
   ...(config.proxyEnvironment ?? runnerProxyEnvironment()),
   // macOS Keychain lookups (claude CLI auth) fail without the login identity.
   // Only the daemon's own identity is meant here: under a run-as prefix the

--- a/scripts/gate-worker/gate-dispatch.sh
+++ b/scripts/gate-worker/gate-dispatch.sh
@@ -270,14 +270,14 @@ run_remote() {
   # so there is no verdict to report and 76 says exactly that; returning the
   # gate's FAIL code here would have dressed a transport or mirror problem up as
   # a judgement about the commit.
-  bash "${SCRIPT_DIR}/mirror-push.sh" "$server" \
+  AGENTOS_GATE_SERVER= bash "${SCRIPT_DIR}/mirror-push.sh" "$server" \
     --candidate "$OID" --baseline "$MASTER_OID" >&2 || {
     printf 'gate-dispatch: mirror-push failed; no gate was run and no verdict exists\n' >&2
     REMOTE_OUTPUT=""
     REMOTE_STATUS="$EXIT_NO_VERDICT"
     return 0
   }
-  REMOTE_OUTPUT="$(bash "${SCRIPT_DIR}/remote-gate.sh" "$server" "$OID" --master "$MASTER_OID")"
+  REMOTE_OUTPUT="$(AGENTOS_GATE_SERVER= bash "${SCRIPT_DIR}/remote-gate.sh" "$server" "$OID" --master "$MASTER_OID")"
   REMOTE_STATUS=$?
 }
 

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -429,6 +429,18 @@ test("the remote path receives the exact candidate and frozen baseline", (t) => 
   assert.match(result.stderr, new RegExp(`remote args: .*${repo.head} --master ${repo.head}`));
 });
 
+test("a configured single server is consumed by the dispatcher before child tools", (t) => {
+  const repo = fixtureRepo(t, {
+    mirrorPush: 'test -z "${AGENTOS_GATE_SERVER:-}"; test "$1" = agentos-gate; printf "MIRROR PUSH: OK\\n"',
+    remoteGate: 'test -z "${AGENTOS_GATE_SERVER:-}"; test "$1" = agentos-gate; printf "MERGE GATE: PASS single-server\\n"',
+  });
+  const result = dispatch(t, repo, [repo.head], { AGENTOS_GATE_SERVER: "agentos-gate" });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /MERGE GATE: PASS single-server/u);
+  assert.match(result.stderr, /primary agentos-gate\(1\)/u);
+  assert.doesNotMatch(result.stderr, /fallback/u);
+});
+
 test("an ssh transport failure retries the exact gate on the fallback", (t) => {
   const repo = fixtureRepo(t, {
     remoteGate:


### PR DESCRIPTION
## Summary
- expose one validated operator-selected Gate worker to agent sessions
- prevent task secrets and run-as isolation from overriding the worker
- make gate-dispatch consume single-server configuration before invoking child tools

## Verification
- runner focused tests: 56 passed
- gate-dispatch tests: 33 passed
- runner typecheck passed
- public snapshot scanner: 20 passed
- MERGE GATE: PASS 3c98e2b8f89e7c2e25c400b8c955e974c11458ba on agentos-gate against 29f7aaaff57a2c4646386fba2b475fb8c19de385