### PR TITLE
fix(workflow): preserve repaired retry authority

### DIFF
--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -247,7 +247,9 @@ Three properties keep the evidence honest even when the worker is trusted:
   ask what is already on the default branch, and the worker mirror does not
   fetch it. So
   `gate-dispatch.sh` asks origin — `git ls-remote --symref origin HEAD`, which
-  names the default branch and its head in one answer — fetches that branch,
+  names the default branch and its head in one answer. It makes at most three
+  short attempts for a transient read failure, then still stops with no verdict
+  if origin remains unreadable. After a successful read it fetches that branch,
   re-reads the answer, and passes the resulting oid through both transport hops
   as `--master`. `mirror-push.sh` pushes the candidate and baseline atomically
   into separate oid-named cache refs and reads both refs back exactly before the

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -4545,6 +4545,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           projectId: candidate.projectId,
           repoId: candidate.repo.id,
           runId: candidate.id,
+          runNumber: candidate.runNumber,
           branch: candidate.branch,
           outputKind: candidate.task.templateStep?.outputKind ?? null,
         });

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -392,6 +392,62 @@ test("a fresh Regression claim carries the prior verdict and exact published rep
   });
 });
 
+test("a repaired Regression retry pins the prior same-task published head without rewriting repair evidence", async () => {
+  const seeded = await exercise("review-fail");
+  const repair = await repairFor(seeded, "review-fix");
+  await completeRepair(seeded, repair.id, "Closed MF-2 and reran its focused regression.");
+  const firstClaim = await claimNext();
+  assert.equal(firstClaim.status, 200);
+  const firstBody = firstClaim.body as {
+    run: { id: string };
+    regressionRepairHandoff: { retry?: unknown };
+  };
+  assert.equal(firstBody.regressionRepairHandoff.retry, undefined);
+
+  const continuationHead = "d".repeat(40);
+  await db.run.update({
+    where: { id: firstBody.run.id },
+    data: {
+      status: "SUCCEEDED",
+      headSha: continuationHead,
+      pushedBranch: BRANCH,
+      pushStatus: "SUCCEEDED",
+      endedAt: new Date(),
+    },
+  });
+  await db.task.update({
+    where: { id: seeded.regression.id },
+    data: { status: TaskStatus.REVIEW, failureReason: "gate formed no verdict" },
+  });
+
+  const priorOperator = process.env.OPERATOR_TOKEN;
+  process.env.OPERATOR_TOKEN = "merge-tail-operator-token";
+  try {
+    const retried = await createApp(db).request(`/tasks/${seeded.regression.id}/retry`, {
+      method: "POST",
+      headers: { Authorization: "Bearer merge-tail-operator-token" },
+    });
+    assert.equal(retried.status, 201, await retried.text());
+  } finally {
+    if (priorOperator === undefined) delete process.env.OPERATOR_TOKEN;
+    else process.env.OPERATOR_TOKEN = priorOperator;
+  }
+
+  const retryClaim = await claimNext();
+  assert.equal(retryClaim.status, 200);
+  const retryBody = retryClaim.body as {
+    regressionRepairHandoff: {
+      repair: { resolvedHeadSha: string };
+      retry: { previousRunId: string; startHeadSha: string };
+    };
+  };
+  assert.equal(retryBody.regressionRepairHandoff.repair.resolvedHeadSha, RESOLVED);
+  assert.deepEqual(retryBody.regressionRepairHandoff.retry, {
+    previousRunId: firstBody.run.id,
+    startHeadSha: continuationHead,
+  });
+});
+
 test("independent-review rejection stops for an explicit repair decision before a fresh Regression claim", async () => {
   const seeded = await seedRegression();
   const rejected = await rejectIndependentReviewAfterPass(seeded);

--- a/packages/api/src/regression-repair-handoff.ts
+++ b/packages/api/src/regression-repair-handoff.ts
@@ -32,6 +32,7 @@ export const regressionRepairHandoffForClaim = async (
     projectId: string;
     repoId: string;
     runId: string;
+    runNumber: number;
     branch: string | null;
     outputKind: string | null;
   },
@@ -209,6 +210,7 @@ export const regressionRepairHandoffForClaim = async (
           kind: true,
           body: true,
           commitSha: true,
+          updatedAt: true,
           run: { select: { status: true, headSha: true, pushedBranch: true, pushStatus: true } },
         },
       },
@@ -224,6 +226,19 @@ export const regressionRepairHandoffForClaim = async (
     || output.run.pushedBranch !== input.branch) {
     return invalid(`repair task ${repairTaskId} did not publish ${resolvedHeadSha} to ${input.branch}`);
   }
+  const retryRun = await tx.run.findFirst({
+    where: {
+      taskId: input.taskId,
+      runNumber: { gt: 1, lt: input.runNumber },
+      status: RunStatus.SUCCEEDED,
+      pushStatus: PushStatus.SUCCEEDED,
+      pushedBranch: input.branch,
+      headSha: { not: null },
+      createdAt: { gte: output.updatedAt },
+    },
+    select: { id: true, headSha: true },
+    orderBy: { runNumber: "desc" },
+  });
   return {
     status: "ok",
     handoff: {
@@ -238,6 +253,9 @@ export const regressionRepairHandoffForClaim = async (
         outputKind: output.kind,
         outputBody: output.body,
       },
+      ...(retryRun?.headSha ? {
+        retry: { previousRunId: retryRun.id, startHeadSha: retryRun.headSha },
+      } : {}),
     },
   };
 };

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -86,6 +86,10 @@ export type RegressionRepairHandoff = {
     outputKind: string;
     outputBody: string;
   };
+  retry?: {
+    previousRunId: string;
+    startHeadSha: string;
+  };
 };
 
 export type ResolverResult =

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -234,6 +234,41 @@ test("buildPrompt gives a fresh Regression session only the head-bound repair ha
   assert.match(prompt, /verify the checked-out starting HEAD equals repair\.resolvedHeadSha/u);
 });
 
+test("buildPrompt pins a repaired Regression retry to the prior same-task pushed head", () => {
+  const prompt = buildPrompt({
+    ...claim,
+    regressionRepairHandoff: {
+      schemaVersion: 1,
+      trigger: {
+        kind: "regression-verdict",
+        verdict: {
+          schemaVersion: 1,
+          outcome: "review-fail",
+          headSha: "a".repeat(40),
+          baseHeadSha: "b".repeat(40),
+          summary: "MF-2 remains open",
+        },
+      },
+      repair: {
+        kind: "review-fix",
+        taskId: "repair-1",
+        startHeadSha: "a".repeat(40),
+        targetHeadSha: "b".repeat(40),
+        resolvedHeadSha: "c".repeat(40),
+        outputKind: "result",
+        outputBody: "Closed MF-2.",
+      },
+      retry: {
+        previousRunId: "regression-run-2",
+        startHeadSha: "d".repeat(40),
+      },
+    },
+  });
+  assert.match(prompt, new RegExp(`previousRunId":"regression-run-2","startHeadSha":"${"d".repeat(40)}`));
+  assert.match(prompt, /verify the checked-out starting HEAD equals retry\.startHeadSha/u);
+  assert.doesNotMatch(prompt, /verify the checked-out starting HEAD equals repair\.resolvedHeadSha/u);
+});
+
 test("buildPrompt gives a retry the immediate prior output without reusing provider context", () => {
   const prompt = buildPrompt({
     ...claim,

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -137,7 +137,12 @@ export const buildPrompt = (claim: ClaimedTask): string => {
       resolvedHeadSha: claim.regressionRepairHandoff.repair.resolvedHeadSha,
       outputKind: claim.regressionRepairHandoff.repair.outputKind,
     })}`,
-    "- Before refreshing the target branch, verify the checked-out starting HEAD equals repair.resolvedHeadSha. Stop loudly on any mismatch.",
+    ...(claim.regressionRepairHandoff.retry ? [
+      `- Retry continuation: ${JSON.stringify(claim.regressionRepairHandoff.retry)}`,
+      "- Before refreshing the target branch, verify the checked-out starting HEAD equals retry.startHeadSha. This retry authority comes only from the prior same-Task Run's successful push; stop loudly on any mismatch.",
+    ] : [
+      "- Before refreshing the target branch, verify the checked-out starting HEAD equals repair.resolvedHeadSha. Stop loudly on any mismatch.",
+    ]),
     `- Repair task output (${claim.regressionRepairHandoff.repair.outputKind}):\n${claim.regressionRepairHandoff.repair.outputBody}`,
   ] : []),
   ].join("\n");

--- a/scripts/gate-worker/gate-dispatch.sh
+++ b/scripts/gate-worker/gate-dispatch.sh
@@ -95,6 +95,21 @@ usage() {
 
 die() { printf 'gate-dispatch: %s\n' "$1" >&2; exit "${2:-$EXIT_USAGE}"; }
 
+read_origin_head() {
+  local attempt output
+  for attempt in 1 2 3; do
+    if output="$(GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" ls-remote --symref origin HEAD 2>/dev/null)"; then
+      printf '%s\n' "$output"
+      return 0
+    fi
+    if [ "$attempt" -lt 3 ]; then
+      printf 'gate-dispatch: origin HEAD read failed; retrying attempt=%s/3\n' "$((attempt + 1))" >&2
+      sleep 1
+    fi
+  done
+  return 1
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --master)
@@ -178,7 +193,7 @@ git -C "$REPO_ROOT" cat-file -e "${OID}^{commit}" 2>/dev/null \
 # advertised. If the branch moved beyond the fetched object, this dispatch stops
 # loudly and can be retried; it never substitutes a stale local ref.
 if [ -z "$MASTER_OID" ]; then
-  symref="$(GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" ls-remote --symref origin HEAD 2>/dev/null)" \
+  symref="$(read_origin_head)" \
     || die "could not read HEAD from origin; pass --master <oid> to state the baseline" "$EXIT_NO_VERDICT"
   DEFAULT_REF="$(printf '%s\n' "$symref" | awk '$1 == "ref:" && $3 == "HEAD" {print $2; exit}')"
   [ -n "$DEFAULT_REF" ] \
@@ -187,7 +202,7 @@ if [ -z "$MASTER_OID" ]; then
     || die "origin named a default branch this dispatcher will not fetch: ${DEFAULT_REF}" "$EXIT_NO_VERDICT"
   GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" fetch --no-tags --no-write-fetch-head origin "$DEFAULT_REF" >/dev/null 2>&1 \
     || die "could not refresh ${DEFAULT_REF} from origin; nothing ran and no verdict exists" "$EXIT_NO_VERDICT"
-  refreshed="$(GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" ls-remote --symref origin HEAD 2>/dev/null)" \
+  refreshed="$(read_origin_head)" \
     || die "could not re-read HEAD from origin after refresh; nothing ran and no verdict exists" "$EXIT_NO_VERDICT"
   refreshed_ref="$(printf '%s\n' "$refreshed" | awk '$1 == "ref:" && $3 == "HEAD" {print $2; exit}')"
   MASTER_OID="$(printf '%s\n' "$refreshed" | awk '$2 == "HEAD" {print $1; exit}')"

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -429,6 +429,34 @@ test("the remote path receives the exact candidate and frozen baseline", (t) => 
   assert.match(result.stderr, new RegExp(`remote args: .*${repo.head} --master ${repo.head}`));
 });
 
+test("origin HEAD discovery retries transient git failures before dispatch", (t) => {
+  const repo = fixtureRepo(t, {});
+  const shim = scratch(t);
+  const counter = join(shim, "ls-remote-count");
+  const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+  const gitShim = join(shim, "git");
+  writeFileSync(gitShim, `#!/usr/bin/env bash
+if [ "$1" = "-C" ] && [ "$3" = "ls-remote" ]; then
+  count=0
+  [ ! -f "$GATE_GIT_COUNTER" ] || count="$(cat "$GATE_GIT_COUNTER")"
+  count=$((count + 1))
+  printf '%s\n' "$count" > "$GATE_GIT_COUNTER"
+  [ "$count" -gt 2 ] || exit 1
+fi
+exec "$REAL_GIT" "$@"
+`);
+  chmodSync(gitShim, 0o755);
+  const result = dispatch(t, repo, [repo.head], {
+    PATH: `${shim}:${process.env.PATH}`,
+    REAL_GIT: realGit,
+    GATE_GIT_COUNTER: counter,
+  });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.equal(readFileSync(counter, "utf8").trim(), "4");
+  assert.match(result.stderr, /origin HEAD read failed; retrying attempt=2\/3/u);
+  assert.match(result.stderr, /origin HEAD read failed; retrying attempt=3\/3/u);
+});
+
 test("a configured single server is consumed by the dispatcher before child tools", (t) => {
   const repo = fixtureRepo(t, {
     mirrorPush: 'test -z "${AGENTOS_GATE_SERVER:-}"; test "$1" = agentos-gate; printf "MIRROR PUSH: OK\\n"',


### PR DESCRIPTION
## Summary
- allow a repaired Regression retry to start from the prior same-Task successfully pushed exact head without rewriting repair evidence
- retry transient origin HEAD reads inside gate dispatch before returning NO VERDICT
- add focused DB, runner prompt, and dispatcher regressions

## Verification
- merge-tail-repair DB tests: 14 pass
- API unit tests: 445 pass, 1 skip
- Runner tests: 233 pass, 2 skip
- gate-dispatch tests: 34 pass
- API, DB, Runner typecheck
- public snapshot scan: 0 blockers