### PR TITLE
fix(merge-lease): verify holder identity before release

### DIFF
--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -775,6 +775,27 @@ test("merge lease acquire is mutually exclusive and release removes the lease", 
   assert.match(status.stdout, /no lease held/u);
 });
 
+test("merge lease release refuses a caller that does not hold the lease", (t) => {
+  const fixture = leaseFixture(t);
+  const held = {
+    holder: "holder@fixture",
+    acquiredAt: new Date().toISOString(),
+    reason: "Active merge",
+    token: "holder-token",
+  };
+  installLease(fixture, held);
+
+  const refused = runLease(fixture, ["release"], "stranger@fixture");
+  assert.notEqual(refused.status, 0, refused.stdout + refused.stderr);
+  assert.match(refused.stderr, /held by holder@fixture, not stranger@fixture/u);
+  assert.deepEqual(readLease(fixture).lease, held);
+
+  const released = runLease(fixture, ["release"], "holder@fixture");
+  assert.equal(released.status, 0, released.stdout + released.stderr);
+  const status = runLease(fixture, ["status"]);
+  assert.match(status.stdout, /no lease held/u);
+});
+
 test("merge lease status prints every field of the current holder", (t) => {
   const fixture = leaseFixture(t);
   const acquired = runLease(

--- a/scripts/merge-lease.sh
+++ b/scripts/merge-lease.sh
@@ -10,7 +10,8 @@
 # Writing code and pushing a feature branch do not need this lease. Hold it only
 # while integrating the latest main, proving the exact candidate, and advancing
 # main. There is deliberately no heartbeat: a machine may steal a lease only
-# after 45 minutes, while a human may steal it immediately.
+# after 45 minutes, while a human may steal it immediately. Release removes only
+# a lease you hold; breaking somebody else's lease requires steal.
 set -uo pipefail
 
 LEASE_REF="refs/merge-lease/holder"
@@ -289,6 +290,15 @@ case "$COMMAND" in
       exit 0
     fi
     released_sha="$REMOTE_SHA"
+    current_holder="$(printf '%s' "$LEASE_JSON" | node -e '
+      let body = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (chunk) => { body += chunk; });
+      process.stdin.on("end", () => process.stdout.write(JSON.parse(body).holder));
+    ')" || die "could not read the current lease holder"
+    if [ "$current_holder" != "$HOLDER" ]; then
+      die "release refused: ${LEASE_REF} is held by ${current_holder}, not ${HOLDER}; use steal to break it"
+    fi
     delete_lease "$released_sha"
     printf 'merge-lease: released %s (%s)\n' "$LEASE_REF" "$released_sha"
     ;;


### PR DESCRIPTION
## Problem

`scripts/merge-lease.sh release` deleted whatever lease was present without checking who held it. The `--force-with-lease` CAS only guards against the lease changing mid-delete; it does not stop a non-holder from removing somebody else's lease. A window that timed out on `acquire`, gave up, and then ran `release` would tear down the lease of the window that actually holds the merge window, and the serialization would fail silently.

## Fix

`release` now reads the `holder` field of the lease JSON and compares it with the caller identity derived the same way `acquire` derives it (`MERGE_LEASE_HOLDER`, `--holder`, else `user@host`). A mismatch exits non-zero, names the current holder on stderr, and points at `steal`. A match takes the existing CAS delete path. Releasing when no lease exists stays idempotently successful.

## Test

`scripts/gate-worker/gate-dispatch.test.mjs` gains one case: a stranger's `release` is refused and the lease survives intact, then the real holder's `release` succeeds.

Scope: `scripts/merge-lease.sh` and that test file only.