### PR TITLE
feat(workflow): integrate chain merge lease

### DIFF
--- a/agents/templates/compound-engineer-workflow/11-regression-verification.md
+++ b/agents/templates/compound-engineer-workflow/11-regression-verification.md
@@ -12,10 +12,13 @@ spawnPolicy: null
 The platform-pinned `run.pullRequestBase` in the agent prompt is the integration
 line authority. Every reference below to the current target branch or target
 branch means that exact branch, regardless of any branch name in task-authored
-text. Refresh `{{branchName}}` onto it before reviewing: fetch
-`origin/<run.pullRequestBase>`, record its exact 40-hex head as `baseHeadSha`,
-then merge that commit into the checked-out chain branch with a normal merge
-commit. If Git reports a conflict, record both pre-refresh head SHAs,
+text. Refresh `{{branchName}}` onto it before reviewing: before the first fetch,
+acquire the chain merge lease with `scripts/merge-lease.sh acquire --task {{chainId}} --reason "chain merge tail {{chainId}}"`.
+An acquire timeout (exit 75) or any other acquire error fails the run loudly.
+Fetch `origin/<run.pullRequestBase>`; if it fails, retry it up to three times
+before failing the run loudly. Then record its exact 40-hex head as `baseHeadSha` and
+merge that commit into the checked-out chain branch with a normal merge commit.
+If Git reports a conflict, record both pre-refresh head SHAs,
 abort the merge so the workspace is deliverable, and finish with the
 `refresh-conflict` output below; do not resolve a hunk yourself.
 
@@ -25,6 +28,10 @@ one unit, account for every must-fix ID, and rerun relevant regressions. If a
 must-fix remains open or the fix introduces a defect, do not run the full gate;
 emit the `review-fail` output below. Only after semantic verification passes,
 `scripts/gate-worker/gate-dispatch.sh <head-sha> --master <baseHeadSha>`.
+If dispatch exits 75 or 76 without a verdict, retry dispatch in place up to two
+more times. If all three attempts return a non-verdict exit, or dispatch returns
+any other non-verdict exit, report it through the activity log and fail the run
+loudly.
 Persist exactly one JSON object as the AgentOS task output and do not write a
 report file:
 
@@ -34,4 +41,4 @@ report file:
 - refresh conflict: `{"schemaVersion":1,"outcome":"refresh-conflict","headSha":"<chain head before refresh>","baseHeadSha":"<target head>","summary":"<conflicted paths>"}`
 
 No other output shape advances the chain. A non-verdict gate exit is neither
-PASS nor FAIL: report it through the activity log and fail the run loudly.
+PASS nor FAIL.

--- a/agents/templates/direct-engineer-workflow/06-regression-verification.md
+++ b/agents/templates/direct-engineer-workflow/06-regression-verification.md
@@ -12,10 +12,13 @@ spawnPolicy: null
 The platform-pinned `run.pullRequestBase` in the agent prompt is the integration
 line authority. Every reference below to the current target branch or target
 branch means that exact branch, regardless of any branch name in task-authored
-text. Refresh `{{branchName}}` onto it before reviewing: fetch
-`origin/<run.pullRequestBase>`, record its exact 40-hex head as `baseHeadSha`,
-then merge that commit into the checked-out chain branch with a normal merge
-commit. If Git reports a conflict, record both pre-refresh head SHAs,
+text. Refresh `{{branchName}}` onto it before reviewing: before the first fetch,
+acquire the chain merge lease with `scripts/merge-lease.sh acquire --task {{chainId}} --reason "chain merge tail {{chainId}}"`.
+An acquire timeout (exit 75) or any other acquire error fails the run loudly.
+Fetch `origin/<run.pullRequestBase>`; if it fails, retry it up to three times
+before failing the run loudly. Then record its exact 40-hex head as `baseHeadSha` and
+merge that commit into the checked-out chain branch with a normal merge commit.
+If Git reports a conflict, record both pre-refresh head SHAs,
 abort the merge so the workspace is deliverable, and finish with the
 `refresh-conflict` output below; do not resolve a hunk yourself.
 
@@ -25,6 +28,10 @@ every must-fix ID, and rerun relevant regressions. If a must-fix remains open
 or the fix introduces a defect, do not run the full gate; emit the
 `review-fail` output below. Only after semantic verification passes, run
 `scripts/gate-worker/gate-dispatch.sh <head-sha> --master <baseHeadSha>`.
+If dispatch exits 75 or 76 without a verdict, retry dispatch in place up to two
+more times. If all three attempts return a non-verdict exit, or dispatch returns
+any other non-verdict exit, report it through the activity log and fail the run
+loudly.
 Persist exactly one JSON object as the AgentOS task output and do not write a
 report file:
 
@@ -34,4 +41,4 @@ report file:
 - refresh conflict: `{"schemaVersion":1,"outcome":"refresh-conflict","headSha":"<chain head before refresh>","baseHeadSha":"<target head>","summary":"<conflicted paths>"}`
 
 No other output shape advances the chain. A non-verdict gate exit is neither
-PASS nor FAIL: report it through the activity log and fail the run loudly.
+PASS nor FAIL.

--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -198,7 +198,8 @@ The job then performs exactly this sequence and stops at the first failure:
    It refuses this rollover while any unarchived Task on the old template is
    unfinished, or when the old template carries webhook configuration, rather
    than changing live-chain semantics or moving operator-owned trigger state
-   implicitly;
+   implicitly. The same guarded rollover preserves both pre-merge-lease
+   canonical templates before installing their lease-aware Regression prompts;
 7. verify the staged generated Prisma client, recheck the barrier and blocking
    statuses, swap the staged `dist/` trees and target `node_modules`, and
    restart the services;

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -117,6 +117,11 @@ import {
   reviewAdjudicationClaimRefusal,
 } from "./canonical-task-output.js";
 import { LOOPBACK_BROWSER_ORIGINS, originMayReachHandlers } from "./local-origin.js";
+import {
+  releaseMergeLease,
+  releaseMergeLeaseSafely,
+  type MergeLeaseReleaser,
+} from "./merge-lease.js";
 import { createRunnerRegistry } from "./runners.js";
 import {
   nextStoredCliAvailability,
@@ -172,6 +177,7 @@ type AppEnvironment = { Variables: { principal: Principal } };
 export interface LiveAppOptions {
   ownership: { assertHeld(): void | Promise<void> };
   onboardingRepositoryPreflight?: typeof preflightOnboardingRepository;
+  releaseMergeLease?: MergeLeaseReleaser;
 }
 
 type DbTx = Prisma.TransactionClient;
@@ -1733,6 +1739,7 @@ const goalInclude = {
 
 export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEnvironment> => {
   const app = new Hono<AppEnvironment>();
+  const releaseChainLease = options.releaseMergeLease ?? releaseMergeLease;
   const noteArchivedQueuedRunsOnClaim = createArchivedRunNoticeScheduler(db);
   const runners = createRunnerRegistry();
   // Authentication circuits are global backend state, so only one daemon must
@@ -5793,6 +5800,12 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             },
           })
         : null;
+      const reviewRegression = typeof reviewMarker?.regressionTaskId === "string"
+        ? await tx.task.findUnique({
+            where: { id: reviewMarker.regressionTaskId },
+            select: { chainId: true },
+          })
+        : null;
       const repairDocumentationTask = repairRegression?.chainId && repairRegression.templateId
         && repairRegression.chainIndex === 11
         && repairRegression.templateStep?.stepIndex === 11
@@ -5825,6 +5838,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       // row: a task's budget being edited mid-run must not retroactively refuse
       // an attempt already authorized.
       const budgetGrants = run.budgetGrants + refunded;
+      const tailLeaseChainId = run.task?.chainId ?? repairRegression?.chainId ?? reviewRegression?.chainId ?? null;
+      let releaseMergeLeaseTask: string | null = null;
       // Completion always mutates its Task, including terminal non-retryable
       // failures. Run is already locked above; acquire the Task/chain mutex now
       // for every outcome rather than only the branches that may retry or
@@ -5975,6 +5990,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         });
         retryCreated = true;
       }
+      if (!succeeded && !retryCreated && (mechanical
+        || run.task?.templateStep?.outputKind === "regression-verification"
+        || mergeTailAuxiliary)) {
+        releaseMergeLeaseTask = tailLeaseChainId;
+      }
       if (run.taskId) {
         const budgetExhausted = !succeeded && retryable && !retryCreated;
         let canonicalOutputFailure: string | null = null;
@@ -6027,6 +6047,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         // may touch it, because a synthesized body would read as a merge that
         // never happened.
         if (succeeded && mechanical && run.task) {
+          releaseMergeLeaseTask = tailLeaseChainId;
           const persisted = await tx.taskStepOutput.findUnique({
             where: { taskId: run.taskId }, select: { kind: true, body: true },
           });
@@ -6100,6 +6121,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                 reason: outputRefusal,
               },
             } });
+            if (run.task.templateStep?.outputKind === "regression-verification") {
+              releaseMergeLeaseTask = tailLeaseChainId;
+            }
           }
           canonicalOutputFailure = outputRefusal;
         }
@@ -6124,6 +6148,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             });
             if (result === "advance") {
               await advanceTemplateTask(tx, run.taskId, run.id, process.env.FEISHU_DEFAULT_CHAT_ID ?? null, now, completionTaskStatus);
+            } else {
+              releaseMergeLeaseTask = tailLeaseChainId;
             }
           } else {
             await advanceTemplateTask(tx, run.taskId, run.id, process.env.FEISHU_DEFAULT_CHAT_ID ?? null, now, completionTaskStatus);
@@ -6282,6 +6308,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           }
           if (repairUnable || reviewRejected) {
             // The failed repair owns the stop; never activate its follow-up.
+            releaseMergeLeaseTask = tailLeaseChainId;
           } else if (run.task.approvalGate) {
             const claimed = await tx.task.updateMany({
               where: { id: run.taskId, status: completionTaskStatus! },
@@ -6367,7 +6394,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           update: { consecutiveAuthFailures: 0 },
         });
       }
-      return { taskId: run.taskId, succeeded, retryCreated, failureClass };
+      return { taskId: run.taskId, succeeded, retryCreated, failureClass, releaseMergeLeaseTask };
     // ReadCommitted lets successor CAS losers observe count=0 instead of
     // surfacing a serialization failure to runners. Every task status write
     // above has its own status CAS so concurrent operator decisions win.
@@ -6378,6 +6405,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         ? context.json({ error: "Run suspended for Inbox", code: "WAITING_INBOX" }, 409)
         : context.json({ error: "Stale fencing token" }, 409);
     }
+    await releaseMergeLeaseSafely(releaseChainLease, result.releaseMergeLeaseTask);
     await options.ownership.assertHeld();
     // Nothing is deleted here, or anywhere else in this process. The runner
     // removed its own workspace before it called /complete and reported the

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -30,10 +30,12 @@ import {
   INTEGRATOR_STEP_INDEX,
   INTEGRATOR_TEMPLATE_NAME,
   legacyNineStepTemplateName,
+  legacyChainLeaseTemplateName,
   legacyRegressionFirstThirteenStepTemplateName,
   legacyTenStepTemplateName,
   loadAgentSources,
   loadTemplateStepSources,
+  previousChainLeasePrompt,
   PrismaClient,
   type Task,
   TaskStatus,
@@ -96,6 +98,8 @@ test("a fresh seed writes the thirteen-step and eight-step autonomous merge temp
   assert.equal(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 10)?.assigneeAgentId,
     (await db.agent.findFirstOrThrow({ where: { name: "librarian" } })).id);
   assert.equal(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 11)?.attachmentsFromPrevious, true);
+  assert.match(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 11)?.prompt ?? "", /merge-lease\.sh acquire --task \{\{chainId\}\}/u);
+  assert.match(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 11)?.prompt ?? "", /exits 75 or 76[\s\S]*up to two[\s\S]*more times/u);
   assert.match(
     step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 3)?.prompt ?? "",
     /vertical slice[\s\S]*blocked_by[\s\S]*expand-migrate-contract[\s\S]*fail at base/iu,
@@ -115,6 +119,7 @@ test("a fresh seed writes the thirteen-step and eight-step autonomous merge temp
   assert.equal(direct.steps[6]?.outputKind, "merge-authorization");
   assert.equal(direct.steps[7]?.assigneeAgent?.name, INTEGRATOR_AGENT_NAME);
   assert.equal(direct.steps[7]?.outputKind, INTEGRATOR_OUTPUT_KIND);
+  assert.match(direct.steps[5]?.prompt ?? "", /retry it up to three times/u);
   const resolver = await db.agent.findFirstOrThrow({ where: { projectId: step.taskTemplate.projectId, name: "merge-resolver" } });
   assert.equal(resolver.model, "gpt-5.6-sol:high");
   assert.equal(resolver.runnerPreference, "CODEX");
@@ -237,6 +242,60 @@ test("canonical sync rolls the regression-first thirteen-step template without r
   assert.equal(preserved.templateStepId, regression.id);
   assert.equal(preserved.templateStep?.outputKind, "regression-verification");
   assert.equal(preserved.templateStep?.taskTemplate.name, legacy.name);
+});
+
+test("canonical sync rolls both pre-lease prompts only after their old tasks finish", async () => {
+  assert.equal((await seed()).code, 0);
+  const direct = await directTemplate();
+  const compound = await db.taskTemplate.findUniqueOrThrow({
+    where: { projectId_name: { projectId: direct.projectId, name: INTEGRATOR_TEMPLATE_NAME } },
+    include: { steps: { include: { assigneeAgent: true }, orderBy: { stepIndex: "asc" } } },
+  });
+  const oldTemplates = [direct, compound];
+  const oldTasks = [];
+  for (const template of oldTemplates) {
+    const regression = template.steps.find((step) => step.outputKind === "regression-verification")!;
+    const oldPrompt = previousChainLeasePrompt(regression.prompt);
+    assert.notEqual(oldPrompt, regression.prompt);
+    await db.taskTemplateStep.update({ where: { id: regression.id }, data: { prompt: oldPrompt } });
+    oldTasks.push(await db.task.create({ data: {
+      projectId: template.projectId,
+      templateId: template.id,
+      templateStepId: regression.id,
+      name: `Pre-lease ${template.name}`,
+      description: oldPrompt,
+      assigneeType: regression.assigneeType,
+      assigneeAgentId: regression.assigneeAgentId,
+      status: TaskStatus.TODO,
+      chainId: `pre-lease-${template.name}-${process.pid}`,
+      chainIndex: regression.stepIndex,
+      chainLayer: regression.layer,
+    } }));
+  }
+
+  const refused = await sync();
+  assert.notEqual(refused.code, 0, refused.output);
+  assert.match(refused.output, /still has 1 unfinished tasks/u);
+  for (const task of oldTasks) {
+    await db.task.update({ where: { id: task.id }, data: { status: TaskStatus.DONE } });
+  }
+
+  const synced = await sync();
+  assert.equal(synced.code, 0, synced.output);
+  assert.match(synced.output, /"createdCanonicalTemplates":2/u);
+  for (const oldTemplate of oldTemplates) {
+    const preserved = await db.taskTemplate.findUniqueOrThrow({
+      where: { id: oldTemplate.id },
+      include: { steps: { orderBy: { stepIndex: "asc" } } },
+    });
+    assert.equal(preserved.name, legacyChainLeaseTemplateName(oldTemplate.name, oldTemplate.id));
+    const replacement = await db.taskTemplate.findUniqueOrThrow({
+      where: { projectId_name: { projectId: oldTemplate.projectId, name: oldTemplate.name } },
+      include: { steps: { orderBy: { stepIndex: "asc" } } },
+    });
+    assert.notEqual(replacement.id, oldTemplate.id);
+    assert.match(replacement.steps.find((step) => step.outputKind === "regression-verification")?.prompt ?? "", /merge-lease\.sh acquire/u);
+  }
 });
 
 test("canonical sync refuses to mutate instantiated canonical steps", async () => {

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -1,0 +1,35 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const mergeLeaseScript = fileURLToPath(new URL("../../../scripts/merge-lease.sh", import.meta.url));
+
+export type MergeLeaseReleaser = (chainId: string) => Promise<void>;
+
+export const releaseMergeLease: MergeLeaseReleaser = async (chainId) => {
+  await new Promise<void>((resolve) => {
+    execFile("bash", [mergeLeaseScript, "release", "--task", chainId], {
+      timeout: 90_000,
+      encoding: "utf8",
+    }, (error, stdout, stderr) => {
+      const detail = `${stdout}${stderr}`.trim();
+      if (error) {
+        console.error(`Merge lease release failed for chain ${chainId}${detail ? `: ${detail}` : ""}`);
+      } else if (detail) {
+        console.log(detail);
+      }
+      resolve();
+    });
+  });
+};
+
+export const releaseMergeLeaseSafely = async (
+  releaser: MergeLeaseReleaser,
+  chainId: string | null,
+): Promise<void> => {
+  if (!chainId) return;
+  try {
+    await releaser(chainId);
+  } catch (error: unknown) {
+    console.error(`Merge lease release failed for chain ${chainId}`, error);
+  }
+};

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -34,6 +34,11 @@ import {
 
 import { evidenceFromSnapshot } from "./merge-evidence-worker.js";
 import { createGitHubReader, type GitHubReader } from "./github-read.js";
+import {
+  releaseMergeLease,
+  releaseMergeLeaseSafely,
+  type MergeLeaseReleaser,
+} from "./merge-lease.js";
 
 export const readinessPollIntervalMs = (): number => {
   const raw = Number(process.env.MERGE_READINESS_POLL_INTERVAL_MS);
@@ -138,6 +143,7 @@ const stopReadiness = async (
     reason: string;
     recovery: RecoveryContext | null;
   },
+  releaseChainLease: MergeLeaseReleaser,
 ): Promise<void> => {
   const recoveryBody = input.recovery
     ? `Automatic base-drift recovery ${input.recovery.attempt} stopped at readiness: ${input.reason}`
@@ -145,8 +151,12 @@ const stopReadiness = async (
   const dedupeKey = input.recovery
     ? `merge-base-drift-recovery-tail-stop:${input.recovery.sourceStopId}:readiness`
     : `merge-readiness-stop:${input.readinessTaskId}:${createHash("sha256").update(input.reason).digest("hex")}`;
-  await db.$transaction(async (tx) => {
+  const chainId = await db.$transaction(async (tx) => {
     await lockTaskMutationRows(tx, input.readinessTaskId);
+    const readiness = await tx.task.findUnique({
+      where: { id: input.readinessTaskId },
+      select: { chainId: true },
+    });
     await tx.task.update({ where: { id: input.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: input.reason } });
     await tx.task.update({ where: { id: input.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: input.reason } });
     if (input.recovery) {
@@ -188,7 +198,9 @@ const stopReadiness = async (
       },
       update: {},
     });
+    return readiness?.chainId ?? null;
   });
+  await releaseMergeLeaseSafely(releaseChainLease, chainId);
 };
 
 const latestReviewState = async (
@@ -357,6 +369,7 @@ export const readinessTick = async (
   reader: GitHubReader | null = createGitHubReader(),
   now = new Date(),
   limit = 5,
+  releaseChainLease: MergeLeaseReleaser = async () => {},
 ): Promise<ReadinessTickResult> => {
   const result: ReadinessTickResult = { claimed: 0, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 };
   const candidates = await db.task.findMany({
@@ -413,24 +426,24 @@ export const readinessTick = async (
         } });
       }
     if (!regression?.stepOutput) {
-      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression?.id ?? readiness.id, reason: "missing head-bound regression PASS evidence", recovery });
+      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression?.id ?? readiness.id, reason: "missing head-bound regression PASS evidence", recovery }, releaseChainLease);
       result.stopped += 1;
       continue;
     }
     const verdict = parseRegressionVerdict(regression.stepOutput.body);
     if (verdict.status !== "ok" || verdict.verdict.outcome !== "pass" || regression.stepOutput.commitSha !== verdict.verdict.headSha) {
-      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: "missing or stale head-bound regression PASS evidence", recovery });
+      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: "missing or stale head-bound regression PASS evidence", recovery }, releaseChainLease);
       result.stopped += 1;
       continue;
     }
     if (!reader?.compareCommits) {
-      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: "server-side GitHub comparison reader is unavailable", recovery });
+      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: "server-side GitHub comparison reader is unavailable", recovery }, releaseChainLease);
       result.stopped += 1;
       continue;
     }
     const target = await db.$transaction((tx) => resolveChainTarget(tx, readiness));
     if (!target.resolved) {
-      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: `pull-request target is ${target.unresolvable}`, recovery });
+      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: `pull-request target is ${target.unresolvable}`, recovery }, releaseChainLease);
       result.stopped += 1;
       continue;
     }
@@ -451,7 +464,7 @@ export const readinessTick = async (
         continue;
       }
       if (!snapshot.baseSha || !snapshot.baseRefName) {
-        await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: "pull request base identity is unavailable", recovery });
+        await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: "pull request base identity is unavailable", recovery }, releaseChainLease);
         result.stopped += 1;
         continue;
       }
@@ -475,7 +488,7 @@ export const readinessTick = async (
           regressionTaskId: regression.id,
           reason: "GitHub comparison file list is truncated or completeness is unproven",
           recovery,
-        });
+        }, releaseChainLease);
         result.stopped += 1;
         continue;
       }
@@ -529,7 +542,7 @@ export const readinessTick = async (
           orderBy: { createdAt: "desc" },
         });
         if (!branchRun?.branch) {
-          await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: "chain branch is unavailable for independent review", recovery });
+          await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: "chain branch is unavailable for independent review", recovery }, releaseChainLease);
           result.stopped += 1;
           continue;
         }
@@ -543,7 +556,7 @@ export const readinessTick = async (
           recovery,
         });
         if (!opened.ok) {
-          await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: opened.reason, recovery });
+          await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: opened.reason, recovery }, releaseChainLease);
           result.stopped += 1;
         } else {
           result.reviewing += 1;
@@ -552,7 +565,7 @@ export const readinessTick = async (
       }
       const evidence = evidenceFromSnapshot(snapshot, randomUUID());
       if ("error" in evidence) {
-        await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: evidence.error, recovery });
+        await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: evidence.error, recovery }, releaseChainLease);
         result.stopped += 1;
         continue;
       }
@@ -601,7 +614,7 @@ export const readinessTick = async (
       });
       result.authorized += 1;
     } catch (error: unknown) {
-      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: `readiness evaluation failed: ${error instanceof Error ? error.message : String(error)}`, recovery });
+      await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: `readiness evaluation failed: ${error instanceof Error ? error.message : String(error)}`, recovery }, releaseChainLease);
       result.stopped += 1;
     } finally {
       if (timer) clearTimeout(timer);
@@ -615,7 +628,7 @@ export const startReadinessWorker = (
   reader: GitHubReader | null = createGitHubReader(),
 ): ReturnType<typeof setInterval> => {
   const timer = setInterval(() => {
-    void readinessTick(db, reader).catch((error: unknown) => console.error("Merge readiness tick failed", error));
+    void readinessTick(db, reader, new Date(), 5, releaseMergeLease).catch((error: unknown) => console.error("Merge readiness tick failed", error));
   }, readinessPollIntervalMs());
   timer.unref?.();
   return timer;

--- a/packages/api/src/merge-stop-state.dbtest.ts
+++ b/packages/api/src/merge-stop-state.dbtest.ts
@@ -29,7 +29,11 @@ import { resetTestDb, setupTestDb } from "./testdb.js";
 
 let db: PrismaClient;
 before(() => { db = setupTestDb(); });
-beforeEach(async () => { await resetTestDb(db); });
+const releasedChainLeases: string[] = [];
+beforeEach(async () => {
+  releasedChainLeases.length = 0;
+  await resetTestDb(db);
+});
 after(async () => { await db.$disconnect(); });
 
 const OPERATOR = "operator-stop-state";
@@ -59,7 +63,9 @@ const call = async (method: string, path: string, body?: unknown, token = OPERAT
   process.env.MERGE_EXECUTOR_TOKEN = EXECUTOR;
   process.env.MERGE_EXECUTOR_RUNNER_IDS = "merge-executor-1";
   try {
-    const response = await createApp(db).request(path, {
+    const response = await createApp(db, {
+      releaseMergeLease: async (chainId) => { releasedChainLeases.push(chainId); },
+    }).request(path, {
       method,
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
@@ -134,6 +140,7 @@ test("N16 a recorded stop lands the stop state: run SUCCEEDED, task REVIEW, ques
   assert.equal(activities.filter((row) => (row.metadata as any)?.kind === MERGE_INTEGRATOR_KIND.result).length, 1);
   assert.equal(activities.filter((row) => row.body.includes("Chain complete")).length, 0);
   assert.equal(await db.run.count({ where: { taskId: chain.integratorTask!.id } }), 1, "no automatic retry");
+  assert.deepEqual(releasedChainLeases, [chain.integratorTask!.chainId]);
 });
 
 test("a legacy integrator base-drift stop retains an abandon-only manual exit", async () => {
@@ -296,6 +303,7 @@ test("a merged outcome advances the chain and lands DONE", async () => {
   assert.equal((await completeRun(run)).status, 200);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: chain.integratorTask!.id } })).status, "DONE");
   assert.equal(await stopQuestionFor(chain.integratorTask!.id), null);
+  assert.deepEqual(releasedChainLeases, [chain.integratorTask!.chainId]);
 });
 
 test("N19 no generic exit from a stop: PATCH, retry and enqueue are all refused", async () => {

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -16,7 +16,12 @@ import { resetTestDb, setupTestDb } from "./testdb.js";
 
 let db: PrismaClient;
 before(() => { db = setupTestDb(); });
-beforeEach(async () => { await resetTestDb(db); });
+const releasedChainLeases: string[] = [];
+const releaseChainLease = async (chainId: string) => { releasedChainLeases.push(chainId); };
+beforeEach(async () => {
+  releasedChainLeases.length = 0;
+  await resetTestDb(db);
+});
 after(async () => { await db.$disconnect(); });
 
 const HEAD = "a".repeat(40);
@@ -203,7 +208,7 @@ test("a conflict resolution that edits existing test lines opens the same review
 test("base drift invalidates a head-bound PASS and returns the chain to regression", async () => {
   const seeded = await seedReadiness();
   const driftedBase = "d".repeat(40);
-  assert.deepEqual(await readinessTick(db, reader([], snapshot({ baseSha: driftedBase }))), { claimed: 1, authorized: 0, reviewing: 0, requeued: 1, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, reader([], snapshot({ baseSha: driftedBase })), new Date(), 5, releaseChainLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 1, stopped: 0 });
   const [readiness, regression] = await Promise.all([
     db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } }),
     db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } }),
@@ -211,6 +216,7 @@ test("base drift invalidates a head-bound PASS and returns the chain to regressi
   assert.equal(readiness.status, TaskStatus.TODO);
   assert.equal(regression.status, TaskStatus.TODO);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 2);
+  assert.deepEqual(releasedChainLeases, [], "base drift requeue keeps the chain lease");
 });
 
 test("ordinary base requeue reuses an approved exact-head review", async () => {
@@ -277,10 +283,12 @@ test("an incomplete compare response and a behind head fail closed", async () =>
     readPullRequest: async () => snapshot(),
     compareCommits: async () => ({ status: "ahead", behindBy: 0, filesComplete: false, files: maxFiles }),
   };
-  assert.deepEqual(await readinessTick(db, incompleteReader), { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 1 });
+  assert.deepEqual(await readinessTick(db, incompleteReader, new Date(), 5, releaseChainLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 1 });
   assert.match((await db.task.findUniqueOrThrow({ where: { id: incomplete.readiness.id } })).failureReason ?? "", /completeness/u);
+  assert.deepEqual(releasedChainLeases, [incomplete.readiness.chainId]);
 
   await resetTestDb(db);
+  releasedChainLeases.length = 0;
   const behind = await seedReadiness();
   const behindReader: GitHubReader = {
     readPullRequest: async () => snapshot(),
@@ -288,6 +296,7 @@ test("an incomplete compare response and a behind head fail closed", async () =>
   };
   assert.deepEqual(await readinessTick(db, behindReader), { claimed: 1, authorized: 0, reviewing: 0, requeued: 1, stopped: 0 });
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: behind.regression.id } })).status, TaskStatus.TODO);
+  assert.deepEqual(releasedChainLeases, []);
 });
 
 test("an absent runner-created PR identity stops loudly before authorization", async () => {
@@ -295,8 +304,9 @@ test("an absent runner-created PR identity stops loudly before authorization", a
   await db.run.updateMany({ where: { taskId: seeded.regression.id }, data: {
     pullRequestNumber: null, pullRequestUrl: null,
   } });
-  assert.deepEqual(await readinessTick(db, reader()), { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 1 });
+  assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 1 });
   assert.match((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).failureReason ?? "", /pull-request target/u);
+  assert.deepEqual(releasedChainLeases, [seeded.readiness.chainId]);
 });
 
 test("manual start cannot turn server-owned readiness into a model run", async () => {

--- a/packages/api/src/run-output.dbtest.ts
+++ b/packages/api/src/run-output.dbtest.ts
@@ -32,7 +32,11 @@ import { resetTestDb, setupTestDb } from "./testdb.js";
 
 let db: PrismaClient;
 before(() => { db = setupTestDb(); });
-beforeEach(async () => { await resetTestDb(db); });
+const releasedChainLeases: string[] = [];
+beforeEach(async () => {
+  releasedChainLeases.length = 0;
+  await resetTestDb(db);
+});
 after(async () => { await db.$disconnect(); });
 
 const OPERATOR = "operator-run-output";
@@ -61,7 +65,9 @@ const withTokens = async <T>(operation: () => T | Promise<T>): Promise<T> => {
 const call = async (
   method: string, path: string, token: string, body?: unknown,
 ): Promise<{ status: number; body: any }> => withTokens(async () => {
-  const response = await createApp(db).request(path, {
+  const response = await createApp(db, {
+    releaseMergeLease: async (chainId) => { releasedChainLeases.push(chainId); },
+  }).request(path, {
     method,
     headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
@@ -346,6 +352,64 @@ test("regression completion keeps final prose as Run.output but requires this ru
   const activities = await db.taskActivity.findMany({ where: { taskId: task.id }, orderBy: { createdAt: "asc" } });
   assert.ok(activities.some(({ body }) => body === nonVerdict), "the agent's original non-verdict activity was lost");
   assert.ok(activities.some(({ body }) => body === "Regression did not advance: missing regression output"));
+  assert.deepEqual(releasedChainLeases, [task.chainId]);
+});
+
+test("every authored Regression stop verdict releases its chain lease", async () => {
+  for (const verdict of [
+    { schemaVersion: 1, outcome: "refresh-conflict", headSha: SHA, baseHeadSha: "b".repeat(40), summary: "conflict" },
+    { schemaVersion: 1, outcome: "review-fail", headSha: SHA, baseHeadSha: "b".repeat(40), summary: "must-fix remains" },
+    { schemaVersion: 1, outcome: "gate-fail", headSha: SHA, baseHeadSha: "b".repeat(40), gateVerdict: "FAIL", summary: "gate failed" },
+  ] as const) {
+    releasedChainLeases.length = 0;
+    const { task } = await seedTask({
+      chained: true,
+      outputKind: "regression-verification",
+      templateName: DIRECT_TEMPLATE_NAME,
+      stepIndex: 6,
+    });
+    const runId = await enqueue(task.id);
+    const { run, sessionToken, fencingToken } = await claimRun(runId, `runner-${verdict.outcome}`);
+    const written = await call("PUT", `/session/runs/${runId}/output`, sessionToken, {
+      fencingToken,
+      kind: "regression-verification",
+      body: JSON.stringify(verdict),
+      commitSha: SHA,
+    });
+    assert.equal(written.status, 200, JSON.stringify(written.body));
+    const completed = await call(
+      "POST",
+      `/runner/runs/${runId}/complete`,
+      RUNNER,
+      succeededCompletion(`runner-${verdict.outcome}`, fencingToken, run.branch ?? "master"),
+    );
+    assert.equal(completed.status, 200, JSON.stringify(completed.body));
+    assert.deepEqual(releasedChainLeases, [task.chainId], verdict.outcome);
+  }
+});
+
+test("a canonical Regression output refusal releases its chain lease", async () => {
+  const { task } = await seedTask({
+    chained: true,
+    outputKind: "regression-verification",
+    templateName: DIRECT_TEMPLATE_NAME,
+    stepIndex: 6,
+  });
+  const runId = await enqueue(task.id);
+  const { run, fencingToken } = await claimRun(runId, "runner-canonical-refusal");
+  const completed = await call(
+    "POST",
+    `/runner/runs/${runId}/complete`,
+    RUNNER,
+    succeededCompletion("runner-canonical-refusal", fencingToken, run.branch ?? "master"),
+  );
+  assert.equal(completed.status, 200, JSON.stringify(completed.body));
+  assert.match((await db.task.findUniqueOrThrow({ where: { id: task.id } })).failureReason ?? "", /missing regression-verification task output/u);
+  const refusal = await db.taskActivity.findFirst({
+    where: { taskId: task.id, metadata: { path: ["kind"], equals: "canonicalTaskOutput.refusal" } },
+  });
+  assert.ok(refusal, "the stop is the canonical output refusal path");
+  assert.deepEqual(releasedChainLeases, [task.chainId]);
 });
 
 test("a runner too old to send an output completes exactly as it always did", async () => {

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -45,7 +45,7 @@ test("instantiating the canonical feature template copies every layer and writes
       id: `step-${contract.stepIndex}`,
       stepIndex: contract.stepIndex,
       name: `Step ${contract.stepIndex}`,
-      prompt: `Work on {{branchName}} step ${contract.stepIndex}`,
+      prompt: `Work on {{branchName}} in chain {{chainId}} step ${contract.stepIndex}`,
       outputKind: contract.outputKind,
       attachmentsFromPrevious: contract.attachmentsFromPrevious,
       assigneeType: agent ? AssigneeType.AGENT : AssigneeType.HUMAN,
@@ -117,6 +117,7 @@ test("instantiating the canonical feature template copies every layer and writes
   assert.equal(result.tasks.length, 13);
   assert.equal(new Set(created.map((task) => task.chainId)).size, 1);
   assert.deepEqual(created.map((task) => task.chainLayer), canonicalTemplateSteps.map((step) => step.layer));
+  assert.ok(created.every((task) => task.description.includes(`chain ${result.chainId}`)), "chainId is a built-in template variable");
   assert.ok(created.every((task) => typeof task.chainLayer === "number"));
   assert.equal(created[11]!.assigneeType, AssigneeType.AGENT);
   assert.equal(created[11]!.approvalGate, false);

--- a/packages/api/src/templates.ts
+++ b/packages/api/src/templates.ts
@@ -155,9 +155,10 @@ export const instantiateTemplate = async (
           }
         }
         const tasks = [];
+        const promptVariables = { ...input.variables, chainId };
         for (const step of template.steps) {
           const context = [
-            interpolate(step.prompt, input.variables),
+            interpolate(step.prompt, promptVariables),
             input.description ? `\nFeature brief:\n${input.description}` : "",
             step.attachmentsFromPrevious ? "\nRead the prior template steps' persisted outputs before working." : "",
             `\nPersist the final ${step.outputKind} output for this step through the AgentOS task output endpoint.`,

--- a/packages/api/src/test-app.ts
+++ b/packages/api/src/test-app.ts
@@ -5,6 +5,7 @@ import type { PrismaClient } from "@agentos/db";
 
 import { createApp as createLiveApp } from "./app.js";
 import { defaultControlPlaneStateDir } from "./control-plane-state.js";
+import type { MergeLeaseReleaser } from "./merge-lease.js";
 import type { preflightOnboardingRepository } from "./onboarding-preflight.js";
 import { defaultWorkspaceRoot } from "./workspace-root.js";
 
@@ -75,6 +76,7 @@ const assertRootIsDisposable = (root: string): string => {
 export const createApp = (db: PrismaClient, options: {
   workspaceRoot?: string;
   onboardingRepositoryPreflight?: typeof preflightOnboardingRepository;
+  releaseMergeLease?: MergeLeaseReleaser;
 } = {}) => {
   const configured = options.workspaceRoot ?? process.env.RUNNER_WORKSPACE_ROOT;
   if (!configured) {
@@ -89,6 +91,7 @@ export const createApp = (db: PrismaClient, options: {
   return createLiveApp(db, {
     ownership: { assertHeld: () => { assertRootIsDisposable(root); } },
     onboardingRepositoryPreflight: options.onboardingRepositoryPreflight ?? (async () => {}),
+    releaseMergeLease: options.releaseMergeLease ?? (async () => {}),
   });
 };
 

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -2,7 +2,12 @@ import { AssigneeType, CodexServiceTier, Prisma, PrismaClient, TaskStatus } from
 
 import { CANONICAL_AGENT_RUNTIME_TRANSITIONS, DIRECT_TEMPLATE_NAME } from "../src/agent-contract.js";
 import { loadAgentSources } from "../src/agent-sources.js";
-import { legacyTemplateShapeRefusal, type PersistedTransitionStep } from "../src/canonical-template-transition.js";
+import {
+  isPreChainLeaseTemplate,
+  legacyChainLeaseTemplateName,
+  legacyTemplateShapeRefusal,
+  type PersistedTransitionStep,
+} from "../src/canonical-template-transition.js";
 import {
   INTEGRATOR_AGENT_NAME,
   INTEGRATOR_OUTPUT_KIND,
@@ -206,6 +211,12 @@ const main = async (): Promise<void> => {
     });
     const legacyCanonical = existing
       && legacyTemplateShapeRefusal(INTEGRATOR_TEMPLATE_NAME, existing.steps as unknown as PersistedTransitionStep[]) === "legacy";
+    const preChainLease = existing
+      && isPreChainLeaseTemplate(
+        INTEGRATOR_TEMPLATE_NAME,
+        existing.steps as unknown as PersistedTransitionStep[],
+        templateSteps,
+      );
     const historicalIntegrator = existing?.steps.find((step) => step.stepIndex === 10);
     const isHistoricalNineStepTemplate = existing?.steps.length === HISTORICAL_NINE_STEP_CONTRACT.length
       && HISTORICAL_NINE_STEP_CONTRACT.every(([stepIndex, agentName, assigneeType, outputKind, approvalGate], index) => {
@@ -234,7 +245,7 @@ const main = async (): Promise<void> => {
       && existing.steps[11]?.outputKind === "merge-authorization"
       && existing.steps[12]?.assigneeAgent?.name === INTEGRATOR_AGENT_NAME
       && existing.steps[12]?.outputKind === INTEGRATOR_OUTPUT_KIND;
-    if (existing && isRegressionFirstThirteenStepTemplate) {
+    if (existing && (isRegressionFirstThirteenStepTemplate || preChainLease)) {
       const unfinishedTasks = await tx.task.count({
         where: { templateId: existing.id, archivedAt: null, status: { not: TaskStatus.DONE } },
       });
@@ -261,6 +272,8 @@ const main = async (): Promise<void> => {
       ? legacyHumanTwelveStepTemplateName(existing.id)
       : existing && isRegressionFirstThirteenStepTemplate
       ? legacyRegressionFirstThirteenStepTemplateName(existing.id)
+      : existing && preChainLease
+      ? legacyChainLeaseTemplateName(INTEGRATOR_TEMPLATE_NAME, existing.id)
       : existing && isHistoricalNineStepTemplate
       ? legacyNineStepTemplateName(existing.id)
       : existing && isHistoricalTenStepTemplate
@@ -338,8 +351,29 @@ const main = async (): Promise<void> => {
   });
   const legacyDirect = historicalDirect
     && legacyTemplateShapeRefusal(DIRECT_TEMPLATE_NAME, historicalDirect.steps as unknown as PersistedTransitionStep[]) === "legacy";
-  if (legacyDirect) {
-    const legacyName = LEGACY_CANONICAL_TEMPLATE_NAMES.get(DIRECT_TEMPLATE_NAME)!;
+  const preChainLeaseDirect = historicalDirect
+    && isPreChainLeaseTemplate(
+      DIRECT_TEMPLATE_NAME,
+      historicalDirect.steps as unknown as PersistedTransitionStep[],
+      directTemplateSteps,
+    );
+  if (preChainLeaseDirect) {
+    const unfinishedTasks = await prisma.task.count({
+      where: { templateId: historicalDirect.id, archivedAt: null, status: { not: TaskStatus.DONE } },
+    });
+    if (unfinishedTasks > 0) {
+      throw new Error(`${DIRECT_TEMPLATE_NAME} ${historicalDirect.id} still has ${unfinishedTasks} unfinished tasks; canonical rollover requires its existing chains to finish first`);
+    }
+    if (historicalDirect.webhookSecretId !== null || historicalDirect.webhookRepoId !== null
+      || historicalDirect.webhookPayloadMapping !== null || historicalDirect.webhookPausedAt !== null
+      || historicalDirect.webhookReplayWindowSec !== null) {
+      throw new Error(`${DIRECT_TEMPLATE_NAME} ${historicalDirect.id} has webhook configuration; canonical rollover will not move operator-owned trigger state`);
+    }
+  }
+  if (legacyDirect || preChainLeaseDirect) {
+    const legacyName = preChainLeaseDirect
+      ? legacyChainLeaseTemplateName(DIRECT_TEMPLATE_NAME, historicalDirect.id)
+      : LEGACY_CANONICAL_TEMPLATE_NAMES.get(DIRECT_TEMPLATE_NAME)!;
     const collision = await prisma.taskTemplate.findUnique({
       where: { projectId_name: { projectId: project.id, name: legacyName } },
       select: { id: true },
@@ -355,12 +389,12 @@ const main = async (): Promise<void> => {
       data: { name: `${DIRECT_TEMPLATE_NAME}-legacy-human-6-${historicalDirect.id}` },
     });
   }
-  if (historicalDirect && !legacyDirect
+  if (historicalDirect && !legacyDirect && !preChainLeaseDirect
     && historicalDirect.steps.length !== directTemplateSteps.length
     && historicalDirect.steps.length !== 6) {
     throw new Error(`Canonical template ${DIRECT_TEMPLATE_NAME} has structural drift: expected ${directTemplateSteps.length} steps, found ${historicalDirect.steps.length}`);
   }
-  if (historicalDirect && !legacyDirect && historicalDirect.steps.length === directTemplateSteps.length
+  if (historicalDirect && !legacyDirect && !preChainLeaseDirect && historicalDirect.steps.length === directTemplateSteps.length
     && historicalDirect.steps.some((step, index) => step.stepIndex !== index + 1)) {
     throw new Error(`Canonical template ${DIRECT_TEMPLATE_NAME} has structural drift: step indexes are not contiguous`);
   }

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -7,6 +7,8 @@ import {
   legacyRegressionFirstThirteenStepTemplateName,
 } from "../src/merge-integrator.js";
 import {
+  isPreChainLeaseTemplate,
+  legacyChainLeaseTemplateName,
   legacyTemplateShapeRefusal,
   type PersistedTransitionStep,
 } from "../src/canonical-template-transition.js";
@@ -237,6 +239,46 @@ const transitionCanonicalTemplateRows = async (
   return created;
 };
 
+const transitionPreChainLeaseTemplates = async (
+  tx: CanonicalTransaction,
+  templateSources: CanonicalSources,
+): Promise<number> => {
+  let created = 0;
+  for (const [templateName, canonical] of templateSources) {
+    const rows = await readCanonicalTemplateRows(tx, templateName);
+    for (const row of rows) {
+      if (!isPreChainLeaseTemplate(
+        templateName,
+        row.steps as unknown as PersistedTransitionStep[],
+        canonical,
+      )) continue;
+      const unfinishedTasks = await tx.task.count({
+        where: { templateId: row.id, archivedAt: null, status: { not: TaskStatus.DONE } },
+      });
+      if (unfinishedTasks > 0) {
+        throw new Error(`${templateName} ${row.id} still has ${unfinishedTasks} unfinished tasks; canonical rollover requires its existing chains to finish first`);
+      }
+      if (row.webhookSecretId !== null || row.webhookRepoId !== null
+        || row.webhookPayloadMapping !== null || row.webhookPausedAt !== null
+        || row.webhookReplayWindowSec !== null) {
+        throw new Error(`${templateName} ${row.id} has webhook configuration; canonical rollover will not move operator-owned trigger state`);
+      }
+      const legacyName = legacyChainLeaseTemplateName(templateName, row.id);
+      const collision = await tx.taskTemplate.findUnique({
+        where: { projectId_name: { projectId: row.projectId, name: legacyName } },
+        select: { id: true },
+      });
+      if (collision) {
+        throw new Error(`Canonical template ${templateName} on project ${row.projectId} cannot rename to ${legacyName}: target already exists`);
+      }
+      await tx.taskTemplate.update({ where: { id: row.id }, data: { name: legacyName } });
+      await createCanonicalTemplate(tx, row.projectId, templateName, canonical);
+      created += 1;
+    }
+  }
+  return created;
+};
+
 // Every canonical template, every step of each, and every role under agents/
 // is synced. Omitting any source here would let a prompt edit silently miss
 // production, so the loader owns the complete template inventory.
@@ -341,7 +383,8 @@ const main = async (): Promise<void> => {
         createdAgents += 1;
       }
       const createdCanonicalTemplates = await transitionRegressionFirstCompoundTemplate(tx, templateSources)
-        + await transitionCanonicalTemplateRows(tx, templateSources);
+        + await transitionCanonicalTemplateRows(tx, templateSources)
+        + await transitionPreChainLeaseTemplates(tx, templateSources);
       const updatedSteps: Record<string, Record<number, number>> = {};
       let adoptedAssignees = 0;
       let adoptedStepBases = 0;

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -1,4 +1,8 @@
+import { isDeepStrictEqual } from "node:util";
+
 import { AssigneeType, Prisma } from "@prisma/client";
+
+import type { TemplateStepSource } from "./template-sources.js";
 
 /**
  * The two graphs that existed immediately before the layered review split.
@@ -48,6 +52,68 @@ export type PersistedTransitionStep = {
   spawnPolicy: Prisma.JsonValue;
   prompt: string;
   _count?: { tasks: number };
+};
+
+const LEASE_PROMPT_STEP = new Map([
+  ["compound-engineer-workflow", 11],
+  ["direct-engineer-workflow", 6],
+]);
+
+const LEASE_FETCH_PROMPT = `text. Refresh \`{{branchName}}\` onto it before reviewing: before the first fetch,
+acquire the chain merge lease with \`scripts/merge-lease.sh acquire --task {{chainId}} --reason "chain merge tail {{chainId}}"\`.
+An acquire timeout (exit 75) or any other acquire error fails the run loudly.
+Fetch \`origin/<run.pullRequestBase>\`; if it fails, retry it up to three times
+before failing the run loudly. Then record its exact 40-hex head as \`baseHeadSha\` and
+merge that commit into the checked-out chain branch with a normal merge commit.
+If Git reports a conflict, record both pre-refresh head SHAs,`;
+
+const PRE_LEASE_FETCH_PROMPT = `text. Refresh \`{{branchName}}\` onto it before reviewing: fetch
+\`origin/<run.pullRequestBase>\`, record its exact 40-hex head as \`baseHeadSha\`,
+then merge that commit into the checked-out chain branch with a normal merge
+commit. If Git reports a conflict, record both pre-refresh head SHAs,`;
+
+const DISPATCH_RETRY_PROMPT = `If dispatch exits 75 or 76 without a verdict, retry dispatch in place up to two
+more times. If all three attempts return a non-verdict exit, or dispatch returns
+any other non-verdict exit, report it through the activity log and fail the run
+loudly.
+`;
+
+export const previousChainLeasePrompt = (prompt: string): string => prompt
+  .replace(LEASE_FETCH_PROMPT, PRE_LEASE_FETCH_PROMPT)
+  .replace(DISPATCH_RETRY_PROMPT, "")
+  .replace(
+    "No other output shape advances the chain. A non-verdict gate exit is neither\nPASS nor FAIL.\n",
+    "No other output shape advances the chain. A non-verdict gate exit is neither\nPASS nor FAIL: report it through the activity log and fail the run loudly.\n",
+  );
+
+export const legacyChainLeaseTemplateName = (templateName: string, templateId: string): string =>
+  `${templateName}-legacy-pre-merge-lease-${templateId}`;
+
+export const isPreChainLeaseTemplate = (
+  templateName: string,
+  steps: readonly PersistedTransitionStep[],
+  canonical: readonly TemplateStepSource[],
+): boolean => {
+  const transitionIndex = LEASE_PROMPT_STEP.get(templateName);
+  if (!transitionIndex || steps.length !== canonical.length) return false;
+  const ordered = [...steps].sort((left, right) => left.stepIndex - right.stepIndex);
+  return ordered.every((step, index) => {
+    const expected = canonical[index];
+    if (!expected || step.stepIndex !== expected.stepIndex) return false;
+    const expectedPrompt = expected.stepIndex === transitionIndex
+      ? previousChainLeasePrompt(expected.prompt)
+      : expected.prompt;
+    return (step.assigneeAgent?.name ?? null) === expected.agentName
+      && step.assigneeType === (expected.agentName === null ? AssigneeType.HUMAN : AssigneeType.AGENT)
+      && step.layer === expected.layer
+      && step.approvalGate === expected.approvalGate
+      && step.outputKind === expected.outputKind
+      && step.attachmentsFromPrevious === expected.attachmentsFromPrevious
+      && step.opensPullRequest === expected.opensPullRequest
+      && step.baseFromStepIndex === expected.baseFromStepIndex
+      && isDeepStrictEqual(step.spawnPolicy, expected.spawnPolicy)
+      && step.prompt === expectedPrompt;
+  });
 };
 
 const legacyShapeFor = (templateName: string): readonly (readonly [

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -26,4 +26,5 @@ export * from "./failure-envelope.js";
 export * from "./agent-sources.js";
 export * from "./agent-contract.js";
 export * from "./template-sources.js";
+export * from "./canonical-template-transition.js";
 export * from "./verify-starter-onboarding.js";

--- a/packages/db/src/template-sources.test.ts
+++ b/packages/db/src/template-sources.test.ts
@@ -56,6 +56,12 @@ test("canonical sources expose the exact layered Direct and Full graphs", async 
   }
   assert.equal(direct.some(({ agentName }) => agentName === "review-adjudicator-opus"), true);
   assert.equal(full.some(({ agentName }) => agentName === "review-adjudicator-opus"), true);
+  for (const steps of [direct, full]) {
+    const regression = steps.find(({ outputKind }) => outputKind === "regression-verification")!;
+    assert.match(regression.prompt, /merge-lease\.sh acquire --task \{\{chainId\}\}/u);
+    assert.match(regression.prompt, /retry it up to three times/u);
+    assert.match(regression.prompt, /exits 75 or 76[\s\S]*up to two[\s\S]*more times/u);
+  }
 });
 
 test("missing layer frontmatter is refused by the source loader", async () => {

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -775,6 +775,54 @@ test("merge lease acquire is mutually exclusive and release removes the lease", 
   assert.match(status.stdout, /no lease held/u);
 });
 
+test("merge lease acquire is reentrant only for the same task", (t) => {
+  const fixture = leaseFixture(t);
+  const first = runLease(
+    fixture,
+    ["acquire", "--reason", "First chain tail", "--task", "chain-42"],
+    "first@fixture",
+  );
+  assert.equal(first.status, 0, first.stdout + first.stderr);
+  const original = readLease(fixture);
+
+  const reentrant = runLease(
+    fixture,
+    ["acquire", "--reason", "Retried chain tail", "--task", "chain-42", "--timeout-minutes", "0"],
+    "second@fixture",
+  );
+  assert.equal(reentrant.status, 0, reentrant.stdout + reentrant.stderr);
+  assert.match(reentrant.stdout, /already held for task chain-42/u);
+  assert.deepEqual(readLease(fixture), original, "reentry must not rewrite the lease object");
+
+  const other = runLease(
+    fixture,
+    ["acquire", "--reason", "Other chain tail", "--task", "chain-43", "--timeout-minutes", "0"],
+    "second@fixture",
+  );
+  assert.equal(other.status, 75, other.stdout + other.stderr);
+  assert.deepEqual(readLease(fixture), original);
+});
+
+test("merge lease task release ignores holder identity and skips a different task", (t) => {
+  const fixture = leaseFixture(t);
+  const acquired = runLease(
+    fixture,
+    ["acquire", "--reason", "Chain tail", "--task", "chain-42"],
+    "runner@fixture",
+  );
+  assert.equal(acquired.status, 0, acquired.stdout + acquired.stderr);
+  const original = readLease(fixture);
+
+  const skipped = runLease(fixture, ["release", "--task", "chain-43"], "api@fixture");
+  assert.equal(skipped.status, 0, skipped.stdout + skipped.stderr);
+  assert.match(skipped.stdout, /release skipped/u);
+  assert.deepEqual(readLease(fixture), original);
+
+  const released = runLease(fixture, ["release", "--task", "chain-42"], "api@fixture");
+  assert.equal(released.status, 0, released.stdout + released.stderr);
+  assert.match(runLease(fixture, ["status"]).stdout, /no lease held/u);
+});
+
 test("merge lease release refuses a caller that does not hold the lease", (t) => {
   const fixture = leaseFixture(t);
   const held = {

--- a/scripts/merge-lease.sh
+++ b/scripts/merge-lease.sh
@@ -272,7 +272,23 @@ case "$COMMAND" in
         0)
           printf 'merge-lease: acquired %s (%s)\n' "$LEASE_REF" "$NEW_SHA"
           exit 0 ;;
-        1) ;;
+        1)
+          load_lease
+          if [ -n "$TASK" ] && [ -n "$REMOTE_SHA" ]; then
+            current_task="$(printf '%s' "$LEASE_JSON" | node -e '
+              let body = "";
+              process.stdin.setEncoding("utf8");
+              process.stdin.on("data", (chunk) => { body += chunk; });
+              process.stdin.on("end", () => {
+                const task = JSON.parse(body).task;
+                if (typeof task === "string") process.stdout.write(task);
+              });
+            ')" || die "could not read the current lease task"
+            if [ "$current_task" = "$TASK" ]; then
+              printf 'merge-lease: already held for task %s (%s)\n' "$TASK" "$REMOTE_SHA"
+              exit 0
+            fi
+          fi ;;
         *) die "could not create ${LEASE_REF} after 3 attempts" ;;
       esac
       if [ "$(date +%s)" -ge "$deadline" ]; then
@@ -290,14 +306,31 @@ case "$COMMAND" in
       exit 0
     fi
     released_sha="$REMOTE_SHA"
-    current_holder="$(printf '%s' "$LEASE_JSON" | node -e '
-      let body = "";
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", (chunk) => { body += chunk; });
-      process.stdin.on("end", () => process.stdout.write(JSON.parse(body).holder));
-    ')" || die "could not read the current lease holder"
-    if [ "$current_holder" != "$HOLDER" ]; then
-      die "release refused: ${LEASE_REF} is held by ${current_holder}, not ${HOLDER}; use steal to break it"
+    if [ -n "$TASK" ]; then
+      current_task="$(printf '%s' "$LEASE_JSON" | node -e '
+        let body = "";
+        process.stdin.setEncoding("utf8");
+        process.stdin.on("data", (chunk) => { body += chunk; });
+        process.stdin.on("end", () => {
+          const task = JSON.parse(body).task;
+          if (typeof task === "string") process.stdout.write(task);
+        });
+      ')" || die "could not read the current lease task"
+      if [ "$current_task" != "$TASK" ]; then
+        printf 'merge-lease: release skipped; %s is held for task %s, not %s\n' \
+          "$LEASE_REF" "${current_task:-<none>}" "$TASK"
+        exit 0
+      fi
+    else
+      current_holder="$(printf '%s' "$LEASE_JSON" | node -e '
+        let body = "";
+        process.stdin.setEncoding("utf8");
+        process.stdin.on("data", (chunk) => { body += chunk; });
+        process.stdin.on("end", () => process.stdout.write(JSON.parse(body).holder));
+      ')" || die "could not read the current lease holder"
+      if [ "$current_holder" != "$HOLDER" ]; then
+        die "release refused: ${LEASE_REF} is held by ${current_holder}, not ${HOLDER}; use steal to break it"
+      fi
     fi
     delete_lease "$released_sha"
     printf 'merge-lease: released %s (%s)\n' "$LEASE_REF" "$released_sha"


### PR DESCRIPTION
## Summary
- acquire the global merge lease in canonical Regression steps with bounded fetch and dispatch retries
- make lease acquisition task-reentrant and release by chain task identity after every merge-tail terminal stop
- roll canonical templates forward without mutating unfinished historical chains

## Tests
- node --test scripts/gate-worker/gate-dispatch.test.mjs
- affected API unit tests and lint
- focused database suites: merge-tail-readiness, merge-stop-state, run-output, merge-integrator-seed