### PR TITLE
fix: retry claim on raw serialization failure and stamp the lease when won

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,15 @@ pushing a feature branch, and opening a PR do not require the lease. The lease
 keeps an exact-head gate proof valid from the moment its baseline is fixed until
 that proof is consumed by the merge.
 
+Pass `--task <id>` to both `acquire` and `release`. The default holder is
+`user@host`, which every agent window on one machine shares, so without a task
+id a release cannot tell its own lease from a sibling window's.
+
+Several agent windows work one checkout at a time. Deliver from a dedicated
+`git worktree` on your own branch, never by switching the shared checkout's
+branch, and stage only the exact paths you changed. A branch switch in the
+shared checkout carries away another window's uncommitted work.
+
 ## Frozen records
 
 `docs/reviews/`, `docs/merge-notes/`, `docs/briefs/`, and

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -161,6 +161,7 @@ import {
   acknowledgeReclaimSalvage, publishReclaimIntents, recordReclaimOutcomes, repairReplacementAfterSalvage,
 } from "./workspace-reclaim.js";
 import { decryptSecret, encryptSecret } from "./secrets.js";
+import { isSerializationConflict, serializationRetryDelay } from "./serialization-retry.js";
 import { suspendForInbox } from "./inbox.js";
 import { createStarterInstallation, onboardingInput, onboardingStatus } from "./onboarding.js";
 import { preflightOnboardingRepository, RepositoryPreflightError } from "./onboarding-preflight.js";
@@ -5087,14 +5088,19 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       return adjudicationRefusal ? { error: adjudicationRefusal } : null;
     }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
     let claimed: Awaited<ReturnType<typeof claimOnce>> = null;
-    for (let attempt = 1; attempt <= 3; attempt += 1) {
+    // Two runners claiming independent chains still touch the same Task pages
+    // through the `FOR UPDATE` chain mutex, and Serializable can abort either
+    // one on a read/write dependency it cannot order. Losing that race is not a
+    // claim failure -- the work is still queued -- so retry the whole
+    // transaction. Matching only P2034 missed the raw-statement half, which
+    // arrives as P2010 carrying SQLSTATE 40001, and that escaped as a 500.
+    for (let attempt = 1; attempt <= 6; attempt += 1) {
       try {
         claimed = await claimOnce();
         break;
       } catch (error: unknown) {
-        if (!(error instanceof Prisma.PrismaClientKnownRequestError)
-          || error.code !== "P2034"
-          || attempt === 3) throw error;
+        if (!isSerializationConflict(error) || attempt === 6) throw error;
+        await serializationRetryDelay(attempt);
       }
     }
     if (claimed && "error" in claimed) return context.json({ error: claimed.error }, 409);

--- a/packages/api/src/serialization-retry.test.ts
+++ b/packages/api/src/serialization-retry.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Prisma } from "@agentos/db";
+
+import { isSerializationConflict } from "./serialization-retry.js";
+
+const knownRequestError = (code: string, meta?: Record<string, unknown>) => (
+  new Prisma.PrismaClientKnownRequestError("Raw query failed", meta
+    ? { code, clientVersion: "test", meta }
+    : { code, clientVersion: "test" })
+);
+
+test("a raw-statement serialization failure is a retryable conflict, not a 500", () => {
+  // The chain mutex is `SELECT ... FOR UPDATE`, so Postgres reports its loss as
+  // SQLSTATE 40001 wrapped in P2010 rather than as Prisma's own P2034. A caller
+  // that matches only P2034 turns a lost race into a failed claim.
+  assert.equal(isSerializationConflict(knownRequestError("P2010", {
+    code: "40001",
+    message: "could not serialize access due to read/write dependencies among transactions",
+  })), true);
+  assert.equal(isSerializationConflict(knownRequestError("P2010", {
+    code: "40P01",
+    message: "deadlock detected",
+  })), true);
+  assert.equal(isSerializationConflict(knownRequestError("P2034")), true);
+});
+
+test("an ordinary failure is not retried as a serialization conflict", () => {
+  assert.equal(isSerializationConflict(knownRequestError("P2010", {
+    code: "23505",
+    message: "duplicate key value violates unique constraint",
+  })), false);
+  assert.equal(isSerializationConflict(knownRequestError("P2010")), false);
+  assert.equal(isSerializationConflict(knownRequestError("P2002")), false);
+  assert.equal(isSerializationConflict(new Error("connection reset")), false);
+});

--- a/packages/api/src/serialization-retry.ts
+++ b/packages/api/src/serialization-retry.ts
@@ -1,0 +1,25 @@
+import { Prisma } from "@agentos/db";
+
+/** serialization_failure and deadlock_detected: both mean "retry the whole transaction". */
+const SERIALIZATION_SQLSTATE = new Set(["40001", "40P01"]);
+
+/**
+ * True when a Serializable transaction lost its conflict and the only correct
+ * response is to run the whole transaction again.
+ *
+ * Prisma reports its own query builder's loss as P2034, but a raw statement --
+ * the `FOR UPDATE` row mutexes every chain writer takes -- comes back as P2010
+ * with the SQLSTATE buried in `meta`. A caller that only matches P2034 lets the
+ * raw-statement half escape as a 500.
+ */
+export const isSerializationConflict = (error: unknown): boolean => {
+  if (!(error instanceof Prisma.PrismaClientKnownRequestError)) return false;
+  if (error.code === "P2034") return true;
+  const sqlstate = (error.meta as { code?: unknown } | undefined)?.code;
+  return error.code === "P2010" && typeof sqlstate === "string" && SERIALIZATION_SQLSTATE.has(sqlstate);
+};
+
+/** Jittered backoff so a serialization queue drains instead of re-colliding in lockstep. */
+export const serializationRetryDelay = async (attempt: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, attempt * 10 + Math.floor(Math.random() * 25)));
+};

--- a/packages/api/src/templates.ts
+++ b/packages/api/src/templates.ts
@@ -14,6 +14,7 @@ import {
 } from "@agentos/db";
 
 import { isValidBranchName } from "./branch-name.js";
+import { isSerializationConflict, serializationRetryDelay } from "./serialization-retry.js";
 
 export type InstantiateTemplateInput = {
   repoId: string;
@@ -24,22 +25,9 @@ export type InstantiateTemplateInput = {
   description?: string | undefined;
 };
 
-/** serialization_failure and deadlock_detected: both mean "retry the whole transaction". */
-const SERIALIZATION_SQLSTATE = new Set(["40001", "40P01"]);
-
 const retryableTransactionConflict = (error: unknown): boolean => {
-  if (!(error instanceof Prisma.PrismaClientKnownRequestError)) return false;
-  if (error.code === "P2034" || error.code === "P2002") return true;
-  // The Agent-row mutex below is a raw statement, and a raw statement that loses
-  // a serializable conflict comes back as P2010 with the SQLSTATE in meta rather
-  // than as the P2034 Prisma raises for its own query builder. Without this the
-  // conflict escapes as a 500 instead of retrying into the named archive error.
-  const sqlstate = (error.meta as { code?: unknown } | undefined)?.code;
-  return error.code === "P2010" && typeof sqlstate === "string" && SERIALIZATION_SQLSTATE.has(sqlstate);
-};
-
-const retryDelay = async (attempt: number): Promise<void> => {
-  await new Promise((resolve) => setTimeout(resolve, attempt * 10 + Math.floor(Math.random() * 25)));
+  if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") return true;
+  return isSerializationConflict(error);
 };
 
 const interpolate = (source: string, variables: Record<string, string>): string => source.replace(
@@ -211,7 +199,7 @@ export const instantiateTemplate = async (
       // make the accepted burst deterministic while still surfacing persistent
       // conflicts instead of looping forever.
       if (!retryableTransactionConflict(error) || attempt >= 12) throw error;
-      await retryDelay(attempt);
+      await serializationRetryDelay(attempt);
     }
   }
 };

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -768,7 +768,7 @@ test("merge lease acquire is mutually exclusive and release removes the lease", 
   assert.equal(second.status, 75, second.stdout + second.stderr);
   assert.equal(readLease(fixture).lease.holder, "first@fixture");
 
-  const released = runLease(fixture, ["release"], "first@fixture");
+  const released = runLease(fixture, ["release", "--force"], "first@fixture");
   assert.equal(released.status, 0, released.stdout + released.stderr);
   const status = runLease(fixture, ["status"]);
   assert.equal(status.status, 0, status.stderr);
@@ -833,15 +833,65 @@ test("merge lease release refuses a caller that does not hold the lease", (t) =>
   };
   installLease(fixture, held);
 
-  const refused = runLease(fixture, ["release"], "stranger@fixture");
+  const refused = runLease(fixture, ["release", "--force"], "stranger@fixture");
   assert.notEqual(refused.status, 0, refused.stdout + refused.stderr);
   assert.match(refused.stderr, /held by holder@fixture, not stranger@fixture/u);
   assert.deepEqual(readLease(fixture).lease, held);
 
-  const released = runLease(fixture, ["release"], "holder@fixture");
+  const released = runLease(fixture, ["release", "--force"], "holder@fixture");
   assert.equal(released.status, 0, released.stdout + released.stderr);
   const status = runLease(fixture, ["status"]);
   assert.match(status.stdout, /no lease held/u);
+});
+
+test("merge lease release without --task is refused rather than freeing a sibling window", (t) => {
+  const fixture = leaseFixture(t);
+  // Both windows are the same user on the same machine, so the holder string is
+  // identical and cannot tell them apart. Only the task id can.
+  const acquired = runLease(
+    fixture,
+    ["acquire", "--reason", "Window A merge", "--task", "chain-42"],
+    "agent@mac",
+  );
+  assert.equal(acquired.status, 0, acquired.stdout + acquired.stderr);
+  const original = readLease(fixture);
+
+  const refused = runLease(fixture, ["release"], "agent@mac");
+  assert.equal(refused.status, 2, refused.stdout + refused.stderr);
+  assert.match(refused.stderr, /release requires --task/u);
+  assert.deepEqual(readLease(fixture), original);
+});
+
+test("merge lease acquire restamps acquiredAt on every attempt while it queues", async (t) => {
+  const fixture = leaseFixture(t);
+  const blocking = {
+    holder: "blocker@fixture",
+    acquiredAt: new Date().toISOString(),
+    reason: "Long merge",
+    token: "blocker-token",
+  };
+  installLease(fixture, blocking);
+
+  const waiter = runLeaseAsync(
+    fixture,
+    ["acquire", "--reason", "Queued merge", "--task", "chain-99", "--poll-seconds", "1"],
+    "waiter@fixture",
+  );
+  // Let the first attempt lose and the poll loop turn over at least once, so the
+  // blob the winner installs is not the one it built at the head of the queue.
+  await new Promise((resolve) => setTimeout(resolve, 2500));
+  const queuedFor = Date.now();
+  execFileSync("git", ["--git-dir", fixture.origin, "update-ref", "-d", "refs/merge-lease/holder"], {
+    env: GIT_ENV,
+  });
+
+  const result = await waiter;
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  const acquiredAt = Date.parse(readLease(fixture).lease.acquiredAt);
+  assert.ok(
+    acquiredAt >= queuedFor - 1000,
+    `acquiredAt ${new Date(acquiredAt).toISOString()} must be stamped when the lease was won, not when queueing began`,
+  );
 });
 
 test("merge lease status prints every field of the current holder", (t) => {

--- a/scripts/merge-lease.sh
+++ b/scripts/merge-lease.sh
@@ -2,16 +2,20 @@
 #
 # Serialize the final merge window through one ref on origin:
 #
-#   scripts/merge-lease.sh acquire --reason "Merge PR #123" [--task task-id]
+#   scripts/merge-lease.sh acquire --reason "Merge PR #123" --task task-id
 #   scripts/merge-lease.sh status
-#   scripts/merge-lease.sh release
+#   scripts/merge-lease.sh release --task task-id
 #   scripts/merge-lease.sh steal --reason "Recover abandoned merge" [--human]
 #
 # Writing code and pushing a feature branch do not need this lease. Hold it only
 # while integrating the latest main, proving the exact candidate, and advancing
 # main. There is deliberately no heartbeat: a machine may steal a lease only
 # after 45 minutes, while a human may steal it immediately. Release removes only
-# a lease you hold; breaking somebody else's lease requires steal.
+# a lease you hold; breaking somebody else's lease requires steal. Release needs
+# --task because the default holder is user@host, which every agent window on
+# one machine shares: without a task only the machine is identified, so one
+# window would release another window's lease. Use --force to fall back to the
+# holder check when the acquiring task id is genuinely unknown.
 set -uo pipefail
 
 LEASE_REF="refs/merge-lease/holder"
@@ -25,10 +29,11 @@ COMMAND="${1:-}"
 REASON=""
 TASK=""
 HUMAN=0
+FORCE=0
 HOLDER="${MERGE_LEASE_HOLDER:-}"
 
 usage() {
-  sed -n '2,14p' "$0" | sed 's/^#\{1,2\} \{0,1\}//'
+  sed -n '2,18p' "$0" | sed 's/^#\{1,2\} \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -65,6 +70,7 @@ while [ $# -gt 0 ]; do
       shift ;;
     --timeout-minutes=*) TIMEOUT_MINUTES="${1#--timeout-minutes=}" ;;
     --human) HUMAN=1 ;;
+    --force) FORCE=1 ;;
     -h|--help) usage 0 ;;
     *) die "unknown argument: $1" 2 ;;
   esac
@@ -80,11 +86,18 @@ esac
 case "$POLL_SECONDS" in ''|*[!0-9]*|0) die "--poll-seconds needs a positive number, got: $POLL_SECONDS" 2 ;; esac
 case "$TIMEOUT_MINUTES" in ''|*[!0-9]*) die "--timeout-minutes needs a number, got: $TIMEOUT_MINUTES" 2 ;; esac
 case "$HUMAN" in 0|1) ;; *) die "--human is invalid" 2 ;; esac
+case "$FORCE" in 0|1) ;; *) die "--force is invalid" 2 ;; esac
 if [ "$COMMAND" = "acquire" ] || [ "$COMMAND" = "steal" ]; then
   [ -n "$REASON" ] || die "$COMMAND requires --reason" 2
 fi
 if [ "$COMMAND" != "steal" ] && [ "$HUMAN" -eq 1 ]; then
   die "--human is valid only with steal" 2
+fi
+if [ "$COMMAND" != "release" ] && [ "$FORCE" -eq 1 ]; then
+  die "--force is valid only with release" 2
+fi
+if [ "$COMMAND" = "release" ] && [ -z "$TASK" ] && [ "$FORCE" -ne 1 ]; then
+  die "release requires --task; pass --force to release by holder instead" 2
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
@@ -263,9 +276,14 @@ case "$COMMAND" in
     fi
     ;;
   acquire)
-    make_lease_blob
     deadline=$(( $(date +%s) + TIMEOUT_MINUTES * 60 ))
     while :; do
+      # Re-stamp before every attempt. acquiredAt is what the 45-minute machine
+      # steal threshold measures, so a blob built once at the top of the queue
+      # would hand the winner a protection window already shortened by however
+      # long it waited -- and past 45 minutes of queueing, a lease stealable the
+      # instant it is won.
+      make_lease_blob
       create_status=0
       try_create_lease || create_status=$?
       case "$create_status" in
@@ -322,6 +340,8 @@ case "$COMMAND" in
         exit 0
       fi
     else
+      # --force only: the holder is user@host, which does not distinguish two
+      # windows on one machine. The check still refuses another machine's lease.
       current_holder="$(printf '%s' "$LEASE_JSON" | node -e '
         let body = "";
         process.stdin.setEncoding("utf8");


### PR DESCRIPTION
Three defects in the merge path, each independently reproducible from its own symptom.

## 1. Executor claim turns a lost serialization race into a 500

`POST /runner/tasks/claim` runs Serializable and takes the chain row mutex through a raw `SELECT ... FOR UPDATE` (`lockChainRows`). When that raw statement loses a read/write-dependency conflict, Postgres reports SQLSTATE 40001 and Prisma surfaces it as `P2010` with the SQLSTATE in `meta` — not as the `P2034` it raises for its own query builder. The claim retry matched only `P2034`, so the conflict escaped as a 500 even though the work was still queued and the correct response was to run the transaction again.

Symptom: `merge-integrator-binding.dbtest.ts` → "concurrent Integrator claims for different target branches do not serialize each other" intermittently FAILs in the merge gate with `[200, 500]`.

`templates.ts` already classified this correctly. That classification and its jittered backoff move to `serialization-retry.ts`; `templates.ts` and the claim path both use it, and the claim retries up to six attempts with backoff instead of three without.

Local dbtest passes 10/10 after the change — but it also passes 12/12 with the old code, so the loop is not evidence: the flake needs the gate's concurrent file load to reproduce. `serialization-retry.test.ts` pins the actual defect directly: `P2010` + `40001`/`40P01` classifies as retryable, `P2010` + `23505` and a bare `P2010` do not.

## 2. `merge-lease.sh acquire` stamps `acquiredAt` when queueing began

`make_lease_blob` ran once before the poll loop, so the winner installed a blob timestamped at the head of the queue. `acquiredAt` is exactly what the 45-minute machine steal threshold measures, so a caller that queued N minutes received a protection window N minutes short — and past 45 minutes of queueing, a lease stealable the instant it was won.

Observed today: a window began queueing at 06:59:49 and won the lease around 07:05; the installed lease still read `acquiredAt: 06:59:49`.

Fixed by re-stamping before every `try_create_lease` attempt. Regression test asserts `acquiredAt` lands at the moment the lease was won, and fails against the old script.

The lease semantics are untouched: 45-minute threshold, no heartbeat, tty steal is immediate, machine steal still requires an over-age lease.

## 3. `merge-lease.sh release` could free a sibling window's lease

The default holder is `user@host`. Every agent window on one machine produces the same string, so `release` without `--task` fell back to a holder check that a different window on the same machine passes — releasing a lease it does not hold, when release exists precisely to remove only your own.

Several windows share one checkout, so nothing under `.git` can distinguish them. `release` now requires `--task`; `--force` opts back into the holder check when the acquiring task id is genuinely unknown. The `--task` idempotent re-entry on `acquire` (same task already held ⇒ success) is unchanged.

## 4. Delivery protocol

AGENTS.md records the `--task` convention for both `acquire` and `release`, and the rule the shared checkout needs: deliver from a dedicated `git worktree` on your own branch and stage only the paths you changed, rather than switching the shared checkout's branch out from under another window's uncommitted work. That failure happened today and cost a window its uncommitted changes.

## Verification

- `npm run build`, `npm run lint` clean
- `npm run test -w @agentos/api` — 455 pass, 0 fail
- `npm run test:gate-worker` (gate-dispatch.test.mjs) — 45 pass, 0 fail
- `merge-integrator-binding.dbtest.ts` — 16 pass, 10 consecutive runs
- merge gate on the exact candidate head

🤖 Generated with [Claude Code](https://claude.com/claude-code)