### PR TITLE
feat: raise plan review coordinator to sol xhigh

### DIFF
--- a/agents/roles/review-coordinator.md
+++ b/agents/roles/review-coordinator.md
@@ -1,7 +1,7 @@
 ---
 name: review-coordinator
 title: Review Coordinator
-model: openai-codex/gpt-5.6-sol:high
+model: openai-codex/gpt-5.6-sol:xhigh
 runner: pi
 inboxAccess: false
 collaborators: []

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -112,7 +112,7 @@ test("signed AgentOS model routing stays pinned in the canonical contract", () =
   });
   assert.deepEqual(canonical.get("review-coordinator"), {
     name: "review-coordinator",
-    model: "openai-codex/gpt-5.6-sol:high",
+    model: "openai-codex/gpt-5.6-sol:xhigh",
     runner: RunnerPreference.PI,
   });
   assert.deepEqual(canonical.get("review-coordinator-sol"), {

--- a/packages/db/src/agent-contract.ts
+++ b/packages/db/src/agent-contract.ts
@@ -15,7 +15,7 @@ export const CANONICAL_AGENT_DEFAULTS = [
   { name: "plan", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "plan-reviser", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "regression-verifier", model: "claude-opus-5:medium", runner: RunnerPreference.CLAUDE },
-  { name: "review-coordinator", model: "openai-codex/gpt-5.6-sol:high", runner: RunnerPreference.PI },
+  { name: "review-coordinator", model: "openai-codex/gpt-5.6-sol:xhigh", runner: RunnerPreference.PI },
   { name: "review-coordinator-opus", model: "claude-opus-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "review-adjudicator-opus", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
   { name: "review-coordinator-sol", model: "openai-codex/gpt-5.6-sol:xhigh", runner: RunnerPreference.PI },
@@ -33,9 +33,12 @@ export const CANONICAL_AGENT_RUNTIME_TRANSITIONS = new Map<string, {
   from: { model: string; runnerPreference: RunnerPreference };
   to: { model: string; runnerPreference: RunnerPreference };
 }>([
+  // 2026-08-25 ruling: the plan review is the sole reviewer gating implementation,
+  // so it buys the same depth as the dual-vendor code review. Supersedes the
+  // earlier CODEX-to-PI runner switch, whose target this from-value matches.
   ["review-coordinator", {
-    from: { model: "gpt-5.6-sol:high", runnerPreference: RunnerPreference.CODEX },
-    to: { model: "openai-codex/gpt-5.6-sol:high", runnerPreference: RunnerPreference.PI },
+    from: { model: "openai-codex/gpt-5.6-sol:high", runnerPreference: RunnerPreference.PI },
+    to: { model: "openai-codex/gpt-5.6-sol:xhigh", runnerPreference: RunnerPreference.PI },
   }],
   ["review-coordinator-sol", {
     from: { model: "openai-codex/gpt-5.6-sol:high", runnerPreference: RunnerPreference.PI },

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -211,7 +211,7 @@ test("sync rolls the exact old graphs forward without touching instantiated evid
 test("sync upgrades only the exact frozen-base review agent defaults", async () => {
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   const names = ["review-coordinator", "review-coordinator-sol"];
-  const frozenBase = { model: "gpt-5.6-sol:high", runnerPreference: RunnerPreference.CODEX };
+  const frozenBase = { model: "openai-codex/gpt-5.6-sol:high", runnerPreference: RunnerPreference.PI };
   const frozenSolBase = { model: "openai-codex/gpt-5.6-sol:high", runnerPreference: RunnerPreference.PI };
 
   await prisma.agent.updateMany({ where: { projectId: project.id, name: "review-coordinator" }, data: frozenBase });
@@ -247,9 +247,7 @@ test("sync upgrades only the exact frozen-base review agent defaults", async () 
   });
   assert.equal(upgraded.length, 2);
   assert.ok(upgraded.every((agent) => agent.runnerPreference === RunnerPreference.PI
-    && agent.model === (agent.name === "review-coordinator"
-      ? "openai-codex/gpt-5.6-sol:high"
-      : "openai-codex/gpt-5.6-sol:xhigh")));
+    && agent.model === "openai-codex/gpt-5.6-sol:xhigh"));
 });
 
 test("sync adopts the exact model-only executioner transition", async () => {


### PR DESCRIPTION
Leo's 2026-08-25 ruling: the plan review (compound step 3) is the sole reviewer gating implementation, so it buys the same reasoning depth as the dual-vendor code review. Re-pins review-coordinator openai-codex/gpt-5.6-sol high -> xhigh (runner stays PI) via a superseding runtime transition; frozen-base dbtest updated to the new from-value. Applies to the live row on the next auto-deploy sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)