### PR TITLE
fix: require --task on merge lease acquire

### DIFF
--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -757,12 +757,16 @@ const runLeaseAsync = (fixture, args, holder) =>
 
 test("merge lease acquire is mutually exclusive and release removes the lease", (t) => {
   const fixture = leaseFixture(t);
-  const first = runLease(fixture, ["acquire", "--reason", "First merge"], "first@fixture");
+  const first = runLease(
+    fixture,
+    ["acquire", "--reason", "First merge", "--task", "chain-1"],
+    "first@fixture",
+  );
   assert.equal(first.status, 0, first.stdout + first.stderr);
 
   const second = runLease(
     fixture,
-    ["acquire", "--reason", "Second merge", "--timeout-minutes", "0"],
+    ["acquire", "--reason", "Second merge", "--task", "chain-2", "--timeout-minutes", "0"],
     "second@fixture",
   );
   assert.equal(second.status, 75, second.stdout + second.stderr);
@@ -842,6 +846,14 @@ test("merge lease release refuses a caller that does not hold the lease", (t) =>
   assert.equal(released.status, 0, released.stdout + released.stderr);
   const status = runLease(fixture, ["status"]);
   assert.match(status.stdout, /no lease held/u);
+});
+
+test("merge lease acquire without --task is refused so every lease records its task", (t) => {
+  const fixture = leaseFixture(t);
+  const refused = runLease(fixture, ["acquire", "--reason", "Missing task"], "agent@mac");
+  assert.equal(refused.status, 2, refused.stdout + refused.stderr);
+  assert.match(refused.stderr, /acquire requires --task/u);
+  assert.match(runLease(fixture, ["status"]).stdout, /no lease held/u);
 });
 
 test("merge lease release without --task is refused rather than freeing a sibling window", (t) => {

--- a/scripts/merge-lease.sh
+++ b/scripts/merge-lease.sh
@@ -11,11 +11,11 @@
 # while integrating the latest main, proving the exact candidate, and advancing
 # main. There is deliberately no heartbeat: a machine may steal a lease only
 # after 45 minutes, while a human may steal it immediately. Release removes only
-# a lease you hold; breaking somebody else's lease requires steal. Release needs
-# --task because the default holder is user@host, which every agent window on
-# one machine shares: without a task only the machine is identified, so one
-# window would release another window's lease. Use --force to fall back to the
-# holder check when the acquiring task id is genuinely unknown.
+# a lease you hold; breaking somebody else's lease requires steal. Acquire and
+# release need --task because the default holder is user@host, which every agent
+# window on one machine shares: without a task only the machine is identified,
+# so one window would release another window's lease. Use --force to fall back
+# to the holder check when the acquiring task id is genuinely unknown.
 set -uo pipefail
 
 LEASE_REF="refs/merge-lease/holder"
@@ -89,6 +89,9 @@ case "$HUMAN" in 0|1) ;; *) die "--human is invalid" 2 ;; esac
 case "$FORCE" in 0|1) ;; *) die "--force is invalid" 2 ;; esac
 if [ "$COMMAND" = "acquire" ] || [ "$COMMAND" = "steal" ]; then
   [ -n "$REASON" ] || die "$COMMAND requires --reason" 2
+fi
+if [ "$COMMAND" = "acquire" ] && [ -z "$TASK" ]; then
+  die "acquire requires --task" 2
 fi
 if [ "$COMMAND" != "steal" ] && [ "$HUMAN" -eq 1 ]; then
   die "--human is valid only with steal" 2


### PR DESCRIPTION
PR #104 made release refuse to run without `--task`, because the default holder `user@host` is shared by every agent window on one machine. Acquire, however, still accepted a lease with no task recorded — such a lease can then only be released with `--force`, reopening the sibling-window confusion the release guard exists to prevent.

This enforces `--task` at acquire time as well (one validation line), updates the header comment, and covers both directions in `gate-dispatch.test.mjs`: a new test asserting acquire without `--task` exits 2 with `acquire requires --task` and leaves no lease, plus `--task` added to the one legacy test that acquired without it.

Both production call sites (the two regression-verification templates) already pass `--task`.

Test: `node --test scripts/gate-worker/gate-dispatch.test.mjs` — 46 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)