### PR TITLE
fix(runner): give the pinned-range fetch the clone timeout profile

### DIFF
--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -240,6 +240,45 @@ test("cloning carries a per-command ceiling while local git commands stay uncapp
   }
 });
 
+test("the pinned-range fetch carries the clone ceiling, not the incremental-fetch one", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agentos-workspace-pinned-timeout-"));
+  try {
+    const config = {
+      workspaceRoot: join(root, "workspaces"),
+      runAsPrefix: [],
+      path: process.env.PATH ?? "/usr/bin:/bin",
+      home: process.env.HOME ?? root,
+    } as unknown as RunnerConfig;
+    const claim = {
+      task: { id: "task-pinned-timeout" },
+      repo: { remoteUrl: "https://github.com/acme/app.git", defaultBranch: "main" },
+      run: {
+        id: "run-pinned-timeout",
+        runNumber: 1,
+        targetBranch: "main",
+        branch: "agentos/task-pinned-timeout/run-1",
+        pinnedBaseSha: "pinned-sha",
+        implementationBaseSha: "impl-base-sha",
+        implementationHeadSha: "pinned-sha",
+      },
+    } as ClaimedTask;
+    const ceilings = new Map<string, number | undefined>();
+    const fake: WorkspaceCommandExecutor = async (_config, executable, args, _cwd, _env, options) => {
+      ceilings.set(`${executable} ${args[0]}`, options?.timeoutMs);
+      if (args[0] === "rev-parse") return "pinned-sha";
+      return "";
+    };
+    await provisionWorkspace(config, claim, fake, { wait: async () => undefined });
+    // Into an empty object database this fetch transfers a clone's worth of
+    // history, so it must get the clone profile a slow link needs.
+    assert.equal(ceilings.get("git fetch"), CLONE_COMMAND_TIMEOUT_MS);
+    assert.equal(ceilings.get("git init"), undefined);
+    assert.equal(ceilings.get("git checkout"), undefined);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("session credentials are created through the run-as prefix, with the token off the command line", async () => {
   // Without this, the daemon's own uid writes into a tree owned by the launched
   // account: the mkdir fails outright, and if it did not, the 0600 file would

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -351,6 +351,11 @@ export const provisionWorkspace = async (
       // implementation range endpoints by object id, and stay detached at its
       // head. With no fetch of the chain branch, successor commits and their
       // report artifacts are not reachable from this object database.
+      //
+      // Into an empty object database this fetch transfers the same history a
+      // clone would, so it runs under the clone profile: a large repository is
+      // slow, not hung, and the 20s command ceiling built for incremental
+      // fetches kills every attempt on a slow link.
       await execute(config, "git", ["init"], workspace, env);
       await execute(config, "git", ["remote", "add", "origin", claim.repo.remoteUrl], workspace, env);
       await runWithNetworkRetry("git", ["fetch"],
@@ -362,7 +367,7 @@ export const provisionWorkspace = async (
           env,
           { timeoutMs },
         ),
-        retryOptions,
+        { commandTimeoutMs: CLONE_COMMAND_TIMEOUT_MS, budgetMs: CLONE_OPERATION_BUDGET_MS, ...retryOptions },
       );
       await execute(config, "git", ["checkout", "--detach", pinnedBaseSha], workspace, env);
       const baseSha = await execute(config, "git", ["rev-parse", "HEAD"], workspace, env);


### PR DESCRIPTION
## Problem
Blind-review (base-pinned) workspace provisioning builds an empty repository and fetches the immutable implementation range by object id. Into an empty object database that fetch transfers a clone's worth of history, but it ran under `NETWORK_COMMAND_TIMEOUT_MS` (20s) — the ceiling built for incremental fetches. On a slow link every attempt hits the ceiling and is killed, so pinned review steps can never provision: chain 17466265 step 8 (Opus adjudication) burned 8 consecutive runs on `git fetch timed out after 20000ms` while ordinary branch-clone steps (120s clone profile) provisioned fine.

## Fix
Pass the clone profile (`CLONE_COMMAND_TIMEOUT_MS`/`CLONE_OPERATION_BUDGET_MS`) to the pinned-range fetch, exactly as the branch-clone call below it already does. Caller-provided retryOptions still override, same ordering as the clone call.

## Tests
New workspace.test.ts case asserts the pinned fetch carries the clone ceiling while local git commands stay uncapped. Full @agentos/runner suite: 234 pass, 0 fail. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)