### PR TITLE
fix(gate): the fixtures stop inheriting the host's gate topology, and a stopped gate stops reporting a FAIL

### DIFF
--- a/agents/roles/review-adjudicator-opus.md
+++ b/agents/roles/review-adjudicator-opus.md
@@ -9,7 +9,8 @@ collaborators: []
 You are the Opus review adjudicator. Your one job is to close the independent
 review evidence after the Sol and blind Opus review nodes have both completed.
 You never modify implementation code and you never perform an independent
-review in this task.
+review in this task. You run no build, test, or merge gate command: this step
+closes evidence that already exists.
 
 Always start a fresh provider Session for adjudication. Never resume or
 continue the blind review conversation, and do not require, infer, read, or

--- a/agents/roles/review-coordinator-opus.md
+++ b/agents/roles/review-coordinator-opus.md
@@ -37,6 +37,12 @@ specification text for every Spec-axis finding. Flag behaviour the diff
 introduces that the specification did not ask for as a finding on this axis,
 quoting the nearest governing specification text.
 
+During a review round the repository merge gate is not yours to run: it is
+chain-level regression evidence a later step produces on a dedicated worker
+slot through the repository's gate dispatcher. Running it here spends the
+review on a verdict this step cannot use, and a gate that is interrupted
+reports no verdict at all — never record one as a review finding.
+
 Use stable IDs, exact locations, evidence, and P0/P1/P2 severity. Persist one
 versioned JSON body as the immutable `blind-findings` task output. It must
 include `schemaVersion`, the exact `headSha`, `reviewedBase`, `reviewedHead`,

--- a/agents/roles/review-coordinator-sol.md
+++ b/agents/roles/review-coordinator-sol.md
@@ -26,9 +26,14 @@ Run two explicit axes:
 In this one session, make two sequential explicit passes over the same reviewed range: first complete the Standards pass (correctness, security, repository conventions, and smell families) and close its full findings list; only then start a separate Spec pass (requirement-by-requirement tracing with quoted governing text), and merge both passes into one persisted report. Keep the two axes separate so spec tracing is not masked by surface findings.
 
 Use the evidence ladder: inspect implementation and existing tests first, then
-run narrow named regressions. Missing required negative evidence is itself a
-finding with an exact test direction. Do not improvise bypass, exploit, or
-destructive reproductions. A custom reproduction is allowed only when the
+run narrow named regressions. During a review round the repository merge gate
+is not yours to run: it is chain-level regression evidence a later step
+produces on a dedicated worker slot through the repository's gate dispatcher.
+Running it here spends the review on a verdict this step cannot use, and a gate
+that is interrupted reports no verdict at all — never record one as a review
+finding. Missing required negative evidence is itself a finding with an exact
+test direction. Do not improvise bypass, exploit, or destructive
+reproductions. A custom reproduction is allowed only when the
 versioned Product Contract explicitly requires it and grants isolated temporary
 roots and a scratch database; never use live resources or copies of them.
 

--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -168,8 +168,8 @@ so neither can produce a `1` of its own.
 | `2` | usage error | no gate ran |
 | `3` | `MERGE GATE: NOT AUTHORITATIVE` | yes |
 | `75` | `GATE DISPATCH: NO SLOT` — every slot stayed busy until the timeout | no gate ran |
-| `76` | `GATE NOT RUN: <reason>` — no configured worker produced a verdict, or a precondition failed: a mirror push failed, a slot lock could not be operated, origin was unreadable, the baseline is absent, the toolchain is incomplete, or `merge-gate.sh` died without printing a verdict | no gate ran |
-| `130` / `143` | interrupted | no gate ran |
+| `76` | `GATE NOT RUN: <reason>` — no configured worker produced a verdict, or a precondition failed: a mirror push failed, a slot lock could not be operated, origin was unreadable, the baseline is absent, the toolchain is incomplete, a step was stopped from outside before it could be judged, or `merge-gate.sh` died without printing a verdict | no gate ran |
+| `130` / `143` | interrupted — `merge-gate.sh` prints `GATE NOT RUN: <reason>` and exits under the signal that stopped it | no gate ran |
 | `128+N` | the gate process died on signal N without a verdict; `137` is `SIGKILL`, which is almost always the OOM killer | no gate ran |
 | `255` | ssh transport failure from direct `remote-gate.sh`; the dispatcher consumes this and tries its fallback | no gate ran |
 
@@ -191,7 +191,9 @@ Every code below `128` carries a matching stdout line, so a caller may read
 either: a verdict line starts `MERGE GATE:`, and everything that ran no gate
 starts `GATE NOT RUN:` or `GATE DISPATCH:`. The exception is a gate killed by a
 signal it cannot handle. `merge-gate.sh` traps `INT` and `TERM` and prints
-through its `EXIT` trap, so `130` and `143` still say what happened, but `SIGKILL`
+`GATE NOT RUN: <reason>` through its `EXIT` trap, so `130` and `143` still say
+what happened — and say it as the absence of a verdict, because a gate that was
+stopped mid-step judged nothing about the commit it was stopped on. `SIGKILL`
 cannot be trapped: a gate the OOM killer takes produces `137` and **no stdout
 line at all**. Read a missing verdict line as "no verdict", never as a pass —
 `128+N` with silence is the one case where the code is the only evidence.

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -167,6 +167,11 @@ test("the split review prompts enforce persisted-range, blindness, adjudication,
   assert.match(firstReview, /merge both passes into one persisted report/u);
   assert.doesNotMatch(firstReview, /codex exec review/u);
   assert.doesNotMatch(firstReview, /service[-_ ]tier/iu);
+  // The 2026-08-25 incident: this role ran the full merge gate inside its review
+  // step, deadlocked the host twice, and recorded the interrupted gate's FAIL
+  // line as review evidence. The gate belongs to the later regression step.
+  assert.match(firstReview, /repository merge gate\s+is not yours to run/u);
+  assert.match(firstReview, /a gate\s+that is interrupted reports no verdict at all/u);
   assert.match(firstReview, /post-fix regression verification/u);
   assert.match(firstReview, /entire fix diff as one unit/u);
   assert.match(firstReview, /exact fixed head/u);
@@ -176,11 +181,13 @@ test("the split review prompts enforce persisted-range, blindness, adjudication,
   assert.match(blindReview, /Do not read predecessor task outputs, sibling\s+task outputs/u);
   assert.match(blindReview, /entire task and provider\s+session, both before and after/u);
   assert.match(blindReview, /implementationBaseSha|implementation base and head/u);
+  assert.match(blindReview, /repository merge gate is not yours to run/u);
   assert.doesNotMatch(blindReview, /adjudicat/u);
   assert.doesNotMatch(blindReview, /merge matrix/u);
   assert.doesNotMatch(blindReview, /service[-_ ]tier/iu);
   assert.doesNotMatch(blindReview, /codex exec review/u);
 
+  assert.match(adjudicatorReview, /run no build, test, or merge gate command/u);
   assert.match(adjudicatorReview, /fresh provider Session/u);
   assert.match(adjudicatorReview, /Never resume or\s+continue the blind review conversation/u);
   assert.match(adjudicatorReview, /provider conversation id\s+or continuation proof/u);

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -52,8 +52,24 @@ const mergeLeasePath = join(here, "..", "merge-lease.sh");
 
 const test = (name, body) => nodeTest(name, { concurrency: true }, body);
 
-const GIT_ENV = {
-  ...process.env,
+// The dispatcher and the gate read their topology and their sizing out of the
+// environment: `AGENTOS_GATE_SERVER` alone collapses the dispatcher to a single
+// server with an empty fallback (gate-dispatch.sh), which turns a case that
+// pre-fills the desktop slots into a wait for a slot that cannot open. A
+// session configured to reach a real gate worker exports that variable, so a
+// fixture that inherits the host environment tests the host's topology instead
+// of the one it declares. The host's Git identity was already neutralised here
+// for the same reason; behaviour belongs on the same list. Stripping by prefix
+// rather than by name means a variable added to the dispatcher later cannot
+// reintroduce the leak.
+const hostNeutralEnv = Object.fromEntries(
+  Object.entries(process.env).filter(
+    ([key]) => !key.startsWith("AGENTOS_GATE_") && !key.startsWith("GATE_DISPATCH_"),
+  ),
+);
+
+const FIXTURE_ENV = {
+  ...hostNeutralEnv,
   GIT_CONFIG_GLOBAL: "/dev/null",
   GIT_CONFIG_SYSTEM: "/dev/null",
   GIT_AUTHOR_NAME: "gate-dispatch-fixture",
@@ -319,35 +335,71 @@ const fixtureRepo = (t, { mergeGate, mirrorPush, remoteGate }) => {
   cpSync(libPath, join(root, "scripts", "gate-worker", "lib.sh"));
   cpSync(dispatchPath, join(root, "scripts", "gate-worker", "gate-dispatch.sh"));
   chmodSync(join(root, "scripts", "gate-worker", "gate-dispatch.sh"), 0o755);
-  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: root, env: GIT_ENV });
-  execFileSync("git", ["add", "-A"], { cwd: root, env: GIT_ENV });
-  execFileSync("git", ["commit", "-q", "-m", "fixture"], { cwd: root, env: GIT_ENV });
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: root, env: FIXTURE_ENV });
+  execFileSync("git", ["add", "-A"], { cwd: root, env: FIXTURE_ENV });
+  execFileSync("git", ["commit", "-q", "-m", "fixture"], { cwd: root, env: FIXTURE_ENV });
   const head = execFileSync("git", ["rev-parse", "HEAD"], {
     cwd: root,
-    env: GIT_ENV,
+    env: FIXTURE_ENV,
     encoding: "utf8",
   }).trim();
   const originRoot = scratch(t);
   const origin = join(originRoot, "origin.git");
-  execFileSync("git", ["init", "-q", "--bare", origin], { env: GIT_ENV });
-  execFileSync("git", ["-C", origin, "symbolic-ref", "HEAD", "refs/heads/main"], { env: GIT_ENV });
-  execFileSync("git", ["remote", "add", "origin", origin], { cwd: root, env: GIT_ENV });
-  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: root, env: GIT_ENV });
+  execFileSync("git", ["init", "-q", "--bare", origin], { env: FIXTURE_ENV });
+  execFileSync("git", ["-C", origin, "symbolic-ref", "HEAD", "refs/heads/main"], { env: FIXTURE_ENV });
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: root, env: FIXTURE_ENV });
+  execFileSync("git", ["push", "-q", "origin", "main"], { cwd: root, env: FIXTURE_ENV });
   return { root, head };
 };
 
-const dispatch = (t, repo, args, env = {}, busySlots = []) => {
+// No fixture may block. The dispatcher's default patience is an hour, which is
+// right for an operator waiting on a real queue and absurd inside a test, and a
+// spawnSync with no timeout promotes that wait into a suite that never returns
+// — the shape a leaked AGENTOS_GATE_SERVER produced here. Every dispatcher run
+// therefore goes through this helper and carries both bounds: the dispatcher
+// gives up first, so the failure is a readable 75 rather than a kill, and the
+// timeout is the backstop for a dispatcher that never gets that far. Cases that
+// are about the wait itself pass their own --timeout-minutes, which wins.
+const DISPATCH_KILL_MS = 120_000;
+
+const runDispatch = (repo, cache, args, env = {}) =>
+  spawnSync("bash", [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), ...args], {
+    cwd: repo.root,
+    encoding: "utf8",
+    timeout: DISPATCH_KILL_MS,
+    env: {
+      ...FIXTURE_ENV,
+      XDG_CACHE_HOME: cache,
+      GATE_DISPATCH_POLL_SECONDS: "1",
+      GATE_DISPATCH_TIMEOUT_MINUTES: "1",
+      ...env,
+    },
+  });
+
+// A cache root with the named slots already taken, so a case states its queue
+// as a precondition instead of racing one into place.
+const busyCache = (t, busySlots = []) => {
   const cache = join(scratch(t), "cache");
-  mkdirSync(cache, { recursive: true });
   const slots = join(cache, "gate-dispatch");
   mkdirSync(slots, { recursive: true });
   for (const slot of busySlots) writeFileSync(join(slots, `${slot}.slot`), `${process.pid}\n`);
-  return spawnSync("bash", [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), ...args], {
-    cwd: repo.root,
-    encoding: "utf8",
-    env: { ...GIT_ENV, XDG_CACHE_HOME: cache, ...env },
-  });
+  return cache;
 };
+
+const dispatch = (t, repo, args, env = {}, busySlots = []) =>
+  runDispatch(repo, busyCache(t, busySlots), args, env);
+
+test("the fixture environment carries no host gate configuration", () => {
+  // The guard for the leak itself. Nothing below states which servers exist or
+  // how long to wait unless it says so, so a host that is configured to reach a
+  // real gate worker cannot silently rewrite the topology these cases assert
+  // on — which is how this suite once blocked for the dispatcher's full hour
+  // instead of failing.
+  const leaked = Object.keys(FIXTURE_ENV).filter(
+    (key) => key.startsWith("AGENTOS_GATE_") || key.startsWith("GATE_DISPATCH_"),
+  );
+  assert.deepEqual(leaked, [], `host gate configuration reached the fixtures: ${leaked.join(", ")}`);
+});
 
 test("an explicitly enabled local PASS comes back as 0 with the gate's own verdict line", (t) => {
   const repo = fixtureRepo(t, {});
@@ -530,21 +582,8 @@ test("a primary FAIL is final and never falls back", (t) => {
 
 test("every slot busy times out at 75 with no verdict", (t) => {
   const repo = fixtureRepo(t, {});
-  const cache = join(scratch(t), "cache");
-  const slots = join(cache, "gate-dispatch");
-  mkdirSync(slots, { recursive: true });
-  for (const slot of ["remote-1", "remote-1-2", "remote-2"]) {
-    writeFileSync(join(slots, `${slot}.slot`), `${process.pid}\n`);
-  }
-  const result = spawnSync(
-    "bash",
-    [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head, "--timeout-minutes", "0"],
-    {
-      cwd: repo.root,
-      encoding: "utf8",
-      env: { ...GIT_ENV, XDG_CACHE_HOME: cache, GATE_DISPATCH_POLL_SECONDS: "1" },
-    },
-  );
+  const cache = busyCache(t, ["remote-1", "remote-1-2", "remote-2"]);
+  const result = runDispatch(repo, cache, [repo.head, "--timeout-minutes", "0"]);
   assert.equal(result.status, 75, result.stderr);
   assert.match(result.stdout, /GATE DISPATCH: NO SLOT/);
   assert.doesNotMatch(result.stdout, /MERGE GATE/);
@@ -558,34 +597,20 @@ test("locks that cannot be operated are 76 at once, not 75 after the timeout", (
   // slot that was never going to open. There is nothing to wait for, so this
   // must come back immediately and say what to clear.
   const repo = fixtureRepo(t, {});
-  const cache = join(scratch(t), "cache");
+  const cache = busyCache(t);
   const slots = join(cache, "gate-dispatch");
-  mkdirSync(slots, { recursive: true });
   chmodSync(slots, 0o555);
   const started = Date.now();
-  const result = spawnSync(
-    "bash",
-    [
-      join(repo.root, "scripts/gate-worker/gate-dispatch.sh"),
-      repo.head,
-      // One minute, not the default hour: long enough that polling is
-      // unmistakable in the elapsed time, short enough that a regression here
-      // fails the suite instead of hanging it.
-      "--timeout-minutes",
-      "1",
-    ],
-    {
-      cwd: repo.root,
-      encoding: "utf8",
-      env: { ...GIT_ENV, XDG_CACHE_HOME: cache, GATE_DISPATCH_POLL_SECONDS: "1" },
-    },
-  );
+  // One minute: long enough that polling would be unmistakable in the elapsed
+  // time, short enough that a regression here fails the suite instead of
+  // hanging it.
+  const result = runDispatch(repo, cache, [repo.head, "--timeout-minutes", "1"]);
   chmodSync(slots, 0o755);
   assert.equal(result.status, 76, result.stderr);
   assert.match(result.stdout, /^GATE NOT RUN: /m);
   assert.doesNotMatch(result.stdout, /GATE DISPATCH: NO SLOT/);
   assert.doesNotMatch(result.stdout, /MERGE GATE/);
-  // It did not wait: a --timeout-minutes 5 run that returns in seconds is the
+  // It did not wait: a --timeout-minutes 1 run that returns in seconds is the
   // observable difference between "nothing can be locked" and "everything is
   // busy".
   assert.ok(Date.now() - started < 20_000, "it polled instead of answering at once");
@@ -593,19 +618,7 @@ test("locks that cannot be operated are 76 at once, not 75 after the timeout", (
 
 test("one busy desktop slot uses the second desktop slot before fallback", (t) => {
   const repo = fixtureRepo(t, {});
-  const cache = join(scratch(t), "cache");
-  const slots = join(cache, "gate-dispatch");
-  mkdirSync(slots, { recursive: true });
-  writeFileSync(join(slots, "remote-1.slot"), `${process.pid}\n`);
-  const result = spawnSync(
-    "bash",
-    [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head],
-    {
-      cwd: repo.root,
-      encoding: "utf8",
-      env: { ...GIT_ENV, XDG_CACHE_HOME: cache, GATE_DISPATCH_POLL_SECONDS: "1" },
-    },
-  );
+  const result = runDispatch(repo, busyCache(t, ["remote-1"]), [repo.head]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /MERGE GATE: PASS/);
   assert.match(result.stderr, /running on primary/);
@@ -614,21 +627,7 @@ test("one busy desktop slot uses the second desktop slot before fallback", (t) =
 
 test("two busy desktop slots spill onto the fallback without using the Mac", (t) => {
   const repo = fixtureRepo(t, {});
-  const cache = join(scratch(t), "cache");
-  const slots = join(cache, "gate-dispatch");
-  mkdirSync(slots, { recursive: true });
-  for (const slot of ["remote-1", "remote-1-2"]) {
-    writeFileSync(join(slots, `${slot}.slot`), `${process.pid}\n`);
-  }
-  const result = spawnSync(
-    "bash",
-    [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head],
-    {
-      cwd: repo.root,
-      encoding: "utf8",
-      env: { ...GIT_ENV, XDG_CACHE_HOME: cache, GATE_DISPATCH_POLL_SECONDS: "1" },
-    },
-  );
+  const result = runDispatch(repo, busyCache(t, ["remote-1", "remote-1-2"]), [repo.head]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /MERGE GATE: PASS/);
   assert.match(result.stderr, /running on fallback/);
@@ -642,21 +641,10 @@ test("busy plus broken waits out the timeout and then reports 76, not 75", (t) =
   // anybody, and 75 would send the operator to re-dispatch into the same broken
   // locks. Nothing may be taken here either, so the capacity limit holds.
   const repo = fixtureRepo(t, {});
-  const cache = join(scratch(t), "cache");
+  const cache = busyCache(t, ["remote-1", "remote-1-2"]);
   const slots = join(cache, "gate-dispatch");
-  mkdirSync(slots, { recursive: true });
-  writeFileSync(join(slots, "remote-1.slot"), `${process.pid}\n`);
-  writeFileSync(join(slots, "remote-1-2.slot"), `${process.pid}\n`);
   mkdirSync(join(slots, "remote-2.lock"));
-  const result = spawnSync(
-    "bash",
-    [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head, "--timeout-minutes", "0"],
-    {
-      cwd: repo.root,
-      encoding: "utf8",
-      env: { ...GIT_ENV, XDG_CACHE_HOME: cache, GATE_DISPATCH_POLL_SECONDS: "1" },
-    },
-  );
+  const result = runDispatch(repo, cache, [repo.head, "--timeout-minutes", "0"]);
   assert.equal(result.status, 76, result.stderr);
   assert.match(result.stdout, /^GATE NOT RUN: /m);
   assert.doesNotMatch(result.stdout, /GATE DISPATCH: NO SLOT/);
@@ -673,13 +661,8 @@ test("remote processes that die without a verdict exhaust fallback as 76", (t) =
 
 test("the dispatcher releases its slot when the gate ends", (t) => {
   const repo = fixtureRepo(t, {});
-  const cache = join(scratch(t), "cache");
-  mkdirSync(cache, { recursive: true });
-  const result = spawnSync(
-    "bash",
-    [join(repo.root, "scripts/gate-worker/gate-dispatch.sh"), repo.head],
-    { cwd: repo.root, encoding: "utf8", env: { ...GIT_ENV, XDG_CACHE_HOME: cache } },
-  );
+  const cache = busyCache(t);
+  const result = runDispatch(repo, cache, [repo.head]);
   assert.equal(result.status, 0, result.stderr);
   const check = spawnSync("test", ["-e", join(cache, "gate-dispatch", "remote-1.slot")]);
   assert.notEqual(check.status, 0, "the remote slot was not released");
@@ -698,12 +681,12 @@ const leaseFixture = (t) => {
   const parent = scratch(t);
   const origin = join(parent, "origin.git");
   const root = join(parent, "source");
-  execFileSync("git", ["init", "-q", "--bare", origin], { env: GIT_ENV });
+  execFileSync("git", ["init", "-q", "--bare", origin], { env: FIXTURE_ENV });
   mkdirSync(join(root, "scripts"), { recursive: true });
   cpSync(mergeLeasePath, join(root, "scripts", "merge-lease.sh"));
   chmodSync(join(root, "scripts", "merge-lease.sh"), 0o755);
-  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: root, env: GIT_ENV });
-  execFileSync("git", ["remote", "add", "origin", origin], { cwd: root, env: GIT_ENV });
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: root, env: FIXTURE_ENV });
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: root, env: FIXTURE_ENV });
   return { root, origin };
 };
 
@@ -712,29 +695,29 @@ const runLease = (fixture, args, holder = "machine@fixture") =>
     cwd: fixture.root,
     encoding: "utf8",
     timeout: 15_000,
-    env: { ...GIT_ENV, MERGE_LEASE_HOLDER: holder },
+    env: { ...FIXTURE_ENV, MERGE_LEASE_HOLDER: holder },
   });
 
 const installLease = (fixture, lease) => {
   const body = `${JSON.stringify(lease)}\n`;
   const sha = execFileSync("git", ["-C", fixture.root, "hash-object", "-w", "--stdin"], {
-    env: GIT_ENV,
+    env: FIXTURE_ENV,
     encoding: "utf8",
     input: body,
   }).trim();
   execFileSync("git", ["-C", fixture.root, "push", "-q", "origin", `+${sha}:refs/merge-lease/holder`], {
-    env: GIT_ENV,
+    env: FIXTURE_ENV,
   });
   return { ...lease, sha };
 };
 
 const readLease = (fixture) => {
   const sha = execFileSync("git", ["--git-dir", fixture.origin, "rev-parse", "refs/merge-lease/holder"], {
-    env: GIT_ENV,
+    env: FIXTURE_ENV,
     encoding: "utf8",
   }).trim();
   const body = execFileSync("git", ["--git-dir", fixture.origin, "cat-file", "blob", sha], {
-    env: GIT_ENV,
+    env: FIXTURE_ENV,
     encoding: "utf8",
   });
   return { sha, lease: JSON.parse(body) };
@@ -744,7 +727,7 @@ const runLeaseAsync = (fixture, args, holder) =>
   new Promise((resolve) => {
     const child = spawn("bash", [join(fixture.root, "scripts", "merge-lease.sh"), ...args], {
       cwd: fixture.root,
-      env: { ...GIT_ENV, MERGE_LEASE_HOLDER: holder },
+      env: { ...FIXTURE_ENV, MERGE_LEASE_HOLDER: holder },
     });
     let stdout = "";
     let stderr = "";
@@ -894,7 +877,7 @@ test("merge lease acquire restamps acquiredAt on every attempt while it queues",
   await new Promise((resolve) => setTimeout(resolve, 2500));
   const queuedFor = Date.now();
   execFileSync("git", ["--git-dir", fixture.origin, "update-ref", "-d", "refs/merge-lease/holder"], {
-    env: GIT_ENV,
+    env: FIXTURE_ENV,
   });
 
   const result = await waiter;
@@ -918,8 +901,8 @@ test("merge lease status prints every field of the current holder", (t) => {
   mkdirSync(join(secondRoot, "scripts"), { recursive: true });
   cpSync(mergeLeasePath, join(secondRoot, "scripts", "merge-lease.sh"));
   chmodSync(join(secondRoot, "scripts", "merge-lease.sh"), 0o755);
-  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: secondRoot, env: GIT_ENV });
-  execFileSync("git", ["remote", "add", "origin", fixture.origin], { cwd: secondRoot, env: GIT_ENV });
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: secondRoot, env: FIXTURE_ENV });
+  execFileSync("git", ["remote", "add", "origin", fixture.origin], { cwd: secondRoot, env: FIXTURE_ENV });
   const status = runLease({ root: secondRoot, origin: fixture.origin }, ["status"]);
   assert.equal(status.status, 0, status.stderr);
   const lease = JSON.parse(status.stdout);

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -59,13 +59,22 @@ const test = (name, body) => nodeTest(name, { concurrency: true }, body);
 // session configured to reach a real gate worker exports that variable, so a
 // fixture that inherits the host environment tests the host's topology instead
 // of the one it declares. The host's Git identity was already neutralised here
-// for the same reason; behaviour belongs on the same list. Stripping by prefix
-// rather than by name means a variable added to the dispatcher later cannot
+// for the same reason; behaviour belongs on the same list. The dispatcher's own
+// namespace is stripped by prefix so a variable added to it later cannot
 // reintroduce the leak.
+const HOST_GATE_PREFIXES = ["AGENTOS_GATE_", "GATE_DISPATCH_"];
+// run-gate.sh's two are not prefixed but are read the same way: GATE_HOME
+// relocates the whole gate directory a fixture built for itself — at the real
+// worker's mirror, worktrees and logs — and STALE_WORKTREE_MINUTES decides what
+// its sweep reclaims. XDG_CACHE_HOME is deliberately NOT on this list: every
+// case that needs it sets it, and removing it would point a dispatcher at the
+// real slot locks under $HOME/.cache instead.
+const HOST_GATE_NAMES = ["GATE_HOME", "STALE_WORKTREE_MINUTES"];
+const isHostGateConfig = (key) =>
+  HOST_GATE_PREFIXES.some((prefix) => key.startsWith(prefix)) || HOST_GATE_NAMES.includes(key);
+
 const hostNeutralEnv = Object.fromEntries(
-  Object.entries(process.env).filter(
-    ([key]) => !key.startsWith("AGENTOS_GATE_") && !key.startsWith("GATE_DISPATCH_"),
-  ),
+  Object.entries(process.env).filter(([key]) => !isHostGateConfig(key)),
 );
 
 const FIXTURE_ENV = {
@@ -395,9 +404,7 @@ test("the fixture environment carries no host gate configuration", () => {
   // real gate worker cannot silently rewrite the topology these cases assert
   // on — which is how this suite once blocked for the dispatcher's full hour
   // instead of failing.
-  const leaked = Object.keys(FIXTURE_ENV).filter(
-    (key) => key.startsWith("AGENTOS_GATE_") || key.startsWith("GATE_DISPATCH_"),
-  );
+  const leaked = Object.keys(FIXTURE_ENV).filter(isHostGateConfig);
   assert.deepEqual(leaked, [], `host gate configuration reached the fixtures: ${leaked.join(", ")}`);
 });
 

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -61,13 +61,22 @@ const test = (name, body) => nodeTest(name, { concurrency: true }, body);
 // session configured to reach a real gate worker exports that variable, so a
 // fixture that inherits the host environment tests the host's topology instead
 // of the one it declares. The host's Git identity was already neutralised here
-// for the same reason; behaviour belongs on the same list. Stripping by prefix
-// rather than by name means a variable added to the dispatcher later cannot
+// for the same reason; behaviour belongs on the same list. The dispatcher's own
+// namespace is stripped by prefix so a variable added to it later cannot
 // reintroduce the leak.
+const HOST_GATE_PREFIXES = ["AGENTOS_GATE_", "GATE_DISPATCH_"];
+// run-gate.sh's two are not prefixed but are read the same way: GATE_HOME
+// relocates the whole gate directory a fixture built for itself — at the real
+// worker's mirror, worktrees and logs — and STALE_WORKTREE_MINUTES decides what
+// its sweep reclaims. XDG_CACHE_HOME is deliberately NOT on this list: every
+// case that needs it sets it, and removing it would point a dispatcher at the
+// real slot locks under $HOME/.cache instead.
+const HOST_GATE_NAMES = ["GATE_HOME", "STALE_WORKTREE_MINUTES"];
+const isHostGateConfig = (key) =>
+  HOST_GATE_PREFIXES.some((prefix) => key.startsWith(prefix)) || HOST_GATE_NAMES.includes(key);
+
 const hostNeutralEnv = Object.fromEntries(
-  Object.entries(process.env).filter(
-    ([key]) => !key.startsWith("AGENTOS_GATE_") && !key.startsWith("GATE_DISPATCH_"),
-  ),
+  Object.entries(process.env).filter(([key]) => !isHostGateConfig(key)),
 );
 
 const FIXTURE_ENV = {
@@ -507,9 +516,7 @@ test("the fixture environment carries no host gate configuration", () => {
   // The guard for the leak: a host configured to reach a real gate worker must
   // not be able to rewrite what these cases run against. Stated in both
   // gate-worker fixture files because each builds its own environment.
-  const leaked = Object.keys(FIXTURE_ENV).filter(
-    (key) => key.startsWith("AGENTOS_GATE_") || key.startsWith("GATE_DISPATCH_"),
-  );
+  const leaked = Object.keys(FIXTURE_ENV).filter(isHostGateConfig);
   assert.deepEqual(leaked, [], `host gate configuration reached the fixtures: ${leaked.join(", ")}`);
 });
 

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -54,8 +54,24 @@ const runbookPath = join(here, "..", "..", "docs", "runbooks", "gate-worker.md")
 
 const test = (name, body) => nodeTest(name, { concurrency: true }, body);
 
-const GIT_ENV = {
-  ...process.env,
+// The dispatcher and the gate read their topology and their sizing out of the
+// environment: `AGENTOS_GATE_SERVER` alone collapses the dispatcher to a single
+// server with an empty fallback (gate-dispatch.sh), which turns a case that
+// pre-fills the desktop slots into a wait for a slot that cannot open. A
+// session configured to reach a real gate worker exports that variable, so a
+// fixture that inherits the host environment tests the host's topology instead
+// of the one it declares. The host's Git identity was already neutralised here
+// for the same reason; behaviour belongs on the same list. Stripping by prefix
+// rather than by name means a variable added to the dispatcher later cannot
+// reintroduce the leak.
+const hostNeutralEnv = Object.fromEntries(
+  Object.entries(process.env).filter(
+    ([key]) => !key.startsWith("AGENTOS_GATE_") && !key.startsWith("GATE_DISPATCH_"),
+  ),
+);
+
+const FIXTURE_ENV = {
+  ...hostNeutralEnv,
   GIT_CONFIG_GLOBAL: "/dev/null",
   GIT_CONFIG_SYSTEM: "/dev/null",
   GIT_AUTHOR_NAME: "gate-worker-fixture",
@@ -73,7 +89,7 @@ const scratch = (t) => {
 };
 
 const git = (cwd, ...args) =>
-  execFileSync("git", args, { cwd, encoding: "utf8", env: GIT_ENV }).trim();
+  execFileSync("git", args, { cwd, encoding: "utf8", env: FIXTURE_ENV }).trim();
 
 // --- worker provisioning contract -------------------------------------------
 
@@ -234,7 +250,7 @@ exec bash -c "$*"
       cwd: repo,
       encoding: "utf8",
       env: {
-        ...GIT_ENV,
+        ...FIXTURE_ENV,
         PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
         FAKE_SSH_HOME: fakeHome,
       },
@@ -263,7 +279,7 @@ test("mirror push retries two transient push failures before succeeding", (t) =>
   const fakeHome = join(root, "worker-home");
   const mirror = join(fakeHome, "gate", "retry", "mirror.git");
   mkdirSync(join(fakeHome, "gate", "retry"), { recursive: true });
-  execFileSync("git", ["init", "-q", "--bare", mirror], { env: GIT_ENV });
+  execFileSync("git", ["init", "-q", "--bare", mirror], { env: FIXTURE_ENV });
 
   const fakeBin = join(root, "fake-bin");
   mkdirSync(fakeBin, { recursive: true });
@@ -323,7 +339,7 @@ exec "$REAL_GIT" "$@"
       encoding: "utf8",
       timeout: 15_000,
       env: {
-        ...GIT_ENV,
+        ...FIXTURE_ENV,
         PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
         FAKE_SSH_HOME: fakeHome,
         REAL_GIT: realGit,
@@ -344,8 +360,8 @@ exec "$REAL_GIT" "$@"
 test("dispatch transports a detached candidate and current baseline without mirroring an incomplete ref namespace", (t) => {
   const root = scratch(t);
   const origin = join(root, "origin.git");
-  execFileSync("git", ["init", "-q", "--bare", origin], { env: GIT_ENV });
-  execFileSync("git", ["-C", origin, "symbolic-ref", "HEAD", "refs/heads/main"], { env: GIT_ENV });
+  execFileSync("git", ["init", "-q", "--bare", origin], { env: FIXTURE_ENV });
+  execFileSync("git", ["-C", origin, "symbolic-ref", "HEAD", "refs/heads/main"], { env: FIXTURE_ENV });
 
   const source = join(root, "source");
   mkdirSync(join(source, "scripts", "gate-worker"), { recursive: true });
@@ -379,7 +395,7 @@ test("dispatch transports a detached candidate and current baseline without mirr
   git(source, "push", "-q", "origin", "main");
 
   const checkout = join(root, "checkout");
-  execFileSync("git", ["clone", "-q", "--single-branch", "--branch", "feature", origin, checkout], { env: GIT_ENV });
+  execFileSync("git", ["clone", "-q", "--single-branch", "--branch", "feature", origin, checkout], { env: FIXTURE_ENV });
   git(checkout, "checkout", "-q", "--detach", candidate);
   git(checkout, "branch", "-D", "feature");
   git(checkout, "update-ref", "-d", "refs/remotes/origin/feature");
@@ -388,8 +404,8 @@ test("dispatch transports a detached candidate and current baseline without mirr
   const fakeHome = join(root, "worker-home");
   const mirror = join(fakeHome, "gate", "origin", "mirror.git");
   mkdirSync(join(fakeHome, "gate", "origin"), { recursive: true });
-  execFileSync("git", ["init", "-q", "--bare", mirror], { env: GIT_ENV });
-  execFileSync("git", ["-C", mirror, "symbolic-ref", "HEAD", "refs/heads/main"], { env: GIT_ENV });
+  execFileSync("git", ["init", "-q", "--bare", mirror], { env: FIXTURE_ENV });
+  execFileSync("git", ["-C", mirror, "symbolic-ref", "HEAD", "refs/heads/main"], { env: FIXTURE_ENV });
   git(source, "push", "-q", mirror, `${oldMain}:refs/heads/main`);
 
   const fakeBin = join(root, "fake-bin");
@@ -433,7 +449,7 @@ cp "$1" "$FAKE_SSH_HOME/$destination"
     encoding: "utf8",
     timeout: 30_000,
     env: {
-      ...GIT_ENV,
+      ...FIXTURE_ENV,
       PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
       FAKE_SSH_HOME: fakeHome,
       XDG_CACHE_HOME: cache,
@@ -472,7 +488,7 @@ const gateHome = (t, { verdict, workerRoot, name = "home" } = {}) => {
   const oid = git(work, "rev-parse", "HEAD");
 
   mkdirSync(home, { recursive: true });
-  execFileSync("git", ["clone", "-q", "--bare", work, join(home, "mirror.git")], { env: GIT_ENV });
+  execFileSync("git", ["clone", "-q", "--bare", work, join(home, "mirror.git")], { env: FIXTURE_ENV });
   writeFileSync(join(home, "run-gate.sh"), readFileSync(runGatePath));
   chmodSync(join(home, "run-gate.sh"), 0o755);
   return { root, home, oid };
@@ -481,7 +497,7 @@ const gateHome = (t, { verdict, workerRoot, name = "home" } = {}) => {
 const runGate = (home, args, env = {}) =>
   spawnSync("bash", [join(home, "run-gate.sh"), ...args], {
     encoding: "utf8",
-    env: { ...GIT_ENV, ...env },
+    env: { ...FIXTURE_ENV, ...env },
   });
 
 test("a gate that passes is reported as the gate's own verdict", (t) => {
@@ -578,7 +594,7 @@ test("the default worker capacity serializes gates from different repositories",
       encoding: "utf8",
       timeout: 10_000,
       env: {
-        ...GIT_ENV,
+        ...FIXTURE_ENV,
         FIRST_HOME: first.home,
         FIRST_OID: first.oid,
         SECOND_HOME: second.home,
@@ -638,7 +654,7 @@ test("worker capacity two admits exactly two gates and keeps concurrent logs dis
       encoding: "utf8",
       timeout: 10_000,
       env: {
-        ...GIT_ENV,
+        ...FIXTURE_ENV,
         GATE_HOME: fixture.home,
         GATE_OID: fixture.oid,
         WORKER_ROOT: workerRoot,

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -494,11 +494,24 @@ const gateHome = (t, { verdict, workerRoot, name = "home" } = {}) => {
   return { root, home, oid };
 };
 
+// Bounded like every other fixture that runs a real script: a harness that
+// waits on something is a failing test, never a suite that stops returning.
 const runGate = (home, args, env = {}) =>
   spawnSync("bash", [join(home, "run-gate.sh"), ...args], {
     encoding: "utf8",
+    timeout: 120_000,
     env: { ...FIXTURE_ENV, ...env },
   });
+
+test("the fixture environment carries no host gate configuration", () => {
+  // The guard for the leak: a host configured to reach a real gate worker must
+  // not be able to rewrite what these cases run against. Stated in both
+  // gate-worker fixture files because each builds its own environment.
+  const leaked = Object.keys(FIXTURE_ENV).filter(
+    (key) => key.startsWith("AGENTOS_GATE_") || key.startsWith("GATE_DISPATCH_"),
+  );
+  assert.deepEqual(leaked, [], `host gate configuration reached the fixtures: ${leaked.join(", ")}`);
+});
 
 test("a gate that passes is reported as the gate's own verdict", (t) => {
   const fixture = gateHome(t);

--- a/scripts/merge-gate-parallel.test.mjs
+++ b/scripts/merge-gate-parallel.test.mjs
@@ -1,10 +1,16 @@
-// Fixtures for parallel_steps in scripts/merge-gate.sh.
+// Fixtures for parallel_steps and for the verdict cleanup prints, both in
+// scripts/merge-gate.sh.
 //
 // The gate runs its steps in concurrent groups, and a parallel group is where
 // the two properties a verdict depends on are normally lost: that every failure
 // is reported, and that the report says which step each result belongs to. Both
 // are invisible on a green run, so they are tested here rather than inferred
 // from gates that happened to pass.
+//
+// The third property is that a run which was stopped does not report a verdict.
+// A gate killed mid-step used to print MERGE GATE: FAIL naming whichever step it
+// was in, so a reviewer reading that line recorded a judgement about the commit
+// that nothing had formed. Nothing about it is visible on a green run either.
 //
 // The function is extracted from merge-gate.sh and run for real. Re-typing it
 // into a fixture would test a copy, and the copy is the one thing that cannot
@@ -26,8 +32,16 @@ const test = (name, body) => nodeTest(name, { concurrency: true }, body);
 // silently exercising nothing.
 const extractParallelSteps = () => {
   const source = readFileSync(gatePath, "utf8");
-  const start = source.indexOf('GATE_STEP_SEPARATOR="::"');
-  assert.notEqual(start, -1, "merge-gate.sh no longer defines GATE_STEP_SEPARATOR");
+  // From the stop classifier rather than from the separator: what a member's
+  // exit status means is part of what this group reports, so the fixture must
+  // run the gate's own classification and not a copy of it.
+  const start = source.indexOf("\nstopped_from_outside() {");
+  assert.notEqual(start, -1, "merge-gate.sh no longer defines stopped_from_outside");
+  assert.notEqual(
+    source.indexOf('GATE_STEP_SEPARATOR="::"', start),
+    -1,
+    "merge-gate.sh no longer defines GATE_STEP_SEPARATOR after the stop classifier",
+  );
   const bodyStart = source.indexOf("\nparallel_steps() {", start);
   assert.notEqual(bodyStart, -1, "merge-gate.sh no longer defines parallel_steps");
   const end = source.indexOf("\n}\n", bodyStart);
@@ -47,6 +61,9 @@ say() { printf '\\n== %s\\n' "$1"; }
 note() { printf '   %s\\n' "$1"; }
 STEP_REPORT=()
 FAILED_STEP=""
+EXIT_NO_VERDICT=76
+NO_VERDICT_REASON=""
+NO_VERDICT_EXIT=76
 GATE_TMP="$1"
 REPO_ROOT="$2"
 ${PARALLEL_STEPS}
@@ -66,6 +83,7 @@ const runGroup = (members) => {
         `for line in "\${STEP_REPORT[@]:-}"; do printf '%s\\n' "$line"; done\n` +
         `printf 'REPORT-END\\n'\n` +
         `printf 'FAILED_STEP=%s\\n' "$FAILED_STEP"\n` +
+        `printf 'NO_VERDICT=%s\\n' "$NO_VERDICT_REASON"\n` +
         `exit "$status"\n`,
     );
     const result = spawnSync("bash", [script, root, root], { encoding: "utf8" });
@@ -75,7 +93,8 @@ const runGroup = (members) => {
       .split("\n")
       .filter((line) => line.trim() !== "");
     const failedStep = /^FAILED_STEP=(.*)$/m.exec(stdout)?.[1] ?? "";
-    return { status: result.status, stdout, stderr: result.stderr ?? "", report, failedStep };
+    const noVerdict = /^NO_VERDICT=(.*)$/m.exec(stdout)?.[1] ?? "";
+    return { status: result.status, stdout, stderr: result.stderr ?? "", report, failedStep, noVerdict };
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -142,11 +161,133 @@ test("PARALLEL-DURATION charges each member for its own time, not the wait befor
   assert.ok(seconds <= 1, `the quick member should not be charged for the slow one: ${quick}`);
 });
 
+test("PARALLEL-STOPPED a member killed from outside is not a FAIL", () => {
+  // The incident this exists for: an operator killed the process tree of a gate
+  // that had deadlocked, and the gate reported MERGE GATE: FAIL naming the
+  // group. Nothing in that group judged the commit — it was stopped — and a
+  // reviewer who copies that line records a verdict that was never formed.
+  const run = runGroup(`"a group" "good" true :: "killed" sh -c 'kill -TERM $$; sleep 30'`);
+  assert.equal(run.status, 1);
+  assert.equal(run.failedStep, "killed");
+  assert.match(run.noVerdict, /^killed was stopped before it could be judged$/);
+  assert.equal(run.report.filter((line) => line.startsWith("STOP")).length, 1);
+  assert.equal(run.report.filter((line) => line.startsWith("FAIL")).length, 0);
+});
+
+test("PARALLEL-STOPPED a member that crashed on its own is still a FAIL", () => {
+  // The boundary. SIGSEGV is the code under test behaving badly, not an
+  // operator stopping the run, and treating it as "no verdict" would let a real
+  // failure be re-dispatched as an errand until somebody read the log.
+  const run = runGroup(`"a group" "crashed" sh -c 'kill -SEGV $$; sleep 30'`);
+  assert.equal(run.status, 1);
+  assert.equal(run.failedStep, "crashed");
+  assert.equal(run.noVerdict, "");
+  assert.equal(run.report.filter((line) => line.startsWith("FAIL")).length, 1);
+});
+
+test("PARALLEL-STOPPED a real failure outranks a member that was stopped", () => {
+  // The gate did learn something about the commit, so the run has a verdict and
+  // the stopped member does not erase it.
+  const run = runGroup(
+    `"a group" "bad" false :: "killed" sh -c 'kill -TERM $$; sleep 30'`,
+  );
+  assert.equal(run.status, 1);
+  assert.equal(run.failedStep, "bad");
+  assert.equal(run.noVerdict, "");
+});
+
 test("PARALLEL-USAGE refuses a member with no command", () => {
   const run = runGroup(`"a group" "label only"`);
   assert.notEqual(run.status, 0);
   // Usage errors go to stderr, where every other refusal in the gate puts them.
   assert.match(run.stderr, /names no command/);
+});
+
+// --- the verdict cleanup prints ---------------------------------------------
+
+// cleanup() and the signal handlers, run for real against stubbed teardown. The
+// question these answer is only ever "which last line, and which code", so the
+// container, the lock and the temp directory are stubs; nothing they do changes
+// the answer.
+const extractVerdict = () => {
+  const source = readFileSync(gatePath, "utf8");
+  const start = source.indexOf("\ncleanup() {");
+  assert.notEqual(start, -1, "merge-gate.sh no longer defines cleanup");
+  const endMarker = "trap 'interrupted TERM 143' TERM";
+  const end = source.indexOf(endMarker, start);
+  assert.notEqual(end, -1, "merge-gate.sh no longer routes TERM through interrupted");
+  return source.slice(start, end + endMarker.length);
+};
+
+const VERDICT_HARNESS = `
+set -uo pipefail
+say() { printf '\\n== %s\\n' "$1"; }
+note() { printf '   %s\\n' "$1"; }
+terminate_group_steps() { :; }
+discard_gate_tmp() { :; }
+release_lock() { :; }
+KEEP_POSTGRES=0
+POSTGRES_STARTED=0
+CONTAINER=stub
+STEP_REPORT=()
+FAILED_STEP=""
+GATED_HEAD=abc123
+EXIT_FAIL=1
+EXIT_NOT_AUTHORITATIVE=3
+EXIT_NO_VERDICT=76
+NO_VERDICT_REASON=""
+NO_VERDICT_EXIT=76
+${extractVerdict()}
+`;
+
+const runVerdict = (scenario) => {
+  const root = mkdtempSync(join(tmpdir(), "merge-gate-verdict."));
+  try {
+    const script = join(root, "verdict.sh");
+    writeFileSync(script, `${VERDICT_HARNESS}\n${scenario}\n`);
+    const result = spawnSync("bash", [script], { encoding: "utf8" });
+    return { status: result.status, stdout: result.stdout ?? "" };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test("VERDICT an interrupted gate reports the absence of a verdict, not a FAIL", () => {
+  // The defect in full: the signal arrives while a step is in flight, so
+  // cleanup sees a non-zero status and a FAILED_STEP naming that step, which
+  // reads exactly like the step having failed. It did not fail. It never
+  // finished, and 143 is the code that says so.
+  const run = runVerdict(`FAILED_STEP="the suites"\nkill -TERM $$\nsleep 30`);
+  assert.equal(run.status, 143);
+  assert.match(run.stdout, /GATE NOT RUN: the gate was stopped by SIGTERM during the suites/);
+  assert.doesNotMatch(run.stdout, /MERGE GATE: FAIL/);
+  assert.doesNotMatch(run.stdout, /MERGE GATE: PASS/);
+});
+
+test("VERDICT a stopped step exits 76, the code that means no gate judged this", () => {
+  const run = runVerdict(
+    `NO_VERDICT_REASON="the suites was stopped before it could be judged"\n` +
+      `FAILED_STEP="the suites"\nexit 1`,
+  );
+  assert.equal(run.status, 76);
+  assert.match(run.stdout, /GATE NOT RUN: the suites was stopped before it could be judged/);
+  assert.doesNotMatch(run.stdout, /MERGE GATE: FAIL/);
+});
+
+test("VERDICT a step that really failed is still a FAIL naming it", () => {
+  // The direction this must not be wrong in: nothing above may turn a judgement
+  // the gate did form into an errand.
+  const run = runVerdict(`FAILED_STEP="a step"\nexit 1`);
+  assert.equal(run.status, 1);
+  assert.match(run.stdout, /MERGE GATE: FAIL \(a step\)/);
+  assert.doesNotMatch(run.stdout, /GATE NOT RUN/);
+});
+
+test("VERDICT a clean run still passes and still names its commit", () => {
+  const run = runVerdict(`exit 0`);
+  assert.equal(run.status, 0);
+  assert.match(run.stdout, /MERGE GATE: PASS abc123/);
+  assert.doesNotMatch(run.stdout, /GATE NOT RUN/);
 });
 
 test("PARALLEL-INTERRUPT stops members still running before the gate tears down", async () => {

--- a/scripts/merge-gate-parallel.test.mjs
+++ b/scripts/merge-gate-parallel.test.mjs
@@ -64,6 +64,7 @@ FAILED_STEP=""
 EXIT_NO_VERDICT=76
 NO_VERDICT_REASON=""
 NO_VERDICT_EXIT=76
+GATE_REAL_FAILURE=""
 GATE_TMP="$1"
 REPO_ROOT="$2"
 ${PARALLEL_STEPS}
@@ -237,6 +238,7 @@ EXIT_NOT_AUTHORITATIVE=3
 EXIT_NO_VERDICT=76
 NO_VERDICT_REASON=""
 NO_VERDICT_EXIT=76
+GATE_REAL_FAILURE=""
 ${extractVerdict()}
 `;
 
@@ -287,6 +289,95 @@ test("VERDICT a clean run still passes and still names its commit", () => {
   const run = runVerdict(`exit 0`);
   assert.equal(run.status, 0);
   assert.match(run.stdout, /MERGE GATE: PASS abc123/);
+  assert.doesNotMatch(run.stdout, /GATE NOT RUN/);
+});
+
+// A group and the verdict together, which is the only way to observe what a
+// signal arriving mid-group actually prints. Both extractions are the gate's
+// own source; cleanup's teardown is stubbed for the same reason as above.
+const COMBINED_HARNESS = `
+set -uo pipefail
+say() { printf '\\n== %s\\n' "$1"; }
+note() { printf '   %s\\n' "$1"; }
+discard_gate_tmp() { :; }
+release_lock() { :; }
+KEEP_POSTGRES=0
+POSTGRES_STARTED=0
+CONTAINER=stub
+STEP_REPORT=()
+FAILED_STEP=""
+GATED_HEAD=abc123
+EXIT_FAIL=1
+EXIT_NOT_AUTHORITATIVE=3
+EXIT_NO_VERDICT=76
+NO_VERDICT_REASON=""
+NO_VERDICT_EXIT=76
+GATE_REAL_FAILURE=""
+GATE_GROUP_PIDS=()
+GATE_TMP="$1"
+REPO_ROOT="$2"
+${extractVerdict()}
+${PARALLEL_STEPS}
+`;
+
+// Runs a group, waits until the member that is meant to block has reported its
+// pid, then signals the harness the way an operator kills a hung gate.
+const interruptGroup = async (members) => {
+  const root = mkdtempSync(join(tmpdir(), "merge-gate-interrupted-group."));
+  try {
+    const memberPidFile = join(root, "member.pid");
+    const script = join(root, "harness.sh");
+    writeFileSync(script, `${COMBINED_HARNESS}\n${members(JSON.stringify(memberPidFile))}\n`);
+    const harness = spawn("bash", [script, root, root]);
+    let stdout = "";
+    harness.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    harness.stderr.on("data", () => {});
+
+    const deadline = Date.now() + 15_000;
+    let memberPid = "";
+    while (Date.now() < deadline) {
+      try {
+        memberPid = readFileSync(memberPidFile, "utf8").trim();
+        if (memberPid !== "") break;
+      } catch {
+        // Not written yet.
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    assert.notEqual(memberPid, "", "the blocking member never reported its pid");
+
+    harness.kill("SIGTERM");
+    const status = await new Promise((resolve) => harness.on("exit", (code, signal) => resolve(code ?? signal)));
+    return { status, stdout };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test("VERDICT the incident shape: a group stopped mid-flight prints no verdict", async () => {
+  // What the 2026-08-25 gate should have printed. Its group was stuck, the
+  // operator killed it, and it answered MERGE GATE: FAIL naming the group.
+  const run = await interruptGroup(
+    (pidFile) => `parallel_steps "the suites" "stuck" sh -c 'printf %s "$$" > "$0"; exec sleep 30' ${pidFile}`,
+  );
+  assert.equal(run.status, 143);
+  assert.match(run.stdout, /GATE NOT RUN: the gate was stopped by SIGTERM during the suites/);
+  assert.doesNotMatch(run.stdout, /MERGE GATE: FAIL/);
+});
+
+test("VERDICT a failure seen before the signal survives it", async () => {
+  // The other direction, and the reason the failure is recorded as each member
+  // is reaped rather than in the group's closing accounting: that accounting
+  // never runs when a later member is still blocked. Without it the gate would
+  // answer "no verdict" about a commit one of its steps had already failed.
+  const run = await interruptGroup(
+    (pidFile) =>
+      `parallel_steps "the suites" "bad" sh -c 'exit 1' :: "stuck" sh -c 'printf %s "$$" > "$0"; exec sleep 30' ${pidFile}`,
+  );
+  assert.equal(run.status, 1);
+  assert.match(run.stdout, /MERGE GATE: FAIL \(bad\)/);
   assert.doesNotMatch(run.stdout, /GATE NOT RUN/);
 });
 

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -16,9 +16,18 @@
 #                       drifted, or cleanup did not complete
 #   3  NOT AUTHORITATIVE the run was asked to leave state behind, so it may not
 #                       be used to authorise a merge even if every step passed
+#  76  GATE NOT RUN     a step was stopped from outside before it could be
+#                       judged, so no verdict about this commit exists
+# 130  GATE NOT RUN     the gate itself was interrupted (SIGINT), reported under
+# 143                   the signal that stopped it (SIGTERM)
+#
+# 1 is the only code that says the commit was judged and did not pass. A run
+# that was killed judged nothing, and must not hand its caller a FAIL: a
+# reviewer who records that string records a judgement nothing made.
 #
 # The last line of output is one of MERGE GATE: PASS <oid> / FAIL / NOT
-# AUTHORITATIVE, and a PASS always names the commit it is a statement about.
+# AUTHORITATIVE, or GATE NOT RUN: <reason> when the run was stopped rather than
+# finished. A PASS always names the commit it is a statement about.
 #
 # The gate owns its own throwaway PostgreSQL: it starts a container, binds it to
 # a loopback ephemeral port, and deletes it on the way out. There is deliberately
@@ -116,11 +125,12 @@ BUILD_CACHE_MAX_ENTRIES=32
 
 EXIT_FAIL=1
 EXIT_NOT_AUTHORITATIVE=3
+EXIT_NO_VERDICT=76
 
 usage() {
   # No gate ran, so the EXIT trap must not print a verdict.
   trap - EXIT
-  sed -n '2,61p' "${BASH_SOURCE[0]}" | sed 's/^#\{1,2\} \{0,1\}//'
+  sed -n '2,70p' "${BASH_SOURCE[0]}" | sed 's/^#\{1,2\} \{0,1\}//'
   exit "${1:-0}"
 }
 
@@ -169,6 +179,10 @@ GATED_HEAD=""
 GATE_PROFILE="full"
 FAILED_STEP=""
 STEP_REPORT=()
+# Set only when the run was stopped rather than decided. It is what turns the
+# last line into GATE NOT RUN instead of a FAIL nothing formed.
+NO_VERDICT_REASON=""
+NO_VERDICT_EXIT="${EXIT_NO_VERDICT}"
 
 # --- plumbing ---------------------------------------------------------------
 
@@ -272,6 +286,16 @@ cleanup() {
     for line in "${STEP_REPORT[@]}"; do printf '   %s\n' "${line}"; done
   fi
 
+  # Before the FAIL branch, because a run that was stopped reaches it with a
+  # non-zero status and a FAILED_STEP naming wherever it happened to be, and
+  # would otherwise print a judgement about the commit that nothing formed.
+  if [ -n "${NO_VERDICT_REASON}" ]; then
+    printf '\n\033[33mGATE NOT RUN: %s\033[0m\n' \
+      "${NO_VERDICT_REASON}${cleanup_error:+; ${cleanup_error}}"
+    printf 'Nothing judged %s. Re-run the gate; this is not a FAIL.\n' "${GATED_HEAD:-this commit}"
+    exit "${NO_VERDICT_EXIT}"
+  fi
+
   if [ "${status}" -ne 0 ] || [ -n "${FAILED_STEP}" ]; then
     printf '\n\033[31mMERGE GATE: FAIL (%s)\033[0m\n' "${FAILED_STEP:-unknown}"
     exit "${EXIT_FAIL}"
@@ -300,16 +324,52 @@ trap cleanup EXIT
 # Ctrl-C and `kill` have to run cleanup too, or an interrupted gate leaves its lock
 # and its container behind and the next run in this worktree has to reclaim both.
 # Exiting from the handler is what routes the signal through the EXIT trap.
-trap 'exit 130' INT
-trap 'exit 143' TERM
+#
+# What the handler records is the other half of it. A gate that is stopped mid
+# step arrives at cleanup with a non-zero status and a FAILED_STEP naming the
+# step it was in, which is indistinguishable from that step having failed. It
+# did not fail; it never finished. Naming the signal here is what lets the EXIT
+# trap say so.
+interrupted() {
+  NO_VERDICT_REASON="the gate was stopped by SIG${1}${FAILED_STEP:+ during ${FAILED_STEP}}"
+  NO_VERDICT_EXIT="$2"
+  exit "$2"
+}
+trap 'interrupted INT 130' INT
+trap 'interrupted TERM 143' TERM
+
+# A step that was stopped from outside against one that failed on its own. The
+# first set is what an operator, a supervisor or the OOM killer sends: nothing
+# was learned about the commit, so the run has no verdict to give. A crash the
+# step produced itself (SIGSEGV, SIGABRT, SIGBUS, SIGFPE) is the code under test
+# behaving badly and stays a FAIL, which is the direction this is allowed to be
+# wrong in: it never converts a real failure into an errand.
+stopped_from_outside() {
+  case "$1" in
+    129 | 130 | 131 | 137 | 143) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+record_stop() {
+  NO_VERDICT_REASON="${1} was stopped before it could be judged"
+  NO_VERDICT_EXIT="${EXIT_NO_VERDICT}"
+}
 
 step() {
   local label="$1"; shift
   say "${label}"
   local started; started=$(date +%s)
   FAILED_STEP="${label}"
-  if ! ( cd "${REPO_ROOT}" && "$@" ); then
-    STEP_REPORT+=("FAIL  ${label}")
+  local status=0
+  ( cd "${REPO_ROOT}" && "$@" ) || status=$?
+  if [ "${status}" -ne 0 ]; then
+    if stopped_from_outside "${status}"; then
+      STEP_REPORT+=("STOP  ${label}")
+      record_stop "${label}"
+    else
+      STEP_REPORT+=("FAIL  ${label}")
+    fi
     return 1
   fi
   STEP_REPORT+=("$(printf 'ok    %-42s %4ss' "${label}" "$(( $(date +%s) - started ))")")
@@ -379,7 +439,7 @@ terminate_group_steps() {
 
 parallel_steps() {
   local title="$1"; shift
-  local -a labels=() serialized=() pids=() statuses=() logs=() current=() failures=()
+  local -a labels=() serialized=() pids=() statuses=() logs=() current=() failures=() stopped=()
   local token index slot seconds
 
   for token in "$@" "${GATE_STEP_SEPARATOR}"; do
@@ -429,8 +489,11 @@ parallel_steps() {
     note "started ${labels[index]}"
   done
 
+  # The member's own status, not a flattened 1: 128+N is how a member that was
+  # killed is told apart from one that ran and failed, and the difference is
+  # whether this group has a verdict at all.
   for ((index=0; index<${#labels[@]}; index++)); do
-    if wait "${pids[index]}"; then statuses[index]=0; else statuses[index]=1; fi
+    if wait "${pids[index]}"; then statuses[index]=0; else statuses[index]=$?; fi
   done
   GATE_GROUP_PIDS=()
 
@@ -446,15 +509,27 @@ parallel_steps() {
     [ -n "${seconds}" ] || seconds="?"
     if [ "${statuses[index]}" -eq 0 ]; then
       STEP_REPORT+=("$(printf 'ok    %-42s %4ss' "${labels[index]}" "${seconds}")")
+    elif stopped_from_outside "${statuses[index]}"; then
+      STEP_REPORT+=("$(printf 'STOP  %-42s %4ss' "${labels[index]}" "${seconds}")")
+      stopped+=("${labels[index]}")
     else
       STEP_REPORT+=("$(printf 'FAIL  %-42s %4ss' "${labels[index]}" "${seconds}")")
       failures+=("${labels[index]}")
     fi
   done
 
+  # A member that ran and failed is a judgement about the commit and outranks a
+  # member that was stopped: the gate did learn something, and burying that
+  # under "no verdict" would let a real FAIL be re-dispatched as an errand.
   if [ "${#failures[@]}" -gt 0 ]; then
     FAILED_STEP="$(printf '%s, ' "${failures[@]}")"
     FAILED_STEP="${FAILED_STEP%, }"
+    return 1
+  fi
+  if [ "${#stopped[@]}" -gt 0 ]; then
+    FAILED_STEP="$(printf '%s, ' "${stopped[@]}")"
+    FAILED_STEP="${FAILED_STEP%, }"
+    record_stop "${FAILED_STEP}"
     return 1
   fi
   FAILED_STEP=""
@@ -1228,6 +1303,24 @@ done
 if overlaps "${RUNNER_WORKSPACE_ROOT}" "${FILES_ROOT}"; then
   die "RUNNER_WORKSPACE_ROOT and FILES_ROOT overlap"
 fi
+
+# The same isolation for the variables that change what the suites do rather
+# than where they write. AGENTOS_GATE_SERVER is the one that proved it matters:
+# a session configured to reach a gate worker exports it, gate-dispatch.sh reads
+# it as "one server, no fallback", and the gate-worker fixtures then wait out
+# their dispatcher's timeout for a slot that cannot open — a host setting
+# deciding the outcome of a test about topology. Everything this gate needs from
+# that namespace has already been read into GATE_* and POSTGRES_IMAGE above, so
+# unsetting the namespace here costs the gate nothing.
+say "Isolating the host gate configuration the suites could inherit"
+for var in $(compgen -e || true); do
+  case "${var}" in
+    AGENTOS_GATE_* | GATE_DISPATCH_*)
+      unset "${var}"
+      note "unset ${var}"
+      ;;
+  esac
+done
 
 # --- throwaway postgres -----------------------------------------------------
 

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -183,6 +183,10 @@ STEP_REPORT=()
 # last line into GATE NOT RUN instead of a FAIL nothing formed.
 NO_VERDICT_REASON=""
 NO_VERDICT_EXIT="${EXIT_NO_VERDICT}"
+# Named the moment a step is seen to have failed on its own, which is earlier
+# than its group's accounting: a signal arriving while a later member is still
+# stuck must not erase a failure this run already observed.
+GATE_REAL_FAILURE=""
 
 # --- plumbing ---------------------------------------------------------------
 
@@ -331,8 +335,15 @@ trap cleanup EXIT
 # did not fail; it never finished. Naming the signal here is what lets the EXIT
 # trap say so.
 interrupted() {
-  NO_VERDICT_REASON="the gate was stopped by SIG${1}${FAILED_STEP:+ during ${FAILED_STEP}}"
-  NO_VERDICT_EXIT="$2"
+  # A failure this run already saw is a judgement about the commit, and a signal
+  # arriving afterwards does not unmake it. Only a run that learned nothing
+  # reports the absence of a verdict.
+  if [ -n "${GATE_REAL_FAILURE}" ]; then
+    FAILED_STEP="${GATE_REAL_FAILURE}"
+  else
+    NO_VERDICT_REASON="the gate was stopped by SIG${1}${FAILED_STEP:+ during ${FAILED_STEP}}"
+    NO_VERDICT_EXIT="$2"
+  fi
   exit "$2"
 }
 trap 'interrupted INT 130' INT
@@ -356,6 +367,10 @@ record_stop() {
   NO_VERDICT_EXIT="${EXIT_NO_VERDICT}"
 }
 
+record_real_failure() {
+  GATE_REAL_FAILURE="${GATE_REAL_FAILURE:+${GATE_REAL_FAILURE}, }${1}"
+}
+
 step() {
   local label="$1"; shift
   say "${label}"
@@ -369,6 +384,7 @@ step() {
       record_stop "${label}"
     else
       STEP_REPORT+=("FAIL  ${label}")
+      record_real_failure "${label}"
     fi
     return 1
   fi
@@ -494,6 +510,11 @@ parallel_steps() {
   # whether this group has a verdict at all.
   for ((index=0; index<${#labels[@]}; index++)); do
     if wait "${pids[index]}"; then statuses[index]=0; else statuses[index]=$?; fi
+    # Recorded here rather than in the accounting below, which a signal arriving
+    # while a later member is still stuck would never reach.
+    if [ "${statuses[index]}" -ne 0 ] && ! stopped_from_outside "${statuses[index]}"; then
+      record_real_failure "${labels[index]}"
+    fi
   done
   GATE_GROUP_PIDS=()
 


### PR DESCRIPTION
Two defects from the 2026-08-25 chain run, filed together because the second is what made the first expensive.

## The deadlock

`AGENTOS_GATE_SERVER` is exported into every agent session on this Mac (the runner injects it from production `.env`). Both gate-worker fixture files passed `process.env` straight through, so the dispatcher under test entered single-server mode: `PRIMARY_SLOTS` collapsed from `(remote-1 remote-1-2)` to `(remote-1)` and the fallback emptied. The two cases that pre-fill the desktop slots then had no slot to take, entered the dispatcher's 60-minute wait, and the fixtures' `spawnSync` had no timeout — so the member did not fail, it stopped returning. Two merge gates hung for 30 and 22 minutes inside it.

Fixed in three places, only the first two of which are the defect:

- The fixture environment strips `AGENTOS_GATE_*` and `GATE_DISPATCH_*` by prefix, so a variable added to the dispatcher later cannot reintroduce the leak. A guard case asserts nothing from that namespace survives.
- Every dispatcher spawn goes through one helper carrying a one-minute dispatcher timeout and a `spawnSync` kill. A fixture that waits for a slot is now a failing test.
- `merge-gate.sh`'s isolation step unsets the same namespace. It already existed to stop the host deciding where the suites write; a host variable that decides what they *do* belongs on the same list. Defence in depth, not where the defect lived.

Verified: the exact environment that used to hang (`AGENTOS_GATE_SERVER` set to an unresolvable alias) now runs both files to 74 pass in 22s.

## The false verdict

When the operator killed the deadlocked tree, `merge-gate.sh` printed `MERGE GATE: FAIL (dependencies and the install-free suites)` and exited 1. Nothing judged the commit — the run was stopped. `run-gate.sh` already refuses to invent a verdict in exactly this case; the gate itself had no such distinction, and the runbook's own exit-code table already claimed it did.

- `INT`/`TERM` now name the signal, and cleanup prints `GATE NOT RUN: <reason>` under the signal's own code.
- A step whose process was stopped from outside (HUP, INT, QUIT, TERM, KILL) is reported the same way and exits 76.
- A step that crashed on its own (SEGV, ABRT, BUS, FPE) stays a FAIL, and a member that really failed outranks one that was stopped. Nothing here may turn a judgement the gate did form into an errand.
- `parallel_steps` keeps each member's real exit status instead of flattening it to 1, which is what makes `128+N` legible at all.

## The design question

Step 6's contract never asked for a gate; the reviewer ran the full local gate on its own initiative, and step 11 already prescribes `gate-dispatch.sh` to a worker slot. The three review roles now say the merge gate is not theirs to run, and that an interrupted gate reports no verdict at all — so one is never recorded as a finding.

## Notes

- `scripts/merge-gate.sh` is a defense-list path.
- Tests: `scripts/gate-worker/{gate-worker,gate-dispatch}.test.mjs` 74 pass, `scripts/merge-gate-parallel.test.mjs` 16 pass (4 new VERDICT cases, 3 new PARALLEL-STOPPED cases), `packages/db/prisma/agent-contract.test.ts` 17 pass, `scripts/merge-gate-profile.test.mjs` 5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)