### PR TITLE
fix(api): truncate an over-long failure reason, and let PATCH clear a stale one

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -966,9 +966,7 @@ const reclaimReportInput = z.object({
   results: z.array(z.object({
     runId: id,
     outcome: z.enum(["REMOVED", "REFUSED", "FAILED"]),
-    // Half the usual limit: a reclaim report carries up to 5000 of these in one
-    // request, so its per-entry bound is a bound on the body as well.
-    failureReason: failureReasonText(FAILURE_REASON_LIMIT / 2).nullable().optional(),
+    failureReason: failureReasonText(FAILURE_REASON_LIMIT).nullable().optional(),
   })).max(5000),
 });
 const reclaimSalvageInput = z.object({
@@ -987,7 +985,7 @@ const heartbeatInput = z.object({
 });
 const cancelRunInput = z.object({
   requestId: z.string().trim().min(1).max(160),
-  reason: z.string().trim().min(1).max(2000),
+  reason: z.string().trim().min(1).pipe(failureReasonText(FAILURE_REASON_LIMIT)),
   parkTask: z.boolean().default(false),
 });
 const cancelAcknowledgeInput = z.object({
@@ -1121,7 +1119,10 @@ const preflightInput = z.object({
   cliVersion: z.string().nullable().optional(),
   authMode: z.string().nullable().optional(),
   capabilities: z.record(z.string(), z.unknown()),
-  error: z.string().nullable().optional(),
+  // Written straight onto every blocked task as its `failureReason` (and kept
+  // as the circuit reason those rows are later matched by), so it is bounded
+  // here, where both writes read the same already-truncated string.
+  error: failureReasonText(FAILURE_REASON_LIMIT).nullable().optional(),
 });
 const runnerAvailabilityInput = z.object({
   // Optional only for the API-first half of a rolling deployment. A runner

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -106,6 +106,7 @@ import { authenticate, issueSessionToken, principalMayAccess, type Principal } f
 import { boardCard, chainDisplayByTask, etagFor, etagMatches, serializeUsageCost } from "./board.js";
 import { isValidBranchName } from "./branch-name.js";
 import { chainExecutionOwner } from "./chain-execution-owner.js";
+import { FAILURE_REASON_LIMIT, failureReasonText } from "./failure-reason.js";
 import {
   canonicalOutputRefusal,
   isCanonicalAdjudicationStep,
@@ -918,8 +919,13 @@ export const taskInput = z.object({
     context.addIssue({ code: "custom", message: "chainId and chainIndex must be provided together" });
   }
 });
-const taskPatch = z.object(taskFields).partial().extend({ status: z.nativeEnum(TaskStatus).optional() })
-  .refine((value) => Object.keys(value).length > 0);
+// `failureReason` is patchable but not creatable: a task is never born with a
+// failure, and an operator whose task carries a stale one needs a way to clear
+// it — an explicit null — without inventing a run.
+const taskPatch = z.object(taskFields).partial().extend({
+  status: z.nativeEnum(TaskStatus).optional(),
+  failureReason: failureReasonText(FAILURE_REASON_LIMIT).nullable().optional(),
+}).refine((value) => Object.keys(value).length > 0);
 const activityInput = z.object({
   actorType: z.string().trim().min(1).max(40).default("operator"),
   actorId: z.string().trim().min(1).nullable().optional(),
@@ -960,7 +966,9 @@ const reclaimReportInput = z.object({
   results: z.array(z.object({
     runId: id,
     outcome: z.enum(["REMOVED", "REFUSED", "FAILED"]),
-    failureReason: z.string().max(2000).nullable().optional(),
+    // Half the usual limit: a reclaim report carries up to 5000 of these in one
+    // request, so its per-entry bound is a bound on the body as well.
+    failureReason: failureReasonText(FAILURE_REASON_LIMIT / 2).nullable().optional(),
   })).max(5000),
 });
 const reclaimSalvageInput = z.object({
@@ -1069,7 +1077,7 @@ const completionInput = z.object({
   terminalSuccess: z.boolean(),
   terminationReason: z.string().nullable().optional(),
   failureClass: z.nativeEnum(FailureClass).optional(),
-  failureReason: z.string().max(4000).optional(),
+  failureReason: failureReasonText(FAILURE_REASON_LIMIT).optional(),
   retryable: z.boolean().optional(),
   externalFailure: z.boolean().default(false),
   branch: z.string().nullable().optional(),

--- a/packages/api/src/failure-reason.dbtest.ts
+++ b/packages/api/src/failure-reason.dbtest.ts
@@ -74,8 +74,11 @@ const seedTask = async () => {
   return { project, agent, repo, task };
 };
 
+const queueRun = async (taskId: string) =>
+  await db.$transaction((tx) => enqueueTaskRun(tx as never, taskId)) as { id: string };
+
 const claimRun = async (taskId: string) => {
-  const queued = await db.$transaction((tx) => enqueueTaskRun(tx as never, taskId)) as { id: string };
+  const queued = await queueRun(taskId);
   const now = new Date();
   const fencingToken = `fence-${queued.id}`;
   const run = await db.run.update({ where: { id: queued.id }, data: {
@@ -162,4 +165,36 @@ test("a failure reason clears on the same request that moves the status", async 
   const after = await db.task.findUniqueOrThrow({ where: { id: task.id } });
   assert.equal(after.status, TaskStatus.TODO);
   assert.equal(after.failureReason, null);
+});
+
+// The `opensPullRequest` branch is a third write path through the same route,
+// and it is the one an operator uses while re-aiming a failed task.
+test("a failure reason clears alongside an opensPullRequest edit", async () => {
+  const { task } = await seedTask();
+  await db.task.update({ where: { id: task.id }, data: { failureReason: "gate formed no verdict" } });
+
+  const patched = await call("PATCH", `/tasks/${task.id}`, OPERATOR, {
+    opensPullRequest: false, failureReason: null,
+  });
+  assert.equal(patched.status, 200, JSON.stringify(patched.body));
+
+  const edited = await db.task.findUniqueOrThrow({ where: { id: task.id } });
+  assert.equal(edited.opensPullRequest, false);
+  assert.equal(edited.failureReason, null);
+});
+
+// A cancellation reason lands on the Run, the Task and the Session as a failure
+// reason, so it goes through the same door rather than a rejecting `.max()`.
+test("an over-long cancellation reason is truncated instead of refused", async () => {
+  const { task } = await seedTask();
+  const run = await queueRun(task.id);
+
+  const cancelled = await call("POST", `/runs/${run.id}/cancel`, OPERATOR, {
+    requestId: "cancel-long-reason", reason: DIAGNOSIS,
+  });
+  assert.equal(cancelled.status, 200, JSON.stringify(cancelled.body));
+
+  const stopped = await db.run.findUniqueOrThrow({ where: { id: run.id } });
+  assert.equal(stopped.failureReason?.length, FAILURE_REASON_LIMIT);
+  assert.match(stopped.failureReason!, /\[truncated by the API: \d+ characters exceeded the 4000-character limit\]$/u);
 });

--- a/packages/api/src/failure-reason.dbtest.ts
+++ b/packages/api/src/failure-reason.dbtest.ts
@@ -1,0 +1,165 @@
+/**
+ * R5: a long diagnosis must not be what kills the run that wrote it.
+ *
+ * `failureReason` used to be `z.string().max(4000)` on the completion route, so
+ * a session that reported a thorough failure got a 400 from zod and lost the
+ * whole completion — the report, the run's disposition, everything — to the
+ * length of its own evidence. It is now truncated at the boundary instead.
+ *
+ * The second half is the way back out: PATCH /tasks/:id could not write
+ * `failureReason` at all, so a task carrying a stale reason had no way to shed
+ * it short of a database edit.
+ */
+
+import "./test-workspace-root.js";
+import assert from "node:assert/strict";
+import { after, before, beforeEach, test } from "node:test";
+
+import { enqueueTaskRun, PrismaClient, TaskStatus } from "@agentos/db";
+
+import { hashToken } from "./auth.js";
+import { FAILURE_REASON_LIMIT } from "./failure-reason.js";
+import { createApp } from "./test-app.js";
+import { resetTestDb, setupTestDb } from "./testdb.js";
+
+let db: PrismaClient;
+before(() => { db = setupTestDb(); });
+beforeEach(async () => { await resetTestDb(db); });
+after(async () => { await db.$disconnect(); });
+
+const OPERATOR = "operator-failure-reason";
+const RUNNER = "runner-failure-reason";
+
+const call = async (
+  method: string, path: string, token: string, body?: unknown,
+): Promise<{ status: number; body: any }> => {
+  const prior = [["OPERATOR_TOKEN", process.env.OPERATOR_TOKEN], ["RUNNER_TOKEN", process.env.RUNNER_TOKEN]] as const;
+  process.env.OPERATOR_TOKEN = OPERATOR;
+  process.env.RUNNER_TOKEN = RUNNER;
+  try {
+    const response = await createApp(db).request(path, {
+      method,
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    return { status: response.status, body: response.status === 204 ? null : await response.json().catch(() => null) };
+  } finally {
+    for (const [key, value] of prior) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+  }
+};
+
+let sequence = 0;
+const seedTask = async () => {
+  sequence += 1;
+  const suffix = `${process.pid}-${sequence}`;
+  const project = await db.project.create({ data: { name: "Failure reason", slug: `failure-reason-${suffix}` } });
+  const environment = await db.environment.create({ data: { projectId: project.id, name: "local", allowedHosts: [] } });
+  const agent = await db.agent.create({ data: {
+    projectId: project.id, environmentId: environment.id, name: `agent-${suffix}`, title: "Agent",
+    model: "claude-opus-5:high", foundationalPrompt: "foundation", rolePrompt: "role",
+  } });
+  const repo = await db.repo.create({ data: {
+    projectId: project.id, name: "repo", remoteUrl: "https://github.com/acme/widgets.git",
+    mountPath: "/repo", defaultBranch: "master",
+  } });
+  await db.agentRepoAccess.create({ data: {
+    projectId: project.id, agentId: agent.id, repoId: repo.id, mountPath: "/repo", permissions: "GIT_WRITE",
+  } });
+  const task = await db.task.create({ data: {
+    projectId: project.id, name: "Step", description: "work", assigneeAgentId: agent.id,
+    repoId: repo.id, status: TaskStatus.TODO, targetBranch: "master",
+  } });
+  return { project, agent, repo, task };
+};
+
+const claimRun = async (taskId: string) => {
+  const queued = await db.$transaction((tx) => enqueueTaskRun(tx as never, taskId)) as { id: string };
+  const now = new Date();
+  const fencingToken = `fence-${queued.id}`;
+  const run = await db.run.update({ where: { id: queued.id }, data: {
+    status: "RUNNING", runnerId: "runner-1", fencingToken, leaseGeneration: 1,
+    leaseExpiresAt: new Date(now.getTime() + 600_000),
+    sessionTokenHash: hashToken(`agos_session_${queued.id}`),
+    sessionTokenExpiresAt: new Date(now.getTime() + 600_000),
+    claimedAt: now, heartbeatAt: now, startedAt: now,
+  } });
+  await db.session.create({ data: {
+    runId: run.id, projectId: run.projectId, agentId: run.agentId, taskId: run.taskId, runner: run.runner,
+    executionStatus: "RUNNING",
+  } });
+  await db.task.update({ where: { id: taskId }, data: { status: TaskStatus.DOING } });
+  return { run, fencingToken };
+};
+
+const DIAGNOSIS = `${"the inbox advisory lock is taken in two orders; ".repeat(300)}TAIL MARKER`;
+
+test("a completion whose failure reason exceeds the limit is truncated, not refused", async () => {
+  const { task } = await seedTask();
+  const { run, fencingToken } = await claimRun(task.id);
+  assert.ok(DIAGNOSIS.length > FAILURE_REASON_LIMIT, "the fixture has to exceed the limit");
+
+  const completed = await call("POST", `/runner/runs/${run.id}/complete`, RUNNER, {
+    runnerId: "runner-1",
+    fencingToken,
+    exitCode: 1,
+    signal: null,
+    terminalEventSeen: false,
+    terminalSuccess: false,
+    failureClass: "TASK_FAILED",
+    retryable: false,
+    failureReason: DIAGNOSIS,
+    branch: run.branch ?? "master",
+    pushStatus: "NOT_REQUESTED",
+    cleanupStatus: "SUCCEEDED",
+    workspaceRetained: false,
+  });
+  // Before R5 this was a 400 from zod's `too_big`, and the run stayed RUNNING
+  // with no disposition at all.
+  assert.equal(completed.status, 200, JSON.stringify(completed.body));
+
+  const closed = await db.run.findUniqueOrThrow({ where: { id: run.id } });
+  assert.equal(closed.status, "FAILED");
+  assert.equal(closed.failureReason?.length, FAILURE_REASON_LIMIT);
+  assert.ok(closed.failureReason!.startsWith("the inbox advisory lock is taken in two orders;"));
+  assert.match(closed.failureReason!, /\[truncated by the API: \d+ characters exceeded the 4000-character limit\]$/u);
+  assert.equal(closed.failureReason!.includes("TAIL MARKER"), false);
+});
+
+test("an operator clears a stale failure reason with an explicit null", async () => {
+  const { task } = await seedTask();
+  await db.task.update({ where: { id: task.id }, data: { failureReason: "gate formed no verdict" } });
+
+  const patched = await call("PATCH", `/tasks/${task.id}`, OPERATOR, { failureReason: null });
+  assert.equal(patched.status, 200, JSON.stringify(patched.body));
+  assert.equal(patched.body.failureReason, null);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: task.id } })).failureReason, null);
+});
+
+test("a patched failure reason is bounded by the same truncation", async () => {
+  const { task } = await seedTask();
+
+  const patched = await call("PATCH", `/tasks/${task.id}`, OPERATOR, { failureReason: DIAGNOSIS });
+  assert.equal(patched.status, 200, JSON.stringify(patched.body));
+
+  const stored = (await db.task.findUniqueOrThrow({ where: { id: task.id } })).failureReason;
+  assert.equal(stored?.length, FAILURE_REASON_LIMIT);
+  assert.match(stored!, /\[truncated by the API: \d+ characters exceeded the 4000-character limit\]$/u);
+});
+
+// A status change takes the locked write path; the reason has to travel with it
+// rather than be dropped by the branch that happens to serve the request.
+test("a failure reason clears on the same request that moves the status", async () => {
+  const { task } = await seedTask();
+  await db.task.update({ where: { id: task.id }, data: {
+    status: TaskStatus.REVIEW, failureReason: "gate formed no verdict",
+  } });
+
+  const patched = await call("PATCH", `/tasks/${task.id}`, OPERATOR, { status: "TODO", failureReason: null });
+  assert.equal(patched.status, 200, JSON.stringify(patched.body));
+
+  const after = await db.task.findUniqueOrThrow({ where: { id: task.id } });
+  assert.equal(after.status, TaskStatus.TODO);
+  assert.equal(after.failureReason, null);
+});

--- a/packages/api/src/failure-reason.test.ts
+++ b/packages/api/src/failure-reason.test.ts
@@ -30,3 +30,18 @@ test("the schema truncates rather than rejecting", () => {
   assert.equal(parsed.success, true);
   assert.equal(parsed.data!.length, FAILURE_REASON_LIMIT);
 });
+
+// PostgreSQL rejects a lone surrogate outright, so a cut that lands between the
+// halves of an astral character must drop the orphan rather than store it.
+test("truncation never cuts a surrogate pair in half", () => {
+  // The sweep is the point: where the cut lands inside the emoji run depends on
+  // the marker's own length, so a single fixture proves only its own offset.
+  for (let head = 3900; head <= 3960; head += 1) {
+    const truncated = truncateFailureReason(`${"a".repeat(head)}${"\u{1f600}".repeat(50)}`, FAILURE_REASON_LIMIT);
+    assert.ok(truncated.length <= FAILURE_REASON_LIMIT, `head ${head}`);
+    for (const character of truncated) {
+      const code = character.codePointAt(0)!;
+      assert.ok(code < 0xd800 || code > 0xdfff, `lone surrogate at head ${head}`);
+    }
+  }
+});

--- a/packages/api/src/failure-reason.test.ts
+++ b/packages/api/src/failure-reason.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { FAILURE_REASON_LIMIT, failureReasonText, truncateFailureReason } from "./failure-reason.js";
+
+test("a reason within the limit is stored exactly as it arrived", () => {
+  const reason = "git push timed out after 6000ms";
+  assert.equal(truncateFailureReason(reason, FAILURE_REASON_LIMIT), reason);
+  assert.equal(truncateFailureReason("x".repeat(100), 100), "x".repeat(100));
+});
+
+test("an over-long reason keeps its head, is marked, and fits the limit", () => {
+  const truncated = truncateFailureReason(`${"d".repeat(9000)}TAIL`, FAILURE_REASON_LIMIT);
+  assert.equal(truncated.length, FAILURE_REASON_LIMIT);
+  assert.ok(truncated.startsWith("d".repeat(100)));
+  assert.equal(truncated.includes("TAIL"), false);
+  assert.match(truncated, /\n\[truncated by the API: 9004 characters exceeded the 4000-character limit\]$/u);
+});
+
+// The marker cannot be honoured below its own length, and a limit that small is
+// a caller's mistake rather than a shape this function may invent an answer
+// for: it still returns evidence, cut to the bound it was given.
+test("a limit narrower than the marker still yields a bounded reason", () => {
+  const truncated = truncateFailureReason("y".repeat(50), 10);
+  assert.equal(truncated, "y".repeat(10));
+});
+
+test("the schema truncates rather than rejecting", () => {
+  const parsed = failureReasonText(FAILURE_REASON_LIMIT).safeParse("z".repeat(20_000));
+  assert.equal(parsed.success, true);
+  assert.equal(parsed.data!.length, FAILURE_REASON_LIMIT);
+});

--- a/packages/api/src/failure-reason.ts
+++ b/packages/api/src/failure-reason.ts
@@ -1,0 +1,28 @@
+/**
+ * A failure reason is evidence, and the API's job is to keep it, not to grade
+ * its length. Refusing an over-long reason with a 400 destroyed the whole
+ * report — a session that wrote a long diagnosis into `failureReason` lost its
+ * run to the validation error rather than to the failure it was describing.
+ *
+ * So the bound stays (unbounded client text is still not stored verbatim) but
+ * it is enforced by truncation: the head of the reason survives, and the marker
+ * says plainly that a tail was dropped so nobody reads the remainder as the
+ * whole story.
+ */
+
+import { z } from "zod";
+
+/** What a single reason may occupy once stored. */
+export const FAILURE_REASON_LIMIT = 4000;
+
+export const truncateFailureReason = (reason: string, limit: number): string => {
+  if (reason.length <= limit) return reason;
+  const marker = `\n[truncated by the API: ${reason.length} characters exceeded the ${limit}-character limit]`;
+  const kept = limit - marker.length;
+  return kept > 0 ? `${reason.slice(0, kept)}${marker}` : reason.slice(0, limit);
+};
+
+/** The failure-reason field every client-facing schema uses, so that no entry
+ *  point can reintroduce the 400 by declaring its own `z.string().max(...)`. */
+export const failureReasonText = (limit: number): z.ZodType<string, string> =>
+  z.string().transform((reason) => truncateFailureReason(reason, limit));

--- a/packages/api/src/failure-reason.ts
+++ b/packages/api/src/failure-reason.ts
@@ -12,14 +12,24 @@
 
 import { z } from "zod";
 
-/** What a single reason may occupy once stored. */
+/** What one stored reason may occupy, wherever it entered from. */
 export const FAILURE_REASON_LIMIT = 4000;
+
+/** A high surrogate is only half a character. Cutting between the halves would
+ *  store a lone surrogate, which is not text PostgreSQL will accept, so the
+ *  orphan goes with the tail it belonged to. */
+const withoutOrphanSurrogate = (text: string): string => {
+  const last = text.charCodeAt(text.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? text.slice(0, -1) : text;
+};
 
 export const truncateFailureReason = (reason: string, limit: number): string => {
   if (reason.length <= limit) return reason;
   const marker = `\n[truncated by the API: ${reason.length} characters exceeded the ${limit}-character limit]`;
   const kept = limit - marker.length;
-  return kept > 0 ? `${reason.slice(0, kept)}${marker}` : reason.slice(0, limit);
+  return kept > 0
+    ? `${withoutOrphanSurrogate(reason.slice(0, kept))}${marker}`
+    : withoutOrphanSurrogate(reason.slice(0, limit));
 };
 
 /** The failure-reason field every client-facing schema uses, so that no entry


### PR DESCRIPTION
Board card R5 (`cmt9bqj3d00knmpruwnf44v74`), ruling in `records/BRIEF-zero-gate-rulings-20260825.md`.

## What was wrong

`failureReason` was `z.string().max(4000)` on the completion route. A session that wrote a long diagnosis into it got a 400 `too_big` back, and the whole completion died with it: no disposition on the run, no record of the failure being described. That is chain step 9 run #1's cause of death on 2026-08-25.

The way back out was missing too. `PATCH /tasks/:id` did not accept `failureReason` at all, so a task carrying a reason from a run that no longer applies had no way to shed it short of a database edit.

## What changed

- `packages/api/src/failure-reason.ts` collects the bound in one place. Over the limit, the head survives and a marker says a tail was dropped, so nobody reads the remainder as the whole story. Truncation never cuts between the halves of a surrogate pair -- a lone surrogate is not text PostgreSQL accepts.
- Every client-facing door that ends up in a `failureReason` column now uses it at one limit: the completion route, the reclaim report, the preflight `error` (written verbatim onto every blocked task and matched again later to clear the circuit), and the cancellation `reason`, which still refused an over-long diagnosis with exactly the 400 this change exists to remove.
- `failureReason` joins the PATCH whitelist, explicit null included. It stays out of the create schema: a task is never born with a failure.

## Review

Reviewed with `codex exec -m gpt-5.6-sol` at `xhigh`; each finding checked independently.

- The over-long preflight `error`, the still-rejecting cancel `reason`, and the surrogate-pair cut were real and are fixed here.
- A comment claiming the reclaim route's per-entry limit bounded the request body was wrong -- the limit runs after `request.json()` -- so the comment and the halved limit it justified are both gone. A real body bound would be a route-level concern, not a zod transform's, and is not this card's.
- One finding is declined: the `status: DONE` gate-replay branch returns the task without applying `updateData`, so a replay drops `failureReason`. That branch already drops every other field the same way and predates this change; it is a deliberate replay guard, not something introduced here.

## Tests

`packages/api/src/failure-reason.test.ts` (limit boundary, marker, surrogate sweep) and `failure-reason.dbtest.ts` (completion truncated rather than 400, PATCH null clears, PATCH truncates, clearing alongside a status change and alongside an `opensPullRequest` edit, cancellation truncated).

`npm test -w @agentos/api`: 466 pass, 1 skipped. `MERGE GATE: PASS c8168a23946bf87186dbc550a4f5de8ea592a431`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
