### PR TITLE
feat(runner): capture PI per-message usage into the session columns

### DIFF
--- a/packages/api/src/usage.test.ts
+++ b/packages/api/src/usage.test.ts
@@ -193,7 +193,9 @@ const PI_AGENT_SETTLED_WITH_USAGE = {
     output: 24,
     cacheRead: 3584,
     cacheWrite: 0,
-    costUsd: 0.00123808,
+    // Integer nano-USD: the runner cannot reach Prisma.Decimal, so it sums the
+    // per-message costs in an exact integer domain instead of in doubles.
+    costNanoUsd: 1_238_080,
   },
 };
 
@@ -321,6 +323,7 @@ test("the PI aggregate is exclusive of the provider vocabularies it replaces", (
   const usage = extractUsage({ ...PI_AGENT_SETTLED_WITH_USAGE, usage: { input_tokens: 99 }, total_cost_usd: 7 });
   assert.equal(usage.inputTokens, 5688);
   assert.equal(usage.costUsd?.toString(), "0.00123808");
+  assert.equal(usage.costUsd?.equals(new Prisma.Decimal("0.00123808")), true);
 });
 
 test("a PI aggregate that reports nothing usable leaves every column null", async () => {
@@ -331,17 +334,35 @@ test("a PI aggregate that reports nothing usable leaves every column null", asyn
     assert.deepEqual(extractUsage({ type: "agent_settled", agentosPiUsage: totals }), {}, JSON.stringify(totals ?? null));
   }
   const { result: usage, warnings } = await withCapturedWarnings(
-    () => extractUsage({ agentosPiUsage: { input: -1, output: 8, cacheRead: 1.5, costUsd: "free" } }),
+    () => extractUsage({ agentosPiUsage: { input: -1, output: 8, cacheRead: 1.5, costNanoUsd: 0.5 } }),
   );
   assert.deepEqual(usage, { outputTokens: 8 });
   assert.equal(warnings.length, 3);
   assert.match(warnings.join("\n"), /agentosPiUsage\.input/u);
-  assert.match(warnings.join("\n"), /agentosPiUsage\.costUsd/u);
+  // A fractional nano-USD did not come from the PI parser, so its exactness —
+  // the whole reason for the integer transport — cannot be assumed.
+  assert.match(warnings.join("\n"), /agentosPiUsage\.costNanoUsd/u);
+});
+
+test("the PI cost transport is exact where a double sum would round the wrong way", () => {
+  // 0.000001 + 0.000049 as doubles is 0.0000499999…, which the column rounds to
+  // 0.0000. The runner sends 1000 + 49000 nano-USD instead, and this is where
+  // that integer becomes the 0.0001 the session actually cost.
+  const usage = extractUsage({ agentosPiUsage: { input: 2, output: 2, costNanoUsd: 50_000 } });
+  assert.equal(usage.costUsd?.toString(), "0.00005");
+  assert.equal(deriveUsageColumns(usage).costUsd?.toString(), "0.0001");
 });
 
 test("PI sessions accumulate across attempts the way every other runner does", () => {
-  // A resumed PI session spawns a fresh process with a fresh accumulator, so
-  // each attempt contributes its own FINAL_OUTPUT row.
+  // A PI session that resumes after SETTLING spawns a fresh process with a fresh
+  // accumulator, so each attempt contributes its own FINAL_OUTPUT row.
+  //
+  // Known limitation, shared with CLAUDE and CODEX rather than introduced here:
+  // an attempt whose process is killed before it settles — an Inbox suspension
+  // is the live case — produces no FINAL_OUTPUT, and its usage is lost. The
+  // fencing rejection that triggers the kill has already cleared the delivery
+  // lease, so there is no event this adapter could emit that would still be
+  // accepted. Closing that needs a control-plane change, not a parser change.
   const total = sumUsage([PI_AGENT_SETTLED_WITH_USAGE, PI_AGENT_SETTLED_WITH_USAGE].map(extractUsage));
   assert.equal(total.inputTokens, 11376);
   assert.equal(total.costUsd?.toString(), "0.00247616");

--- a/packages/api/src/usage.test.ts
+++ b/packages/api/src/usage.test.ts
@@ -180,6 +180,23 @@ const CODEX_TURN_COMPLETED = {
 
 const PI_AGENT_SETTLED = { type: "agent_settled" };
 
+// What the runner's PI parser attaches to that same terminal event once it has
+// summed the session's per-message usage. Numbers are the real ones from the
+// 2026-08-25 pi 0.84.2 capture the runner test carries: two assistant messages
+// of 4620/19 and 1068/5 tokens, the second reading 3584 tokens from cache.
+const PI_AGENT_SETTLED_WITH_USAGE = {
+  type: "agent_settled",
+  agentosPiUsage: {
+    messages: 2,
+    reported: 2,
+    input: 5688,
+    output: 24,
+    cacheRead: 3584,
+    cacheWrite: 0,
+    costUsd: 0.00123808,
+  },
+};
+
 type SessionColumns = {
   inputTokens: number | null;
   outputTokens: number | null;
@@ -273,6 +290,61 @@ test("extractUsage reads the real CODEX turn.completed payload and finds no cost
 
 test("extractUsage finds nothing in PI's empty terminal event", () => {
   assert.deepEqual(extractUsage(PI_AGENT_SETTLED), {});
+});
+
+test("extractUsage reads the runner's PI aggregate, cache disjoint from input", () => {
+  const usage: SessionUsage = extractUsage(PI_AGENT_SETTLED_WITH_USAGE);
+  assert.deepEqual(usage, {
+    inputTokens: 5688,
+    outputTokens: 24,
+    // cacheRead + cacheWrite, the same fold CLAUDE's read/creation pair gets.
+    cachedInputTokens: 3584,
+    costUsd: new Prisma.Decimal("0.00123808"),
+  });
+  // The caliber, asserted rather than left to the comment: PI's `input` excludes
+  // cache reads, so totalTokens is uncached input + output and 3584 cached
+  // tokens are NOT in it. CODEX's totalTokens, whose input_tokens already
+  // contains its cached figure, does include them — the two are not comparable.
+  const derived = deriveUsageColumns(usage);
+  assert.equal(derived.totalTokens, 5712);
+  assert.equal(derived.cachedInputTokens, 3584);
+  assert.equal(derived.costUsd?.toString(), "0.0012");
+  const codex = deriveUsageColumns(extractUsage(CODEX_TURN_COMPLETED));
+  assert.equal(codex.totalTokens, 41017);
+  assert.ok(codex.totalTokens! > codex.cachedInputTokens!, "CODEX totals already contain the cached tokens");
+});
+
+test("the PI aggregate is exclusive of the provider vocabularies it replaces", () => {
+  // A payload carrying both must not be summed twice. PI's terminal event never
+  // carries `usage` today; this is the guard that keeps that assumption honest
+  // if the shape ever changes.
+  const usage = extractUsage({ ...PI_AGENT_SETTLED_WITH_USAGE, usage: { input_tokens: 99 }, total_cost_usd: 7 });
+  assert.equal(usage.inputTokens, 5688);
+  assert.equal(usage.costUsd?.toString(), "0.00123808");
+});
+
+test("a PI aggregate that reports nothing usable leaves every column null", async () => {
+  // The runner omits `agentosPiUsage` entirely when no message reported usage,
+  // and diagnoses that separately. Whatever else arrives here, no field may be
+  // invented: absent stays absent, never zero.
+  for (const totals of [undefined, null, 42, {}, { messages: 3, reported: 0 }]) {
+    assert.deepEqual(extractUsage({ type: "agent_settled", agentosPiUsage: totals }), {}, JSON.stringify(totals ?? null));
+  }
+  const { result: usage, warnings } = await withCapturedWarnings(
+    () => extractUsage({ agentosPiUsage: { input: -1, output: 8, cacheRead: 1.5, costUsd: "free" } }),
+  );
+  assert.deepEqual(usage, { outputTokens: 8 });
+  assert.equal(warnings.length, 3);
+  assert.match(warnings.join("\n"), /agentosPiUsage\.input/u);
+  assert.match(warnings.join("\n"), /agentosPiUsage\.costUsd/u);
+});
+
+test("PI sessions accumulate across attempts the way every other runner does", () => {
+  // A resumed PI session spawns a fresh process with a fresh accumulator, so
+  // each attempt contributes its own FINAL_OUTPUT row.
+  const total = sumUsage([PI_AGENT_SETTLED_WITH_USAGE, PI_AGENT_SETTLED_WITH_USAGE].map(extractUsage));
+  assert.equal(total.inputTokens, 11376);
+  assert.equal(total.costUsd?.toString(), "0.00247616");
 });
 
 test("extractUsage is total over unknown input", () => {

--- a/packages/db/src/usage.ts
+++ b/packages/db/src/usage.ts
@@ -66,15 +66,15 @@ const tokenCount = (value: unknown, field: string): number | null => {
  * once at the column boundary. Adding binary JS numbers first is not exact —
  * 0.000001 + 0.000049 lands just below the half-unit and rounds to 0.0000.
  */
-const costAmount = (value: unknown): Prisma.Decimal | null => {
+const costAmount = (value: unknown, field = "total_cost_usd"): Prisma.Decimal | null => {
   if (value === undefined) return null;
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-    console.warn(`[usage] ignoring total_cost_usd=${render(value)}: not a storable cost`);
+    console.warn(`[usage] ignoring ${field}=${render(value)}: not a storable cost`);
     return null;
   }
   const decimal = new Prisma.Decimal(String(value));
   if (decimal.toDecimalPlaces(COST_SCALE).greaterThanOrEqualTo(MAX_COST)) {
-    console.warn(`[usage] ignoring total_cost_usd=${render(value)}: exceeds Decimal(12, 4)`);
+    console.warn(`[usage] ignoring ${field}=${render(value)}: exceeds Decimal(12, 4)`);
     return null;
   }
   return decimal;
@@ -125,6 +125,47 @@ const extractModelUsage = (value: unknown): ModelTotals | null => {
 };
 
 /**
+ * PI's totals, aggregated by the runner's PI parser and attached to the
+ * FINAL_OUTPUT payload as `agentosPiUsage`. The name is deliberate: unlike
+ * `usage` and `modelUsage`, which are the providers' own vocabularies, this
+ * object is AgentOS-computed, and reading it as a provider payload would hide
+ * that.
+ *
+ * CALIBER, which is not the same as the other two runners':
+ * - `input` is uncached input only — PI reports `cacheRead` DISJOINT from it,
+ *   so the stored `totalTokens` (input + output) excludes cache reads. That
+ *   matches CLAUDE and deliberately differs from CODEX, whose `input_tokens`
+ *   already contains `cached_input_tokens` and whose stored `totalTokens`
+ *   therefore includes them.
+ * - `output` already contains PI's reasoning tokens, so there is no reasoning
+ *   field to fold in here.
+ * - `costUsd` is PI's own per-message `cost.total` summed, not derived from the
+ *   pricing table. PI is the only one of the three that prices itself per
+ *   message.
+ *
+ * `messages` and `reported` are the runner's diagnostics and are read by nobody
+ * here; they exist so a stored event can answer "was the cost missing, or was
+ * it genuinely nothing".
+ */
+const extractPiUsage = (value: unknown): SessionUsage | null => {
+  const totals = asRecord(value);
+  if (!totals) return null;
+  const result: SessionUsage = {};
+  const input = tokenCount(totals.input, "agentosPiUsage.input");
+  if (input !== null) result.inputTokens = input;
+  const output = tokenCount(totals.output, "agentosPiUsage.output");
+  if (output !== null) result.outputTokens = output;
+  const cacheRead = tokenCount(totals.cacheRead, "agentosPiUsage.cacheRead");
+  const cacheWrite = tokenCount(totals.cacheWrite, "agentosPiUsage.cacheWrite");
+  if (cacheRead !== null || cacheWrite !== null) result.cachedInputTokens = (cacheRead ?? 0) + (cacheWrite ?? 0);
+  const cost = costAmount(totals.costUsd, "agentosPiUsage.costUsd");
+  if (cost !== null) result.costUsd = cost;
+  // Nothing usable routes back to the other branches rather than claiming the
+  // payload, exactly as an unusable `modelUsage` does.
+  return Object.keys(result).length === 0 ? null : result;
+};
+
+/**
  * One event payload → whatever usage it carries. Shape-driven rather than
  * runner-driven, and total over `unknown`: any payload that does not match
  * yields `{}` and nothing throws.
@@ -139,12 +180,20 @@ const extractModelUsage = (value: unknown): ModelTotals | null => {
  *   it already equals the sum of the per-model `costUSD` values.
  * - CODEX `turn.completed`: `usage.{input_tokens,cached_input_tokens,output_tokens}`,
  *   no `modelUsage`, no cost anywhere — the fallback branch, unchanged.
- * - PI `agent_settled`: literally `{"type":"agent_settled"}` — no usage, no cost.
- *   PI reports usage per message instead, which this batch does not harvest.
+ * - PI `agent_settled`: literally `{"type":"agent_settled"}` — no usage, no
+ *   cost. PI prices itself per message instead, so the runner's PI parser sums
+ *   those messages and attaches `agentosPiUsage`, which is EXCLUSIVE of the two
+ *   provider vocabularies above and carries its own caliber. See
+ *   `extractPiUsage`.
  */
 export const extractUsage = (payload: unknown): SessionUsage => {
   const event = asRecord(payload);
   if (!event) return {};
+  // Exclusive and first: an `agentosPiUsage` payload is already a whole
+  // session's totals, cost included, and PI's terminal event carries no other
+  // usage vocabulary for the branches below to add to it.
+  const pi = extractPiUsage(event.agentosPiUsage);
+  if (pi) return pi;
   const usage = asRecord(event.usage);
   const result: SessionUsage = {};
 

--- a/packages/db/src/usage.ts
+++ b/packages/db/src/usage.ts
@@ -66,15 +66,15 @@ const tokenCount = (value: unknown, field: string): number | null => {
  * once at the column boundary. Adding binary JS numbers first is not exact —
  * 0.000001 + 0.000049 lands just below the half-unit and rounds to 0.0000.
  */
-const costAmount = (value: unknown, field = "total_cost_usd"): Prisma.Decimal | null => {
+const costAmount = (value: unknown): Prisma.Decimal | null => {
   if (value === undefined) return null;
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-    console.warn(`[usage] ignoring ${field}=${render(value)}: not a storable cost`);
+    console.warn(`[usage] ignoring total_cost_usd=${render(value)}: not a storable cost`);
     return null;
   }
   const decimal = new Prisma.Decimal(String(value));
   if (decimal.toDecimalPlaces(COST_SCALE).greaterThanOrEqualTo(MAX_COST)) {
-    console.warn(`[usage] ignoring ${field}=${render(value)}: exceeds Decimal(12, 4)`);
+    console.warn(`[usage] ignoring total_cost_usd=${render(value)}: exceeds Decimal(12, 4)`);
     return null;
   }
   return decimal;
@@ -139,14 +139,37 @@ const extractModelUsage = (value: unknown): ModelTotals | null => {
  *   therefore includes them.
  * - `output` already contains PI's reasoning tokens, so there is no reasoning
  *   field to fold in here.
- * - `costUsd` is PI's own per-message `cost.total` summed, not derived from the
- *   pricing table. PI is the only one of the three that prices itself per
- *   message.
+ * - `costNanoUsd` is PI's own per-message `cost.total` summed, not derived from
+ *   the pricing table — PI is the only one of the three that prices itself per
+ *   message. It arrives as an INTEGER count of nano-USD because the runner
+ *   cannot reach Prisma.Decimal and summing the raw doubles would hit the very
+ *   half-unit error `costAmount` exists to avoid. Dividing by a power of ten in
+ *   decimal is exact, so nothing is lost on the way to the column.
  *
  * `messages` and `reported` are the runner's diagnostics and are read by nobody
  * here; they exist so a stored event can answer "was the cost missing, or was
  * it genuinely nothing".
  */
+const NANOS_PER_USD = 1_000_000_000;
+
+/** The PI aggregate's integer nano-USD as an exact Decimal. Same drop-with-a-
+ * diagnostic discipline as `costAmount`, against the integer domain the runner
+ * actually sends: a non-integer here means the payload was not written by the
+ * PI parser and its value cannot be trusted to be exact. */
+const piCostAmount = (value: unknown): Prisma.Decimal | null => {
+  if (value === undefined) return null;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    console.warn(`[usage] ignoring agentosPiUsage.costNanoUsd=${render(value)}: not a storable cost`);
+    return null;
+  }
+  const decimal = new Prisma.Decimal(value).dividedBy(NANOS_PER_USD);
+  if (decimal.toDecimalPlaces(COST_SCALE).greaterThanOrEqualTo(MAX_COST)) {
+    console.warn(`[usage] ignoring agentosPiUsage.costNanoUsd=${render(value)}: exceeds Decimal(12, 4)`);
+    return null;
+  }
+  return decimal;
+};
+
 const extractPiUsage = (value: unknown): SessionUsage | null => {
   const totals = asRecord(value);
   if (!totals) return null;
@@ -158,7 +181,7 @@ const extractPiUsage = (value: unknown): SessionUsage | null => {
   const cacheRead = tokenCount(totals.cacheRead, "agentosPiUsage.cacheRead");
   const cacheWrite = tokenCount(totals.cacheWrite, "agentosPiUsage.cacheWrite");
   if (cacheRead !== null || cacheWrite !== null) result.cachedInputTokens = (cacheRead ?? 0) + (cacheWrite ?? 0);
-  const cost = costAmount(totals.costUsd, "agentosPiUsage.costUsd");
+  const cost = piCostAmount(totals.costNanoUsd);
   if (cost !== null) result.costUsd = cost;
   // Nothing usable routes back to the other branches rather than claiming the
   // payload, exactly as an unusable `modelUsage` does.

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -766,6 +766,120 @@ test("every runner is handed the prompt and the resume input byte-exact at the p
   }
 });
 
+// A REAL `pi --mode json` transcript, captured 2026-08-25 against pi 0.84.2 and
+// openai-codex/gpt-5.6-luna with the exact flags argsForRunner builds:
+//
+//   echo "Run the bash command 'echo hello' and then tell me its output." \
+//     | pi -p --mode json --session-dir ./sess --model openai-codex/gpt-5.6-luna \
+//         --thinking low --no-skills --no-prompt-templates --no-themes \
+//         --no-context-files --no-approve
+//
+// Trimmed to the events that decide the harvest, each one byte-verbatim: the two
+// assistant `message_end`s, the two `turn_end`s that REPEAT them (the double
+// count this must not make), and the empty terminal event. If an assertion below
+// ever disagrees with these numbers, the code is wrong, never the capture.
+const PI_TRANSCRIPT: unknown[] = [
+  {"type": "message_end", "message": {"role": "assistant", "content": [{"type": "toolCall", "id": "call_BRyJNXBbsbjHm3nGCztVKlvn|fc_00e0eb3701447702016a8e2fcce81487d0ae08cfa4c0db0a75", "name": "bash", "arguments": {"command": "echo hello"}}], "api": "openai-codex-responses", "provider": "openai-codex", "model": "gpt-5.6-luna", "usage": {"input": 4620, "output": 19, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0, "totalTokens": 4639, "cost": {"input": 0.0009240000000000001, "output": 2.28e-05, "cacheRead": 0, "cacheWrite": 0, "total": 0.0009468000000000001}}, "stopReason": "toolUse", "timestamp": 1787703240541, "responseId": "resp_00e0eb3701447702016a8e2fcb669887d0ade1277f25377b3a", "rawStopReason": "completed"}},
+  {"type": "turn_end", "message": {"role": "assistant", "content": [{"type": "toolCall", "id": "call_BRyJNXBbsbjHm3nGCztVKlvn|fc_00e0eb3701447702016a8e2fcce81487d0ae08cfa4c0db0a75", "name": "bash", "arguments": {"command": "echo hello"}}], "api": "openai-codex-responses", "provider": "openai-codex", "model": "gpt-5.6-luna", "usage": {"input": 4620, "output": 19, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0, "totalTokens": 4639, "cost": {"input": 0.0009240000000000001, "output": 2.28e-05, "cacheRead": 0, "cacheWrite": 0, "total": 0.0009468000000000001}}, "stopReason": "toolUse", "timestamp": 1787703240541, "responseId": "resp_00e0eb3701447702016a8e2fcb669887d0ade1277f25377b3a", "rawStopReason": "completed"}, "toolResults": [{"role": "toolResult", "toolCallId": "call_BRyJNXBbsbjHm3nGCztVKlvn|fc_00e0eb3701447702016a8e2fcce81487d0ae08cfa4c0db0a75", "toolName": "bash", "content": [{"type": "text", "text": "hello\n"}], "isError": false, "timestamp": 1787703245849}]},
+  {"type": "message_end", "message": {"role": "assistant", "content": [{"type": "text", "text": "hello", "textSignature": "{\"v\":1,\"id\":\"msg_00e0eb3701447702016a8e2fd2dea087d09a0c85f07de241ae\",\"phase\":\"final_answer\"}"}], "api": "openai-codex-responses", "provider": "openai-codex", "model": "gpt-5.6-luna", "usage": {"input": 1068, "output": 5, "cacheRead": 3584, "cacheWrite": 0, "reasoning": 0, "totalTokens": 4657, "cost": {"input": 0.00021360000000000001, "output": 6e-06, "cacheRead": 7.168e-05, "cacheWrite": 0, "total": 0.00029128000000000004}}, "stopReason": "stop", "timestamp": 1787703245851, "responseId": "resp_00e0eb3701447702016a8e2fcebd1087d0be678fe9ff2a3a20", "rawStopReason": "completed"}},
+  {"type": "turn_end", "message": {"role": "assistant", "content": [{"type": "text", "text": "hello", "textSignature": "{\"v\":1,\"id\":\"msg_00e0eb3701447702016a8e2fd2dea087d09a0c85f07de241ae\",\"phase\":\"final_answer\"}"}], "api": "openai-codex-responses", "provider": "openai-codex", "model": "gpt-5.6-luna", "usage": {"input": 1068, "output": 5, "cacheRead": 3584, "cacheWrite": 0, "reasoning": 0, "totalTokens": 4657, "cost": {"input": 0.00021360000000000001, "output": 6e-06, "cacheRead": 7.168e-05, "cacheWrite": 0, "total": 0.00029128000000000004}}, "stopReason": "stop", "timestamp": 1787703245851, "responseId": "resp_00e0eb3701447702016a8e2fcebd1087d0be678fe9ff2a3a20", "rawStopReason": "completed"}, "toolResults": []},
+  {"type": "agent_settled"},
+];
+
+// The second message is the one that settles the caliber: input 1068 and
+// cacheRead 3584 are DISJOINT (1068 + 5 + 3584 = 4657, PI's own totalTokens),
+// so uncached input is what reaches inputTokens.
+const PI_EXPECTED = {
+  messages: 2,
+  reported: 2,
+  input: 4620 + 1068,
+  output: 19 + 5,
+  cacheRead: 3584,
+  cacheWrite: 0,
+  costUsd: 0.0009468000000000001 + 0.00029128000000000004,
+};
+
+/** Drive the PI parser over a literal event stream: the stub reads the prompt
+ * off stdin exactly as a real CLI does, then writes the lines and exits. */
+const piStream = async (lines: unknown[]): Promise<Array<{ type: string; payload: Record<string, unknown> }>> => {
+  const emitScript = [
+    'const chunks = [];',
+    'process.stdin.on("data", (chunk) => chunks.push(chunk));',
+    `process.stdin.on("end", () => process.stdout.write(${JSON.stringify(lines.map((line) => `${JSON.stringify(line)}\n`).join(""))}));`,
+  ].join("");
+  const spec = {
+    ...runSpec(),
+    config: {
+      binaries: { CLAUDE: "claude", CODEX: "codex", PI: "pi" },
+      runAsPrefix: [process.execPath, "-e", emitScript],
+    } as unknown as RunnerConfig,
+    claim: { ...claim, runner: "PI" as const },
+    workingDirectory: process.cwd(),
+    env: process.env,
+  };
+  const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+  const handle = await adapters.PI.start(spec, (event) => { events.push(event); });
+  await handle.exit;
+  return events;
+};
+
+const finalOutputOf = (events: Array<{ type: string; payload: Record<string, unknown> }>): Record<string, unknown> => {
+  const final = events.filter((event) => event.type === "FINAL_OUTPUT");
+  assert.equal(final.length, 1, "a PI session settles exactly once");
+  return final[0]!.payload;
+};
+
+test("PI per-message usage is aggregated onto the terminal event, counting each message once", { timeout: 30_000 }, async () => {
+  const events = await piStream(PI_TRANSCRIPT);
+  const payload = finalOutputOf(events);
+  assert.equal(payload.type, "agent_settled", "the provider's own terminal event is preserved");
+  assert.deepEqual(payload.agentosPiUsage, PI_EXPECTED);
+  // The failure this guards is silent arithmetic: turn_end carries the same
+  // message object, so a parser that harvested both would report exactly double.
+  assert.notEqual((payload.agentosPiUsage as { input: number }).input, PI_EXPECTED.input * 2);
+  assert.equal(events.some((event) => event.type === "ADAPTER_ERROR"), false);
+});
+
+test("a PI session that reports no usage settles loudly instead of leaving silent nulls", { timeout: 30_000 }, async () => {
+  const events = await piStream([
+    { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "done" }] } },
+    { type: "agent_settled" },
+  ]);
+  const payload = finalOutputOf(events);
+  // No invented zeroes: the columns must stay NULL, which means the aggregate
+  // must be absent from the payload entirely.
+  assert.equal("agentosPiUsage" in payload, false);
+  const reported = events.filter((event) => event.type === "ADAPTER_ERROR");
+  assert.equal(reported.length, 1);
+  assert.match(String(reported[0]!.payload.error), /cost will be unavailable.*no usage on any of 1/u);
+  assert.equal(reported[0]!.payload.messages, 1);
+  assert.equal(reported[0]!.payload.reported, 0);
+});
+
+test("a PI session whose reported usage sums to zero tokens is a gap, not a free session", { timeout: 30_000 }, async () => {
+  const events = await piStream([
+    { type: "message_end", message: { role: "assistant", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } } } },
+    { type: "agent_settled" },
+  ]);
+  assert.deepEqual(finalOutputOf(events).agentosPiUsage, {
+    messages: 1, reported: 1, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costUsd: 0,
+  });
+  const reported = events.filter((event) => event.type === "ADAPTER_ERROR");
+  assert.equal(reported.length, 1);
+  assert.match(String(reported[0]!.payload.error), /but no tokens/u);
+});
+
+test("one unusable PI usage field is dropped without taking its siblings with it", { timeout: 30_000 }, async () => {
+  const events = await piStream([
+    { type: "message_end", message: { role: "assistant", usage: { input: "lots", output: 7, cacheRead: -1, cost: { total: 0.5 } } } },
+    { type: "message_end", message: { role: "user", usage: { input: 999, output: 999 } } },
+    { type: "agent_settled" },
+  ]);
+  // input and cacheRead are rejected, so they stay ABSENT rather than becoming
+  // zero; the user message is not an assistant turn and is never harvested.
+  assert.deepEqual(finalOutputOf(events).agentosPiUsage, { messages: 1, reported: 1, output: 7, costUsd: 0.5 });
+});
+
 // A run's checkout may predate any given safety fix (chain and salvage runs
 // are pinned to old bases), so the runner — always current code — has to point
 // the session's roots at throwaway directories itself. Both 2026-08-18

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -796,7 +796,10 @@ const PI_EXPECTED = {
   output: 19 + 5,
   cacheRead: 3584,
   cacheWrite: 0,
-  costUsd: 0.0009468000000000001 + 0.00029128000000000004,
+  // Integer nano-USD, written out rather than summed as doubles: adding the two
+  // captured costs in JS gives 0.0012380800000000001, and the point of the
+  // integer transport is that the stored value does not depend on that error.
+  costNanoUsd: 1_238_080,
 };
 
 /** Drive the PI parser over a literal event stream: the stub reads the prompt
@@ -851,22 +854,76 @@ test("a PI session that reports no usage settles loudly instead of leaving silen
   assert.equal("agentosPiUsage" in payload, false);
   const reported = events.filter((event) => event.type === "ADAPTER_ERROR");
   assert.equal(reported.length, 1);
-  assert.match(String(reported[0]!.payload.error), /cost will be unavailable.*no usage on any of 1/u);
+  assert.match(String(reported[0]!.payload.error), /cost is incomplete.*no usage on any of 1/u);
   assert.equal(reported[0]!.payload.messages, 1);
   assert.equal(reported[0]!.payload.reported, 0);
 });
 
-test("a PI session whose reported usage sums to zero tokens is a gap, not a free session", { timeout: 30_000 }, async () => {
+test("a PI session whose reported usage sums to zero is a gap, not a free session", { timeout: 30_000 }, async () => {
   const events = await piStream([
     { type: "message_end", message: { role: "assistant", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } } } },
     { type: "agent_settled" },
   ]);
   assert.deepEqual(finalOutputOf(events).agentosPiUsage, {
-    messages: 1, reported: 1, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costUsd: 0,
+    messages: 1, reported: 1, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costNanoUsd: 0,
   });
   const reported = events.filter((event) => event.type === "ADAPTER_ERROR");
   assert.equal(reported.length, 1);
-  assert.match(String(reported[0]!.payload.error), /but no tokens/u);
+  assert.match(String(reported[0]!.payload.error), /no tokens; PI reported no cost/u);
+});
+
+test("real tokens with no cost is diagnosed rather than left as a silent null column", { timeout: 30_000 }, async () => {
+  // The dangerous half of a partial report: the token columns land, look
+  // healthy, and the cost column stays NULL with nothing saying why.
+  const events = await piStream([
+    { type: "message_end", message: { role: "assistant", usage: { input: 100, output: 10 } } },
+    { type: "agent_settled" },
+  ]);
+  assert.deepEqual(finalOutputOf(events).agentosPiUsage, { messages: 1, reported: 1, input: 100, output: 10 });
+  const reported = events.filter((event) => event.type === "ADAPTER_ERROR");
+  assert.equal(reported.length, 1);
+  assert.match(String(reported[0]!.payload.error), /^Session cost is incomplete: PI reported no cost$/u);
+});
+
+test("a session only some of whose messages reported usage does not pass off a short total as whole", { timeout: 30_000 }, async () => {
+  // Without this the stored total is the reporting messages' alone, and nothing
+  // downstream can tell that it is short.
+  const events = await piStream([
+    { type: "message_end", message: { role: "assistant", usage: { input: 100, output: 10, cost: { total: 0.002 } } } },
+    { type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "no usage on this one" }] } },
+    { type: "agent_settled" },
+  ]);
+  assert.deepEqual(finalOutputOf(events).agentosPiUsage, {
+    messages: 2, reported: 1, input: 100, output: 10, costNanoUsd: 2_000_000,
+  });
+  const reported = events.filter((event) => event.type === "ADAPTER_ERROR");
+  assert.equal(reported.length, 1);
+  assert.match(String(reported[0]!.payload.error), /usage on only 1 of 2 assistant message\(s\)/u);
+});
+
+test("PI costs are summed exactly, not through the binary addition the column would round away", { timeout: 30_000 }, async () => {
+  // usage.ts documents this exact pair: 0.000001 + 0.000049 as doubles lands
+  // just below the half-unit and rounds to 0.0000 instead of 0.0001.
+  assert.ok(0.000001 + 0.000049 < 0.00005, "the double sum must really fall short, or this proves nothing");
+  const events = await piStream([
+    { type: "message_end", message: { role: "assistant", usage: { input: 1, output: 1, cost: { total: 0.000001 } } } },
+    { type: "message_end", message: { role: "assistant", usage: { input: 1, output: 1, cost: { total: 0.000049 } } } },
+    { type: "agent_settled" },
+  ]);
+  assert.equal((finalOutputOf(events).agentosPiUsage as { costNanoUsd: number }).costNanoUsd, 50_000);
+});
+
+test("PI reasoning tokens are a breakdown of output and cacheWrite is cached input", { timeout: 30_000 }, async () => {
+  // output 29 / reasoning 22 is the real second capture; a nonzero cacheWrite is
+  // constructed, because neither capture produced one and the fold must still
+  // be exercised. Adding reasoning to output would give 51, not 29.
+  const events = await piStream([
+    { type: "message_end", message: { role: "assistant", usage: { input: 4627, output: 29, cacheRead: 100, cacheWrite: 200, reasoning: 22, cost: { total: 0.0009602 } } } },
+    { type: "agent_settled" },
+  ]);
+  assert.deepEqual(finalOutputOf(events).agentosPiUsage, {
+    messages: 1, reported: 1, input: 4627, output: 29, cacheRead: 100, cacheWrite: 200, costNanoUsd: 960_200,
+  });
 });
 
 test("one unusable PI usage field is dropped without taking its siblings with it", { timeout: 30_000 }, async () => {
@@ -877,7 +934,7 @@ test("one unusable PI usage field is dropped without taking its siblings with it
   ]);
   // input and cacheRead are rejected, so they stay ABSENT rather than becoming
   // zero; the user message is not an assistant turn and is never harvested.
-  assert.deepEqual(finalOutputOf(events).agentosPiUsage, { messages: 1, reported: 1, output: 7, costUsd: 0.5 });
+  assert.deepEqual(finalOutputOf(events).agentosPiUsage, { messages: 1, reported: 1, output: 7, costNanoUsd: 500_000_000 });
 });
 
 // A run's checkout may predate any given safety fix (chain and salvage runs

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -341,6 +341,25 @@ export type HeartbeatSnapshot = {
   inFlightTool: InFlightTool | null;
 };
 
+/**
+ * A PI session's harvested token and cost totals. Every field is `null` until a
+ * message actually reports it — absent is never zero, matching the
+ * `SessionUsage` contract these totals are ingested through.
+ *
+ * `messages` and `reported` are diagnostics carried into the payload: they are
+ * what lets an operator tell "the session sent nothing" apart from "the session
+ * sent messages and PI reported no usage for them".
+ */
+export type PiUsageTotals = {
+  messages: number;
+  reported: number;
+  input: number | null;
+  output: number | null;
+  cacheRead: number | null;
+  cacheWrite: number | null;
+  costUsd: number | null;
+};
+
 export type RuntimeHandle = {
   runId: string;
   runner: RunnerKind;
@@ -358,6 +377,7 @@ export type RuntimeHandle = {
   providerError: string | null;
   piTurnCompleted: boolean;
   piFinalAttemptFailed: boolean;
+  piUsage: PiUsageTotals;
   finalOutput: string | null;
   stdout: string;
   stderr: string;
@@ -515,6 +535,97 @@ const parseCodex = (handle: RuntimeHandle, event: Record<string, unknown>, sink:
   } else emit(handle, sink, "PROVIDER_STATUS", event);
 };
 
+const emptyPiUsage = (): PiUsageTotals =>
+  ({ messages: 0, reported: 0, input: null, output: null, cacheRead: null, cacheWrite: null, costUsd: null });
+
+/**
+ * One number out of a PI usage object, or null when PI said nothing usable.
+ * Rejection is per field and never throws: one absurd value must not discard
+ * the siblings that were fine, and a usage object must not be able to kill the
+ * session that carried it.
+ */
+const piNumber = (value: unknown, field: string, integral: boolean): number | null => {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0 && (!integral || Number.isInteger(value))) return value;
+  console.warn(JSON.stringify({ audit: "pi-usage", event: "field-dropped", field, value: String(value) }));
+  return null;
+};
+
+/**
+ * Fold one PI message's usage into the session totals.
+ *
+ * Source, verified against a real `pi --mode json` capture (0.84.2,
+ * openai-codex/gpt-5.6-luna): the usage object on a `message_end` event whose
+ * message role is `assistant`. Shape:
+ *
+ *   {"input":1068,"output":5,"cacheRead":3584,"cacheWrite":0,"reasoning":0,
+ *    "totalTokens":4657,"cost":{"input":…,"output":…,"cacheRead":…,"cacheWrite":…,"total":…}}
+ *
+ * Three properties of that capture drive this function, and none of them are
+ * guesses:
+ *
+ * - `message_end` is the ONLY event harvested. `message_start` and every
+ *   `message_update` carry a usage object too, and `turn_end` repeats the last
+ *   message's object verbatim — summing any of them double counts.
+ * - `input` EXCLUDES `cacheRead`: the captured message reconciles as
+ *   1068 + 5 + 3584 = 4657, PI's own `totalTokens`. So `input` maps straight
+ *   onto `inputTokens` with nothing to subtract.
+ * - `output` INCLUDES `reasoning` (a second capture reported output 29 with
+ *   reasoning 22 and totalTokens = input + output). `reasoning` is therefore
+ *   read as a breakdown of output, never added to it — the same rule CODEX's
+ *   `reasoning_output_tokens` already gets.
+ *
+ * PI reports cost directly, per message, in `cost.total` USD, so no pricing
+ * lookup is involved. Summing those doubles in JS is exact enough: the single
+ * rounding that matters happens once, at the Decimal(12, 4) column boundary.
+ */
+const harvestPiUsage = (totals: PiUsageTotals, message: Record<string, unknown>): void => {
+  totals.messages += 1;
+  const usage = asRecord(message.usage);
+  if (!usage) return;
+  totals.reported += 1;
+  const input = piNumber(usage.input, "input", true);
+  if (input !== null) totals.input = (totals.input ?? 0) + input;
+  const output = piNumber(usage.output, "output", true);
+  if (output !== null) totals.output = (totals.output ?? 0) + output;
+  const cacheRead = piNumber(usage.cacheRead, "cacheRead", true);
+  if (cacheRead !== null) totals.cacheRead = (totals.cacheRead ?? 0) + cacheRead;
+  const cacheWrite = piNumber(usage.cacheWrite, "cacheWrite", true);
+  if (cacheWrite !== null) totals.cacheWrite = (totals.cacheWrite ?? 0) + cacheWrite;
+  const cost = piNumber(asRecord(usage.cost)?.total, "cost.total", false);
+  if (cost !== null) totals.costUsd = (totals.costUsd ?? 0) + cost;
+};
+
+/** The totals as the FINAL_OUTPUT payload carries them: only fields PI actually
+ * reported, so an absent field stays absent all the way to the column. */
+const piUsagePayload = (totals: PiUsageTotals): Record<string, unknown> => ({
+  messages: totals.messages,
+  reported: totals.reported,
+  ...(totals.input === null ? {} : { input: totals.input }),
+  ...(totals.output === null ? {} : { output: totals.output }),
+  ...(totals.cacheRead === null ? {} : { cacheRead: totals.cacheRead }),
+  ...(totals.cacheWrite === null ? {} : { cacheWrite: totals.cacheWrite }),
+  ...(totals.costUsd === null ? {} : { costUsd: totals.costUsd }),
+});
+
+/**
+ * Why a PI session's cost would be invisible, or null when it is not.
+ *
+ * A session that reports nothing must not settle quietly: the columns stay NULL
+ * either way, and NULL that nobody was told about reads exactly like a session
+ * that cost nothing. A zero total counts as reporting nothing for the same
+ * reason — PI emitted usage objects, but they say the session was free, which
+ * for a session that ran a model is not a fact, it is a gap.
+ */
+const piUsageGap = (totals: PiUsageTotals): string | null => {
+  if (totals.messages === 0) return "PI settled without ending a single assistant message";
+  if (totals.reported === 0) return `PI reported no usage on any of ${totals.messages} assistant message(s)`;
+  if ((totals.input ?? 0) + (totals.output ?? 0) === 0) {
+    return `PI reported usage on ${totals.reported} of ${totals.messages} assistant message(s) but no tokens`;
+  }
+  return null;
+};
+
 const parsePi = (handle: RuntimeHandle, event: Record<string, unknown>, sink: SessionEventSink): void => {
   const type = stringField(event, "type");
   if (type === "session") {
@@ -535,6 +646,11 @@ const parsePi = (handle: RuntimeHandle, event: Record<string, unknown>, sink: Se
   } else if (type === "turn_end" || type === "message_end") {
     handle.piTurnCompleted = true;
     const message = asRecord(event.message);
+    // Usage is harvested from message_end alone; see harvestPiUsage for why
+    // turn_end, which repeats the same message, must not contribute.
+    if (type === "message_end" && message && stringField(message, "role") === "assistant") {
+      harvestPiUsage(handle.piUsage, message);
+    }
     if (message && stringField(message, "role") === "assistant" && Array.isArray(message.content)) {
       const text = message.content
         .map((part) => stringField(asRecord(part) ?? {}, "text"))
@@ -556,7 +672,19 @@ const parsePi = (handle: RuntimeHandle, event: Record<string, unknown>, sink: Se
   } else if (type === "agent_settled") {
     handle.terminalEventSeen = true;
     handle.terminalSuccess = handle.piTurnCompleted && !handle.piFinalAttemptFailed && !handle.sawError;
-    emit(handle, sink, "FINAL_OUTPUT", event);
+    // PI's terminal event is literally {"type":"agent_settled"} — it carries no
+    // usage and no cost. The per-message totals this parser accumulated are
+    // attached here, under a name that says who computed them, because
+    // FINAL_OUTPUT is the one event the usage ingest reads. The provider's own
+    // untouched event is still on record: PROVIDER_RAW emitted it first.
+    const gap = piUsageGap(handle.piUsage);
+    if (gap) {
+      console.warn(JSON.stringify({ audit: "pi-usage", event: "unavailable", runId: handle.runId, reason: gap }));
+      emit(handle, sink, "ADAPTER_ERROR", { error: `Session cost will be unavailable: ${gap}`, ...piUsagePayload(handle.piUsage) });
+    }
+    emit(handle, sink, "FINAL_OUTPUT", handle.piUsage.reported === 0
+      ? event
+      : { ...event, agentosPiUsage: piUsagePayload(handle.piUsage) });
   } else {
     if (type?.includes("error")) handle.sawError = true;
     emit(handle, sink, type?.includes("message") ? "MODEL_DELTA" : "PROVIDER_STATUS", event);
@@ -730,6 +858,7 @@ const spawnRuntime = (runner: RunnerKind, spec: RunSpec, sink: SessionEventSink,
     providerError: null,
     piTurnCompleted: false,
     piFinalAttemptFailed: false,
+    piUsage: emptyPiUsage(),
     finalOutput: null,
     stdout: "",
     stderr: "",

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -357,7 +357,7 @@ export type PiUsageTotals = {
   output: number | null;
   cacheRead: number | null;
   cacheWrite: number | null;
-  costUsd: number | null;
+  costNanoUsd: number | null;
 };
 
 export type RuntimeHandle = {
@@ -535,8 +535,11 @@ const parseCodex = (handle: RuntimeHandle, event: Record<string, unknown>, sink:
   } else emit(handle, sink, "PROVIDER_STATUS", event);
 };
 
+/** PI prices per message in USD; the accumulator carries integer nano-USD. */
+const NANOS_PER_USD = 1_000_000_000;
+
 const emptyPiUsage = (): PiUsageTotals =>
-  ({ messages: 0, reported: 0, input: null, output: null, cacheRead: null, cacheWrite: null, costUsd: null });
+  ({ messages: 0, reported: 0, input: null, output: null, cacheRead: null, cacheWrite: null, costNanoUsd: null });
 
 /**
  * One number out of a PI usage object, or null when PI said nothing usable.
@@ -576,8 +579,15 @@ const piNumber = (value: unknown, field: string, integral: boolean): number | nu
  *   `reasoning_output_tokens` already gets.
  *
  * PI reports cost directly, per message, in `cost.total` USD, so no pricing
- * lookup is involved. Summing those doubles in JS is exact enough: the single
- * rounding that matters happens once, at the Decimal(12, 4) column boundary.
+ * lookup is involved. Those costs are summed as INTEGER nano-USD rather than as
+ * JS doubles, and the payload carries the integer. Adding the doubles would
+ * reintroduce exactly the error `usage.ts` documents and avoids — 0.000001 +
+ * 0.000049 lands just below the half-unit and rounds to 0.0000 — and this
+ * package cannot reach that module's Prisma.Decimal without pulling a database
+ * client into the runner. Nano-USD is five orders of magnitude finer than the
+ * Decimal(12, 4) column and every cost PI has been observed to report is an
+ * exact multiple of it, so the scaling is lossless in practice and the one
+ * rounding that matters still happens once, at the column boundary.
  */
 const harvestPiUsage = (totals: PiUsageTotals, message: Record<string, unknown>): void => {
   totals.messages += 1;
@@ -593,7 +603,15 @@ const harvestPiUsage = (totals: PiUsageTotals, message: Record<string, unknown>)
   const cacheWrite = piNumber(usage.cacheWrite, "cacheWrite", true);
   if (cacheWrite !== null) totals.cacheWrite = (totals.cacheWrite ?? 0) + cacheWrite;
   const cost = piNumber(asRecord(usage.cost)?.total, "cost.total", false);
-  if (cost !== null) totals.costUsd = (totals.costUsd ?? 0) + cost;
+  if (cost !== null) {
+    const nanos = Math.round(cost * NANOS_PER_USD);
+    // The sum stays exact only while it is an exact integer double. A total past
+    // 9e6 USD is not a session, it is a bug, and it is dropped rather than
+    // silently losing precision from there on.
+    if (!Number.isSafeInteger(nanos) || !Number.isSafeInteger((totals.costNanoUsd ?? 0) + nanos)) {
+      console.warn(JSON.stringify({ audit: "pi-usage", event: "field-dropped", field: "cost.total", value: String(cost) }));
+    } else totals.costNanoUsd = (totals.costNanoUsd ?? 0) + nanos;
+  }
 };
 
 /** The totals as the FINAL_OUTPUT payload carries them: only fields PI actually
@@ -605,25 +623,36 @@ const piUsagePayload = (totals: PiUsageTotals): Record<string, unknown> => ({
   ...(totals.output === null ? {} : { output: totals.output }),
   ...(totals.cacheRead === null ? {} : { cacheRead: totals.cacheRead }),
   ...(totals.cacheWrite === null ? {} : { cacheWrite: totals.cacheWrite }),
-  ...(totals.costUsd === null ? {} : { costUsd: totals.costUsd }),
+  ...(totals.costNanoUsd === null ? {} : { costNanoUsd: totals.costNanoUsd }),
 });
 
 /**
- * Why a PI session's cost would be invisible, or null when it is not.
+ * Every way this session's cost ends up wrong or invisible, or an empty list.
  *
  * A session that reports nothing must not settle quietly: the columns stay NULL
  * either way, and NULL that nobody was told about reads exactly like a session
- * that cost nothing. A zero total counts as reporting nothing for the same
- * reason — PI emitted usage objects, but they say the session was free, which
- * for a session that ran a model is not a fact, it is a gap.
+ * that cost nothing. The partial cases are the dangerous ones, because they do
+ * not stay NULL — they store a real-looking number that is too small:
+ *
+ * - Fewer reporting messages than messages: the total is the reporting ones
+ *   alone, and nothing downstream can tell it is short.
+ * - A zero token or cost total: PI emitted usage objects that say the session
+ *   was free, which for a session that ran a model is not a fact, it is a gap.
+ *
+ * Absent reads as zero here on purpose. This is the diagnostic, not the
+ * ingest — a field PI never reported is precisely what the operator must hear
+ * about, and the columns themselves still keep absent and zero apart.
  */
-const piUsageGap = (totals: PiUsageTotals): string | null => {
-  if (totals.messages === 0) return "PI settled without ending a single assistant message";
-  if (totals.reported === 0) return `PI reported no usage on any of ${totals.messages} assistant message(s)`;
-  if ((totals.input ?? 0) + (totals.output ?? 0) === 0) {
-    return `PI reported usage on ${totals.reported} of ${totals.messages} assistant message(s) but no tokens`;
+const piUsageGaps = (totals: PiUsageTotals): string[] => {
+  if (totals.messages === 0) return ["PI settled without ending a single assistant message"];
+  if (totals.reported === 0) return [`PI reported no usage on any of ${totals.messages} assistant message(s)`];
+  const gaps: string[] = [];
+  if (totals.reported < totals.messages) {
+    gaps.push(`PI reported usage on only ${totals.reported} of ${totals.messages} assistant message(s)`);
   }
-  return null;
+  if ((totals.input ?? 0) + (totals.output ?? 0) === 0) gaps.push("PI reported no tokens");
+  if ((totals.costNanoUsd ?? 0) === 0) gaps.push("PI reported no cost");
+  return gaps;
 };
 
 const parsePi = (handle: RuntimeHandle, event: Record<string, unknown>, sink: SessionEventSink): void => {
@@ -677,10 +706,11 @@ const parsePi = (handle: RuntimeHandle, event: Record<string, unknown>, sink: Se
     // attached here, under a name that says who computed them, because
     // FINAL_OUTPUT is the one event the usage ingest reads. The provider's own
     // untouched event is still on record: PROVIDER_RAW emitted it first.
-    const gap = piUsageGap(handle.piUsage);
-    if (gap) {
-      console.warn(JSON.stringify({ audit: "pi-usage", event: "unavailable", runId: handle.runId, reason: gap }));
-      emit(handle, sink, "ADAPTER_ERROR", { error: `Session cost will be unavailable: ${gap}`, ...piUsagePayload(handle.piUsage) });
+    const gaps = piUsageGaps(handle.piUsage);
+    if (gaps.length > 0) {
+      const reason = gaps.join("; ");
+      console.warn(JSON.stringify({ audit: "pi-usage", event: "incomplete", runId: handle.runId, reason }));
+      emit(handle, sink, "ADAPTER_ERROR", { error: `Session cost is incomplete: ${reason}`, ...piUsagePayload(handle.piUsage) });
     }
     emit(handle, sink, "FINAL_OUTPUT", handle.piUsage.reported === 0
       ? event


### PR DESCRIPTION
Board card R7 (`cmt9bqj4j00kvmprutum0npxf`); brief `records/BRIEF-pi-usage-capture-20260825.md`.

## Problem

PI's terminal event is literally `{"type":"agent_settled"}` — no usage, no cost — so every PI session stored null token and cost columns. After the 2026-08-24 tier rulings that blinds run cost for the librarian and both review coordinators, three of the fleet's heaviest roles; roughly a third of the 2026-08-25 13-step chain was invisible.

## Change

PI prices itself per message. The PI parser sums the usage object on each assistant `message_end` and attaches the total to the `FINAL_OUTPUT` payload as `agentosPiUsage`, which the existing `packages/db/src/usage.ts` ingest reads into the same columns. No new columns, no change to Claude or Codex capture.

## Evidence

Written against a real `pi --mode json` capture (0.84.2, `openai-codex/gpt-5.6-luna`, the exact flags `argsForRunner` builds), not documentation. Three facts from it drive the code:

- `turn_end` repeats the last `message_end`'s message object verbatim, and `message_start`/`message_update` carry usage too. Only `message_end` is harvested; harvesting any other would double every session.
- PI's `input` **excludes** `cacheRead`: the captured message reconciles as 1068 + 5 + 3584 = 4657, PI's own `totalTokens`.
- PI's `output` already **includes** `reasoning` (a second capture: output 29, reasoning 22, totalTokens = input + output).

**Caliber**, spelled out in `extractPiUsage` and asserted in the tests: the stored `totalTokens` is uncached input + output, so it **excludes** cache reads. That matches CLAUDE and deliberately differs from CODEX, whose `input_tokens` already contains `cached_input_tokens`. The aggregate is named for who computed it so it is not mistaken for a provider vocabulary; the provider's untouched event is still on record as `PROVIDER_RAW`.

## Fail loudly

A session PI reports no usage for keeps null columns rather than inventing zeroes, but does not settle quietly — it emits an `ADAPTER_ERROR` (rendered inline in the session stream) plus an audit line. Short totals are diagnosed too, because those do not stay null, they store a real-looking number nothing downstream can tell is incomplete: fewer reporting messages than messages, zero tokens, and zero cost each count as a gap, and all of them are reported at once.

## Exactness

Costs are summed as integer nano-USD, not doubles. Adding the raw values reintroduces the error `usage.ts` documents and avoids — 0.000001 + 0.000049 falls just below the half-unit and `Decimal(12, 4)` rounds it to 0.0000 instead of 0.0001. This package cannot reach `Prisma.Decimal` without pulling a database client into the runner, so exactness lives in the integer transport and the ingest divides by a power of ten in decimal.

## Known limitation, not introduced here

An attempt killed before it settles — Inbox suspension is the live case — loses its usage. The fencing rejection that triggers the kill has already cleared the delivery lease, so no event this adapter emits would still be accepted. Claude and Codex lose the same window; closing it needs a control-plane change.

## Deviation from the brief

The brief asks for the fresh capture to land in `spikes/cli-capabilities/samples/`. That tree has never existed in this repository (it is the public snapshot; the samples `usage.test.ts` cites are absent here too), so the captured events are checked in verbatim as test fixtures instead, with the exact capture command in a comment.

## Verification

- Merge gate PASS on 11949be against baseline 274c5c0.
- `@agentos/runner` 242 pass / 2 skipped, `@agentos/api` 466 pass / 1 skipped, `@agentos/db` 234 pass, `npm run lint` clean.
- End-to-end replay of the full real transcript through the adapter and the ingest yields inputTokens 5688, outputTokens 24, cachedInputTokens 3584, totalTokens 5712, costUsd 0.0012, with no double count from `turn_end`.
- Reviewed by `codex exec -m gpt-5.6-sol` at xhigh; four of five findings were confirmed and fixed in the second commit, the fifth is the documented limitation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)