### PR TITLE
feat(merge-tail): autonomous repair loop with review severity and park recovery

### DIFF
--- a/agents/roles/review-coordinator.md
+++ b/agents/roles/review-coordinator.md
@@ -9,9 +9,13 @@ collaborators: []
 When the task is named `Autonomous merge tail: independent review`, perform the
 blind exact-range code review described by that task instead of plan review.
 Do not read prior review outputs. Inspect the brief, both range endpoints, the
-entire diff, and affected tests; explicitly approve only when no must-fix defect
-remains, otherwise reject with a bounded must-fix summary. Persist exactly the
-versioned JSON decision the task requests and never modify the repository.
+entire diff, and affected tests. Report findings with severity and let the
+control plane derive the verdict: `blocking` is only a reachable behavioural
+defect — correctness, data integrity, or security — and carries the concrete
+reachability argument that proves it; specification inconsistency no caller can
+reach, style, and defensive hardening are `follow-up`, which become backlog
+cards while the merge proceeds. Persist exactly the versioned JSON decision the
+task requests and never modify the repository.
 
 For every other task, you are the plan review coordinator. Your one job: review the proposed
 implementation plan against the approved specification and the repository at

--- a/agents/templates/compound-engineer-workflow/12-merge-readiness.md
+++ b/agents/templates/compound-engineer-workflow/12-merge-readiness.md
@@ -11,6 +11,8 @@ spawnPolicy: null
 ---
 This is a server-owned mechanical readiness step. No model run executes it.
 The control plane recomputes the pull-request head and defense-list triggers,
-requires any open independent review to approve, and emits an exact-head merge
-authorization. Missing or stale PASS evidence leaves this step blocked at
+requires any open independent review to clear — approved, or accepted with
+follow-up cards — and emits an exact-head merge authorization. A review that
+reports a blocking finding sends the tail back through automatic repair, up to
+three blocking rounds. Missing or stale PASS evidence leaves this step blocked at
 regression verification with a named reason.

--- a/agents/templates/direct-engineer-workflow/07-merge-readiness.md
+++ b/agents/templates/direct-engineer-workflow/07-merge-readiness.md
@@ -11,6 +11,8 @@ spawnPolicy: null
 ---
 This is a server-owned mechanical readiness step. No model run executes it.
 The control plane recomputes the pull-request head and defense-list triggers,
-requires any open independent review to approve, and emits an exact-head merge
-authorization. Missing or stale PASS evidence leaves this step blocked at
+requires any open independent review to clear — approved, or accepted with
+follow-up cards — and emits an exact-head merge authorization. A review that
+reports a blocking finding sends the tail back through automatic repair, up to
+three blocking rounds. Missing or stale PASS evidence leaves this step blocked at
 regression verification with a named reason.

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -89,11 +89,14 @@ import {
   type DecisionRow,
   asJsonObject,
   isMergeReadinessStep,
+  MAX_BLOCKING_REVIEW_ROUNDS,
   MERGE_TAIL_KIND,
   MergeRecoveryStatus,
   mergeRecoveryPhase,
+  parseIndependentReviewDecision,
   parseRegressionVerdict,
   parseResolverResult,
+  type IndependentReviewFinding,
   type MergeRecoveryAttempt,
 } from "@agentos/db";
 import { Hono, type Context } from "hono";
@@ -302,27 +305,81 @@ const stopBaseDriftRecoveryTail = async (
   ] });
 };
 
-const openMergeTailReviewDecisionInbox = async (
+/**
+ * Resolves the agent that repairs what this chain's independent review found:
+ * the chain's own fix step assignee, or `senior-dev` when the chain has none.
+ */
+const mergeTailFixAgentName = async (
   tx: DbTx,
-  input: { taskId: string; agentId: string; sessionId?: string; reason: string },
-): Promise<void> => {
-  await tx.inboxMessage.create({ data: {
-    from: "AGENT",
-    agentId: input.agentId,
-    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
-    taskId: input.taskId,
-    kind: "MULTIPLE_CHOICE",
-    body: [
-      `Autonomous merge tail stopped: ${input.reason}`,
-      "Choose one explicit operator action. No repair or merge will start automatically.",
+  regression: { projectId: string; chainId: string | null; templateId: string | null } | null,
+): Promise<string> => {
+  if (!regression) return "senior-dev";
+  const fixTask = await tx.task.findFirst({
+    where: {
+      projectId: regression.projectId,
+      chainId: regression.chainId,
+      templateId: regression.templateId,
+      templateStep: { outputKind: "fixed-implementation" },
+    },
+    select: { assigneeAgent: { select: { name: true } } },
+  });
+  return fixTask?.assigneeAgent?.name ?? "senior-dev";
+};
+
+/**
+ * Parks one follow-up finding as a backlog card.
+ *
+ * A follow-up is by contract not a reachable behavioural defect, so it never
+ * holds the merge; the card is what keeps it from being lost instead.
+ */
+const createReviewFollowUpCard = async (
+  tx: DbTx,
+  input: {
+    projectId: string;
+    repoId: string | null;
+    agentName: string;
+    reviewTaskId: string;
+    headSha: string;
+    finding: IndependentReviewFinding;
+  },
+): Promise<{ taskId: string } | { refusal: string }> => {
+  if (!input.repoId) return { refusal: "independent review task has no repository" };
+  const agent = await tx.agent.findFirst({
+    where: { projectId: input.projectId, name: input.agentName, archivedAt: null },
+  });
+  if (!agent) return { refusal: `follow-up agent ${input.agentName} is absent or archived` };
+  const grant = await tx.agentRepoAccess.findFirst({
+    where: { projectId: input.projectId, agentId: agent.id, repoId: input.repoId },
+  });
+  if (!grant) return { refusal: `follow-up agent ${input.agentName} has no repository grant` };
+  const task = await tx.task.create({ data: {
+    projectId: input.projectId,
+    repoId: input.repoId,
+    name: `Merge tail follow-up: ${input.finding.title}`,
+    description: [
+      input.finding.detail,
+      `Raised as a follow-up by the autonomous merge tail independent review ${input.reviewTaskId} at exact head ${input.headSha}. It did not block that merge.`,
     ].join("\n\n"),
-    choices: [
-      { id: "create-repair", label: "Create one review-fix task" },
-      { id: "adopt-head", label: "Adopt current exact head and rerun Regression" },
-      { id: "operator-takeover", label: "Park autonomous tail for operator takeover" },
-    ],
-    dedupeKey: `merge-tail-review-rejection:${input.taskId}:${createHash("sha256").update(input.reason).digest("hex")}`,
+    assigneeType: "AGENT",
+    assigneeAgentId: agent.id,
+    approvalGate: false,
+    opensPullRequest: false,
+    status: TaskStatus.BACKLOG,
   } });
+  await tx.taskActivity.create({ data: {
+    taskId: task.id,
+    actorType: "control-plane",
+    body: `Follow-up finding from independent review ${input.reviewTaskId} at ${input.headSha}`,
+    metadata: {
+      kind: MERGE_TAIL_KIND.reviewObligation,
+      schemaVersion: 1,
+      state: "follow-up",
+      reviewTaskId: input.reviewTaskId,
+      headSha: input.headSha,
+      title: input.finding.title,
+    },
+  } });
+  return { taskId: task.id };
 };
 
 const openMergeTailStopNotice = async (
@@ -428,148 +485,6 @@ const createMergeTailRepairTask = async (
     data: { status: TaskStatus.REVIEW, failureReason: `${input.repairKind}: automatic repair ${task.id} queued at ${input.headSha}` },
   });
   return { taskId: task.id };
-};
-
-const applyMergeTailOperatorDecision = async (
-  tx: DbTx,
-  input: { messageId: string; requestId: string; decision: string; now: Date },
-): Promise<null | { duplicate: boolean; resumed: false; messageId: string; action?: string; error?: string }> => {
-  const card = await tx.inboxMessage.findUnique({
-    where: { id: input.messageId },
-    include: {
-      session: { include: { run: true } },
-      task: { include: { templateStep: true, runs: { orderBy: { runNumber: "desc" }, take: 5 } } },
-    },
-  });
-  if (!card?.dedupeKey?.startsWith("merge-tail-review-rejection:")) return null;
-  if (!card.task || !card.session?.run) return { duplicate: false, resumed: false, messageId: card.id, error: "Merge-tail decision is missing its Regression task or source Run" };
-  if (!["create-repair", "adopt-head", "operator-takeover"].includes(input.decision)) {
-    return { duplicate: false, resumed: false, messageId: card.id, error: "Unknown merge-tail operator decision" };
-  }
-  if (card.status !== InboxStatus.OPEN) {
-    return {
-      duplicate: true,
-      resumed: false,
-      messageId: card.id,
-      ...(card.selectedChoiceId ? { action: card.selectedChoiceId } : {}),
-    };
-  }
-  const regression = card.task;
-  if (regression.templateStep?.outputKind !== "regression-verification" || !regression.chainId || !regression.templateId) {
-    return { duplicate: false, resumed: false, messageId: card.id, error: "Merge-tail decision is not bound to a canonical Regression task" };
-  }
-  if (regression.chainId) {
-    await lockChainRows(tx, { projectId: regression.projectId, chainId: regression.chainId });
-  } else {
-    await lockTask(tx, regression.id);
-  }
-  const readiness = await tx.task.findFirst({
-    where: {
-      projectId: regression.projectId,
-      chainId: regression.chainId,
-      templateId: regression.templateId,
-      templateStep: { outputKind: "merge-authorization" },
-    },
-  });
-  if (!readiness) return { duplicate: false, resumed: false, messageId: card.id, error: "Merge-tail readiness task is missing" };
-  const rows = await tx.taskActivity.findMany({
-    where: {
-      taskId: readiness.id,
-      actorType: "control-plane",
-      metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.reviewObligation },
-    },
-    select: { createdAt: true, metadata: true },
-    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-    take: 50,
-  });
-  const rejection = rows.map((row) => ({ row, metadata: asJsonObject(row.metadata) })).find(({ metadata }) => (
-    metadata?.state === "rejected" && typeof metadata.headSha === "string"
-  ));
-  const headSha = typeof rejection?.metadata?.headSha === "string" ? rejection.metadata.headSha : null;
-  const baseHeadSha = typeof rejection?.metadata?.baseSha === "string" ? rejection.metadata.baseSha : null;
-  const summary = typeof rejection?.metadata?.summary === "string" ? rejection.metadata.summary : null;
-  if (!headSha || !baseHeadSha || !summary || !/^[0-9a-f]{40}$/u.test(headSha) || !/^[0-9a-f]{40}$/u.test(baseHeadSha)) {
-    return { duplicate: false, resumed: false, messageId: card.id, error: "Merge-tail rejection lacks exact head/base evidence" };
-  }
-  const claimed = await tx.inboxMessage.updateMany({
-    where: { id: card.id, status: InboxStatus.OPEN },
-    data: { status: InboxStatus.ANSWERED, selectedChoiceId: input.decision, answeredAt: input.now },
-  });
-  if (claimed.count !== 1) return { duplicate: true, resumed: false, messageId: card.id };
-  const externalEventId = `web:${input.requestId}`;
-  await tx.inboxDecision.create({ data: {
-    inboxMessageId: card.id,
-    runId: card.session.run.id,
-    externalEventId,
-    decision: input.decision,
-    actorOpenId: "web-operator",
-  } });
-  await tx.inboxMessage.create({ data: {
-    from: "HUMAN",
-    agentId: card.agentId,
-    sessionId: card.sessionId,
-    taskId: card.taskId,
-    replyToMessageId: card.id,
-    kind: "TEXT",
-    body: input.decision,
-    selectedChoiceId: input.decision,
-    status: InboxStatus.CLOSED,
-    dedupeKey: `decision:${externalEventId}:reply`,
-    deliveryStatus: "DELIVERED",
-    deliveredAt: input.now,
-  } });
-  await tx.taskActivity.create({ data: {
-    taskId: regression.id,
-    actorType: "operator",
-    body: `Merge-tail operator decision ${input.decision} for exact head ${headSha}`,
-    metadata: {
-      kind: MERGE_TAIL_KIND.operatorDecision,
-      schemaVersion: 1,
-      action: input.decision,
-      headSha,
-      baseHeadSha,
-      reviewTaskId: typeof rejection?.metadata?.reviewTaskId === "string" ? rejection.metadata.reviewTaskId : null,
-      requestId: input.requestId,
-    },
-  } });
-
-  if (input.decision === "create-repair") {
-    const fixTask = await tx.task.findFirst({
-      where: {
-        projectId: regression.projectId,
-        chainId: regression.chainId,
-        templateId: regression.templateId,
-        templateStep: { outputKind: "fixed-implementation" },
-      },
-      select: { assigneeAgent: { select: { name: true } } },
-    });
-    const sourceRun = regression.runs.find((run) => run.branch !== null);
-    const repair = await createMergeTailRepairTask(tx, {
-      regressionTask: regression,
-      sourceRun: { id: card.session.run.id, branch: sourceRun?.branch ?? null },
-      agentName: fixTask?.assigneeAgent?.name ?? "senior-dev",
-      repairKind: "review-fix",
-      headSha,
-      baseHeadSha,
-      summary,
-      now: input.now,
-    });
-    if ("refusal" in repair) throw new Error(repair.refusal);
-  } else if (input.decision === "adopt-head") {
-    await tx.task.update({ where: { id: regression.id }, data: { status: TaskStatus.TODO, failureReason: null } });
-    await tx.task.update({ where: { id: readiness.id }, data: { status: TaskStatus.TODO, failureReason: null } });
-    await enqueueTaskRun(tx, regression.id, input.now);
-  } else {
-    const integrator = await tx.task.findFirst({
-      where: { projectId: regression.projectId, chainId: regression.chainId, templateId: regression.templateId, templateStep: { outputKind: "merge-result" } },
-      select: { id: true },
-    });
-    await tx.task.updateMany({
-      where: { id: { in: [regression.id, readiness.id, ...(integrator ? [integrator.id] : [])] } },
-      data: { status: TaskStatus.REVIEW, failureReason: `Autonomous merge tail parked by operator at ${headSha}` },
-    });
-  }
-  return { duplicate: false, resumed: false, messageId: card.id, action: input.decision };
 };
 
 export const handleRegressionCompletion = async (
@@ -1625,10 +1540,20 @@ const activateMergeTailTarget = async (
     return;
   }
   if (isMergeReadinessStep(target.templateStep)) {
+    // Readiness runs on the server worker, which only claims TODO/DOING. The
+    // obligation parked this step in REVIEW while the review ran, so resolving
+    // the review has to hand it back; anything else in REVIEW is a real stop
+    // and stays stopped.
+    const resumed = await tx.task.updateMany({
+      where: { id: taskId, status: TaskStatus.REVIEW, failureReason: { startsWith: "independent-review-open:" } },
+      data: { status: TaskStatus.TODO, failureReason: null },
+    });
     await tx.taskActivity.create({ data: {
       taskId,
       actorType: "control-plane",
-      body: "Merge-tail readiness target queued for server worker",
+      body: resumed.count === 1
+        ? "Independent review resolved; readiness target returned to the server worker"
+        : "Merge-tail readiness target queued for server worker",
       metadata: { kind: MERGE_TAIL_KIND.readiness, schemaVersion: 1, state: "queued" },
     } });
     return;
@@ -4506,17 +4431,6 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/inbox/messages/:messageId/decision", async (context) => {
     const body = await readJson(context.req.raw, inboxDecisionInput);
     try {
-      const mergeTail = await db.$transaction((tx) => applyMergeTailOperatorDecision(tx, {
-        messageId: id.parse(context.req.param("messageId")),
-        requestId: body.requestId,
-        decision: body.decision,
-        now: new Date(),
-      }));
-      if (mergeTail) {
-        return mergeTail.error
-          ? context.json({ error: mergeTail.error }, 409)
-          : context.json(mergeTail, mergeTail.duplicate ? 200 : 201);
-      }
       const result = await applyInboxDecision(db, {
         inboxMessageId: id.parse(context.req.param("messageId")),
         externalEventId: `web:${body.requestId}`,
@@ -5968,7 +5882,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       const reviewRegression = typeof reviewMarker?.regressionTaskId === "string"
         ? await tx.task.findUnique({
             where: { id: reviewMarker.regressionTaskId },
-            select: { chainId: true },
+            select: { projectId: true, repoId: true, templateId: true, chainId: true, targetBranch: true },
           })
         : null;
       const repairDocumentationTask = repairRegression?.chainId && repairRegression.templateId
@@ -6326,72 +6240,126 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             && typeof reviewMarker.readinessTaskId === "string"
             && typeof reviewMarker.regressionTaskId === "string"
             && typeof reviewMarker.headSha === "string") {
+            const readinessTaskId = reviewMarker.readinessTaskId;
+            const regressionTaskId = reviewMarker.regressionTaskId;
+            const reviewHeadSha = reviewMarker.headSha;
+            const reviewBaseSha = typeof reviewMarker.baseSha === "string" ? reviewMarker.baseSha : null;
             const reviewOutput = await tx.taskStepOutput.findUnique({ where: { taskId: run.taskId }, select: { body: true } });
-            let decision: Record<string, unknown> | null = null;
-            try { decision = JSON.parse(reviewOutput?.body ?? "null") as Record<string, unknown> | null; } catch { decision = null; }
-            const validHead = decision?.schemaVersion === 1 && decision.headSha === reviewMarker.headSha;
-            if (!validHead || (decision?.outcome !== "approved" && decision?.outcome !== "rejected")) {
+            const parsedReview = parseIndependentReviewDecision(reviewOutput?.body, reviewHeadSha);
+            const reviewSessionId = run.session.id;
+            const stopTail = async (reason: string): Promise<void> => {
+              await tx.task.update({ where: { id: readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
+              await tx.task.update({ where: { id: regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
+              await openMergeTailStopNotice(tx, { taskId: regressionTaskId, agentId: run.agentId, sessionId: reviewSessionId, reason });
+            };
+            if (parsedReview.status === "invalid") {
               reviewRejected = true;
-              const reason = `independent review returned missing, malformed, or stale decision for ${reviewMarker.headSha}`;
+              const reason = `independent review returned an unusable decision for ${reviewHeadSha}: ${parsedReview.reason}`;
               await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: reason } });
-              await tx.task.update({ where: { id: reviewMarker.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-              await openMergeTailStopNotice(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
-            } else if (decision.outcome === "approved") {
-              await tx.taskActivity.create({ data: {
-                taskId: reviewMarker.readinessTaskId,
-                actorType: "control-plane",
-                body: `Independent review approved exact head ${reviewMarker.headSha}`,
-                metadata: jsonValue({
-                  kind: MERGE_TAIL_KIND.reviewObligation,
-                  schemaVersion: 1,
-                  state: "approved",
+              await tx.task.update({ where: { id: readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
+              await openMergeTailStopNotice(tx, { taskId: regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+            } else if (parsedReview.decision.outcome !== "rejected") {
+              // Follow-up findings never hold the merge. Each becomes a backlog
+              // card, so the merge proceeds with the work recorded instead of
+              // with the finding lost.
+              const followUpCardIds: string[] = [];
+              let followUpRefusal: string | null = null;
+              const followUpAgentName = await mergeTailFixAgentName(tx, reviewRegression);
+              for (const finding of parsedReview.decision.findings) {
+                const card = await createReviewFollowUpCard(tx, {
+                  projectId: run.task.projectId,
+                  repoId: run.task.repoId,
+                  agentName: followUpAgentName,
                   reviewTaskId: run.taskId,
-                  headSha: reviewMarker.headSha,
-                  baseSha: typeof reviewMarker.baseSha === "string" ? reviewMarker.baseSha : null,
-                }),
-              } });
+                  headSha: reviewHeadSha,
+                  finding,
+                });
+                if ("refusal" in card) { followUpRefusal = card.refusal; break; }
+                followUpCardIds.push(card.taskId);
+              }
+              if (followUpRefusal) {
+                reviewRejected = true;
+                const reason = `independent review follow-up card could not be created: ${followUpRefusal}`;
+                await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: reason } });
+                await stopTail(reason);
+              } else {
+                await tx.taskActivity.create({ data: {
+                  taskId: readinessTaskId,
+                  actorType: "control-plane",
+                  body: followUpCardIds.length === 0
+                    ? `Independent review approved exact head ${reviewHeadSha}`
+                    : `Independent review accepted exact head ${reviewHeadSha} with ${followUpCardIds.length} follow-up card(s)`,
+                  metadata: jsonValue({
+                    kind: MERGE_TAIL_KIND.reviewObligation,
+                    schemaVersion: 1,
+                    state: parsedReview.decision.outcome,
+                    reviewTaskId: run.taskId,
+                    headSha: reviewHeadSha,
+                    baseSha: reviewBaseSha,
+                    followUpCardIds,
+                  }),
+                } });
+              }
             } else {
               reviewRejected = true;
+              const summary = parsedReview.decision.blockingSummary;
               const prior = await tx.taskActivity.findMany({
-                where: { taskId: reviewMarker.readinessTaskId }, select: { metadata: true },
+                where: { taskId: readinessTaskId }, select: { metadata: true },
               });
-              const alreadyRejected = prior.some((row) => {
+              const round = prior.filter((row) => {
                 const metadata = asJsonObject(row.metadata);
                 return metadata?.kind === MERGE_TAIL_KIND.reviewObligation && metadata.state === "rejected";
-              });
-              const summary = typeof decision.summary === "string" ? decision.summary : "independent review rejected without a summary";
+              }).length + 1;
               await tx.taskActivity.create({ data: {
-                taskId: reviewMarker.readinessTaskId,
+                taskId: readinessTaskId,
                 actorType: "control-plane",
-                body: `Independent review rejected exact head ${reviewMarker.headSha}`,
+                body: `Independent review rejected exact head ${reviewHeadSha} on blocking round ${round}`,
                 metadata: {
                   kind: MERGE_TAIL_KIND.reviewObligation,
                   schemaVersion: 1,
                   state: "rejected",
                   reviewTaskId: run.taskId,
-                  headSha: reviewMarker.headSha,
-                  baseSha: typeof reviewMarker.baseSha === "string" ? reviewMarker.baseSha : null,
+                  headSha: reviewHeadSha,
+                  baseSha: reviewBaseSha,
                   summary,
+                  blockingRound: round,
                 },
               } });
               await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: `independent review rejected: ${summary}` } });
               const driftRecovery = await baseDriftRecoveryContext(
                 tx,
-                reviewMarker.regressionTaskId,
+                regressionTaskId,
                 undefined,
                 typeof reviewMarker.recoverySourceStopId === "string" ? reviewMarker.recoverySourceStopId : "no-recovery-context",
               );
               if (driftRecovery) {
-                await stopBaseDriftRecoveryTail(tx, driftRecovery, "independent-review", `rejected ${reviewMarker.headSha}: ${summary}`);
-              } else if (alreadyRejected) {
-                const reason = `second independent review rejection at ${reviewMarker.headSha}: ${summary}`;
-                await tx.task.update({ where: { id: reviewMarker.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-                await openMergeTailReviewDecisionInbox(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+                await stopBaseDriftRecoveryTail(tx, driftRecovery, "independent-review", `rejected ${reviewHeadSha}: ${summary}`);
+              } else if (round >= MAX_BLOCKING_REVIEW_ROUNDS) {
+                // The ceiling is an exception path, not an approval gate: three
+                // blocking rounds mean the repair loop is not converging, so the
+                // tail stops and says so instead of spending a fourth round.
+                await stopTail(`independent review rejected ${reviewHeadSha} on blocking round ${round} of ${MAX_BLOCKING_REVIEW_ROUNDS}; automatic repair is exhausted: ${summary}`);
+              } else if (!reviewRegression || !reviewBaseSha) {
+                await stopTail(`independent review rejected ${reviewHeadSha} but its Regression task or base head is unavailable for automatic repair`);
               } else {
-                const reason = `independent review rejected exact head ${reviewMarker.headSha}: ${summary}`;
-                await tx.task.update({ where: { id: reviewMarker.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-                await tx.task.update({ where: { id: reviewMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-                await openMergeTailReviewDecisionInbox(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+                const repair = await createMergeTailRepairTask(tx, {
+                  regressionTask: { id: regressionTaskId, ...reviewRegression },
+                  sourceRun: { id: run.id, branch: run.branch },
+                  agentName: await mergeTailFixAgentName(tx, reviewRegression),
+                  repairKind: "review-fix",
+                  headSha: reviewHeadSha,
+                  baseHeadSha: reviewBaseSha,
+                  summary,
+                  now,
+                });
+                if ("refusal" in repair) {
+                  await stopTail(`independent review rejected ${reviewHeadSha} and automatic repair was refused: ${repair.refusal}`);
+                } else {
+                  await tx.task.update({
+                    where: { id: readinessTaskId },
+                    data: { status: TaskStatus.REVIEW, failureReason: `review-fix: automatic repair ${repair.taskId} queued at ${reviewHeadSha}` },
+                  });
+                }
               }
             }
           }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -88,6 +88,7 @@ import {
   type CardRow,
   type DecisionRow,
   asJsonObject,
+  INDEPENDENT_REVIEW_OPEN_PREFIX,
   isMergeReadinessStep,
   MAX_BLOCKING_REVIEW_ROUNDS,
   MERGE_TAIL_KIND,
@@ -344,12 +345,18 @@ const createReviewFollowUpCard = async (
   },
 ): Promise<{ taskId: string } | { refusal: string }> => {
   if (!input.repoId) return { refusal: "independent review task has no repository" };
-  const agent = await tx.agent.findFirst({
-    where: { projectId: input.projectId, name: input.agentName, archivedAt: null },
+  const named = await tx.agent.findFirst({
+    where: { projectId: input.projectId, name: input.agentName },
+    select: { id: true },
   });
-  if (!agent) return { refusal: `follow-up agent ${input.agentName} is absent or archived` };
-  const grant = await tx.agentRepoAccess.findFirst({
-    where: { projectId: input.projectId, agentId: agent.id, repoId: input.repoId },
+  if (!named) return { refusal: `follow-up agent ${input.agentName} is absent` };
+  // A card assigned to an agent archived a moment later, or pointing at a
+  // revoked grant, is a card nothing can ever run. Both facts are therefore
+  // taken under the same mutexes the archive and revoke paths take.
+  const agent = await lockAgentRow(tx, named.id);
+  if (!agent || agent.archivedAt) return { refusal: `follow-up agent ${input.agentName} is absent or archived` };
+  const grant = await lockAgentRepoGrant(tx, {
+    projectId: input.projectId, agentId: agent.id, repoId: input.repoId,
   });
   if (!grant) return { refusal: `follow-up agent ${input.agentName} has no repository grant` };
   const task = await tx.task.create({ data: {
@@ -1545,7 +1552,7 @@ const activateMergeTailTarget = async (
     // the review has to hand it back; anything else in REVIEW is a real stop
     // and stays stopped.
     const resumed = await tx.task.updateMany({
-      where: { id: taskId, status: TaskStatus.REVIEW, failureReason: { startsWith: "independent-review-open:" } },
+      where: { id: taskId, status: TaskStatus.REVIEW, failureReason: { startsWith: INDEPENDENT_REVIEW_OPEN_PREFIX } },
       data: { status: TaskStatus.TODO, failureReason: null },
     });
     await tx.taskActivity.create({ data: {
@@ -6244,8 +6251,24 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             const regressionTaskId = reviewMarker.regressionTaskId;
             const reviewHeadSha = reviewMarker.headSha;
             const reviewBaseSha = typeof reviewMarker.baseSha === "string" ? reviewMarker.baseSha : null;
-            const reviewOutput = await tx.taskStepOutput.findUnique({ where: { taskId: run.taskId }, select: { body: true } });
-            const parsedReview = parseIndependentReviewDecision(reviewOutput?.body, reviewHeadSha);
+            // Review evidence is run-scoped even though TaskStepOutput is not.
+            // An earlier attempt's decision is not this attempt's decision, and
+            // a decision not bound to the reviewed head is not evidence about
+            // it: either one would let an unreviewed head through.
+            const persistedReview = await tx.taskStepOutput.findUnique({
+              where: { taskId: run.taskId }, select: { body: true, runId: true, commitSha: true },
+            });
+            const reviewOutput = persistedReview?.runId === run.id && persistedReview.commitSha === reviewHeadSha
+              ? persistedReview
+              : null;
+            const parsedReview = reviewOutput
+              ? parseIndependentReviewDecision(reviewOutput.body, reviewHeadSha)
+              : {
+                status: "invalid" as const,
+                reason: persistedReview
+                  ? `decision is bound to run ${persistedReview.runId ?? "none"} at ${persistedReview.commitSha ?? "no head"}, not this run at ${reviewHeadSha}`
+                  : "missing independent review output",
+              };
             const reviewSessionId = run.session.id;
             // A finding's own text reaches these reasons, so every one of them
             // is bounded exactly where a client-supplied reason would be.
@@ -6267,7 +6290,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
               // with the finding lost.
               const followUpCardIds: string[] = [];
               let followUpRefusal: string | null = null;
-              const followUpAgentName = await mergeTailFixAgentName(tx, reviewRegression);
+              const followUpAgentName = await mergeTailFixAgentName(tx, await tx.task.findUnique({
+                where: { id: regressionTaskId },
+                select: { projectId: true, chainId: true, templateId: true },
+              }));
               for (const finding of parsedReview.decision.findings) {
                 const card = await createReviewFollowUpCard(tx, {
                   projectId: run.task.projectId,
@@ -6345,26 +6371,58 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                 // blocking rounds mean the repair loop is not converging, so the
                 // tail stops and says so instead of spending a fourth round.
                 await stopTail(`independent review rejected ${reviewHeadSha} on blocking round ${round} of ${MAX_BLOCKING_REVIEW_ROUNDS}; automatic repair is exhausted: ${summary}`);
-              } else if (!reviewRegression || !reviewBaseSha) {
-                await stopTail(`independent review rejected ${reviewHeadSha} but its Regression task or base head is unavailable for automatic repair`);
+              } else if (!reviewBaseSha) {
+                await stopTail(`independent review rejected ${reviewHeadSha} but its base head is unavailable for automatic repair`);
               } else {
-                const repair = await createMergeTailRepairTask(tx, {
-                  regressionTask: { id: regressionTaskId, ...reviewRegression },
-                  sourceRun: { id: run.id, branch: run.branch },
-                  agentName: await mergeTailFixAgentName(tx, reviewRegression),
-                  repairKind: "review-fix",
-                  headSha: reviewHeadSha,
-                  baseHeadSha: reviewBaseSha,
-                  summary,
-                  now,
+                // The chain mutex is held now; the Regression row read before it
+                // may already be stale, and a repair bound to a stale repository
+                // or target branch cannot hand off to the fresh Regression run.
+                const lockedRegression = await tx.task.findUnique({
+                  where: { id: regressionTaskId },
+                  select: { projectId: true, repoId: true, templateId: true, chainId: true, targetBranch: true },
                 });
-                if ("refusal" in repair) {
-                  await stopTail(`independent review rejected ${reviewHeadSha} and automatic repair was refused: ${repair.refusal}`);
+                // Claiming the park this review owns is what makes the repair
+                // automatic without overruling anyone: an operator who moved
+                // readiness out of it while the review ran keeps that decision,
+                // and no repair run starts behind their back.
+                const claimedPark = await tx.task.updateMany({
+                  where: { id: readinessTaskId, status: TaskStatus.REVIEW, failureReason: { startsWith: INDEPENDENT_REVIEW_OPEN_PREFIX } },
+                  data: { failureReason: `review-fix: automatic repair queued at ${reviewHeadSha}` },
+                });
+                if (!lockedRegression) {
+                  await stopTail(`independent review rejected ${reviewHeadSha} but its Regression task is gone`);
+                } else if (claimedPark.count !== 1) {
+                  await tx.taskActivity.create({ data: {
+                    taskId: readinessTaskId,
+                    actorType: "control-plane",
+                    body: `Independent review rejected ${reviewHeadSha}, but readiness is no longer parked on that review; automatic repair was not started`,
+                    metadata: {
+                      kind: MERGE_TAIL_KIND.reviewObligation,
+                      schemaVersion: 1,
+                      state: "repair-skipped",
+                      reviewTaskId: run.taskId,
+                      headSha: reviewHeadSha,
+                    },
+                  } });
                 } else {
-                  await tx.task.update({
-                    where: { id: readinessTaskId },
-                    data: { status: TaskStatus.REVIEW, failureReason: `review-fix: automatic repair ${repair.taskId} queued at ${reviewHeadSha}` },
+                  const repair = await createMergeTailRepairTask(tx, {
+                    regressionTask: { id: regressionTaskId, ...lockedRegression },
+                    sourceRun: { id: run.id, branch: run.branch },
+                    agentName: await mergeTailFixAgentName(tx, lockedRegression),
+                    repairKind: "review-fix",
+                    headSha: reviewHeadSha,
+                    baseHeadSha: reviewBaseSha,
+                    summary,
+                    now,
                   });
+                  if ("refusal" in repair) {
+                    await stopTail(`independent review rejected ${reviewHeadSha} and automatic repair was refused: ${repair.refusal}`);
+                  } else {
+                    await tx.task.update({
+                      where: { id: readinessTaskId },
+                      data: { status: TaskStatus.REVIEW, failureReason: `review-fix: automatic repair ${repair.taskId} queued at ${reviewHeadSha}` },
+                    });
+                  }
                 }
               }
             }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -109,7 +109,7 @@ import { authenticate, issueSessionToken, principalMayAccess, type Principal } f
 import { boardCard, chainDisplayByTask, etagFor, etagMatches, serializeUsageCost } from "./board.js";
 import { isValidBranchName } from "./branch-name.js";
 import { chainExecutionOwner } from "./chain-execution-owner.js";
-import { FAILURE_REASON_LIMIT, failureReasonText } from "./failure-reason.js";
+import { FAILURE_REASON_LIMIT, failureReasonText, truncateFailureReason } from "./failure-reason.js";
 import {
   canonicalOutputRefusal,
   isCanonicalAdjudicationStep,
@@ -6247,7 +6247,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             const reviewOutput = await tx.taskStepOutput.findUnique({ where: { taskId: run.taskId }, select: { body: true } });
             const parsedReview = parseIndependentReviewDecision(reviewOutput?.body, reviewHeadSha);
             const reviewSessionId = run.session.id;
-            const stopTail = async (reason: string): Promise<void> => {
+            // A finding's own text reaches these reasons, so every one of them
+            // is bounded exactly where a client-supplied reason would be.
+            const stopTail = async (unbounded: string): Promise<void> => {
+              const reason = truncateFailureReason(unbounded, FAILURE_REASON_LIMIT);
               await tx.task.update({ where: { id: readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
               await tx.task.update({ where: { id: regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
               await openMergeTailStopNotice(tx, { taskId: regressionTaskId, agentId: run.agentId, sessionId: reviewSessionId, reason });
@@ -6325,7 +6328,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                   blockingRound: round,
                 },
               } });
-              await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: `independent review rejected: ${summary}` } });
+              await tx.task.update({ where: { id: run.taskId }, data: {
+                status: TaskStatus.DONE,
+                failureReason: truncateFailureReason(`independent review rejected: ${summary}`, FAILURE_REASON_LIMIT),
+              } });
               const driftRecovery = await baseDriftRecoveryContext(
                 tx,
                 regressionTaskId,

--- a/packages/api/src/chain.dbtest.ts
+++ b/packages/api/src/chain.dbtest.ts
@@ -7,6 +7,7 @@ import {
   activateChainSuccessor,
   applyInboxDecisionTx,
   CHAIN_AUTO_RESUME_KIND,
+  INDEPENDENT_REVIEW_OPEN_PREFIX,
   MAX_AUTOMATIC_SUCCESSOR_RESUMES,
   COMPOUND_IMPLEMENTATION_ASSIGNEE_ERROR_CODE,
   Prisma,
@@ -1197,6 +1198,21 @@ test("a stalled REVIEW successor is automatically returned to the queue", { time
   assert.equal(await db.taskActivity.count({ where: {
     taskId: successor.id, metadata: { path: ["kind"], equals: CHAIN_AUTO_RESUME_KIND },
   } }), 1);
+});
+
+test("a successor held by an open independent review is left to that review", { timeout: 20_000 }, async () => {
+  const { predecessor, successor } = await seedExecutableChain();
+  await db.task.update({ where: { id: successor.id }, data: {
+    status: "REVIEW", failureReason: `${INDEPENDENT_REVIEW_OPEN_PREFIX}review-task-id:${"a".repeat(40)}`,
+  } });
+  await activateOnParkedSuccessor(predecessor);
+  const held = await db.task.findUniqueOrThrow({ where: { id: successor.id } });
+  assert.equal(held.status, "REVIEW");
+  assert.equal(await db.run.count({ where: { taskId: successor.id } }), 0);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: successor.id, metadata: { path: ["kind"], equals: CHAIN_AUTO_RESUME_KIND },
+  } }), 0);
+  assert.match(await latestActivity(successor.id), /held by an open independent review/u);
 });
 
 test("a successor that keeps returning to REVIEW stops the chain and opens an inbox notice", { timeout: 20_000 }, async () => {

--- a/packages/api/src/chain.dbtest.ts
+++ b/packages/api/src/chain.dbtest.ts
@@ -6,6 +6,8 @@ import { after, before, beforeEach, test } from "node:test";
 import {
   activateChainSuccessor,
   applyInboxDecisionTx,
+  CHAIN_AUTO_RESUME_KIND,
+  MAX_AUTOMATIC_SUCCESSOR_RESUMES,
   COMPOUND_IMPLEMENTATION_ASSIGNEE_ERROR_CODE,
   Prisma,
   PrismaClient,
@@ -1178,6 +1180,42 @@ test("a BACKLOG successor is parked, not spun on", { timeout: 20_000 }, async ()
   assert.equal(await db.run.count({ where: { taskId: successor.id } }), 0);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: successor.id } })).status, "BACKLOG");
   assert.match(await latestActivity(successor.id), /parked in Backlog/);
+});
+
+// A REVIEW successor at dispatch time is a stalled chain, not a decision: it is
+// where a failed attempt, a park, or an operator drag leaves the row. It used to
+// be logged and abandoned, which is how a chain can sit for hours with nothing
+// watching it.
+test("a stalled REVIEW successor is automatically returned to the queue", { timeout: 20_000 }, async () => {
+  const { predecessor, successor } = await seedExecutableChain();
+  await db.task.update({ where: { id: successor.id }, data: { status: "REVIEW", failureReason: "Execution failed" } });
+  await activateOnParkedSuccessor(predecessor);
+  const resumed = await db.task.findUniqueOrThrow({ where: { id: successor.id } });
+  assert.equal(resumed.status, "TODO");
+  assert.equal(resumed.failureReason, null);
+  assert.equal(await db.run.count({ where: { taskId: successor.id } }), 1);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: successor.id, metadata: { path: ["kind"], equals: CHAIN_AUTO_RESUME_KIND },
+  } }), 1);
+});
+
+test("a successor that keeps returning to REVIEW stops the chain and opens an inbox notice", { timeout: 20_000 }, async () => {
+  const { predecessor, successor } = await seedExecutableChain();
+  for (let attempt = 1; attempt <= MAX_AUTOMATIC_SUCCESSOR_RESUMES; attempt += 1) {
+    await db.task.update({ where: { id: successor.id }, data: { status: "REVIEW", failureReason: "Execution failed" } });
+    await activateOnParkedSuccessor(predecessor);
+    assert.equal((await db.task.findUniqueOrThrow({ where: { id: successor.id } })).status, "TODO");
+    await db.run.deleteMany({ where: { taskId: successor.id } });
+  }
+  await db.task.update({ where: { id: successor.id }, data: { status: "REVIEW", failureReason: "Execution failed" } });
+  await activateOnParkedSuccessor(predecessor);
+  const stopped = await db.task.findUniqueOrThrow({ where: { id: successor.id } });
+  assert.equal(stopped.status, "REVIEW");
+  assert.match(stopped.failureReason ?? "", /automatic resumes/u);
+  assert.equal(await db.run.count({ where: { taskId: successor.id } }), 0);
+  const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: successor.id } });
+  assert.equal(notice.kind, "TEXT");
+  assert.match(notice.body, /needs an operator/u);
 });
 
 test("an archived successor is parked, not spun on", { timeout: 20_000 }, async () => {

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -676,7 +676,12 @@ test("a recovery-cycle independent-review rejection stops once without a review-
   await db.task.update({ where: { id: reviewTask.id }, data: { status: TaskStatus.DOING } });
   await db.taskStepOutput.create({ data: {
     taskId: reviewTask.id, runId: reviewRun.id, kind: "review",
-    body: JSON.stringify({ schemaVersion: 1, outcome: "rejected", headSha: HEAD, summary: "must fix" }), commitSha: HEAD,
+    body: JSON.stringify({ schemaVersion: 1, headSha: HEAD, findings: [{
+      severity: "blocking",
+      title: "must fix",
+      detail: "the recovery head reintroduces the defect",
+      reachability: "every merge of this head reaches it",
+    }] }), commitSha: HEAD,
   } });
   const priorToken = process.env.RUNNER_TOKEN;
   process.env.RUNNER_TOKEN = "review-runner-token";

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -244,7 +244,14 @@ const createReviewObligation = async (
     description: [
       `Blindly review the exact diff ${input.baseSha}..${input.headSha}.`,
       `The server-side trigger set is ${JSON.stringify(input.triggers)}.`,
-      "Do not read prior review outputs. Find correctness or safety defects in the triggered merge-tail surface, run focused checks, then persist exactly one JSON object: {\"schemaVersion\":1,\"outcome\":\"approved\",\"headSha\":\"<40 hex>\"} or {\"schemaVersion\":1,\"outcome\":\"rejected\",\"headSha\":\"<40 hex>\",\"summary\":\"<must-fix>\"}.",
+      "Do not read prior review outputs. Find defects in the triggered merge-tail surface, run focused checks, then persist exactly one JSON object:",
+      `{"schemaVersion":1,"headSha":"${input.headSha}","findings":[{"severity":"blocking"|"follow-up","title":"<short>","detail":"<what is wrong and where>","reachability":"<required for blocking>"}]}`,
+      [
+        "Severity is the whole decision and the server derives the verdict from it; you do not state a verdict.",
+        "Mark a finding `blocking` only when it is a reachable behavioural defect — correctness, data integrity, or security — and prove reachability in `reachability`: name the concrete inputs, state, or interleaving that reaches it. A blocking finding without that argument voids the whole decision.",
+        "Everything else is `follow-up`: specification inconsistency no caller can reach, style, naming, defensive hardening, and any concern you cannot show a caller reaching. Each follow-up becomes a backlog card and the merge proceeds.",
+        "An empty `findings` array is the approval.",
+      ].join("\n"),
     ].join("\n\n"),
     assigneeType: AssigneeType.AGENT,
     assigneeAgentId: agent.id,
@@ -527,7 +534,8 @@ export const readinessTick = async (
         verdict.verdict.headSha,
         recovery ? snapshot.baseSha : null,
       );
-      if (triggers.length > 0 && review?.state !== "approved") {
+      const reviewCleared = review?.state === "approved" || review?.state === "accepted-with-followups";
+      if (triggers.length > 0 && !reviewCleared) {
         if (review?.state === "open") {
           await db.$transaction(async (tx) => {
             await lockTaskMutationRows(tx, readiness.id);

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -21,6 +21,7 @@ import {
   authorizationMetadata,
   defenseTriggers,
   enqueueTaskRun,
+  INDEPENDENT_REVIEW_OPEN_PREFIX,
   isMergeReadinessStep,
   lockChainRows,
   lockTaskRow,
@@ -204,7 +205,7 @@ const stopReadiness = async (
 };
 
 const latestReviewState = async (
-  db: PrismaClient,
+  db: PrismaClient | Prisma.TransactionClient,
   readinessTaskId: string,
   headSha: string,
   recoveryBaseSha: string | null,
@@ -229,9 +230,21 @@ const createReviewObligation = async (
     headSha: string;
     triggers: Array<{ path: string; reason: string }>;
     recovery: RecoveryContext | null;
+    claimReason: string;
   },
-): Promise<{ ok: true } | { ok: false; reason: string }> => db.$transaction(async (tx) => {
+): Promise<{ ok: true } | { ok: false; reason: string } | { ok: false; lost: true }> => db.$transaction(async (tx) => {
   await lockTaskMutationRows(tx, input.readinessTask.id);
+  // The claim is only evidence until it is re-read under the chain mutex. A
+  // worker whose lease expired while it read GitHub has already been replaced,
+  // and opening a second obligation for the same head would double every
+  // decision the tail makes from it: two repairs, two backlog cards, two
+  // blocking rounds off the ceiling.
+  const held = await tx.task.count({
+    where: { id: input.readinessTask.id, status: TaskStatus.DOING, failureReason: input.claimReason },
+  });
+  if (held !== 1) return { ok: false as const, lost: true as const };
+  const open = await latestReviewState(tx, input.readinessTask.id, input.headSha, input.recovery ? input.baseSha : null);
+  if (open?.state === "open") return { ok: false as const, lost: true as const };
   if (!input.readinessTask.repoId) return { ok: false as const, reason: "readiness task has no repository" };
   const agent = await tx.agent.findFirst({ where: { projectId: input.readinessTask.projectId, name: "review-coordinator", archivedAt: null } });
   if (!agent) return { ok: false as const, reason: "review-coordinator is absent or archived" };
@@ -302,7 +315,7 @@ const createReviewObligation = async (
   ] });
   await tx.task.update({ where: { id: input.readinessTask.id }, data: {
     status: TaskStatus.REVIEW,
-    failureReason: `independent-review-open:${task.id}:${input.headSha}`,
+    failureReason: `${INDEPENDENT_REVIEW_OPEN_PREFIX}${task.id}:${input.headSha}`,
   } });
   return { ok: true as const };
 });
@@ -537,9 +550,18 @@ export const readinessTick = async (
       const reviewCleared = review?.state === "approved" || review?.state === "accepted-with-followups";
       if (triggers.length > 0 && !reviewCleared) {
         if (review?.state === "open") {
+          // The obligation is re-read inside the mutex before the park is
+          // written. Between the read above and here the review can have
+          // completed and handed this step back; parking on that stale read
+          // would strand a step no review is coming back for.
           await db.$transaction(async (tx) => {
             await lockTaskMutationRows(tx, readiness.id);
-            await tx.task.update({ where: { id: readiness.id }, data: { status: TaskStatus.REVIEW, failureReason: `independent-review-open:${String(review.reviewTaskId)}` } });
+            const current = await latestReviewState(tx, readiness.id, verdict.verdict.headSha, recovery ? snapshot.baseSha : null);
+            if (current?.state !== "open") return;
+            await tx.task.updateMany({
+              where: { id: readiness.id, status: TaskStatus.DOING, failureReason: claimReason },
+              data: { status: TaskStatus.REVIEW, failureReason: `${INDEPENDENT_REVIEW_OPEN_PREFIX}${String(current.reviewTaskId)}` },
+            });
           });
           result.reviewing += 1;
           continue;
@@ -562,12 +584,17 @@ export const readinessTick = async (
           headSha: verdict.verdict.headSha,
           triggers,
           recovery,
+          claimReason,
         });
-        if (!opened.ok) {
+        if (opened.ok) {
+          result.reviewing += 1;
+        } else if ("lost" in opened) {
+          // Another worker owns this readiness step now. Leaving its state
+          // alone is the whole point of noticing.
+          result.reviewing += 1;
+        } else {
           await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: opened.reason, recovery }, releaseChainLease);
           result.stopped += 1;
-        } else {
-          result.reviewing += 1;
         }
         continue;
       }

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -225,7 +225,24 @@ test("successful auxiliary repair completion preserves success when its chain ta
   }
 });
 
-const rejectIndependentReviewAfterPass = async (seeded: Awaited<ReturnType<typeof seedRegression>>) => {
+const BLOCKING_FINDING = {
+  severity: "blocking",
+  title: "defense-list change lacks a fail-closed regression",
+  detail: "the new merge-tail branch has no test that fails when it regresses",
+  reachability: "every merge that touches the defense list reaches it",
+};
+const FOLLOW_UP_FINDING = {
+  severity: "follow-up",
+  title: "comment names a field no caller reads",
+  detail: "the doc comment above the parser describes a retired shape",
+};
+const blockingSummary = `${BLOCKING_FINDING.title}: ${BLOCKING_FINDING.detail}`;
+
+const rejectIndependentReviewAfterPass = async (
+  seeded: Awaited<ReturnType<typeof seedRegression>>,
+  findings: unknown[] = [BLOCKING_FINDING],
+  priorBlockingRounds = 0,
+) => {
   const pass = JSON.stringify({
     schemaVersion: 1, outcome: "pass", headSha: HEAD, baseHeadSha: BASE, gateVerdict: "PASS",
   });
@@ -247,6 +264,7 @@ const rejectIndependentReviewAfterPass = async (seeded: Awaited<ReturnType<typeo
     assigneeType: AssigneeType.AGENT,
     assigneeAgentId: seeded.reviewAgent.id,
     status: TaskStatus.REVIEW,
+    failureReason: "independent-review-open:pending",
     chainId: seeded.regression.chainId,
     chainIndex: seeded.readinessStep.stepIndex,
     chainLayer: seeded.readinessStep.layer,
@@ -291,12 +309,12 @@ const rejectIndependentReviewAfterPass = async (seeded: Awaited<ReturnType<typeo
     runner: "CODEX",
     executionStatus: "RUNNING",
   } });
-  const summary = "defense-list change lacks a fail-closed regression";
+  const outputBody = JSON.stringify({ schemaVersion: 1, headSha: HEAD, findings });
   await db.taskStepOutput.create({ data: {
     taskId: review.id,
     runId: reviewRun.id,
     kind: "result",
-    body: JSON.stringify({ schemaVersion: 1, outcome: "rejected", headSha: HEAD, summary }),
+    body: outputBody,
     commitSha: HEAD,
   } });
   await db.taskActivity.createMany({ data: [
@@ -320,6 +338,16 @@ const rejectIndependentReviewAfterPass = async (seeded: Awaited<ReturnType<typeo
       },
     },
   ] });
+  if (priorBlockingRounds > 0) await db.taskActivity.createMany({ data:
+    Array.from({ length: priorBlockingRounds }, (_unused, index) => ({
+      taskId: readiness.id,
+      actorType: "control-plane",
+      body: `Independent review rejected exact head ${HEAD} on blocking round ${String(index + 1)}`,
+      metadata: {
+        kind: "mergeTail.reviewObligation", schemaVersion: 1, state: "rejected",
+        headSha: HEAD, baseSha: BASE, summary: blockingSummary, blockingRound: index + 1,
+      },
+    })) });
   const prior = process.env.RUNNER_TOKEN;
   process.env.RUNNER_TOKEN = "merge-tail-review-token";
   try {
@@ -345,7 +373,7 @@ const rejectIndependentReviewAfterPass = async (seeded: Awaited<ReturnType<typeo
     if (prior === undefined) delete process.env.RUNNER_TOKEN;
     else process.env.RUNNER_TOKEN = prior;
   }
-  return { readiness, review, summary };
+  return { readiness, review, summary: blockingSummary, outputBody };
 };
 
 test("a refresh conflict creates exactly one resolver and its completion re-runs regression", async () => {
@@ -504,29 +532,16 @@ test("a repaired Regression retry pins the prior same-task published head withou
   });
 });
 
-test("independent-review rejection stops for an explicit repair decision before a fresh Regression claim", async () => {
+test("a blocking independent-review rejection repairs itself and hands the rejection to the fresh Regression", async () => {
   const seeded = await seedRegression();
   const rejected = await rejectIndependentReviewAfterPass(seeded);
-  assert.equal(await db.task.count({ where: { projectId: seeded.project.id, name: "Autonomous merge tail: review-fix" } }), 0);
-  const card = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id, status: "OPEN" } });
-  assert.equal(card.kind, "MULTIPLE_CHOICE");
-  const priorOperator = process.env.OPERATOR_TOKEN;
-  process.env.OPERATOR_TOKEN = "merge-tail-operator-token";
-  try {
-    const response = await createApp(db).request(`/inbox/messages/${card.id}/decision`, {
-      method: "POST",
-      headers: { Authorization: "Bearer merge-tail-operator-token", "Content-Type": "application/json" },
-      body: JSON.stringify({ requestId: "create-repair-1", decision: "create-repair" }),
-    });
-    assert.equal(response.status, 201, await response.text());
-  } finally {
-    if (priorOperator === undefined) delete process.env.OPERATOR_TOKEN;
-    else process.env.OPERATOR_TOKEN = priorOperator;
-  }
   const repair = await db.task.findFirstOrThrow({ where: {
     projectId: seeded.project.id,
     name: "Autonomous merge tail: review-fix",
   } });
+  assert.equal((await db.agent.findUniqueOrThrow({ where: { id: repair.assigneeAgentId! } })).name, "senior-dev");
+  // The rejection is repaired, not asked about: no operator card is opened.
+  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id, kind: "MULTIPLE_CHOICE" } }), 0);
   const repairOutput = "Added the fail-closed regression and verified the defense-list path.";
   await completeRepair(seeded, repair.id, repairOutput);
 
@@ -553,7 +568,7 @@ test("independent-review rejection stops for an explicit repair decision before 
       baseHeadSha: BASE,
       summary: rejected.summary,
       outputKind: "result",
-      outputBody: JSON.stringify({ schemaVersion: 1, outcome: "rejected", headSha: HEAD, summary: rejected.summary }),
+      outputBody: rejected.outputBody,
     },
   });
   assert.deepEqual(body.regressionRepairHandoff.repair, {
@@ -567,64 +582,65 @@ test("independent-review rejection stops for an explicit repair decision before 
   });
 });
 
-test("operator exact-head adoption re-runs Regression without manufacturing repair evidence", async () => {
+test("follow-up findings alone become backlog cards and hand readiness back to the server worker", async () => {
   const seeded = await seedRegression();
-  await rejectIndependentReviewAfterPass(seeded);
-  const card = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id, status: "OPEN" } });
-  const priorOperator = process.env.OPERATOR_TOKEN;
-  process.env.OPERATOR_TOKEN = "merge-tail-operator-token";
-  try {
-    const response = await createApp(db).request(`/inbox/messages/${card.id}/decision`, {
-      method: "POST",
-      headers: { Authorization: "Bearer merge-tail-operator-token", "Content-Type": "application/json" },
-      body: JSON.stringify({ requestId: "adopt-head-1", decision: "adopt-head" }),
-    });
-    assert.equal(response.status, 201, await response.text());
-  } finally {
-    if (priorOperator === undefined) delete process.env.OPERATOR_TOKEN;
-    else process.env.OPERATOR_TOKEN = priorOperator;
-  }
-  assert.equal(await db.task.count({ where: { projectId: seeded.project.id, name: "Autonomous merge tail: review-fix" } }), 0);
-  const claimed = await claimNext();
-  assert.equal(claimed.status, 200);
-  assert.equal((claimed.body as { regressionRepairHandoff: unknown }).regressionRepairHandoff, null);
-  const decision = await db.taskActivity.findFirstOrThrow({ where: {
-    taskId: seeded.regression.id,
-    metadata: { path: ["kind"], equals: "mergeTail.operatorDecision" },
+  const accepted = await rejectIndependentReviewAfterPass(seeded, [FOLLOW_UP_FINDING, FOLLOW_UP_FINDING]);
+  assert.equal(await db.task.count({ where: {
+    projectId: seeded.project.id, name: "Autonomous merge tail: review-fix",
+  } }), 0);
+  const cards = await db.task.findMany({ where: {
+    projectId: seeded.project.id, name: `Merge tail follow-up: ${FOLLOW_UP_FINDING.title}`,
   } });
-  assert.match(decision.body, new RegExp(HEAD));
+  assert.equal(cards.length, 2);
+  assert.deepEqual([...new Set(cards.map((card) => card.status))], [TaskStatus.BACKLOG]);
+  const readiness = await db.task.findUniqueOrThrow({ where: { id: accepted.readiness.id } });
+  assert.equal(readiness.status, TaskStatus.TODO);
+  assert.equal(readiness.failureReason, null);
+  const obligation = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: accepted.readiness.id,
+    metadata: { path: ["state"], equals: "accepted-with-followups" },
+  } });
+  assert.match(obligation.body, /accepted exact head/u);
+  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 0);
 });
 
-test("operator takeover parks the autonomous tail without creating work", async () => {
+test("an empty findings array approves the head and no follow-up card is created", async () => {
   const seeded = await seedRegression();
-  const rejected = await rejectIndependentReviewAfterPass(seeded);
-  const card = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id, status: "OPEN" } });
-  const priorOperator = process.env.OPERATOR_TOKEN;
-  process.env.OPERATOR_TOKEN = "merge-tail-operator-token";
-  try {
-    const response = await createApp(db).request(`/inbox/messages/${card.id}/decision`, {
-      method: "POST",
-      headers: { Authorization: "Bearer merge-tail-operator-token", "Content-Type": "application/json" },
-      body: JSON.stringify({ requestId: "operator-takeover-1", decision: "operator-takeover" }),
-    });
-    assert.equal(response.status, 201, await response.text());
-  } finally {
-    if (priorOperator === undefined) delete process.env.OPERATOR_TOKEN;
-    else process.env.OPERATOR_TOKEN = priorOperator;
-  }
-  const [regression, readiness] = await Promise.all([
-    db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } }),
-    db.task.findUniqueOrThrow({ where: { id: rejected.readiness.id } }),
-  ]);
-  assert.equal(regression.status, TaskStatus.REVIEW);
-  assert.equal(readiness.status, TaskStatus.REVIEW);
-  assert.match(regression.failureReason ?? "", /parked by operator/u);
+  const approved = await rejectIndependentReviewAfterPass(seeded, []);
   assert.equal(await db.task.count({ where: {
-    projectId: seeded.project.id,
-    name: { startsWith: "Autonomous merge tail:" },
-    id: { not: rejected.review.id },
+    projectId: seeded.project.id, name: { startsWith: "Merge tail follow-up:" },
   } }), 0);
-  assert.equal(await db.run.count({ where: { taskId: seeded.regression.id, runNumber: { gt: 1 } } }), 0);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: approved.readiness.id } })).status, TaskStatus.TODO);
+  await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: approved.readiness.id,
+    metadata: { path: ["state"], equals: "approved" },
+  } });
+});
+
+test("the third blocking round stops the tail with a notice instead of a fourth repair", async () => {
+  const seeded = await seedRegression();
+  const stopped = await rejectIndependentReviewAfterPass(seeded, [BLOCKING_FINDING], 2);
+  assert.equal(await db.task.count({ where: {
+    projectId: seeded.project.id, name: "Autonomous merge tail: review-fix",
+  } }), 0);
+  const [readiness, regression] = await Promise.all([
+    db.task.findUniqueOrThrow({ where: { id: stopped.readiness.id } }),
+    db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } }),
+  ]);
+  assert.equal(readiness.status, TaskStatus.REVIEW);
+  assert.equal(regression.status, TaskStatus.REVIEW);
+  assert.match(readiness.failureReason ?? "", /blocking round 3 of 3; automatic repair is exhausted/u);
+  const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
+  assert.equal(notice.kind, "TEXT");
+  assert.match(notice.body, /automatic repair is exhausted/u);
+});
+
+test("a second blocking round still repairs itself", async () => {
+  const seeded = await seedRegression();
+  await rejectIndependentReviewAfterPass(seeded, [BLOCKING_FINDING], 1);
+  assert.equal(await db.task.count({ where: {
+    projectId: seeded.project.id, name: "Autonomous merge tail: review-fix",
+  } }), 1);
 });
 
 test("a stale repair output stops the queued Regression Run before a provider session starts", async () => {

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -242,6 +242,7 @@ const rejectIndependentReviewAfterPass = async (
   seeded: Awaited<ReturnType<typeof seedRegression>>,
   findings: unknown[] = [BLOCKING_FINDING],
   priorBlockingRounds = 0,
+  beforeCompletion: (input: { readinessId: string; reviewTaskId: string; reviewRunId: string }) => Promise<void> = async () => {},
 ) => {
   const pass = JSON.stringify({
     schemaVersion: 1, outcome: "pass", headSha: HEAD, baseHeadSha: BASE, gateVerdict: "PASS",
@@ -348,6 +349,7 @@ const rejectIndependentReviewAfterPass = async (
         headSha: HEAD, baseSha: BASE, summary: blockingSummary, blockingRound: index + 1,
       },
     })) });
+  await beforeCompletion({ readinessId: readiness.id, reviewTaskId: review.id, reviewRunId: reviewRun.id });
   const prior = process.env.RUNNER_TOKEN;
   process.env.RUNNER_TOKEN = "merge-tail-review-token";
   try {
@@ -641,6 +643,39 @@ test("a second blocking round still repairs itself", async () => {
   assert.equal(await db.task.count({ where: {
     projectId: seeded.project.id, name: "Autonomous merge tail: review-fix",
   } }), 1);
+});
+
+test("a decision left behind by an earlier review run is not evidence about this one", async () => {
+  const seeded = await seedRegression();
+  const stopped = await rejectIndependentReviewAfterPass(seeded, [], 0, async ({ reviewTaskId }) => {
+    const other = await db.run.create({ data: {
+      projectId: seeded.project.id, taskId: reviewTaskId, agentId: seeded.reviewAgent.id, repoId: seeded.repo.id,
+      runNumber: 2, dedupeKey: `task:${reviewTaskId}:run:2`, runner: "CODEX", model: seeded.reviewAgent.model,
+      promptHash: "stale", status: "FAILED",
+    } });
+    await db.taskStepOutput.update({ where: { taskId: reviewTaskId }, data: { runId: other.id } });
+  });
+  const readiness = await db.task.findUniqueOrThrow({ where: { id: stopped.readiness.id } });
+  assert.equal(readiness.status, TaskStatus.REVIEW);
+  assert.match(readiness.failureReason ?? "", /unusable decision/u);
+  const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
+  assert.equal(notice.kind, "TEXT");
+});
+
+test("a blocking rejection does not restart work an operator parked while the review ran", async () => {
+  const seeded = await seedRegression();
+  await rejectIndependentReviewAfterPass(seeded, [BLOCKING_FINDING], 0, async ({ readinessId }) => {
+    await db.task.update({ where: { id: readinessId }, data: { status: TaskStatus.BACKLOG, failureReason: null } });
+  });
+  assert.equal(await db.task.count({ where: {
+    projectId: seeded.project.id, name: "Autonomous merge tail: review-fix",
+  } }), 0);
+  const parked = await db.task.findFirstOrThrow({ where: { projectId: seeded.project.id, name: "Readiness" } });
+  assert.equal(parked.status, TaskStatus.BACKLOG);
+  assert.equal(parked.failureReason, null);
+  await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: parked.id, metadata: { path: ["state"], equals: "repair-skipped" },
+  } });
 });
 
 test("a stale repair output stops the queued Regression Run before a provider session starts", async () => {

--- a/packages/api/src/regression-repair-handoff.ts
+++ b/packages/api/src/regression-repair-handoff.ts
@@ -1,6 +1,7 @@
 import {
   asJsonObject,
   MERGE_TAIL_KIND,
+  parseIndependentReviewDecision,
   parseRegressionVerdict,
   Prisma,
   PushStatus,
@@ -125,35 +126,12 @@ export const regressionRepairHandoffForClaim = async (
       || reviewOutput.run.headSha !== parsed.verdict.headSha) {
       return invalid(`independent-review task ${reviewTaskId} is not bound to successful head ${parsed.verdict.headSha}`);
     }
-    let decision: Record<string, unknown> | null = null;
-    try { decision = asJsonObject(JSON.parse(reviewOutput.body) as Prisma.JsonValue); } catch { decision = null; }
-    if (decision?.schemaVersion !== 1
-      || decision.outcome !== "rejected"
-      || decision.headSha !== parsed.verdict.headSha
-      || decision.summary !== summary) {
+    const decision = parseIndependentReviewDecision(reviewOutput.body, parsed.verdict.headSha);
+    if (decision.status === "invalid"
+      || decision.decision.outcome !== "rejected"
+      || decision.decision.blockingSummary !== summary) {
       return invalid(`independent-review task ${reviewTaskId} output does not match its rejection record`);
     }
-    const operatorRows = await tx.taskActivity.findMany({
-      where: {
-        taskId: input.taskId,
-        actorType: "operator",
-        createdAt: { gte: rejectedRow.createdAt },
-        metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.operatorDecision },
-      },
-      select: { metadata: true },
-      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-      take: 20,
-    });
-    const adopted = operatorRows.map((row) => asJsonObject(row.metadata)).some((metadata) => (
-      metadata?.action === "adopt-head"
-      && metadata.headSha === parsed.verdict.headSha
-      && metadata.baseHeadSha === parsed.verdict.baseHeadSha
-      && metadata.reviewTaskId === reviewTaskId
-    ));
-    // Explicit operator adoption licenses one fresh exact-head Regression run;
-    // it does not authorize readiness or merge. The fresh verdict must still
-    // bind the head/base pair before the autonomous tail can continue.
-    if (adopted) return { status: "none" };
     trigger = {
       kind: "independent-review-rejection",
       verdict: parsed.verdict,

--- a/packages/db/src/merge-tail.test.ts
+++ b/packages/db/src/merge-tail.test.ts
@@ -11,6 +11,8 @@ import {
   isMergeReadinessStep,
   mergeRecoveryPhase,
   mergeRecoveryTransitionAllowed,
+  MAX_REVIEW_FINDINGS,
+  MAX_REVIEW_FINDING_TEXT,
   parseIndependentReviewDecision,
   parseResolverResult,
   parseRegressionVerdict,
@@ -171,4 +173,12 @@ test("a finding with an unknown severity or an empty title is invalid", () => {
   assert.equal(parseIndependentReviewDecision(reviewBody([{ ...followUp, severity: "must-fix" }]), A).status, "invalid");
   assert.equal(parseIndependentReviewDecision(reviewBody([{ ...followUp, title: "  " }]), A).status, "invalid");
   assert.equal(parseIndependentReviewDecision(reviewBody([{ ...followUp, detail: "" }]), A).status, "invalid");
+});
+
+test("a decision with more findings than one range can carry, or an over-long field, is invalid", () => {
+  const many = Array.from({ length: MAX_REVIEW_FINDINGS + 1 }, () => followUp);
+  assert.equal(parseIndependentReviewDecision(reviewBody(many), A).status, "invalid");
+  assert.equal(parseIndependentReviewDecision(reviewBody(Array.from({ length: MAX_REVIEW_FINDINGS }, () => followUp)), A).status, "ok");
+  const long = { ...followUp, detail: "d".repeat(MAX_REVIEW_FINDING_TEXT + 1) };
+  assert.equal(parseIndependentReviewDecision(reviewBody([long]), A).status, "invalid");
 });

--- a/packages/db/src/merge-tail.test.ts
+++ b/packages/db/src/merge-tail.test.ts
@@ -11,6 +11,7 @@ import {
   isMergeReadinessStep,
   mergeRecoveryPhase,
   mergeRecoveryTransitionAllowed,
+  parseIndependentReviewDecision,
   parseResolverResult,
   parseRegressionVerdict,
   resolutionTestTriggers,
@@ -116,4 +117,58 @@ test("renames preserve guarded source identities", () => {
     previousFilename: "packages/api/src/merge-readiness-worker.ts",
     patch: null,
   }]), [{ path: "packages/api/src/merge-readiness-worker.ts", reason: "merge-tail-machinery" }]);
+});
+
+const reviewBody = (findings: unknown[], headSha = A) => JSON.stringify({ schemaVersion: 1, headSha, findings });
+
+const blocking = {
+  severity: "blocking",
+  title: "rollback loses the predecessor row",
+  detail: "the compensating write runs outside the transaction",
+  reachability: "reached whenever the second write fails after the first commits",
+};
+const followUp = { severity: "follow-up", title: "spec drift", detail: "the comment names a field that no caller reads" };
+
+test("an empty findings array is the approval", () => {
+  const parsed = parseIndependentReviewDecision(reviewBody([]), A);
+  assert.equal(parsed.status, "ok");
+  assert.equal(parsed.status === "ok" && parsed.decision.outcome, "approved");
+  assert.equal(parsed.status === "ok" && parsed.decision.blockingSummary, "");
+});
+
+test("only follow-up findings accept the head with follow-ups instead of rejecting it", () => {
+  const parsed = parseIndependentReviewDecision(reviewBody([followUp, followUp]), A);
+  assert.equal(parsed.status === "ok" && parsed.decision.outcome, "accepted-with-followups");
+  assert.equal(parsed.status === "ok" && parsed.decision.findings.length, 2);
+});
+
+test("one blocking finding rejects the head and its summary carries every blocking finding", () => {
+  const parsed = parseIndependentReviewDecision(reviewBody([followUp, blocking]), A);
+  assert.equal(parsed.status === "ok" && parsed.decision.outcome, "rejected");
+  assert.equal(
+    parsed.status === "ok" && parsed.decision.blockingSummary,
+    `${blocking.title}: ${blocking.detail}`,
+  );
+});
+
+test("a blocking finding without a reachability argument voids the decision", () => {
+  const { reachability, ...unproven } = blocking;
+  assert.equal(reachability.length > 0, true);
+  const parsed = parseIndependentReviewDecision(reviewBody([unproven]), A);
+  assert.equal(parsed.status, "invalid");
+  assert.match(parsed.status === "invalid" ? parsed.reason : "", /reachability/u);
+});
+
+test("a decision bound to another head, or with no findings array, is invalid", () => {
+  assert.equal(parseIndependentReviewDecision(reviewBody([], B), A).status, "invalid");
+  assert.equal(parseIndependentReviewDecision(JSON.stringify({ schemaVersion: 1, headSha: A }), A).status, "invalid");
+  assert.equal(parseIndependentReviewDecision(JSON.stringify({ schemaVersion: 2, headSha: A, findings: [] }), A).status, "invalid");
+  assert.equal(parseIndependentReviewDecision("not json", A).status, "invalid");
+  assert.equal(parseIndependentReviewDecision(null, A).status, "invalid");
+});
+
+test("a finding with an unknown severity or an empty title is invalid", () => {
+  assert.equal(parseIndependentReviewDecision(reviewBody([{ ...followUp, severity: "must-fix" }]), A).status, "invalid");
+  assert.equal(parseIndependentReviewDecision(reviewBody([{ ...followUp, title: "  " }]), A).status, "invalid");
+  assert.equal(parseIndependentReviewDecision(reviewBody([{ ...followUp, detail: "" }]), A).status, "invalid");
 });

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -22,6 +22,13 @@ export const MERGE_TAIL_KIND = {
   readiness: "mergeTail.readiness",
 } as const;
 
+/**
+ * The failure reason a merge-readiness step carries while an independent review
+ * is open. It is a park the review owns and resolves, not a stalled step, so
+ * generic recovery has to be able to recognise it.
+ */
+export const INDEPENDENT_REVIEW_OPEN_PREFIX = "independent-review-open:";
+
 export const MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES = 2;
 export const MAX_BASE_DRIFT_CLASSIFICATION_RETRIES = 30;
 
@@ -286,6 +293,18 @@ export type IndependentReviewParse =
 /** Blocking rejections the autonomous tail repairs before it stops for a human. */
 export const MAX_BLOCKING_REVIEW_ROUNDS = 3;
 
+/**
+ * What one decision may contain.
+ *
+ * Every follow-up finding becomes a Task and an Activity written serially while
+ * the completion transaction holds the whole chain mutex, so an unbounded
+ * findings array is an unbounded transaction. A review that has more than this
+ * to say about one exact range is not a decision the tail can act on.
+ */
+export const MAX_REVIEW_FINDINGS = 50;
+export const MAX_REVIEW_FINDING_TITLE = 200;
+export const MAX_REVIEW_FINDING_TEXT = 4_000;
+
 const reviewFinding = (value: unknown, index: number): IndependentReviewFinding | string => {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return `finding ${index} is not an object`;
@@ -297,12 +316,21 @@ const reviewFinding = (value: unknown, index: number): IndependentReviewFinding 
   if (typeof finding.title !== "string" || finding.title.trim().length === 0) {
     return `finding ${index} has no title`;
   }
+  if (finding.title.length > MAX_REVIEW_FINDING_TITLE) {
+    return `finding ${index} has a title longer than ${String(MAX_REVIEW_FINDING_TITLE)} characters`;
+  }
   if (typeof finding.detail !== "string" || finding.detail.trim().length === 0) {
     return `finding ${index} has no detail`;
+  }
+  if (finding.detail.length > MAX_REVIEW_FINDING_TEXT) {
+    return `finding ${index} has a detail longer than ${String(MAX_REVIEW_FINDING_TEXT)} characters`;
   }
   if (finding.severity === "blocking"
     && (typeof finding.reachability !== "string" || finding.reachability.trim().length === 0)) {
     return `blocking finding ${index} has no reachability argument`;
+  }
+  if (typeof finding.reachability === "string" && finding.reachability.length > MAX_REVIEW_FINDING_TEXT) {
+    return `finding ${index} has a reachability argument longer than ${String(MAX_REVIEW_FINDING_TEXT)} characters`;
   }
   return {
     severity: finding.severity,
@@ -341,6 +369,9 @@ export const parseIndependentReviewDecision = (
     return { status: "invalid", reason: `independent review decision is bound to ${value.headSha}, not ${expectedHeadSha}` };
   }
   if (!Array.isArray(value.findings)) return { status: "invalid", reason: "independent review output has no findings array" };
+  if (value.findings.length > MAX_REVIEW_FINDINGS) {
+    return { status: "invalid", reason: `independent review reported more than ${String(MAX_REVIEW_FINDINGS)} findings for one exact range` };
+  }
   const findings: IndependentReviewFinding[] = [];
   for (const [index, entry] of value.findings.entries()) {
     const finding = reviewFinding(entry, index);

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -19,7 +19,6 @@ export const MERGE_TAIL_KIND = {
   repairAttempt: "mergeTail.repairAttempt",
   repairResult: "mergeTail.repairResult",
   reviewObligation: "mergeTail.reviewObligation",
-  operatorDecision: "mergeTail.operatorDecision",
   readiness: "mergeTail.readiness",
 } as const;
 
@@ -253,3 +252,109 @@ export const resolutionTestTriggers = (files: ChangedFile[]): Array<{ path: stri
 export const asJsonObject = (value: Prisma.JsonValue | null | undefined): Record<string, unknown> | null => (
   typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null
 );
+
+/**
+ * A single defect the independent merge-tail review found, with the severity
+ * that decides whether the merge stops for it.
+ *
+ * `blocking` is reserved for a reachable behavioural defect — correctness, data
+ * integrity, or security — and the reviewer owes a reachability argument for it.
+ * Everything else (specification consistency that no caller can reach, style,
+ * defensive hardening) is `follow-up`: it becomes a backlog card and the merge
+ * proceeds.
+ */
+export type IndependentReviewFinding = {
+  severity: "blocking" | "follow-up";
+  title: string;
+  detail: string;
+  reachability?: string;
+};
+
+export type IndependentReviewDecision = {
+  headSha: string;
+  findings: IndependentReviewFinding[];
+  /** Derived from the findings; the reviewer never states it. */
+  outcome: "approved" | "accepted-with-followups" | "rejected";
+  /** The blocking findings rendered for the repair agent; empty when none. */
+  blockingSummary: string;
+};
+
+export type IndependentReviewParse =
+  | { status: "ok"; decision: IndependentReviewDecision }
+  | { status: "invalid"; reason: string };
+
+/** Blocking rejections the autonomous tail repairs before it stops for a human. */
+export const MAX_BLOCKING_REVIEW_ROUNDS = 3;
+
+const reviewFinding = (value: unknown, index: number): IndependentReviewFinding | string => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return `finding ${index} is not an object`;
+  }
+  const finding = value as Record<string, unknown>;
+  if (finding.severity !== "blocking" && finding.severity !== "follow-up") {
+    return `finding ${index} has no blocking or follow-up severity`;
+  }
+  if (typeof finding.title !== "string" || finding.title.trim().length === 0) {
+    return `finding ${index} has no title`;
+  }
+  if (typeof finding.detail !== "string" || finding.detail.trim().length === 0) {
+    return `finding ${index} has no detail`;
+  }
+  if (finding.severity === "blocking"
+    && (typeof finding.reachability !== "string" || finding.reachability.trim().length === 0)) {
+    return `blocking finding ${index} has no reachability argument`;
+  }
+  return {
+    severity: finding.severity,
+    title: finding.title.trim(),
+    detail: finding.detail.trim(),
+    ...(typeof finding.reachability === "string" ? { reachability: finding.reachability.trim() } : {}),
+  };
+};
+
+/**
+ * Reads the independent review's decision and derives its outcome server-side.
+ *
+ * The reviewer reports findings and their severity; it does not report a
+ * verdict. One authority over "does this stop the merge" is the whole point —
+ * a stated outcome could disagree with the severities under it, and there would
+ * be no non-arbitrary way to settle that disagreement inside the tail.
+ */
+export const parseIndependentReviewDecision = (
+  body: string | null | undefined,
+  expectedHeadSha: string,
+): IndependentReviewParse => {
+  if (!body) return { status: "invalid", reason: "missing independent review output" };
+  let parsed: unknown;
+  try { parsed = JSON.parse(body); } catch { return { status: "invalid", reason: "independent review output is not JSON" }; }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { status: "invalid", reason: "independent review output is not an object" };
+  }
+  const value = parsed as Record<string, unknown>;
+  if (value.schemaVersion !== MERGE_TAIL_SCHEMA_VERSION) {
+    return { status: "invalid", reason: "unsupported independent review schemaVersion" };
+  }
+  if (typeof value.headSha !== "string" || !SHA.test(value.headSha)) {
+    return { status: "invalid", reason: "invalid independent review headSha" };
+  }
+  if (value.headSha !== expectedHeadSha) {
+    return { status: "invalid", reason: `independent review decision is bound to ${value.headSha}, not ${expectedHeadSha}` };
+  }
+  if (!Array.isArray(value.findings)) return { status: "invalid", reason: "independent review output has no findings array" };
+  const findings: IndependentReviewFinding[] = [];
+  for (const [index, entry] of value.findings.entries()) {
+    const finding = reviewFinding(entry, index);
+    if (typeof finding === "string") return { status: "invalid", reason: finding };
+    findings.push(finding);
+  }
+  const blocking = findings.filter((finding) => finding.severity === "blocking");
+  return {
+    status: "ok",
+    decision: {
+      headSha: value.headSha,
+      findings,
+      outcome: blocking.length > 0 ? "rejected" : findings.length > 0 ? "accepted-with-followups" : "approved",
+      blockingSummary: blocking.map((finding) => `${finding.title}: ${finding.detail}`).join("\n"),
+    },
+  };
+};

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -1189,17 +1189,105 @@ const dispatchBoundSuccessor = async (
 /**
  * Why this successor must not be claimed, or null if it may be.
  *
- * The CAS below only matches TODO/DOING/REVIEW. A successor outside that set
- * and not DONE — archived, or parked in BACKLOG — makes `updateMany` match zero
- * rows forever while the re-read keeps returning the same row, so the loop spins
- * inside the caller's transaction and run completion never returns. Returning
- * early is what makes Backlog a place a chain step can sit.
+ * Both answers are an operator's explicit intent: an archived task is retired
+ * and a Backlog task is parked, so a predecessor completing does not get to
+ * drag either back into execution.
+ *
+ * A REVIEW successor is deliberately absent. It used to sit here as a
+ * fall-through, which is how a chain could stop for hours with nothing but an
+ * activity row to say so; `resumeParkedSuccessor` now owns that case.
  */
 const parkedReason = (successor: { status: TaskStatus; archivedAt?: Date | null }): string | null => {
   if (successor.archivedAt) return "successor is archived and was not queued";
   if (successor.status === TaskStatus.BACKLOG) return "successor is parked in Backlog — use Start now";
-  if (successor.status === TaskStatus.REVIEW) return "successor is awaiting operator retry or approval";
   return null;
+};
+
+/** Activity kind recording one automatic recovery of a REVIEW successor. */
+export const CHAIN_AUTO_RESUME_KIND = "chainDispatch.autoResume";
+
+/**
+ * How many times a chain may return the same successor to TODO by itself.
+ *
+ * The recovery exists because a REVIEW successor at dispatch time is a stalled
+ * chain, not a decision anyone made. The ceiling exists because a step that
+ * keeps landing back in REVIEW is failing for a reason no requeue fixes, and
+ * spinning on it is worse than stopping and saying so.
+ *
+ * Five, not three: a merge-readiness step is legitimately parked and re-queued
+ * once per automatic repair round, and the tail allows three of those, so a
+ * lower ceiling would stop a converging chain rather than a thrashing one.
+ */
+export const MAX_AUTOMATIC_SUCCESSOR_RESUMES = 5;
+
+/**
+ * Returns a stalled REVIEW successor to the queue, or stops the chain when it
+ * has already been returned too many times.
+ *
+ * `true` means the caller may go on to dispatch it; `false` means this
+ * successor is parked for a human and the caller must skip it.
+ */
+const resumeParkedSuccessor = async (
+  tx: Tx,
+  predecessor: ChainTask,
+  successor: ChainSuccessor,
+): Promise<boolean> => {
+  const priorResumes = await tx.taskActivity.count({
+    where: {
+      taskId: successor.id,
+      actorType: "control-plane",
+      metadata: { path: ["kind"], equals: CHAIN_AUTO_RESUME_KIND },
+    },
+  });
+  const attempt = priorResumes + 1;
+  if (attempt > MAX_AUTOMATIC_SUCCESSOR_RESUMES) {
+    const reason = `successor returned to REVIEW after ${String(MAX_AUTOMATIC_SUCCESSOR_RESUMES)} automatic resumes; chain stopped for an operator`;
+    await tx.task.update({
+      where: { id: successor.id },
+      data: { status: TaskStatus.REVIEW, failureReason: reason },
+    });
+    await tx.taskActivity.create({ data: {
+      taskId: successor.id,
+      actorType: "control-plane",
+      body: `Predecessor layer completed; ${reason}`,
+      metadata: {
+        kind: CHAIN_AUTO_RESUME_KIND,
+        schemaVersion: 1,
+        state: "exhausted",
+        attempt,
+        predecessorTaskId: predecessor.id,
+      },
+    } });
+    await tx.inboxMessage.upsert({
+      where: { dedupeKey: `chain-successor-auto-resume-exhausted:${successor.id}` },
+      create: {
+        from: "AGENT",
+        taskId: successor.id,
+        kind: "TEXT",
+        body: `Chain step ${successor.name} was automatically resumed ${String(MAX_AUTOMATIC_SUCCESSOR_RESUMES)} times and is back in REVIEW; the chain is stopped and needs an operator.`,
+        dedupeKey: `chain-successor-auto-resume-exhausted:${successor.id}`,
+      },
+      update: {},
+    });
+    return false;
+  }
+  await tx.task.update({
+    where: { id: successor.id },
+    data: { status: TaskStatus.TODO, failureReason: null },
+  });
+  await tx.taskActivity.create({ data: {
+    taskId: successor.id,
+    actorType: "control-plane",
+    body: `Predecessor layer completed; successor was stalled in REVIEW and was automatically returned to the queue (resume ${String(attempt)} of ${String(MAX_AUTOMATIC_SUCCESSOR_RESUMES)})`,
+    metadata: {
+      kind: CHAIN_AUTO_RESUME_KIND,
+      schemaVersion: 1,
+      state: "resumed",
+      attempt,
+      predecessorTaskId: predecessor.id,
+    },
+  } });
+  return true;
 };
 
 type ChainSuccessorOptions = {
@@ -1378,6 +1466,7 @@ const activateChainSuccessorInternal = async (
       } });
       continue;
     }
+    if (successor.status === TaskStatus.REVIEW && !await resumeParkedSuccessor(tx, current, successor)) continue;
 
     const successorStep = successor.templateStepId
       ? await tx.taskTemplateStep.findUnique({

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -43,7 +43,7 @@ import {
   resolveChainTarget,
   stopStateFor,
 } from "./merge-integrator-db.js";
-import { isMergeReadinessStep, MERGE_TAIL_KIND } from "./merge-tail.js";
+import { INDEPENDENT_REVIEW_OPEN_PREFIX, isMergeReadinessStep, MERGE_TAIL_KIND } from "./merge-tail.js";
 
 type Tx = Prisma.TransactionClient;
 
@@ -1463,6 +1463,21 @@ const activateChainSuccessorInternal = async (
         taskId: successor.id,
         actorType: "control-plane",
         body: `Predecessor layer completed; ${parked}`,
+      } });
+      continue;
+    }
+    // A merge-readiness step parked on an open independent review is not
+    // stalled: the review owns that park and hands the step back when it
+    // resolves. Resuming it here would race the worker into re-parking a step
+    // whose review has already finished, which is the stall this recovery
+    // exists to prevent.
+    const reviewOwnedPark = successor.status === TaskStatus.REVIEW
+      && (successor.failureReason?.startsWith(INDEPENDENT_REVIEW_OPEN_PREFIX) ?? false);
+    if (reviewOwnedPark) {
+      await tx.taskActivity.create({ data: {
+        taskId: successor.id,
+        actorType: "control-plane",
+        body: "Predecessor layer completed; successor is held by an open independent review",
       } });
       continue;
     }


### PR DESCRIPTION
Implements board cards R2 and R3 from `BRIEF-zero-gate-rulings-20260825.md`.

## R2 — the independent review decides by severity, and the tail repairs itself

- The review output contract gains `findings[]`, each `blocking` or `follow-up`. `blocking` is narrowed to a reachable behavioural defect (correctness, data integrity, security) and must carry a reachability argument; spec-consistency without a reachable path, style and defensive hardening are always `follow-up`. `parseIndependentReviewDecision` in `packages/db/src/merge-tail.ts` is the single authority deriving the verdict, and the review prompt in `merge-readiness-worker.ts` states the same contract.
- A blocking finding yields `rejected` and queues an automatic `review-fix` repair on the existing senior-dev dispatch path. Follow-ups alone yield `accepted-with-followups`: each one becomes a BACKLOG card and the merge proceeds.
- Blocking rounds are capped at 3. The cap opens an inbox notice as an exception backstop, not an approval gate.
- The human three-choice decision inbox (`openMergeTailReviewDecisionInbox`, `applyMergeTailOperatorDecision`, the `mergeTail.operatorDecision` marker and the `adopt-head` handoff branch) is deleted; there is no compatibility switch.

## R3 — a parked chain successor recovers itself

`packages/db/src/workflow.ts` used to log a `parkedReason` activity for a REVIEW successor and continue, which is what silently stalled a chain for 5h12m on 2026-08-25. A REVIEW successor is now flipped back to TODO and re-enqueued, up to `MAX_AUTOMATIC_SUCCESSOR_RESUMES`; past that the chain stops with an inbox notice. A successor held by an open independent review is left to the review that owns it.

## Concurrency

The completion path binds the review decision to the completing run and reviewed head, gates the automatic repair on a CAS over the readiness park so an operator park is never overruled, binds `createReviewObligation` to the readiness claim, and takes the agent row and repo grant locks before creating a follow-up card. The parser caps the findings array and each field.

## Tests

`api` 472 unit / 528 dbtest, `db` 241, all passing. New coverage: severity verdict derivation and parser limits, follow-up auto-carding, the three-round cap, a decision left behind by an earlier review run, an operator park surviving a blocking rejection, successor auto-recovery, review-owned parks, and the anti-thrash ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)