### PR TITLE
feat(runner): provision workspaces from a machine-local bare mirror

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,9 @@ acceptance criterion or caller requires it.
 ## Test safely
 
 - Before tests outside the merge gate, set `RUNNER_WORKSPACE_ROOT` to a new
-  temporary directory. Runner tests provision real workspaces.
+  temporary directory. Runner tests provision real workspaces. A test that
+  builds a `RunnerConfig` by hand must also point `home` at a temporary
+  directory: provisioning keeps its repository mirror under it.
 - Run database tests only against a throwaway PostgreSQL server. Set
   `TEST_DATABASE_URL` and `TEST_DATABASE_MAINTENANCE_URL`, and give each
   worktree its own `?schema=`. `npm run test:db` drops and recreates its target.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,8 @@ something outside the checkout.
 - `export RUNNER_WORKSPACE_ROOT=$(mktemp -d)` before any test run. The runner's
   tests provision real workspaces, and without this they are provisioned wherever
   the configuration points — which on a working checkout is a directory holding
-  someone's runs.
+  someone's runs. The same applies to `home` in a hand-built `RunnerConfig`:
+  provisioning keeps its persistent repository mirror under it.
 - Database tests target a scratch PostgreSQL and nothing else. Point
   `TEST_DATABASE_URL` and `TEST_DATABASE_MAINTENANCE_URL` at a throwaway server,
   and give each worktree its own `?schema=` so parallel runs stay apart. Never

--- a/packages/runner/src/config.test.ts
+++ b/packages/runner/src/config.test.ts
@@ -51,18 +51,22 @@ test("the dependency cache defaults beside the workspace root and accepts an exp
   }
 });
 
-test("the repository mirror defaults beside the workspace root and accepts an explicit runner-owned root", () => {
-  const previousWorkspace = process.env.RUNNER_WORKSPACE_ROOT;
+// The mirror belongs to the account that runs the tasks, not to the machine's
+// workspace area: it is fetched with that account's credentials and read only
+// by it, and its home is the one directory every deployment already gives that
+// account at 0700.
+test("the repository mirror defaults into the task account's home and accepts an explicit root", () => {
+  const previousHome = process.env.RUNNER_HOME;
   const previousMirror = process.env.RUNNER_REPO_MIRROR_ROOT;
   try {
-    process.env.RUNNER_WORKSPACE_ROOT = "/var/agentos/workspaces";
+    process.env.RUNNER_HOME = "/opt/agentos/accounts/runner-1";
     delete process.env.RUNNER_REPO_MIRROR_ROOT;
-    assert.equal(loadRunnerConfig().repoMirrorRoot, "/var/agentos/repo-mirrors");
+    assert.equal(loadRunnerConfig().repoMirrorRoot, "/opt/agentos/accounts/runner-1/.agentos/repo-mirrors");
     process.env.RUNNER_REPO_MIRROR_ROOT = "/srv/agentos/mirrors";
     assert.equal(loadRunnerConfig().repoMirrorRoot, "/srv/agentos/mirrors");
   } finally {
-    if (previousWorkspace === undefined) delete process.env.RUNNER_WORKSPACE_ROOT;
-    else process.env.RUNNER_WORKSPACE_ROOT = previousWorkspace;
+    if (previousHome === undefined) delete process.env.RUNNER_HOME;
+    else process.env.RUNNER_HOME = previousHome;
     if (previousMirror === undefined) delete process.env.RUNNER_REPO_MIRROR_ROOT;
     else process.env.RUNNER_REPO_MIRROR_ROOT = previousMirror;
   }

--- a/packages/runner/src/config.test.ts
+++ b/packages/runner/src/config.test.ts
@@ -51,6 +51,23 @@ test("the dependency cache defaults beside the workspace root and accepts an exp
   }
 });
 
+test("the repository mirror defaults beside the workspace root and accepts an explicit runner-owned root", () => {
+  const previousWorkspace = process.env.RUNNER_WORKSPACE_ROOT;
+  const previousMirror = process.env.RUNNER_REPO_MIRROR_ROOT;
+  try {
+    process.env.RUNNER_WORKSPACE_ROOT = "/var/agentos/workspaces";
+    delete process.env.RUNNER_REPO_MIRROR_ROOT;
+    assert.equal(loadRunnerConfig().repoMirrorRoot, "/var/agentos/repo-mirrors");
+    process.env.RUNNER_REPO_MIRROR_ROOT = "/srv/agentos/mirrors";
+    assert.equal(loadRunnerConfig().repoMirrorRoot, "/srv/agentos/mirrors");
+  } finally {
+    if (previousWorkspace === undefined) delete process.env.RUNNER_WORKSPACE_ROOT;
+    else process.env.RUNNER_WORKSPACE_ROOT = previousWorkspace;
+    if (previousMirror === undefined) delete process.env.RUNNER_REPO_MIRROR_ROOT;
+    else process.env.RUNNER_REPO_MIRROR_ROOT = previousMirror;
+  }
+});
+
 test("the daemon reports the runner package version", () => {
   const metadata = require("../package.json") as { version: string };
   assert.equal(loadRunnerConfig().daemonVersion, metadata.version);

--- a/packages/runner/src/config.ts
+++ b/packages/runner/src/config.ts
@@ -34,7 +34,7 @@ export type RunnerConfig = {
   workspaceRoot: string;
   /** Runner-owned, write-once dependency snapshots. Defaults beside workspaceRoot. */
   dependencyCacheRoot?: string;
-  /** Runner-owned persistent bare mirrors. Defaults beside workspaceRoot. */
+  /** Persistent bare mirrors, in the home of the account that runs tasks. */
   repoMirrorRoot?: string;
   failedWorkspaceRetention: number;
   workspaceReclaimIntervalMs: number;
@@ -85,6 +85,7 @@ export const loadRunnerConfig = (): RunnerConfig => {
   const leaseSeconds = Number.parseInt(process.env.RUNNER_LEASE_SECONDS ?? "60", 10);
   const runAsPrefix = splitPrefix(process.env.RUNNER_RUN_AS_PREFIX ?? "");
   const workspaceRoot = process.env.RUNNER_WORKSPACE_ROOT ?? join(homedir(), ".agentos", "runs");
+  const home = process.env.RUNNER_HOME ?? process.env.HOME ?? "/var/empty";
   const gateServer = optionalSshDestination("RUNNER_GATE_SERVER", process.env.RUNNER_GATE_SERVER);
   // First, and before this function returns anything a caller could dial: the
   // runner's own index.ts builds the client, the preflight and the poll loop out
@@ -100,16 +101,17 @@ export const loadRunnerConfig = (): RunnerConfig => {
     leaseSeconds,
     heartbeatIntervalMs: Number.parseInt(process.env.RUNNER_HEARTBEAT_INTERVAL_MS ?? String(Math.max(5_000, leaseSeconds * 500)), 10),
     path: process.env.RUNNER_PATH ?? "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
-    home: process.env.RUNNER_HOME ?? process.env.HOME ?? "/var/empty",
+    home,
     ...(gateServer ? { gateServer } : {}),
     proxyEnvironment: runnerProxyEnvironment(),
     sessionConfigBaselineRoot: process.env.RUNNER_SESSION_CONFIG_BASELINE_ROOT ?? defaultSessionConfigBaselineRoot(),
     workspaceRoot,
     dependencyCacheRoot: process.env.RUNNER_DEPENDENCY_CACHE_ROOT ?? join(dirname(workspaceRoot), "dependency-cache"),
-    // One bare mirror per remote, per machine. Provisioning clones every
-    // workspace out of it and only ever fetches incrementally from GitHub; see
-    // repo-mirror.ts for why a full clone per run had to go.
-    repoMirrorRoot: process.env.RUNNER_REPO_MIRROR_ROOT ?? join(dirname(workspaceRoot), "repo-mirrors"),
+    // One bare mirror per remote. Provisioning clones every workspace out of it
+    // and only ever fetches incrementally from GitHub; see repo-mirror.ts for
+    // why a full clone per run had to go, and why the mirror lives in the home
+    // of the account that runs the tasks rather than beside the workspaces.
+    repoMirrorRoot: process.env.RUNNER_REPO_MIRROR_ROOT ?? join(home, ".agentos", "repo-mirrors"),
     failedWorkspaceRetention: Number.parseInt(process.env.RUNNER_FAILED_WORKSPACE_RETENTION ?? "2", 10),
     // How often this runner asks the control plane which of its directories may
     // be reclaimed (issue #115). Workspace disposal is not urgent — the runner

--- a/packages/runner/src/config.ts
+++ b/packages/runner/src/config.ts
@@ -34,6 +34,8 @@ export type RunnerConfig = {
   workspaceRoot: string;
   /** Runner-owned, write-once dependency snapshots. Defaults beside workspaceRoot. */
   dependencyCacheRoot?: string;
+  /** Runner-owned persistent bare mirrors. Defaults beside workspaceRoot. */
+  repoMirrorRoot?: string;
   failedWorkspaceRetention: number;
   workspaceReclaimIntervalMs: number;
   toolDeadlineMs: number;
@@ -104,6 +106,10 @@ export const loadRunnerConfig = (): RunnerConfig => {
     sessionConfigBaselineRoot: process.env.RUNNER_SESSION_CONFIG_BASELINE_ROOT ?? defaultSessionConfigBaselineRoot(),
     workspaceRoot,
     dependencyCacheRoot: process.env.RUNNER_DEPENDENCY_CACHE_ROOT ?? join(dirname(workspaceRoot), "dependency-cache"),
+    // One bare mirror per remote, per machine. Provisioning clones every
+    // workspace out of it and only ever fetches incrementally from GitHub; see
+    // repo-mirror.ts for why a full clone per run had to go.
+    repoMirrorRoot: process.env.RUNNER_REPO_MIRROR_ROOT ?? join(dirname(workspaceRoot), "repo-mirrors"),
     failedWorkspaceRetention: Number.parseInt(process.env.RUNNER_FAILED_WORKSPACE_RETENTION ?? "2", 10),
     // How often this runner asks the control plane which of its directories may
     // be reclaimed (issue #115). Workspace disposal is not urgent — the runner

--- a/packages/runner/src/provision-failure.test.ts
+++ b/packages/runner/src/provision-failure.test.ts
@@ -7,6 +7,7 @@ import { afterEach, test } from "node:test";
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { type FailureEnvelope, RUNNER_EXCEPTION_REASON, runnerExceptionEnvelope } from "./envelope.js";
+import { runCommand } from "./exec.js";
 import { executeClaim } from "./runner.js";
 import { provisionWorkspace } from "./workspace.js";
 
@@ -25,7 +26,9 @@ import { provisionWorkspace } from "./workspace.js";
  * the exact objects they produce; keep the two in step.
  */
 
-const config = (workspaceRoot: string): RunnerConfig => ({
+// Separate roots on purpose: the runner refuses a mirror root that overlaps the
+// workspace root, because workspace reclamation sweeps what it finds there.
+const config = (root: string): RunnerConfig => ({
   apiUrl: "http://api.invalid",
   runnerToken: "runner-token",
   runnerId: "runner-1",
@@ -34,8 +37,8 @@ const config = (workspaceRoot: string): RunnerConfig => ({
   leaseSeconds: 60,
   heartbeatIntervalMs: 5_000,
   path: "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
-  home: workspaceRoot,
-  workspaceRoot,
+  home: join(root, "home"),
+  workspaceRoot: join(root, "runs"),
   failedWorkspaceRetention: 2,
   workspaceReclaimIntervalMs: 300_000,
   toolDeadlineMs: 60_000,
@@ -103,14 +106,14 @@ const originalFetch = globalThis.fetch;
 afterEach(() => { globalThis.fetch = originalFetch; });
 
 test("a clone that cannot succeed reaches the API as a PROVISION envelope stamped 'runner exception'", async () => {
-  const workspaceRoot = await mkdtemp(join(tmpdir(), "runner-provision-"));
+  const root = await mkdtemp(join(tmpdir(), "runner-provision-"));
   const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
   globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
     posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
     return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
   }) as typeof fetch;
 
-  await executeClaim(config(workspaceRoot), claim(UNREACHABLE_REMOTE));
+  await executeClaim(config(root), claim(UNREACHABLE_REMOTE));
 
   const completion = posts.find((post) => post.path.endsWith("/complete"));
   assert.ok(completion, "provisioning failure must still complete the run");
@@ -130,7 +133,7 @@ test("a clone that cannot succeed reaches the API as a PROVISION envelope stampe
 });
 
 test("a transient mirror fetch failure escapes provisioning as a transient error, and the envelope says so", async () => {
-  const workspaceRoot = await mkdtemp(join(tmpdir(), "runner-provision-transient-"));
+  const root = await mkdtemp(join(tmpdir(), "runner-provision-transient-"));
   // The 2026-08-17 error, thrown by the real call site that still reaches the
   // network: the mirror's own fetch. `attempts: 1` collapses the real retry
   // ladder rather than replacing it — the loop, its transient predicate and its
@@ -138,11 +141,14 @@ test("a transient mirror fetch failure escapes provisioning as a transient error
   const message = "git failed (128): fatal: unable to access 'https://example.test/repo.git/': "
     + "LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to example.test:443";
   const escaped = await provisionWorkspace(
-    config(workspaceRoot),
+    config(root),
     claim("https://example.test/repo.git"),
-    (_config, _executable, args) => {
+    async (executorConfig, executable, args, cwd, env) => {
+      // Only git is faked: the mirror's own filesystem bookkeeping is real work
+      // in a temporary directory, and the retry under test rides on the fetch.
+      if (executable === "/bin/sh") return runCommand(executorConfig.runAsPrefix, executable, args, cwd, env, {});
       if (args[0] === "fetch") throw new Error(message);
-      return Promise.resolve("");
+      return "";
     },
     { attempts: 1 },
   ).then(() => null, (error: unknown) => error);

--- a/packages/runner/src/provision-failure.test.ts
+++ b/packages/runner/src/provision-failure.test.ts
@@ -129,21 +129,24 @@ test("a clone that cannot succeed reaches the API as a PROVISION envelope stampe
   assert.equal(completion.body.terminationReason, RUNNER_EXCEPTION_REASON);
 });
 
-test("a transient clone failure escapes provisioning as a transient error, and the envelope says so", async () => {
+test("a transient mirror fetch failure escapes provisioning as a transient error, and the envelope says so", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "runner-provision-transient-"));
-  // The 2026-08-17 error, thrown by the real `git clone` call site. `attempts:
-  // 1` collapses the real retry ladder rather than replacing it: the loop, its
-  // transient predicate and its rethrow are the production ones, and the
-  // backoff is the only thing skipped.
+  // The 2026-08-17 error, thrown by the real call site that still reaches the
+  // network: the mirror's own fetch. `attempts: 1` collapses the real retry
+  // ladder rather than replacing it — the loop, its transient predicate and its
+  // rethrow are the production ones, and the backoff is the only thing skipped.
   const message = "git failed (128): fatal: unable to access 'https://example.test/repo.git/': "
     + "LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to example.test:443";
   const escaped = await provisionWorkspace(
     config(workspaceRoot),
     claim("https://example.test/repo.git"),
-    () => { throw new Error(message); },
+    (_config, _executable, args) => {
+      if (args[0] === "fetch") throw new Error(message);
+      return Promise.resolve("");
+    },
     { attempts: 1 },
   ).then(() => null, (error: unknown) => error);
-  assert.ok(escaped instanceof Error, "the clone failure must escape provisioning, not be swallowed");
+  assert.ok(escaped instanceof Error, "the fetch failure must escape provisioning, not be swallowed");
 
   // Through the same function the production catch calls.
   const envelope = runnerExceptionEnvelope({

--- a/packages/runner/src/repo-mirror.test.ts
+++ b/packages/runner/src/repo-mirror.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -269,6 +269,87 @@ test("every mirror command runs through the run-as prefix, so the account with t
     // same account, not by node's fs as the daemon.
     assert.equal(argv.includes(`/bin/sh -c`), true);
     assert.equal(argv.includes(mirrorRoot), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a mirror root reached through a symlinked ancestor still counts as inside the workspace root", async () => {
+  const { root, remote, config } = await fixture("overlap");
+  const env = workspaceEnvironment(config);
+  try {
+    // Nothing textual connects these two paths; the link is what puts the
+    // mirror inside the tree the runner reclaims between runs.
+    await mkdir(config.workspaceRoot, { recursive: true });
+    await symlink(config.workspaceRoot, join(root, "alias"));
+    const overlapping = { ...config, repoMirrorRoot: join(root, "alias", "mirrors") } as RunnerConfig;
+
+    await assert.rejects(
+      withRepoMirror(overlapping, remote, root, env, passthrough, { report: silent() }, async () => undefined),
+      /overlaps the workspace root/u,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("staging the sweep could not remove is reported rather than swallowed", async () => {
+  const { root, remote, config, mirrorRoot } = await fixture("staging");
+  const env = workspaceEnvironment(config);
+  const stranded = join(mirrorRoot, ".stage-abandoned");
+  try {
+    await mkdir(mirrorRoot, { recursive: true });
+    // What a process killed between mktemp and mv leaves behind, aged past the
+    // sweep's threshold and made unremovable the way a restrictive ACL or a
+    // read-only filesystem would: rm cannot descend into it to empty it.
+    await mkdir(stranded, { recursive: true });
+    await writeFile(join(stranded, "HEAD"), "ref: refs/heads/main\n");
+    const aged = new Date(Date.now() - 3_600_000);
+    await utimes(stranded, aged, aged);
+    await chmod(stranded, 0o000);
+
+    const progress: RepoMirrorProgress[] = [];
+    await withRepoMirror(
+      config, remote, root, env, passthrough,
+      { report: (event) => progress.push(event) },
+      async () => undefined,
+    );
+
+    // The run still succeeds — a leaked copy is not a reason to refuse work —
+    // but it names what is now occupying the disk instead of exiting 0 over it.
+    assert.deepEqual(
+      progress.filter((event) => event.event === "staging-retained").map((event) => event.mirror),
+      [stranded],
+    );
+  } finally {
+    await chmod(stranded, 0o700).catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("mirror git runs are addressed by GIT_DIR, never by entering the mirror the daemon cannot", async () => {
+  const { root, remote, config, mirror } = await fixture("git-dir");
+  const env = workspaceEnvironment(config);
+  const runs: { args: string[]; cwd: string; gitDir: string | undefined }[] = [];
+  const observed: MirrorCommandExecutor = (mirrorConfig, executable, args, cwd, commandEnv, options = {}) => {
+    if (executable === "git") runs.push({ args, cwd, gitDir: commandEnv.GIT_DIR });
+    return runCommand(mirrorConfig.runAsPrefix, executable, args, cwd, commandEnv, options);
+  };
+  try {
+    await withRepoMirror(config, remote, root, env, observed, { report: silent() }, async () => undefined);
+
+    const bare = runs.filter((run) => run.args[0] === "fetch" || run.args[0] === "config");
+    assert.equal(bare.length > 0, true);
+    for (const run of bare) {
+      // GIT_DIR, because node chdirs into cwd as the daemon's own uid before
+      // the run-as prefix executes, and a task account's home is 0700.
+      assert.equal(typeof run.gitDir, "string");
+      assert.equal(run.cwd.startsWith(mirror), false);
+      assert.equal(run.cwd, root);
+      // The subcommand stays at argv[0] so network-retry's allowlist, and the
+      // timeout riding on it, still match.
+      assert.equal(run.args[0] === "fetch" || run.args[0] === "config", true);
+    }
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/runner/src/repo-mirror.test.ts
+++ b/packages/runner/src/repo-mirror.test.ts
@@ -191,6 +191,26 @@ test("a held lock is waited for, and one left behind by a dead holder is stolen"
   }
 });
 
+test("a file where the lock directory belongs is stolen rather than waited on", async () => {
+  const { root, remote, config, mirror } = await fixture("lock-file");
+  const env = workspaceEnvironment(config);
+  try {
+    // What a heartbeat that raced its own release leaves behind. No mkdir can
+    // ever acquire it, so waiting out the stale window would wedge the machine
+    // for nothing.
+    await mkdir(join(root, "mirrors"), { recursive: true });
+    await writeFile(`${mirror}.lock`, "");
+    const taken = await withRepoMirror(
+      config, remote, root, env, passthrough,
+      { lockWaitMs: 10, lockPollMs: 1, report: silent() },
+      async (path) => path,
+    );
+    assert.equal(taken, mirror);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("a holder that was taken over does not delete its successor's lock", async () => {
   const { root, remote, config, mirror } = await fixture("release");
   const env = workspaceEnvironment(config);

--- a/packages/runner/src/repo-mirror.test.ts
+++ b/packages/runner/src/repo-mirror.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import type { ClaimedTask } from "./api.js";
+import type { RunnerConfig } from "./config.js";
+import { runCommand } from "./exec.js";
+import {
+  mirrorRevisionsPresent, repoMirrorPath, RepoMirrorError, withRepoMirror,
+  type MirrorCommandExecutor, type RepoMirrorProgress,
+} from "./repo-mirror.js";
+import { provisionWorkspace, workspaceEnvironment, type WorkspaceCommandExecutor } from "./workspace.js";
+
+const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+type Fixture = { root: string; remote: string; seed: string; config: RunnerConfig; mirrorRoot: string; mirror: string };
+
+const fixture = async (label: string): Promise<Fixture> => {
+  // realpath: macOS resolves the temp root through /var -> /private/var, and the
+  // mirror root is resolved before anything is created under it.
+  const root = await realpath(await mkdtemp(join(tmpdir(), `agentos-repo-mirror-${label}-`)));
+  const remote = join(root, "origin.git");
+  const seed = join(root, "seed");
+  git(root, "init", "--bare", "--initial-branch=main", remote);
+  git(root, "init", "--initial-branch=main", seed);
+  git(seed, "config", "user.name", "AgentOS Test");
+  git(seed, "config", "user.email", "runner@agentos.local");
+  await writeFile(join(seed, "tree.txt"), "base\n");
+  git(seed, "add", "tree.txt");
+  git(seed, "commit", "-m", "base");
+  git(seed, "remote", "add", "origin", remote);
+  git(seed, "push", "-u", "origin", "main");
+  const mirrorRoot = join(root, "mirrors");
+  const config = {
+    workspaceRoot: join(root, "workspaces"),
+    repoMirrorRoot: mirrorRoot,
+    runnerId: "runner-under-test",
+    runAsPrefix: [],
+    path: process.env.PATH ?? "/usr/bin:/bin",
+    home: process.env.HOME ?? root,
+  } as unknown as RunnerConfig;
+  return { root, remote, seed, config, mirrorRoot, mirror: repoMirrorPath(mirrorRoot, remote) };
+};
+
+const claimFor = (remote: string, id: string): ClaimedTask => ({
+  task: { id: `task-${id}` },
+  repo: { remoteUrl: remote, defaultBranch: "main" },
+  run: { id: `run-${id}`, runNumber: 1, targetBranch: "main", branch: "main" },
+} as ClaimedTask);
+
+/** The production executor, with every argv it is handed recorded. */
+const recorded = (calls: { args: string[]; cwd: string }[]): WorkspaceCommandExecutor =>
+  async (config, executable, args, cwd, env, options = {}) => {
+    calls.push({ args, cwd });
+    return runCommand(config.runAsPrefix, executable, args, cwd, env, options);
+  };
+
+const passthrough: MirrorCommandExecutor = (config, executable, args, cwd, env, options = {}) =>
+  runCommand(config.runAsPrefix, executable, args, cwd, env, options);
+
+const silent = (): ((progress: RepoMirrorProgress) => void) => (): void => undefined;
+
+test("the second run reuses the machine's mirror and fetches only what changed", async () => {
+  const { root, remote, seed, config, mirror } = await fixture("reuse");
+  try {
+    await provisionWorkspace(config, claimFor(remote, "one"), undefined, {}, {}, { report: silent() });
+    const created = (await stat(mirror)).birthtimeMs;
+
+    await writeFile(join(seed, "tree.txt"), "second\n");
+    git(seed, "commit", "-am", "second");
+    git(seed, "push", "origin", "main");
+    const head = git(seed, "rev-parse", "HEAD");
+
+    const calls: { args: string[]; cwd: string }[] = [];
+    const workspace = await provisionWorkspace(
+      config, claimFor(remote, "two"), recorded(calls), {}, {}, { report: silent() },
+    );
+
+    // Same mirror directory, not a rebuilt one, and the run sees the commit
+    // pushed after it was created — so the refresh really did reach the remote.
+    assert.equal((await stat(mirror)).birthtimeMs, created);
+    assert.equal(workspace.baseSha, head);
+    assert.equal(await readFile(join(workspace.path, "tree.txt"), "utf8"), "second\n");
+
+    // Nothing in the run touched the remote except the mirror's own fetch.
+    const remoteReaders = calls.filter(({ args }) => args.includes(remote));
+    assert.deepEqual(remoteReaders.map(({ args }) => args[0]), ["remote"]);
+    const clone = calls.find(({ args }) => args[0] === "clone");
+    assert.equal(clone?.args.at(-2), mirror);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the mirror carries branches and tags but not the remote's other refs", async () => {
+  const { root, remote, seed, config, mirror } = await fixture("refspec");
+  try {
+    git(seed, "tag", "v1");
+    git(seed, "push", "origin", "v1");
+    // GitHub advertises refs/pull/*; no run has ever needed it and mirroring it
+    // would make every fetch pay for the repository's whole review history.
+    git(seed, "push", "origin", "HEAD:refs/pull/7/head");
+
+    await provisionWorkspace(config, claimFor(remote, "refspec"), undefined, {}, {}, { report: silent() });
+
+    const refs = git(mirror, "for-each-ref", "--format=%(refname)").split("\n");
+    assert.equal(refs.includes("refs/heads/main"), true);
+    assert.equal(refs.includes("refs/tags/v1"), true);
+    assert.equal(refs.includes("refs/pull/7/head"), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a mirror pointing at a different remote is refused instead of quietly re-cloning", async () => {
+  const { root, remote, config, mirror } = await fixture("mismatch");
+  try {
+    await provisionWorkspace(config, claimFor(remote, "first"), undefined, {}, {}, { report: silent() });
+    git(mirror, "remote", "set-url", "origin", "https://github.com/acme/somewhere-else.git");
+
+    const failure = await provisionWorkspace(
+      config, claimFor(remote, "second"), undefined, {}, {}, { report: silent() },
+    ).then(() => null, (error: unknown) => error);
+    assert.equal(failure instanceof RepoMirrorError, true);
+    assert.equal((failure as RepoMirrorError).condition, "remote-url-mismatch");
+    assert.match((failure as RepoMirrorError).message, /refuses to fall back to a full remote clone/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a mirror that is not a readable git repository is refused, not rebuilt", async () => {
+  const { root, remote, config, mirror } = await fixture("corrupt");
+  try {
+    await mkdir(mirror, { recursive: true });
+    await writeFile(join(mirror, "not-a-repository"), "\n");
+
+    const failure = await provisionWorkspace(
+      config, claimFor(remote, "corrupt"), undefined, {}, {}, { report: silent() },
+    ).then(() => null, (error: unknown) => error);
+    assert.equal(failure instanceof RepoMirrorError, true);
+    assert.equal((failure as RepoMirrorError).condition, "not-a-readable-git-repository");
+    // The refusal leaves the evidence in place for whoever has to look at it.
+    assert.equal((await stat(join(mirror, "not-a-repository"))).isFile(), true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a held lock is waited for, and one left behind by a dead holder is taken over", async () => {
+  const { root, remote, config, mirror } = await fixture("lock");
+  const env = workspaceEnvironment(config);
+  try {
+    const lock = `${mirror}.lock`;
+    await mkdir(join(root, "mirrors"), { recursive: true });
+    await mkdir(lock);
+
+    const refused = await withRepoMirror(
+      config, remote, env, passthrough,
+      { lockWaitMs: 10, lockPollMs: 1, report: silent() },
+      async () => "unreachable",
+    ).then(() => null, (error: unknown) => error);
+    assert.match((refused as Error).message, /waiting for the runner repository mirror lock/u);
+
+    // Backdated past the staleness threshold: no live holder can be that old,
+    // because every operation under the lock is bounded far below it.
+    const stale = new Date(Date.now() - 3_600_000);
+    await utimes(lock, stale, stale);
+    let takeovers = 0;
+    const taken = await withRepoMirror(
+      config, remote, env, passthrough,
+      {
+        lockWaitMs: 10,
+        lockPollMs: 1,
+        report: (progress) => { if (progress.event === "lock-takeover") takeovers += 1; },
+      },
+      async (path) => path,
+    );
+    assert.equal(taken, mirror);
+    assert.equal(takeovers, 1);
+    // Released on the way out, or the next run on this machine would wait ten
+    // minutes for a mirror nobody is holding.
+    await assert.rejects(stat(lock));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("object presence is read from cat-file's own answer, never from an exit code", async () => {
+  const { root, remote, seed, config } = await fixture("objects");
+  const env = workspaceEnvironment(config);
+  try {
+    const present = git(seed, "rev-parse", "HEAD");
+    const absent = "0".repeat(40);
+    const answers = await withRepoMirror(
+      config, remote, env, passthrough, { report: silent() },
+      (mirror) => mirrorRevisionsPresent(config, mirror, [present, absent], env, passthrough),
+    );
+    assert.equal(answers.get(present), true);
+    assert.equal(answers.get(absent), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/runner/src/repo-mirror.test.ts
+++ b/packages/runner/src/repo-mirror.test.ts
@@ -37,10 +37,11 @@ const fixture = async (label: string): Promise<Fixture> => {
   const config = {
     workspaceRoot: join(root, "workspaces"),
     repoMirrorRoot: mirrorRoot,
+    // The mirror lives in the task account's home; here the fixture is it.
+    home: root,
     runnerId: "runner-under-test",
     runAsPrefix: [],
     path: process.env.PATH ?? "/usr/bin:/bin",
-    home: process.env.HOME ?? root,
   } as unknown as RunnerConfig;
   return { root, remote, seed, config, mirrorRoot, mirror: repoMirrorPath(mirrorRoot, remote) };
 };
@@ -60,6 +61,7 @@ const recorded = (calls: { args: string[]; cwd: string }[]): WorkspaceCommandExe
 
 const passthrough: MirrorCommandExecutor = (config, executable, args, cwd, env, options = {}) =>
   runCommand(config.runAsPrefix, executable, args, cwd, env, options);
+
 
 const silent = (): ((progress: RepoMirrorProgress) => void) => (): void => undefined;
 
@@ -150,7 +152,7 @@ test("a mirror that is not a readable git repository is refused, not rebuilt", a
   }
 });
 
-test("a held lock is waited for, and one left behind by a dead holder is taken over", async () => {
+test("a held lock is waited for, and one left behind by a dead holder is stolen", async () => {
   const { root, remote, config, mirror } = await fixture("lock");
   const env = workspaceEnvironment(config);
   try {
@@ -159,28 +161,28 @@ test("a held lock is waited for, and one left behind by a dead holder is taken o
     await mkdir(lock);
 
     const refused = await withRepoMirror(
-      config, remote, env, passthrough,
+      config, remote, root, env, passthrough,
       { lockWaitMs: 10, lockPollMs: 1, report: silent() },
       async () => "unreachable",
     ).then(() => null, (error: unknown) => error);
     assert.match((refused as Error).message, /waiting for the runner repository mirror lock/u);
 
-    // Backdated past the staleness threshold: no live holder can be that old,
-    // because every operation under the lock is bounded far below it.
+    // Backdated past the staleness threshold. A live holder touches its own
+    // lock every heartbeat, so only a dead one can get this old.
     const stale = new Date(Date.now() - 3_600_000);
     await utimes(lock, stale, stale);
-    let takeovers = 0;
+    let steals = 0;
     const taken = await withRepoMirror(
-      config, remote, env, passthrough,
+      config, remote, root, env, passthrough,
       {
         lockWaitMs: 10,
         lockPollMs: 1,
-        report: (progress) => { if (progress.event === "lock-takeover") takeovers += 1; },
+        report: (progress) => { if (progress.event === "lock-steal") steals += 1; },
       },
       async (path) => path,
     );
     assert.equal(taken, mirror);
-    assert.equal(takeovers, 1);
+    assert.equal(steals, 1);
     // Released on the way out, or the next run on this machine would wait ten
     // minutes for a mirror nobody is holding.
     await assert.rejects(stat(lock));
@@ -194,7 +196,7 @@ test("a holder that was taken over does not delete its successor's lock", async 
   const env = workspaceEnvironment(config);
   const lock = `${mirror}.lock`;
   try {
-    await withRepoMirror(config, remote, env, passthrough, { report: silent() }, async () => {
+    await withRepoMirror(config, remote, root, env, passthrough, { report: silent() }, async () => {
       // What a stale takeover looks like from inside the declared-dead holder:
       // its lock is gone and someone else's is at the path.
       await rm(lock, { recursive: true, force: true });
@@ -208,19 +210,46 @@ test("a holder that was taken over does not delete its successor's lock", async 
   }
 });
 
-test("the mirror stays readable to another account whatever umask the daemon runs under", async () => {
-  const { root, remote, config, mirror } = await fixture("umask");
-  const previous = process.umask(0o077);
+test("the mirror is private to the account that runs the tasks", async () => {
+  const { root, remote, config, mirror, mirrorRoot } = await fixture("private");
+  const previous = process.umask(0o022);
   try {
-    await provisionWorkspace(config, claimFor(remote, "umask"), undefined, {}, {}, { report: silent() });
-    // A RUNNER_RUN_AS_PREFIX deployment clones as an account that owns nothing
-    // here, so every directory git created must stay world-traversable and
-    // listable — including the ones `git init` made before any config existed.
-    for (const path of [mirror, join(mirror, "objects"), join(mirror, "refs")]) {
-      assert.equal((await stat(path)).mode & 0o055, 0o055, path);
-    }
+    await provisionWorkspace(config, claimFor(remote, "private"), undefined, {}, {}, { report: silent() });
+    // The mirror carries the same history as the run workspace and lives in the
+    // task account's own home. Nothing outside that account has business
+    // reading it, and a permissive umask must not decide otherwise.
+    assert.equal((await stat(mirrorRoot)).mode & 0o777, 0o700);
+    assert.equal((await stat(mirror)).isDirectory(), true);
   } finally {
     process.umask(previous);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("every mirror command runs through the run-as prefix, so the account with the credentials fetches", async () => {
+  const { root, remote, config, mirrorRoot } = await fixture("run-as");
+  try {
+    const log = join(root, "prefix.log");
+    const launcher = join(root, "run-as.sh");
+    // Stands in for `sudo -u agentrunner`: same uid, but it records the argv it
+    // was handed. The mirror lives in a launched account's 0700 home, which the
+    // daemon's own uid cannot even enter — so anything the daemon did directly
+    // would fail in a real OS-isolated deployment.
+    await writeFile(launcher, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${log}\nexec "$@"\n`, { mode: 0o755 });
+    const isolated = { ...config, runAsPrefix: [launcher] } as RunnerConfig;
+    await mkdir(config.workspaceRoot, { recursive: true });
+
+    await provisionWorkspace(isolated, claimFor(remote, "run-as"), undefined, {}, {}, { report: silent() });
+
+    const argv = await readFile(log, "utf8");
+    assert.match(argv, /git init --bare/u);
+    assert.match(argv, /git fetch --prune/u);
+    assert.match(argv, /git clone --branch/u);
+    // The mirror root, the lock and the staging directory are created by the
+    // same account, not by node's fs as the daemon.
+    assert.equal(argv.includes(`/bin/sh -c`), true);
+    assert.equal(argv.includes(mirrorRoot), true);
+  } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -232,8 +261,8 @@ test("object presence is read from cat-file's own answer, never from an exit cod
     const present = git(seed, "rev-parse", "HEAD");
     const absent = "0".repeat(40);
     const answers = await withRepoMirror(
-      config, remote, env, passthrough, { report: silent() },
-      (mirror) => mirrorRevisionsPresent(config, mirror, [present, absent], env, passthrough),
+      config, remote, root, env, passthrough, { report: silent() },
+      (mirror) => mirrorRevisionsPresent(config, mirror, [present, absent], root, env, passthrough),
     );
     assert.equal(answers.get(present), true);
     assert.equal(answers.get(absent), false);

--- a/packages/runner/src/repo-mirror.test.ts
+++ b/packages/runner/src/repo-mirror.test.ts
@@ -189,6 +189,42 @@ test("a held lock is waited for, and one left behind by a dead holder is taken o
   }
 });
 
+test("a holder that was taken over does not delete its successor's lock", async () => {
+  const { root, remote, config, mirror } = await fixture("release");
+  const env = workspaceEnvironment(config);
+  const lock = `${mirror}.lock`;
+  try {
+    await withRepoMirror(config, remote, env, passthrough, { report: silent() }, async () => {
+      // What a stale takeover looks like from inside the declared-dead holder:
+      // its lock is gone and someone else's is at the path.
+      await rm(lock, { recursive: true, force: true });
+      await mkdir(lock);
+      await writeFile(join(lock, "owner"), "successor\n");
+      return null;
+    });
+    assert.equal((await readFile(join(lock, "owner"), "utf8")).trim(), "successor");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the mirror stays readable to another account whatever umask the daemon runs under", async () => {
+  const { root, remote, config, mirror } = await fixture("umask");
+  const previous = process.umask(0o077);
+  try {
+    await provisionWorkspace(config, claimFor(remote, "umask"), undefined, {}, {}, { report: silent() });
+    // A RUNNER_RUN_AS_PREFIX deployment clones as an account that owns nothing
+    // here, so every directory git created must stay world-traversable and
+    // listable — including the ones `git init` made before any config existed.
+    for (const path of [mirror, join(mirror, "objects"), join(mirror, "refs")]) {
+      assert.equal((await stat(path)).mode & 0o055, 0o055, path);
+    }
+  } finally {
+    process.umask(previous);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("object presence is read from cat-file's own answer, never from an exit code", async () => {
   const { root, remote, seed, config } = await fixture("objects");
   const env = workspaceEnvironment(config);

--- a/packages/runner/src/repo-mirror.ts
+++ b/packages/runner/src/repo-mirror.ts
@@ -1,6 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { chmod, lstat, mkdir, mkdtemp, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join, resolve, sep } from "node:path";
+import { join, resolve, sep } from "node:path";
 
 import type { RunnerConfig } from "./config.js";
 import type { CommandOptions } from "./exec.js";
@@ -9,8 +8,8 @@ import {
 } from "./network-retry.js";
 
 /**
- * A persistent, machine-local bare mirror of every remote this runner
- * provisions from.
+ * A persistent bare mirror of every remote this runner provisions from, owned
+ * by the same account that runs the tasks.
  *
  * Provisioning used to clone the whole repository from GitHub for every single
  * run. On 2026-08-25 that clone measured 125.9s against a 120s command ceiling,
@@ -24,8 +23,15 @@ import {
  * fetch, which is proportional to what changed rather than to the repository.
  * Run workspaces then clone from local disk, where there is no exit to shake.
  *
- * Two properties are deliberate and load-bearing:
+ * Four properties are deliberate and load-bearing:
  *
+ * - Every operation here — git and filesystem alike — runs through the same
+ *   `RUNNER_RUN_AS_PREFIX` the clone always did, and the mirror lives in that
+ *   principal's own home. The account that can reach the remote is therefore
+ *   the account that fetches, no deployment has to grant a second principal
+ *   credentials, and nothing outside that 0700 home can read the mirror. That
+ *   is also why the filesystem work is small shell scripts rather than node's
+ *   fs: the daemon's uid cannot enter a launched account's home.
  * - The remote fetch keeps the clone retry profile from network-retry.ts. The
  *   first fetch into an empty mirror transfers exactly what a clone did, so it
  *   needs the same bound; later fetches are far smaller and finish well inside
@@ -35,6 +41,10 @@ import {
  *   fallback is precisely the behaviour this module exists to eliminate, and a
  *   silent one would restore it on exactly the machines whose mirror broke —
  *   invisibly, run after run.
+ * - The lock is taken by `mkdir` and stolen by `mv`, both atomic, and a live
+ *   holder keeps its lock young by touching it. A contender therefore cannot
+ *   remove a lock another contender has already replaced, and a holder that is
+ *   merely slow is never mistaken for a dead one.
  */
 
 export type MirrorCommandExecutor = (
@@ -47,7 +57,7 @@ export type MirrorCommandExecutor = (
 ) => Promise<string>;
 
 export type RepoMirrorProgress = {
-  event: "created" | "refreshed" | "object-top-up" | "lock-wait" | "lock-takeover" | "elapsed";
+  event: "created" | "refreshed" | "object-top-up" | "lock-wait" | "lock-steal" | "staging-retained" | "elapsed";
   mirror?: string;
   condition?: string;
   elapsedMs?: number;
@@ -58,8 +68,10 @@ export type RepoMirrorOptions = {
   /** Retry budget for the remote fetches; defaults to the clone profile. */
   fetchRetryOptions?: RetryOptions;
   lockWaitMs?: number;
-  lockStaleMs?: number;
+  /** Minutes of silence after which a lock is treated as a dead holder's. */
+  lockStaleMinutes?: number;
   lockPollMs?: number;
+  lockHeartbeatMs?: number;
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   report?: (progress: RepoMirrorProgress) => void;
@@ -75,18 +87,15 @@ export type RepoMirrorOptions = {
 const MIRROR_LOCK_WAIT_MS = 600_000;
 
 /**
- * A lock older than this belonged to a process that died holding it. It is
- * comfortably above the longest legitimate hold — one clone-profile fetch
- * (300s) plus a local clone — so a takeover cannot race a live holder.
+ * A lock nobody has touched for this long belonged to a process that died
+ * holding it. The holder refreshes its own lock every MIRROR_LOCK_HEARTBEAT_MS,
+ * so this is a liveness signal rather than a guess about how long the work
+ * takes — which matters because the local clone under the lock is deliberately
+ * uncapped, and a laptop can suspend in the middle of one.
  */
-const MIRROR_LOCK_STALE_MS = 900_000;
+const MIRROR_LOCK_STALE_MINUTES = 5;
+const MIRROR_LOCK_HEARTBEAT_MS = 30_000;
 const MIRROR_LOCK_POLL_MS = 500;
-
-/** Bare mirrors hold no secret: every account that can run a task can clone the
- *  repository anyway. They must be world-traversable *and* listable, because a
- *  clone under RUNNER_RUN_AS_PREFIX runs as another account and git enumerates
- *  the pack directory. */
-const MIRROR_DIRECTORY_MODE = 0o755;
 
 export class RepoMirrorError extends Error {
   readonly mirrorPath: string;
@@ -105,8 +114,6 @@ export class RepoMirrorError extends Error {
   }
 }
 
-const errorCode = (error: unknown): string | undefined => (error as NodeJS.ErrnoException).code;
-
 const insideOrEqual = (root: string, candidate: string): boolean =>
   candidate === root || candidate.startsWith(`${root}${sep}`);
 
@@ -116,11 +123,14 @@ const progressReporter = (progress: RepoMirrorProgress): void => {
 
 const defaultSleep = (ms: number): Promise<void> => new Promise<void>((done) => { setTimeout(done, ms); });
 
-/** Where this runner keeps its mirrors. Beside the workspace root by default,
- *  exactly like the dependency cache, so one operator decision about disk
- *  placement covers every runner-owned durable directory. */
-export const repoMirrorRoot = (config: Pick<RunnerConfig, "workspaceRoot" | "repoMirrorRoot">): string =>
-  config.repoMirrorRoot ?? join(dirname(resolve(config.workspaceRoot)), "repo-mirrors");
+/**
+ * Where this runner keeps its mirrors: inside the home of the account that runs
+ * the tasks. That home already exists at 0700 in every deployment — the
+ * os-isolation provisioner creates one per runner account — so the mirror needs
+ * no new directory, no new owner, and no new mode to get wrong.
+ */
+export const repoMirrorRoot = (config: Pick<RunnerConfig, "home" | "repoMirrorRoot">): string =>
+  config.repoMirrorRoot ?? join(config.home, ".agentos", "repo-mirrors");
 
 /** One directory per remote URL. The digest, not the URL, is the name: remote
  *  URLs contain characters a path cannot hold, and a digest cannot collide with
@@ -130,20 +140,56 @@ export const repoMirrorRoot = (config: Pick<RunnerConfig, "workspaceRoot" | "rep
 export const repoMirrorPath = (root: string, remoteUrl: string): string =>
   join(root, `${createHash("sha256").update(remoteUrl).digest("hex")}.git`);
 
-const ensureMirrorRoot = async (config: RunnerConfig, options: RepoMirrorOptions): Promise<string> => {
-  const requested = resolve(options.mirrorRoot ?? repoMirrorRoot(config));
-  await mkdir(requested, { recursive: true, mode: MIRROR_DIRECTORY_MODE });
-  if ((await lstat(requested)).isSymbolicLink()) throw new Error(`Runner repository mirror root is a symlink: ${requested}`);
-  const root = await realpath(requested);
-  const workspaceRoot = resolve(config.workspaceRoot);
-  if (insideOrEqual(root, workspaceRoot) || insideOrEqual(workspaceRoot, root)) {
-    throw new Error(`Runner repository mirror root ${root} overlaps the workspace root ${workspaceRoot}`);
-  }
-  await chmod(root, MIRROR_DIRECTORY_MODE);
-  return root;
-};
+/**
+ * Run a shell fragment as the task principal.
+ *
+ * `cwd` is not where the work happens — every path the fragment touches is
+ * absolute — it is only somewhere node can chdir *before* the prefix runs, as
+ * the daemon's own uid. The mirror's own directories are not that place.
+ */
+const shell = (
+  config: RunnerConfig,
+  execute: MirrorCommandExecutor,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  body: string,
+  ...args: string[]
+): Promise<string> => execute(config, "/bin/sh", ["-c", body, "agentos-mirror", ...args], cwd, env);
+
+/** Git addressed by GIT_DIR rather than by cwd, for the same reason. Keeping
+ *  the subcommand at argv[0] also keeps network-retry.ts's allowlist — and the
+ *  timeout that rides on it — matching what it is meant to match. */
+const gitEnvironment = (env: NodeJS.ProcessEnv, mirror: string): NodeJS.ProcessEnv =>
+  ({ ...env, GIT_DIR: mirror });
+
+const ENSURE_ROOT = 'mkdir -p "$1" && chmod 700 "$1" && [ ! -L "$1" ] || exit 1;'
+  // Staging left behind by a process that died between mktemp and mv. Nothing
+  // else may remove it: a *live* creation for a different remote holds a
+  // different lock and is not covered by this one.
+  + ' find "$1" -maxdepth 1 -name ".stage-*" -mmin +"$2" -exec rm -rf {} + 2>/dev/null; exit 0';
+
+const PROBE = 'if [ -L "$1" ]; then printf unusable;'
+  + ' elif [ -d "$1" ]; then printf present;'
+  + ' elif [ -e "$1" ]; then printf unusable;'
+  + ' else printf absent; fi';
+
+// mkdir is the atomic acquisition. The steal is a rename, which is the other
+// atomic operation: two contenders that both judge a lock dead cannot both
+// succeed, so the loser retries instead of deleting the winner's fresh lock.
+const ACQUIRE = 'if mkdir "$1" 2>/dev/null; then printf %s "$2" > "$1/owner" && printf acquired;'
+  + ' elif [ -n "$(find "$1" -maxdepth 0 -mmin +"$3" 2>/dev/null)" ]; then'
+  + ' if mv "$1" "$1.dead.$$" 2>/dev/null; then rm -rf "$1.dead.$$"; printf stolen; else printf held; fi;'
+  + ' else printf held; fi';
+
+/** Release removes this lock, not whatever lock happens to be at the path: a
+ *  holder whose lock was stolen must not delete its successor's. */
+const RELEASE = 'if [ "$(cat "$1/owner" 2>/dev/null)" = "$2" ]; then rm -rf "$1"; fi';
 
 const acquireMirrorLock = async (
+  config: RunnerConfig,
+  execute: MirrorCommandExecutor,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
   lockPath: string,
   owner: string,
   options: RepoMirrorOptions,
@@ -152,47 +198,35 @@ const acquireMirrorLock = async (
   const now = options.now ?? ((): number => Date.now());
   const sleep = options.sleep ?? defaultSleep;
   const waitMs = options.lockWaitMs ?? MIRROR_LOCK_WAIT_MS;
-  const staleMs = options.lockStaleMs ?? MIRROR_LOCK_STALE_MS;
+  const staleMinutes = options.lockStaleMinutes ?? MIRROR_LOCK_STALE_MINUTES;
+  const heartbeatMs = options.lockHeartbeatMs ?? MIRROR_LOCK_HEARTBEAT_MS;
   const pollMs = options.lockPollMs ?? MIRROR_LOCK_POLL_MS;
   const deadline = now() + waitMs;
+  const held = `${owner}:${process.pid}:${randomUUID()}`;
   let waited = false;
   for (;;) {
-    try {
-      // mkdir is the atomic operation: exactly one caller creates it, everyone
-      // else gets EEXIST. No lock file content participates in the decision.
-      await mkdir(lockPath, { mode: MIRROR_DIRECTORY_MODE });
-      const held = `${owner}:${process.pid}:${randomUUID()}\n`;
-      const ownerFile = join(lockPath, "owner");
-      const discard = async (): Promise<void> => { await rm(lockPath, { recursive: true, force: true }); };
-      try {
-        await writeFile(ownerFile, held, { mode: 0o644 });
-      } catch (error: unknown) {
-        await discard();
-        throw error;
-      }
-      // Release removes this lock, not whatever lock happens to be at the path.
-      // Without the check, a holder that was declared stale and taken over would
-      // delete its successor's lock on the way out, and the mirror would end up
-      // with two writers and no lock at all.
+    const outcome = await shell(config, execute, cwd, env, ACQUIRE, lockPath, held, String(staleMinutes));
+    if (outcome === "acquired") {
+      // A holder that stops touching its lock is a holder that died. Without
+      // this, the staleness threshold would have to bound the uncapped local
+      // clone under the lock — and a suspended machine bounds nothing.
+      const heartbeat = setInterval(() => {
+        void shell(config, execute, cwd, env, 'touch "$1" 2>/dev/null || true', lockPath).catch(() => undefined);
+      }, heartbeatMs);
+      heartbeat.unref?.();
       return async (): Promise<void> => {
-        const current = await readFile(ownerFile, "utf8").catch(() => "");
-        if (current === held) await discard();
+        clearInterval(heartbeat);
+        await shell(config, execute, cwd, env, RELEASE, lockPath, held);
       };
-    } catch (error: unknown) {
-      if (errorCode(error) !== "EEXIST") throw error;
     }
-    const held = await lstat(lockPath).catch((error: unknown) => {
-      if (errorCode(error) === "ENOENT") return null;
-      throw error;
-    });
-    if (held === null) continue;
-    if (now() - held.mtimeMs > staleMs) {
-      // The holder cannot still be alive: every operation under this lock is
-      // bounded well below the staleness threshold.
-      report({ event: "lock-takeover", mirror: lockPath, elapsedMs: Math.round(now() - held.mtimeMs) });
-      await rm(lockPath, { recursive: true, force: true });
+    if (outcome === "stolen") {
+      report({ event: "lock-steal", mirror: lockPath });
       continue;
     }
+    // Anything else means the acquisition script did not run: treating an
+    // unrecognised answer as "someone else holds it" would spend the whole wait
+    // budget and then blame a lock that was never there.
+    if (outcome !== "held") throw new Error(`Runner repository mirror lock ${lockPath} answered "${outcome}"`);
     if (now() >= deadline) {
       throw new Error(
         `Timed out after ${waitMs}ms waiting for the runner repository mirror lock ${lockPath}; `
@@ -211,6 +245,7 @@ const fetchFromRemote = async (
   config: RunnerConfig,
   mirror: string,
   args: string[],
+  cwd: string,
   env: NodeJS.ProcessEnv,
   execute: MirrorCommandExecutor,
   retryOptions: RetryOptions,
@@ -220,7 +255,7 @@ const fetchFromRemote = async (
   // while the runner heartbeat holds the lease, so the bound only has to
   // separate "hung" from "slow".
   await runWithNetworkRetry("git", args,
-    ({ timeoutMs }) => execute(config, "git", args, mirror, env, { timeoutMs }),
+    ({ timeoutMs }) => execute(config, "git", args, cwd, gitEnvironment(env, mirror), { timeoutMs }),
     { commandTimeoutMs: CLONE_COMMAND_TIMEOUT_MS, budgetMs: CLONE_OPERATION_BUDGET_MS, ...retryOptions },
   );
 };
@@ -230,23 +265,18 @@ const REFRESH_ARGS = ["fetch", "--prune", "--prune-tags", "--tags", "--quiet", "
 const configureMirror = async (
   config: RunnerConfig,
   mirror: string,
+  cwd: string,
   env: NodeJS.ProcessEnv,
   execute: MirrorCommandExecutor,
 ): Promise<void> => {
+  const gitEnv = gitEnvironment(env, mirror);
   // Heads only: GitHub advertises refs/pull/*, which no run has ever needed and
   // which would make every fetch pay for the repository's whole review history.
-  await execute(config, "git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"], mirror, env);
-  // Every object git writes here gets 0644 (directories 0755) whatever the
-  // daemon's umask is. Without it, a restrictive umask would make the mirror
-  // unreadable to the account a RUNNER_RUN_AS_PREFIX deployment clones as —
-  // and only on the machines that set one. `git init --shared` covers the
-  // directories init creates; this covers every write after it, and re-asserts
-  // the setting on a mirror whose configuration was edited by hand.
-  await execute(config, "git", ["config", "core.sharedRepository", "0644"], mirror, env);
+  await execute(config, "git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"], cwd, gitEnv);
   // Blind-review provisioning fetches an exact object id out of this mirror.
   // upload-pack refuses unadvertised objects by default, and the refusal would
   // read as a mirror fault rather than as the policy it is.
-  await execute(config, "git", ["config", "uploadpack.allowAnySHA1InWant", "true"], mirror, env);
+  await execute(config, "git", ["config", "uploadpack.allowAnySHA1InWant", "true"], cwd, gitEnv);
 };
 
 const createMirror = async (
@@ -254,23 +284,29 @@ const createMirror = async (
   root: string,
   mirror: string,
   remoteUrl: string,
+  cwd: string,
   env: NodeJS.ProcessEnv,
   execute: MirrorCommandExecutor,
   retryOptions: RetryOptions,
+  report: (progress: RepoMirrorProgress) => void,
 ): Promise<void> => {
   // Staged beside the destination and renamed only after the first fetch
   // succeeds, so an interrupted creation can never leave a directory that later
   // runs would mistake for a populated mirror.
-  const staging = await mkdtemp(join(root, ".stage-"));
+  const staging = await shell(config, execute, cwd, env, 'd=$(mktemp -d "$1/.stage-XXXXXXXX") && printf %s "$d"', root);
+  if (!insideOrEqual(root, staging)) throw new Error(`Runner repository mirror staging escaped its root: ${staging}`);
   try {
-    await execute(config, "git", ["init", "--bare", "--shared=0644", "--quiet", staging], root, env);
-    await execute(config, "git", ["remote", "add", "origin", remoteUrl], staging, env);
-    await configureMirror(config, staging, env, execute);
-    await fetchFromRemote(config, staging, [...REFRESH_ARGS], env, execute, retryOptions);
-    await chmod(staging, MIRROR_DIRECTORY_MODE);
-    await rename(staging, mirror);
+    await execute(config, "git", ["init", "--bare", "--quiet", staging], cwd, env);
+    await execute(config, "git", ["remote", "add", "origin", remoteUrl], cwd, gitEnvironment(env, staging));
+    await configureMirror(config, staging, cwd, env, execute);
+    await fetchFromRemote(config, staging, [...REFRESH_ARGS], cwd, env, execute, retryOptions);
+    await shell(config, execute, cwd, env, 'mv "$1" "$2"', staging, mirror);
   } finally {
-    await rm(staging, { recursive: true, force: true }).catch(() => undefined);
+    // The sweep in ENSURE_ROOT is what covers a process that dies before this
+    // runs; a failure here is reported rather than swallowed, because a staging
+    // directory is close to a whole repository in size.
+    await shell(config, execute, cwd, env, 'rm -rf "$1"', staging)
+      .catch(() => { report({ event: "staging-retained", mirror: staging }); });
   }
 };
 
@@ -278,17 +314,16 @@ const validateMirror = async (
   config: RunnerConfig,
   mirror: string,
   remoteUrl: string,
+  cwd: string,
   env: NodeJS.ProcessEnv,
   execute: MirrorCommandExecutor,
 ): Promise<void> => {
-  const info = await lstat(mirror);
-  if (info.isSymbolicLink() || !info.isDirectory()) throw new RepoMirrorError(mirror, "not-a-directory");
-  if (await realpath(mirror) !== mirror) throw new RepoMirrorError(mirror, "symlinked-path");
+  const gitEnv = gitEnvironment(env, mirror);
   let bare: string;
   let configured: string;
   try {
-    bare = await execute(config, "git", ["rev-parse", "--is-bare-repository"], mirror, env);
-    configured = await execute(config, "git", ["config", "--get", "remote.origin.url"], mirror, env);
+    bare = await execute(config, "git", ["rev-parse", "--is-bare-repository"], cwd, gitEnv);
+    configured = await execute(config, "git", ["config", "--get", "remote.origin.url"], cwd, gitEnv);
   } catch (error: unknown) {
     throw new RepoMirrorError(mirror, "not-a-readable-git-repository", { cause: error });
   }
@@ -307,12 +342,13 @@ export const mirrorRevisionsPresent = async (
   config: RunnerConfig,
   mirror: string,
   revisions: readonly string[],
+  cwd: string,
   env: NodeJS.ProcessEnv,
   execute: MirrorCommandExecutor,
 ): Promise<Map<string, boolean>> => {
   if (revisions.length === 0) return new Map();
   const output = await execute(
-    config, "git", ["cat-file", "--batch-check=%(objectname) %(objecttype)"], mirror, env,
+    config, "git", ["cat-file", "--batch-check=%(objectname) %(objecttype)"], cwd, gitEnvironment(env, mirror),
     { input: `${revisions.join("\n")}\n` },
   );
   const lines = output.split("\n");
@@ -327,33 +363,27 @@ export const mirrorRevisionsPresent = async (
  * one is absent. A run's pinned base is pushed by an earlier run, so a mirror
  * refreshed moments ago normally has it already; a top-up covers the ref that
  * was deleted upstream after the object was recorded.
- *
- * A top-up that does not produce the object is a hard failure. It is the one
- * place where "just clone it from GitHub instead" would be tempting, and the
- * one place where doing so would hide a real inconsistency between the control
- * plane's recorded history and the remote's.
  */
 export const ensureMirrorRevisions = async (
   config: RunnerConfig,
   mirror: string,
   revisions: readonly string[],
+  cwd: string,
   env: NodeJS.ProcessEnv,
   execute: MirrorCommandExecutor,
   retryOptions: RetryOptions = {},
   report: (progress: RepoMirrorProgress) => void = progressReporter,
 ): Promise<void> => {
-  const present = await mirrorRevisionsPresent(config, mirror, revisions, env, execute);
+  const present = await mirrorRevisionsPresent(config, mirror, revisions, cwd, env, execute);
   const missing = revisions.filter((revision) => present.get(revision) !== true);
   if (missing.length === 0) return;
   report({ event: "object-top-up", mirror, condition: missing.join(",") });
-  await fetchFromRemote(config, mirror, ["fetch", "--no-tags", "--quiet", "origin", ...missing], env, execute, retryOptions);
-  const settled = await mirrorRevisionsPresent(config, mirror, missing, env, execute);
+  await fetchFromRemote(config, mirror, ["fetch", "--no-tags", "--quiet", "origin", ...missing], cwd, env, execute, retryOptions);
+  const settled = await mirrorRevisionsPresent(config, mirror, missing, cwd, env, execute);
   const absent = missing.filter((revision) => settled.get(revision) !== true);
   // Not a RepoMirrorError: the mirror did what it was asked and the remote came
   // back without the object. Rebuilding the mirror would not change that answer.
-  if (absent.length > 0) {
-    throw new Error(`Recorded commits are absent from the remote: ${absent.join(", ")}`);
-  }
+  if (absent.length > 0) throw new Error(`Recorded commits are absent from the remote: ${absent.join(", ")}`);
 };
 
 /** Whether the mirror carries this branch. Read after a refresh, this is the
@@ -362,11 +392,14 @@ export const mirrorHasBranch = async (
   config: RunnerConfig,
   mirror: string,
   branch: string,
+  cwd: string,
   env: NodeJS.ProcessEnv,
   execute: MirrorCommandExecutor,
 ): Promise<boolean> => {
   const reference = `refs/heads/${branch}`;
-  const listed = await execute(config, "git", ["for-each-ref", "--format=%(refname)", reference], mirror, env);
+  const listed = await execute(
+    config, "git", ["for-each-ref", "--format=%(refname)", reference], cwd, gitEnvironment(env, mirror),
+  );
   return listed.split("\n").includes(reference);
 };
 
@@ -374,10 +407,14 @@ export const mirrorHasBranch = async (
  * Refresh (or create) the mirror for `remoteUrl` and run `use` against it while
  * the machine-wide lock is still held, so nothing repacks the object database
  * while a workspace is being cloned out of it.
+ *
+ * `cwd` must be a directory the runner daemon's own uid can enter: node chdirs
+ * into it before the run-as prefix executes. The workspace root is one.
  */
 export const withRepoMirror = async <T>(
   config: RunnerConfig,
   remoteUrl: string,
+  cwd: string,
   env: NodeJS.ProcessEnv,
   execute: MirrorCommandExecutor,
   options: RepoMirrorOptions,
@@ -386,24 +423,27 @@ export const withRepoMirror = async <T>(
   const started = Date.now();
   const report = options.report ?? progressReporter;
   const retryOptions = options.fetchRetryOptions ?? {};
-  const root = await ensureMirrorRoot(config, options);
+  const staleMinutes = options.lockStaleMinutes ?? MIRROR_LOCK_STALE_MINUTES;
+  const root = resolve(options.mirrorRoot ?? repoMirrorRoot(config));
+  const workspaceRoot = resolve(config.workspaceRoot);
+  if (insideOrEqual(root, workspaceRoot) || insideOrEqual(workspaceRoot, root)) {
+    throw new Error(`Runner repository mirror root ${root} overlaps the workspace root ${workspaceRoot}`);
+  }
+  await shell(config, execute, cwd, env, ENSURE_ROOT, root, String(staleMinutes));
   const mirror = repoMirrorPath(root, remoteUrl);
-  const release = await acquireMirrorLock(`${mirror}.lock`, config.runnerId ?? "runner", options, report);
+  const release = await acquireMirrorLock(
+    config, execute, cwd, env, `${mirror}.lock`, config.runnerId, options, report,
+  );
   try {
-    let exists = true;
-    try {
-      await lstat(mirror);
-    } catch (error: unknown) {
-      if (errorCode(error) !== "ENOENT") throw error;
-      exists = false;
-    }
-    if (exists) {
-      await validateMirror(config, mirror, remoteUrl, env, execute);
-      await configureMirror(config, mirror, env, execute);
-      await fetchFromRemote(config, mirror, [...REFRESH_ARGS], env, execute, retryOptions);
+    const state = await shell(config, execute, cwd, env, PROBE, mirror);
+    if (state === "unusable") throw new RepoMirrorError(mirror, "not-a-directory");
+    if (state === "present") {
+      await validateMirror(config, mirror, remoteUrl, cwd, env, execute);
+      await configureMirror(config, mirror, cwd, env, execute);
+      await fetchFromRemote(config, mirror, [...REFRESH_ARGS], cwd, env, execute, retryOptions);
       report({ event: "refreshed", mirror });
     } else {
-      await createMirror(config, root, mirror, remoteUrl, env, execute, retryOptions);
+      await createMirror(config, root, mirror, remoteUrl, cwd, env, execute, retryOptions, report);
       report({ event: "created", mirror });
     }
     return await use(mirror);

--- a/packages/runner/src/repo-mirror.ts
+++ b/packages/runner/src/repo-mirror.ts
@@ -1,0 +1,399 @@
+import { createHash } from "node:crypto";
+import { chmod, lstat, mkdir, mkdtemp, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve, sep } from "node:path";
+
+import type { RunnerConfig } from "./config.js";
+import type { CommandOptions } from "./exec.js";
+import {
+  CLONE_COMMAND_TIMEOUT_MS, CLONE_OPERATION_BUDGET_MS, runWithNetworkRetry, type RetryOptions,
+} from "./network-retry.js";
+
+/**
+ * A persistent, machine-local bare mirror of every remote this runner
+ * provisions from.
+ *
+ * Provisioning used to clone the whole repository from GitHub for every single
+ * run. On 2026-08-25 that clone measured 125.9s against a 120s command ceiling,
+ * so a structurally flaky exit turned every provision into a timeout, a retry,
+ * and eventually a failed run: one chain spent 3h04m with a 47% infrastructure
+ * failure rate. Raising the ceiling was rejected — it moves the wall without
+ * removing it.
+ *
+ * What removes it is transferring the history once. The mirror is created on
+ * the first run that needs it and afterwards only ever receives an *incremental*
+ * fetch, which is proportional to what changed rather than to the repository.
+ * Run workspaces then clone from local disk, where there is no exit to shake.
+ *
+ * Two properties are deliberate and load-bearing:
+ *
+ * - The remote fetch keeps the clone retry profile from network-retry.ts. The
+ *   first fetch into an empty mirror transfers exactly what a clone did, so it
+ *   needs the same bound; later fetches are far smaller and finish well inside
+ *   it.
+ * - A mirror that exists but cannot be verified is a hard failure
+ *   (`RepoMirrorError`), never a quiet fall back to a full remote clone. The
+ *   fallback is precisely the behaviour this module exists to eliminate, and a
+ *   silent one would restore it on exactly the machines whose mirror broke —
+ *   invisibly, run after run.
+ */
+
+export type MirrorCommandExecutor = (
+  config: RunnerConfig,
+  executable: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  options?: CommandOptions,
+) => Promise<string>;
+
+export type RepoMirrorProgress = {
+  event: "created" | "refreshed" | "object-top-up" | "lock-wait" | "lock-takeover" | "elapsed";
+  mirror?: string;
+  condition?: string;
+  elapsedMs?: number;
+};
+
+export type RepoMirrorOptions = {
+  mirrorRoot?: string;
+  /** Retry budget for the remote fetches; defaults to the clone profile. */
+  fetchRetryOptions?: RetryOptions;
+  lockWaitMs?: number;
+  lockStaleMs?: number;
+  lockPollMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  report?: (progress: RepoMirrorProgress) => void;
+};
+
+/**
+ * The lock is held across the mirror fetch *and* the workspace clone that reads
+ * it, so a concurrent runner on the same machine cannot repack the object
+ * database out from under a clone. Waiting is the correct behaviour rather than
+ * a failure: the holder is bounded by the clone budget, and the wait replaces a
+ * remote clone that cost longer than this on a bad day.
+ */
+const MIRROR_LOCK_WAIT_MS = 600_000;
+
+/**
+ * A lock older than this belonged to a process that died holding it. It is
+ * comfortably above the longest legitimate hold — one clone-profile fetch
+ * (300s) plus a local clone — so a takeover cannot race a live holder.
+ */
+const MIRROR_LOCK_STALE_MS = 900_000;
+const MIRROR_LOCK_POLL_MS = 500;
+
+/** Bare mirrors hold no secret: every account that can run a task can clone the
+ *  repository anyway. They must be world-traversable *and* listable, because a
+ *  clone under RUNNER_RUN_AS_PREFIX runs as another account and git enumerates
+ *  the pack directory. */
+const MIRROR_DIRECTORY_MODE = 0o755;
+
+export class RepoMirrorError extends Error {
+  readonly mirrorPath: string;
+  readonly condition: string;
+
+  constructor(mirrorPath: string, condition: string, options: { cause?: unknown } = {}) {
+    super(
+      `Runner repository mirror ${mirrorPath} is unusable (${condition}). `
+      + "Provisioning refuses to fall back to a full remote clone; remove that directory "
+      + "to have the next run rebuild the mirror from scratch.",
+      options,
+    );
+    this.name = "RepoMirrorError";
+    this.mirrorPath = mirrorPath;
+    this.condition = condition;
+  }
+}
+
+const errorCode = (error: unknown): string | undefined => (error as NodeJS.ErrnoException).code;
+
+const insideOrEqual = (root: string, candidate: string): boolean =>
+  candidate === root || candidate.startsWith(`${root}${sep}`);
+
+const progressReporter = (progress: RepoMirrorProgress): void => {
+  console.log(JSON.stringify({ audit: "repo-mirror", ...progress }));
+};
+
+const defaultSleep = (ms: number): Promise<void> => new Promise<void>((done) => { setTimeout(done, ms); });
+
+/** Where this runner keeps its mirrors. Beside the workspace root by default,
+ *  exactly like the dependency cache, so one operator decision about disk
+ *  placement covers every runner-owned durable directory. */
+export const repoMirrorRoot = (config: Pick<RunnerConfig, "workspaceRoot" | "repoMirrorRoot">): string =>
+  config.repoMirrorRoot ?? join(dirname(resolve(config.workspaceRoot)), "repo-mirrors");
+
+/** One directory per remote URL. The digest, not the URL, is the name: remote
+ *  URLs contain characters a path cannot hold, and a digest cannot collide with
+ *  the lock or staging entries beside it. The mirror's own
+ *  `remote.origin.url` is what an operator reads to identify it, and this
+ *  module verifies that field on every use. */
+export const repoMirrorPath = (root: string, remoteUrl: string): string =>
+  join(root, `${createHash("sha256").update(remoteUrl).digest("hex")}.git`);
+
+const ensureMirrorRoot = async (config: RunnerConfig, options: RepoMirrorOptions): Promise<string> => {
+  const requested = resolve(options.mirrorRoot ?? repoMirrorRoot(config));
+  await mkdir(requested, { recursive: true, mode: MIRROR_DIRECTORY_MODE });
+  if ((await lstat(requested)).isSymbolicLink()) throw new Error(`Runner repository mirror root is a symlink: ${requested}`);
+  const root = await realpath(requested);
+  const workspaceRoot = resolve(config.workspaceRoot);
+  if (insideOrEqual(root, workspaceRoot) || insideOrEqual(workspaceRoot, root)) {
+    throw new Error(`Runner repository mirror root ${root} overlaps the workspace root ${workspaceRoot}`);
+  }
+  await chmod(root, MIRROR_DIRECTORY_MODE);
+  return root;
+};
+
+const acquireMirrorLock = async (
+  lockPath: string,
+  owner: string,
+  options: RepoMirrorOptions,
+  report: (progress: RepoMirrorProgress) => void,
+): Promise<() => Promise<void>> => {
+  const now = options.now ?? ((): number => Date.now());
+  const sleep = options.sleep ?? defaultSleep;
+  const waitMs = options.lockWaitMs ?? MIRROR_LOCK_WAIT_MS;
+  const staleMs = options.lockStaleMs ?? MIRROR_LOCK_STALE_MS;
+  const pollMs = options.lockPollMs ?? MIRROR_LOCK_POLL_MS;
+  const deadline = now() + waitMs;
+  let waited = false;
+  for (;;) {
+    try {
+      // mkdir is the atomic operation: exactly one caller creates it, everyone
+      // else gets EEXIST. No lock file content participates in the decision.
+      await mkdir(lockPath, { mode: MIRROR_DIRECTORY_MODE });
+      const release = async (): Promise<void> => { await rm(lockPath, { recursive: true, force: true }); };
+      try {
+        await writeFile(join(lockPath, "owner"), `${owner}\n`, { mode: 0o644 });
+      } catch (error: unknown) {
+        await release();
+        throw error;
+      }
+      return release;
+    } catch (error: unknown) {
+      if (errorCode(error) !== "EEXIST") throw error;
+    }
+    const held = await lstat(lockPath).catch((error: unknown) => {
+      if (errorCode(error) === "ENOENT") return null;
+      throw error;
+    });
+    if (held === null) continue;
+    if (now() - held.mtimeMs > staleMs) {
+      // The holder cannot still be alive: every operation under this lock is
+      // bounded well below the staleness threshold.
+      report({ event: "lock-takeover", mirror: lockPath, elapsedMs: Math.round(now() - held.mtimeMs) });
+      await rm(lockPath, { recursive: true, force: true });
+      continue;
+    }
+    if (now() >= deadline) {
+      throw new Error(
+        `Timed out after ${waitMs}ms waiting for the runner repository mirror lock ${lockPath}; `
+        + "another run on this machine is still refreshing or reading the mirror.",
+      );
+    }
+    if (!waited) {
+      waited = true;
+      report({ event: "lock-wait", mirror: lockPath });
+    }
+    await sleep(pollMs);
+  }
+};
+
+const fetchFromRemote = async (
+  config: RunnerConfig,
+  mirror: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  execute: MirrorCommandExecutor,
+  retryOptions: RetryOptions,
+): Promise<void> => {
+  // The clone profile, not delivery's. The first fetch into an empty mirror
+  // moves the same bytes a clone did; every later one is incremental. Both run
+  // while the runner heartbeat holds the lease, so the bound only has to
+  // separate "hung" from "slow".
+  await runWithNetworkRetry("git", args,
+    ({ timeoutMs }) => execute(config, "git", args, mirror, env, { timeoutMs }),
+    { commandTimeoutMs: CLONE_COMMAND_TIMEOUT_MS, budgetMs: CLONE_OPERATION_BUDGET_MS, ...retryOptions },
+  );
+};
+
+const REFRESH_ARGS = ["fetch", "--prune", "--prune-tags", "--tags", "--quiet", "origin"] as const;
+
+const configureMirror = async (
+  config: RunnerConfig,
+  mirror: string,
+  env: NodeJS.ProcessEnv,
+  execute: MirrorCommandExecutor,
+): Promise<void> => {
+  // Heads only: GitHub advertises refs/pull/*, which no run has ever needed and
+  // which would make every fetch pay for the repository's whole review history.
+  await execute(config, "git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"], mirror, env);
+  // Every object git writes here gets 0644 (directories 0755) whatever the
+  // daemon's umask is. Without it, a restrictive umask would make the mirror
+  // unreadable to the account a RUNNER_RUN_AS_PREFIX deployment clones as —
+  // and only on the machines that set one.
+  await execute(config, "git", ["config", "core.sharedRepository", "0644"], mirror, env);
+  // Blind-review provisioning fetches an exact object id out of this mirror.
+  // upload-pack refuses unadvertised objects by default, and the refusal would
+  // read as a mirror fault rather than as the policy it is.
+  await execute(config, "git", ["config", "uploadpack.allowAnySHA1InWant", "true"], mirror, env);
+};
+
+const createMirror = async (
+  config: RunnerConfig,
+  root: string,
+  mirror: string,
+  remoteUrl: string,
+  env: NodeJS.ProcessEnv,
+  execute: MirrorCommandExecutor,
+  retryOptions: RetryOptions,
+): Promise<void> => {
+  // Staged beside the destination and renamed only after the first fetch
+  // succeeds, so an interrupted creation can never leave a directory that later
+  // runs would mistake for a populated mirror.
+  const staging = await mkdtemp(join(root, ".stage-"));
+  try {
+    await execute(config, "git", ["init", "--bare", "--quiet", staging], root, env);
+    await execute(config, "git", ["remote", "add", "origin", remoteUrl], staging, env);
+    await configureMirror(config, staging, env, execute);
+    await fetchFromRemote(config, staging, [...REFRESH_ARGS], env, execute, retryOptions);
+    await chmod(staging, MIRROR_DIRECTORY_MODE);
+    await rename(staging, mirror);
+  } finally {
+    await rm(staging, { recursive: true, force: true }).catch(() => undefined);
+  }
+};
+
+const validateMirror = async (
+  config: RunnerConfig,
+  mirror: string,
+  remoteUrl: string,
+  env: NodeJS.ProcessEnv,
+  execute: MirrorCommandExecutor,
+): Promise<void> => {
+  const info = await lstat(mirror);
+  if (info.isSymbolicLink() || !info.isDirectory()) throw new RepoMirrorError(mirror, "not-a-directory");
+  if (await realpath(mirror) !== mirror) throw new RepoMirrorError(mirror, "symlinked-path");
+  let bare: string;
+  let configured: string;
+  try {
+    bare = await execute(config, "git", ["rev-parse", "--is-bare-repository"], mirror, env);
+    configured = await execute(config, "git", ["config", "--get", "remote.origin.url"], mirror, env);
+  } catch (error: unknown) {
+    throw new RepoMirrorError(mirror, "not-a-readable-git-repository", { cause: error });
+  }
+  if (bare !== "true") throw new RepoMirrorError(mirror, "not-a-bare-repository");
+  if (configured !== remoteUrl) throw new RepoMirrorError(mirror, "remote-url-mismatch");
+};
+
+/**
+ * Which of `revisions` the mirror already has, resolved in one batch.
+ *
+ * `--batch-check` answers "missing" on its stdout instead of failing, so
+ * absence never has to be inferred from a non-zero exit — which is what keeps a
+ * genuinely broken object database from being read as "not fetched yet".
+ */
+export const mirrorRevisionsPresent = async (
+  config: RunnerConfig,
+  mirror: string,
+  revisions: readonly string[],
+  env: NodeJS.ProcessEnv,
+  execute: MirrorCommandExecutor,
+): Promise<Map<string, boolean>> => {
+  if (revisions.length === 0) return new Map();
+  const output = await execute(
+    config, "git", ["cat-file", "--batch-check=%(objectname) %(objecttype)"], mirror, env,
+    { input: `${revisions.join("\n")}\n` },
+  );
+  const lines = output.split("\n");
+  if (lines.length !== revisions.length) {
+    throw new RepoMirrorError(mirror, `object-probe-unreadable:${lines.length}-of-${revisions.length}`);
+  }
+  return new Map(revisions.map((revision, index) => [revision, !(lines[index] ?? "").endsWith(" missing")]));
+};
+
+/**
+ * Make the mirror hold every listed object id, topping up from the remote when
+ * one is absent. A run's pinned base is pushed by an earlier run, so a mirror
+ * refreshed moments ago normally has it already; a top-up covers the ref that
+ * was deleted upstream after the object was recorded.
+ *
+ * A top-up that does not produce the object is a hard failure. It is the one
+ * place where "just clone it from GitHub instead" would be tempting, and the
+ * one place where doing so would hide a real inconsistency between the control
+ * plane's recorded history and the remote's.
+ */
+export const ensureMirrorRevisions = async (
+  config: RunnerConfig,
+  mirror: string,
+  revisions: readonly string[],
+  env: NodeJS.ProcessEnv,
+  execute: MirrorCommandExecutor,
+  retryOptions: RetryOptions = {},
+  report: (progress: RepoMirrorProgress) => void = progressReporter,
+): Promise<void> => {
+  const present = await mirrorRevisionsPresent(config, mirror, revisions, env, execute);
+  const missing = revisions.filter((revision) => present.get(revision) !== true);
+  if (missing.length === 0) return;
+  report({ event: "object-top-up", mirror, condition: missing.join(",") });
+  await fetchFromRemote(config, mirror, ["fetch", "--no-tags", "--quiet", "origin", ...missing], env, execute, retryOptions);
+  const settled = await mirrorRevisionsPresent(config, mirror, missing, env, execute);
+  const absent = missing.filter((revision) => settled.get(revision) !== true);
+  if (absent.length > 0) throw new RepoMirrorError(mirror, `object-absent-on-remote:${absent.join(",")}`);
+};
+
+/** Whether the mirror carries this branch. Read after a refresh, this is the
+ *  same truth an `ls-remote` would have returned, without the round trip. */
+export const mirrorHasBranch = async (
+  config: RunnerConfig,
+  mirror: string,
+  branch: string,
+  env: NodeJS.ProcessEnv,
+  execute: MirrorCommandExecutor,
+): Promise<boolean> => {
+  const reference = `refs/heads/${branch}`;
+  const listed = await execute(config, "git", ["for-each-ref", "--format=%(refname)", reference], mirror, env);
+  return listed.split("\n").includes(reference);
+};
+
+/**
+ * Refresh (or create) the mirror for `remoteUrl` and run `use` against it while
+ * the machine-wide lock is still held, so nothing repacks the object database
+ * while a workspace is being cloned out of it.
+ */
+export const withRepoMirror = async <T>(
+  config: RunnerConfig,
+  remoteUrl: string,
+  env: NodeJS.ProcessEnv,
+  execute: MirrorCommandExecutor,
+  options: RepoMirrorOptions,
+  use: (mirror: string) => Promise<T>,
+): Promise<T> => {
+  const started = Date.now();
+  const report = options.report ?? progressReporter;
+  const retryOptions = options.fetchRetryOptions ?? {};
+  const root = await ensureMirrorRoot(config, options);
+  const mirror = repoMirrorPath(root, remoteUrl);
+  const release = await acquireMirrorLock(`${mirror}.lock`, config.runnerId ?? "runner", options, report);
+  try {
+    let exists = true;
+    try {
+      await lstat(mirror);
+    } catch (error: unknown) {
+      if (errorCode(error) !== "ENOENT") throw error;
+      exists = false;
+    }
+    if (exists) {
+      await validateMirror(config, mirror, remoteUrl, env, execute);
+      await configureMirror(config, mirror, env, execute);
+      await fetchFromRemote(config, mirror, [...REFRESH_ARGS], env, execute, retryOptions);
+      report({ event: "refreshed", mirror });
+    } else {
+      await createMirror(config, root, mirror, remoteUrl, env, execute, retryOptions);
+      report({ event: "created", mirror });
+    }
+    return await use(mirror);
+  } finally {
+    await release();
+    report({ event: "elapsed", mirror, elapsedMs: Date.now() - started });
+  }
+};

--- a/packages/runner/src/repo-mirror.ts
+++ b/packages/runner/src/repo-mirror.ts
@@ -1,5 +1,5 @@
-import { createHash } from "node:crypto";
-import { chmod, lstat, mkdir, mkdtemp, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
+import { chmod, lstat, mkdir, mkdtemp, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve, sep } from "node:path";
 
 import type { RunnerConfig } from "./config.js";
@@ -161,14 +161,23 @@ const acquireMirrorLock = async (
       // mkdir is the atomic operation: exactly one caller creates it, everyone
       // else gets EEXIST. No lock file content participates in the decision.
       await mkdir(lockPath, { mode: MIRROR_DIRECTORY_MODE });
-      const release = async (): Promise<void> => { await rm(lockPath, { recursive: true, force: true }); };
+      const held = `${owner}:${process.pid}:${randomUUID()}\n`;
+      const ownerFile = join(lockPath, "owner");
+      const discard = async (): Promise<void> => { await rm(lockPath, { recursive: true, force: true }); };
       try {
-        await writeFile(join(lockPath, "owner"), `${owner}\n`, { mode: 0o644 });
+        await writeFile(ownerFile, held, { mode: 0o644 });
       } catch (error: unknown) {
-        await release();
+        await discard();
         throw error;
       }
-      return release;
+      // Release removes this lock, not whatever lock happens to be at the path.
+      // Without the check, a holder that was declared stale and taken over would
+      // delete its successor's lock on the way out, and the mirror would end up
+      // with two writers and no lock at all.
+      return async (): Promise<void> => {
+        const current = await readFile(ownerFile, "utf8").catch(() => "");
+        if (current === held) await discard();
+      };
     } catch (error: unknown) {
       if (errorCode(error) !== "EEXIST") throw error;
     }
@@ -230,7 +239,9 @@ const configureMirror = async (
   // Every object git writes here gets 0644 (directories 0755) whatever the
   // daemon's umask is. Without it, a restrictive umask would make the mirror
   // unreadable to the account a RUNNER_RUN_AS_PREFIX deployment clones as —
-  // and only on the machines that set one.
+  // and only on the machines that set one. `git init --shared` covers the
+  // directories init creates; this covers every write after it, and re-asserts
+  // the setting on a mirror whose configuration was edited by hand.
   await execute(config, "git", ["config", "core.sharedRepository", "0644"], mirror, env);
   // Blind-review provisioning fetches an exact object id out of this mirror.
   // upload-pack refuses unadvertised objects by default, and the refusal would
@@ -252,7 +263,7 @@ const createMirror = async (
   // runs would mistake for a populated mirror.
   const staging = await mkdtemp(join(root, ".stage-"));
   try {
-    await execute(config, "git", ["init", "--bare", "--quiet", staging], root, env);
+    await execute(config, "git", ["init", "--bare", "--shared=0644", "--quiet", staging], root, env);
     await execute(config, "git", ["remote", "add", "origin", remoteUrl], staging, env);
     await configureMirror(config, staging, env, execute);
     await fetchFromRemote(config, staging, [...REFRESH_ARGS], env, execute, retryOptions);
@@ -338,7 +349,11 @@ export const ensureMirrorRevisions = async (
   await fetchFromRemote(config, mirror, ["fetch", "--no-tags", "--quiet", "origin", ...missing], env, execute, retryOptions);
   const settled = await mirrorRevisionsPresent(config, mirror, missing, env, execute);
   const absent = missing.filter((revision) => settled.get(revision) !== true);
-  if (absent.length > 0) throw new RepoMirrorError(mirror, `object-absent-on-remote:${absent.join(",")}`);
+  // Not a RepoMirrorError: the mirror did what it was asked and the remote came
+  // back without the object. Rebuilding the mirror would not change that answer.
+  if (absent.length > 0) {
+    throw new Error(`Recorded commits are absent from the remote: ${absent.join(", ")}`);
+  }
 };
 
 /** Whether the mirror carries this branch. Read after a refresh, this is the

--- a/packages/runner/src/repo-mirror.ts
+++ b/packages/runner/src/repo-mirror.ts
@@ -176,8 +176,15 @@ const PROBE = 'if [ -L "$1" ]; then printf unusable;'
 // mkdir is the atomic acquisition. The steal is a rename, which is the other
 // atomic operation: two contenders that both judge a lock dead cannot both
 // succeed, so the loser retries instead of deleting the winner's fresh lock.
-const ACQUIRE = 'if mkdir "$1" 2>/dev/null; then printf %s "$2" > "$1/owner" && printf acquired;'
-  + ' elif [ -n "$(find "$1" -maxdepth 0 -mmin +"$3" 2>/dev/null)" ]; then'
+//
+// A lock whose owner file could not be written is removed rather than left for
+// the staleness path: it would otherwise block every run on this machine for
+// the whole stale window over a failure that is already known here. Anything at
+// the path that is not a directory was never a lock — only a heartbeat that
+// raced its own release can put a file there — and is stolen on sight.
+const ACQUIRE = 'if mkdir "$1" 2>/dev/null; then'
+  + ' if printf %s "$2" > "$1/owner"; then printf acquired; else rm -rf "$1"; exit 1; fi;'
+  + ' elif [ ! -d "$1" ] || [ -n "$(find "$1" -maxdepth 0 -mmin +"$3" 2>/dev/null)" ]; then'
   + ' if mv "$1" "$1.dead.$$" 2>/dev/null; then rm -rf "$1.dead.$$"; printf stolen; else printf held; fi;'
   + ' else printf held; fi';
 
@@ -211,7 +218,10 @@ const acquireMirrorLock = async (
       // this, the staleness threshold would have to bound the uncapped local
       // clone under the lock — and a suspended machine bounds nothing.
       const heartbeat = setInterval(() => {
-        void shell(config, execute, cwd, env, 'touch "$1" 2>/dev/null || true', lockPath).catch(() => undefined);
+        // Guarded: an unguarded touch that lost a race with its own release
+        // would create a *file* where the lock directory was, and no later
+        // mkdir could acquire it.
+        void shell(config, execute, cwd, env, 'if [ -d "$1" ]; then touch "$1"; fi', lockPath).catch(() => undefined);
       }, heartbeatMs);
       heartbeat.unref?.();
       return async (): Promise<void> => {

--- a/packages/runner/src/repo-mirror.ts
+++ b/packages/runner/src/repo-mirror.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
-import { join, resolve, sep } from "node:path";
+import { realpathSync } from "node:fs";
+import { dirname, join, resolve, sep } from "node:path";
 
 import type { RunnerConfig } from "./config.js";
 import type { CommandOptions } from "./exec.js";
@@ -92,6 +93,16 @@ const MIRROR_LOCK_WAIT_MS = 600_000;
  * so this is a liveness signal rather than a guess about how long the work
  * takes — which matters because the local clone under the lock is deliberately
  * uncapped, and a laptop can suspend in the middle of one.
+ *
+ * A holder that stays alive but stops being scheduled for ten consecutive
+ * heartbeats is still stolen from, and no ordering of shell operations closes
+ * that: mutual exclusion built out of mkdir and mv bottoms out in "the lock
+ * looks dead". What makes it affordable is that the lock is an efficiency
+ * device and not the correctness barrier. Git is the barrier: concurrent
+ * fetches into one bare repository contend on ref locks and fail loudly, and
+ * nothing here prunes objects out from under a concurrent clone. The cost of a
+ * wrong steal is duplicated work or a visible git error, never a silently
+ * corrupt mirror.
  */
 const MIRROR_LOCK_STALE_MINUTES = 5;
 const MIRROR_LOCK_HEARTBEAT_MS = 30_000;
@@ -116,6 +127,32 @@ export class RepoMirrorError extends Error {
 
 const insideOrEqual = (root: string, candidate: string): boolean =>
   candidate === root || candidate.startsWith(`${root}${sep}`);
+
+/**
+ * The path as the filesystem sees it: symlinked ancestors resolved, and on a
+ * case-insensitive filesystem the case the directory actually has. A textual
+ * comparison would let `/srv/alias/mirrors` sit inside `/srv/runs` unnoticed
+ * whenever `/srv/alias` points at `/srv/runs`.
+ *
+ * Neither root need exist yet, and the daemon's own uid cannot traverse a 0700
+ * task home, so this walks up to whatever ancestor it can read and leaves the
+ * rest textual. That makes the overlap check sharper than it was, not exact —
+ * it is a tripwire for operator misconfiguration, and the paths it guards come
+ * from RUNNER_WORKSPACE_ROOT and RUNNER_REPO_MIRROR_ROOT.
+ */
+const canonicalize = (path: string): string => {
+  const absolute = resolve(path);
+  for (let ancestor = absolute, suffix = ""; ;) {
+    try {
+      return suffix ? join(realpathSync(ancestor), suffix) : realpathSync(ancestor);
+    } catch {
+      const parent = dirname(ancestor);
+      if (parent === ancestor) return absolute;
+      suffix = suffix ? join(ancestor.slice(parent.length + 1), suffix) : ancestor.slice(parent.length + 1);
+      ancestor = parent;
+    }
+  }
+};
 
 const progressReporter = (progress: RepoMirrorProgress): void => {
   console.log(JSON.stringify({ audit: "repo-mirror", ...progress }));
@@ -166,7 +203,11 @@ const ENSURE_ROOT = 'mkdir -p "$1" && chmod 700 "$1" && [ ! -L "$1" ] || exit 1;
   // Staging left behind by a process that died between mktemp and mv. Nothing
   // else may remove it: a *live* creation for a different remote holds a
   // different lock and is not covered by this one.
-  + ' find "$1" -maxdepth 1 -name ".stage-*" -mmin +"$2" -exec rm -rf {} + 2>/dev/null; exit 0';
+  + ' find "$1" -maxdepth 1 -name ".stage-*" -mmin +"$2" -exec rm -rf {} + 2>/dev/null;'
+  // What the sweep could not remove is named rather than swallowed: a
+  // permission, ACL or read-only-filesystem failure here leaks a whole
+  // repository copy per crash, and an exit status alone would not say which.
+  + ' find "$1" -maxdepth 1 -name ".stage-*" -mmin +"$2" -print 2>/dev/null; exit 0';
 
 const PROBE = 'if [ -L "$1" ]; then printf unusable;'
   + ' elif [ -d "$1" ]; then printf present;'
@@ -189,7 +230,14 @@ const ACQUIRE = 'if mkdir "$1" 2>/dev/null; then'
   + ' else printf held; fi';
 
 /** Release removes this lock, not whatever lock happens to be at the path: a
- *  holder whose lock was stolen must not delete its successor's. */
+ *  holder whose lock was stolen must not delete its successor's.
+ *
+ *  The read and the removal are two operations, so a holder that is stolen from
+ *  in between them still deletes its successor's lock. That window opens only
+ *  once the lock is already older than the stale threshold, which is the same
+ *  condition as a live holder being stolen from at all — see the note on
+ *  MIRROR_LOCK_STALE_MINUTES for why that costs a loud failure and not a
+ *  corrupt mirror. */
 const RELEASE = 'if [ "$(cat "$1/owner" 2>/dev/null)" = "$2" ]; then rm -rf "$1"; fi';
 
 const acquireMirrorLock = async (
@@ -218,9 +266,11 @@ const acquireMirrorLock = async (
       // this, the staleness threshold would have to bound the uncapped local
       // clone under the lock — and a suspended machine bounds nothing.
       const heartbeat = setInterval(() => {
-        // Guarded: an unguarded touch that lost a race with its own release
-        // would create a *file* where the lock directory was, and no later
-        // mkdir could acquire it.
+        // Guarded because an unguarded touch that lost a race with its own
+        // release would create a *file* where the lock directory was. The test
+        // and the touch are still two operations, so the guard narrows that
+        // window rather than closing it; what closes it is that the next
+        // acquisition steals anything at the path that is not a directory.
         void shell(config, execute, cwd, env, 'if [ -d "$1" ]; then touch "$1"; fi', lockPath).catch(() => undefined);
       }, heartbeatMs);
       heartbeat.unref?.();
@@ -435,11 +485,17 @@ export const withRepoMirror = async <T>(
   const retryOptions = options.fetchRetryOptions ?? {};
   const staleMinutes = options.lockStaleMinutes ?? MIRROR_LOCK_STALE_MINUTES;
   const root = resolve(options.mirrorRoot ?? repoMirrorRoot(config));
-  const workspaceRoot = resolve(config.workspaceRoot);
-  if (insideOrEqual(root, workspaceRoot) || insideOrEqual(workspaceRoot, root)) {
-    throw new Error(`Runner repository mirror root ${root} overlaps the workspace root ${workspaceRoot}`);
+  const canonicalRoot = canonicalize(root);
+  const canonicalWorkspaceRoot = canonicalize(config.workspaceRoot);
+  if (insideOrEqual(canonicalRoot, canonicalWorkspaceRoot) || insideOrEqual(canonicalWorkspaceRoot, canonicalRoot)) {
+    throw new Error(
+      `Runner repository mirror root ${root} overlaps the workspace root ${config.workspaceRoot}`,
+    );
   }
-  await shell(config, execute, cwd, env, ENSURE_ROOT, root, String(staleMinutes));
+  const retained = await shell(config, execute, cwd, env, ENSURE_ROOT, root, String(staleMinutes));
+  for (const staging of retained.split("\n").map((line) => line.trim()).filter(Boolean)) {
+    report({ event: "staging-retained", mirror: staging });
+  }
   const mirror = repoMirrorPath(root, remoteUrl);
   const release = await acquireMirrorLock(
     config, execute, cwd, env, `${mirror}.lock`, config.runnerId, options, report,

--- a/packages/runner/src/run-output.test.ts
+++ b/packages/runner/src/run-output.test.ts
@@ -77,6 +77,9 @@ const seedRemote = async (root: string): Promise<string> => {
   return remote;
 };
 
+// `home` is deliberately not the workspace root: the runner keeps its
+// repository mirror under the former and refuses one that overlaps the latter,
+// which workspace reclamation sweeps.
 const config = (workspaceRoot: string, agentBinary: string): RunnerConfig => ({
   apiUrl: "http://api.invalid",
   runnerToken: "runner-token",
@@ -86,7 +89,7 @@ const config = (workspaceRoot: string, agentBinary: string): RunnerConfig => ({
   leaseSeconds: 60,
   heartbeatIntervalMs: 60_000,
   path: process.env.PATH ?? "/usr/bin:/bin",
-  home: workspaceRoot,
+  home: join(workspaceRoot, "..", "home"),
   workspaceRoot,
   failedWorkspaceRetention: 0,
   workspaceReclaimIntervalMs: 300_000,

--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -7,7 +7,7 @@ import test from "node:test";
 
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
-import { CLONE_COMMAND_TIMEOUT_MS, NETWORK_COMMAND_TIMEOUT_MS } from "./network-retry.js";
+import { CLONE_COMMAND_TIMEOUT_MS } from "./network-retry.js";
 import {
   cleanupAgentScratch, provisionAgentScratch, provisionSessionConfig, provisionWorkspace, sessionConfigBaselineRoot,
   workspaceEnvironment, writeSessionCredentials,
@@ -173,9 +173,10 @@ test("a pinned workspace fetches only the recorded commit and never creates the 
   }
 });
 
-test("workspace clone retries two transient failures and succeeds on the third attempt", async () => {
+test("the mirror fetch retries two transient failures and succeeds on the third attempt", async () => {
   const root = await mkdtemp(join(tmpdir(), "agentos-workspace-retry-"));
   try {
+    let fetchCalls = 0;
     let cloneCalls = 0;
     const config = {
       workspaceRoot: join(root, "workspaces"),
@@ -189,22 +190,38 @@ test("workspace clone retries two transient failures and succeeds on the third a
       run: { id: "run-retry", runNumber: 1, targetBranch: "main", branch: "main" },
     } as ClaimedTask;
     const fake = async (_config: RunnerConfig, executable: string, args: string[]): Promise<string> => {
-      if (executable === "git" && args[0] === "clone") {
-        cloneCalls += 1;
-        if (cloneCalls < 3) throw new Error("fatal: unable to access remote: ECONNRESET");
+      if (executable === "git" && args[0] === "fetch") {
+        fetchCalls += 1;
+        if (fetchCalls < 3) throw new Error("fatal: unable to access remote: ECONNRESET");
       }
+      if (executable === "git" && args[0] === "clone") cloneCalls += 1;
+      if (executable === "git" && args[0] === "for-each-ref") return args[2] ?? "";
       if (executable === "git" && args[0] === "rev-parse") return "base-sha";
       return "";
     };
     const workspace = await provisionWorkspace(config, claim, fake, { wait: async () => undefined });
-    assert.equal(cloneCalls, 3);
+    // The retried operation is now the mirror's fetch. The clone that follows
+    // reads local disk, so retrying it would only repeat a failure that no
+    // amount of waiting can change.
+    assert.equal(fetchCalls, 3);
+    assert.equal(cloneCalls, 1);
     assert.equal(workspace.baseSha, "base-sha");
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test("cloning carries a per-command ceiling while local git commands stay uncapped", async () => {
+type RecordedCommand = { args: string[]; cwd: string; timeoutMs: number | undefined };
+
+const recordingExecutor = (
+  calls: RecordedCommand[],
+  answer: (args: string[]) => string,
+): WorkspaceCommandExecutor => async (_config, _executable, args, cwd, _env, options) => {
+  calls.push({ args, cwd, timeoutMs: options?.timeoutMs });
+  return answer(args);
+};
+
+test("the mirror's remote fetch carries a per-command ceiling while local git commands stay uncapped", async () => {
   const root = await mkdtemp(join(tmpdir(), "agentos-workspace-timeout-"));
   try {
     const config = {
@@ -218,29 +235,42 @@ test("cloning carries a per-command ceiling while local git commands stay uncapp
       repo: { remoteUrl: "https://github.com/acme/app.git", defaultBranch: "main" },
       run: { id: "run-timeout", runNumber: 1, targetBranch: "main", branch: "agentos/task-timeout/run-1" },
     } as ClaimedTask;
-    const ceilings = new Map<string, number | undefined>();
-    const fake: WorkspaceCommandExecutor = async (_config, executable, args, _cwd, _env, options) => {
-      ceilings.set(`${executable} ${args[0]}`, options?.timeoutMs);
-      // Exit 2 from ls-remote: the intended head is not published yet.
-      if (args[0] === "ls-remote") throw new Error("git failed (2): ");
+    const calls: RecordedCommand[] = [];
+    // Only main is published: the intended head's probe finds nothing, exactly
+    // as the `ls-remote` round trip it replaced used to report.
+    const fake = recordingExecutor(calls, (args) => {
+      if (args[0] === "for-each-ref") return args[2] === "refs/heads/main" ? "refs/heads/main" : "";
       if (args[0] === "rev-parse") return "base-sha";
       return "";
-    };
+    });
     await provisionWorkspace(config, claim, fake, { wait: async () => undefined });
-    // Nothing bounds a hung clone before the agent starts, so the two commands
-    // that talk to a remote are capped — the clone generously, because a large
-    // repo is slow rather than hung and provisioning heartbeats cover slow.
-    assert.equal(ceilings.get("git ls-remote"), NETWORK_COMMAND_TIMEOUT_MS);
-    assert.equal(ceilings.get("git clone"), CLONE_COMMAND_TIMEOUT_MS);
-    // ...while checkout of a huge tree is slow, not hung, and stays uncapped.
-    assert.equal(ceilings.get("git rev-parse"), undefined);
-    assert.equal(ceilings.get("git switch"), undefined);
+    const ceiling = (name: string): number | undefined => calls.find(({ args }) => args[0] === name)?.timeoutMs;
+    // The only command still talking to GitHub is the mirror's fetch, and a
+    // hung one is what nothing else bounds before the agent starts.
+    assert.equal(ceiling("fetch"), CLONE_COMMAND_TIMEOUT_MS);
+    // The clone now reads local disk. Capping it would kill a working run on a
+    // large repository to protect against a network that is no longer in play.
+    assert.equal(ceiling("clone"), undefined);
+    assert.equal(ceiling("for-each-ref"), undefined);
+    assert.equal(ceiling("rev-parse"), undefined);
+    assert.equal(ceiling("switch"), undefined);
+    const clone = calls.find(({ args }) => args[0] === "clone");
+    // macOS resolves the temp root through /var -> /private/var; the mirror
+    // root is realpath'd before anything is created under it.
+    const mirrors = join(await realpath(root), "repo-mirrors");
+    assert.equal(clone?.args.at(-2)?.startsWith(mirrors), true, "the clone source must be the mirror");
+    // Delivery pushes to origin: the mirror must not survive as the run's
+    // publication target.
+    assert.deepEqual(
+      calls.find(({ args }) => args[0] === "remote" && args[1] === "set-url")?.args,
+      ["remote", "set-url", "origin", "https://github.com/acme/app.git"],
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test("the pinned-range fetch carries the clone ceiling, not the incremental-fetch one", async () => {
+test("the pinned range is fetched out of the mirror, and only the mirror's own fetch is capped", async () => {
   const root = await mkdtemp(join(tmpdir(), "agentos-workspace-pinned-timeout-"));
   try {
     const config = {
@@ -262,18 +292,23 @@ test("the pinned-range fetch carries the clone ceiling, not the incremental-fetc
         implementationHeadSha: "pinned-sha",
       },
     } as ClaimedTask;
-    const ceilings = new Map<string, number | undefined>();
-    const fake: WorkspaceCommandExecutor = async (_config, executable, args, _cwd, _env, options) => {
-      ceilings.set(`${executable} ${args[0]}`, options?.timeoutMs);
+    const calls: RecordedCommand[] = [];
+    const fake = recordingExecutor(calls, (args) => {
+      if (args[0] === "cat-file") return "impl-base-sha commit\npinned-sha commit";
       if (args[0] === "rev-parse") return "pinned-sha";
       return "";
-    };
+    });
     await provisionWorkspace(config, claim, fake, { wait: async () => undefined });
-    // Into an empty object database this fetch transfers a clone's worth of
-    // history, so it must get the clone profile a slow link needs.
-    assert.equal(ceilings.get("git fetch"), CLONE_COMMAND_TIMEOUT_MS);
-    assert.equal(ceilings.get("git init"), undefined);
-    assert.equal(ceilings.get("git checkout"), undefined);
+    const remoteFetch = calls.find(({ args }) => args[0] === "fetch" && args.includes("origin"));
+    const rangeFetch = calls.find(({ args }) => args[0] === "fetch" && args.includes("pinned-sha"));
+    assert.equal(remoteFetch?.timeoutMs, CLONE_COMMAND_TIMEOUT_MS);
+    // Both endpoints were already in the mirror, so the range is assembled from
+    // local disk: slow on a long history, but it cannot hang.
+    assert.equal(rangeFetch?.timeoutMs, undefined);
+    assert.equal(rangeFetch?.args[2]?.startsWith(join(await realpath(root), "repo-mirrors")), true);
+    assert.equal(calls.some(({ args }) => args[0] === "clone"), false);
+    assert.equal(calls.find(({ args }) => args[0] === "init" && args.length === 1)?.timeoutMs, undefined);
+    assert.equal(calls.find(({ args }) => args[0] === "checkout")?.timeoutMs, undefined);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { CLONE_COMMAND_TIMEOUT_MS } from "./network-retry.js";
+import { runCommand } from "./exec.js";
 import {
   cleanupAgentScratch, provisionAgentScratch, provisionSessionConfig, provisionWorkspace, sessionConfigBaselineRoot,
   workspaceEnvironment, writeSessionCredentials,
@@ -15,6 +16,18 @@ import {
 } from "./workspace.js";
 
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+
+/**
+ * Faking git means faking a repository, but the mirror's bookkeeping — its
+ * root, its lock, its staging directory — is real filesystem work in a
+ * temporary directory. These executors run that for real and answer only for
+ * `git`, so the lock protocol under test is the production one.
+ */
+const realShell = async (
+  config: RunnerConfig, executable: string, args: string[], cwd: string, env: NodeJS.ProcessEnv,
+): Promise<string | null> => (executable === "/bin/sh"
+  ? runCommand(config.runAsPrefix, executable, args, cwd, env, {})
+  : null);
 
 test("provisioning trusts an already-published intended head after its database ACK was lost", async () => {
   const root = await mkdtemp(join(tmpdir(), "agentos-workspace-publication-"));
@@ -40,7 +53,8 @@ test("provisioning trusts an already-published intended head after its database 
       workspaceRoot: join(root, "workspaces"),
       runAsPrefix: [],
       path: process.env.PATH ?? "/usr/bin:/bin",
-      home: process.env.HOME ?? root,
+      // Never the real home: provisioning keeps its mirror there.
+      home: root,
     } as unknown as RunnerConfig;
     const claim = {
       task: { id: "task-1" },
@@ -90,7 +104,7 @@ test("a resolver-confirmed newer salvage base outranks an existing declared head
     const salvageSha = git(seed, "rev-parse", "HEAD");
     const config = {
       workspaceRoot: join(root, "workspaces"), runAsPrefix: [],
-      path: process.env.PATH ?? "/usr/bin:/bin", home: process.env.HOME ?? root,
+      path: process.env.PATH ?? "/usr/bin:/bin", home: root,
     } as unknown as RunnerConfig;
     const claim = {
       task: { id: "task-1" },
@@ -140,7 +154,8 @@ test("a pinned workspace fetches only the recorded commit and never creates the 
       workspaceRoot: join(root, "workspaces"),
       runAsPrefix: [],
       path: process.env.PATH ?? "/usr/bin:/bin",
-      home: process.env.HOME ?? root,
+      // Never the real home: provisioning keeps its mirror there.
+      home: root,
     } as unknown as RunnerConfig;
     const claim = {
       task: { id: "task-blind" },
@@ -182,14 +197,17 @@ test("the mirror fetch retries two transient failures and succeeds on the third 
       workspaceRoot: join(root, "workspaces"),
       runAsPrefix: [],
       path: process.env.PATH ?? "/usr/bin:/bin",
-      home: process.env.HOME ?? root,
+      // Never the real home: provisioning keeps its mirror there.
+      home: root,
     } as unknown as RunnerConfig;
     const claim = {
       task: { id: "task-retry" },
       repo: { remoteUrl: "https://github.com/acme/app.git", defaultBranch: "main" },
       run: { id: "run-retry", runNumber: 1, targetBranch: "main", branch: "main" },
     } as ClaimedTask;
-    const fake = async (_config: RunnerConfig, executable: string, args: string[]): Promise<string> => {
+    const fake = async (config: RunnerConfig, executable: string, args: string[], cwd: string, env: NodeJS.ProcessEnv): Promise<string> => {
+      const shell = await realShell(config, executable, args, cwd, env);
+      if (shell !== null) return shell;
       if (executable === "git" && args[0] === "fetch") {
         fetchCalls += 1;
         if (fetchCalls < 3) throw new Error("fatal: unable to access remote: ECONNRESET");
@@ -216,9 +234,10 @@ type RecordedCommand = { args: string[]; cwd: string; timeoutMs: number | undefi
 const recordingExecutor = (
   calls: RecordedCommand[],
   answer: (args: string[]) => string,
-): WorkspaceCommandExecutor => async (_config, _executable, args, cwd, _env, options) => {
+): WorkspaceCommandExecutor => async (config, executable, args, cwd, env, options) => {
   calls.push({ args, cwd, timeoutMs: options?.timeoutMs });
-  return answer(args);
+  const shell = await realShell(config, executable, args, cwd, env);
+  return shell ?? answer(args);
 };
 
 test("the mirror's remote fetch carries a per-command ceiling while local git commands stay uncapped", async () => {
@@ -228,7 +247,8 @@ test("the mirror's remote fetch carries a per-command ceiling while local git co
       workspaceRoot: join(root, "workspaces"),
       runAsPrefix: [],
       path: process.env.PATH ?? "/usr/bin:/bin",
-      home: process.env.HOME ?? root,
+      // Never the real home: provisioning keeps its mirror there.
+      home: root,
     } as unknown as RunnerConfig;
     const claim = {
       task: { id: "task-timeout" },
@@ -255,9 +275,7 @@ test("the mirror's remote fetch carries a per-command ceiling while local git co
     assert.equal(ceiling("rev-parse"), undefined);
     assert.equal(ceiling("switch"), undefined);
     const clone = calls.find(({ args }) => args[0] === "clone");
-    // macOS resolves the temp root through /var -> /private/var; the mirror
-    // root is realpath'd before anything is created under it.
-    const mirrors = join(await realpath(root), "repo-mirrors");
+    const mirrors = join(root, ".agentos", "repo-mirrors");
     assert.equal(clone?.args.at(-2)?.startsWith(mirrors), true, "the clone source must be the mirror");
     // Delivery pushes to origin: the mirror must not survive as the run's
     // publication target.
@@ -277,7 +295,8 @@ test("the pinned range is fetched out of the mirror, and only the mirror's own f
       workspaceRoot: join(root, "workspaces"),
       runAsPrefix: [],
       path: process.env.PATH ?? "/usr/bin:/bin",
-      home: process.env.HOME ?? root,
+      // Never the real home: provisioning keeps its mirror there.
+      home: root,
     } as unknown as RunnerConfig;
     const claim = {
       task: { id: "task-pinned-timeout" },
@@ -305,7 +324,7 @@ test("the pinned range is fetched out of the mirror, and only the mirror's own f
     // Both endpoints were already in the mirror, so the range is assembled from
     // local disk: slow on a long history, but it cannot hang.
     assert.equal(rangeFetch?.timeoutMs, undefined);
-    assert.equal(rangeFetch?.args[2]?.startsWith(join(await realpath(root), "repo-mirrors")), true);
+    assert.equal(rangeFetch?.args[2]?.startsWith(join(root, ".agentos", "repo-mirrors")), true);
     assert.equal(calls.some(({ args }) => args[0] === "clone"), false);
     assert.equal(calls.find(({ args }) => args[0] === "init" && args.length === 1)?.timeoutMs, undefined);
     assert.equal(calls.find(({ args }) => args[0] === "checkout")?.timeoutMs, undefined);

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -372,6 +372,14 @@ export const provisionWorkspace = async (
           // source is the mirror, which does carry the chain ref: a fetch
           // transfers only what the requested objects reach, never the mirror's
           // other refs.
+          //
+          // What this has never been is a sandbox. The mirror sits in the
+          // reviewer's own account home, and the reviewer could already fetch
+          // the chain ref straight from GitHub: no runtime reads
+          // Environment.networking, and a session is not isolated from other
+          // processes of its own user (see api/src/onboarding.ts). The property
+          // is that provisioning does not *hand* a blind reviewer its
+          // predecessor's report, and that is what the object-id fetch keeps.
           await ensureMirrorRevisions(
             config, mirror, [implementationBaseSha, pinnedBaseSha], root, env, execute, retryOptions,
           );

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -9,7 +9,7 @@ import { materializeWorkspaceDependencies, type DependencyCacheOptions } from ".
 import { runCommand, type CommandOptions } from "./exec.js";
 import { type RetryOptions } from "./network-retry.js";
 import {
-  ensureMirrorRevisions, mirrorHasBranch, withRepoMirror, RepoMirrorError, type RepoMirrorOptions,
+  ensureMirrorRevisions, mirrorHasBranch, withRepoMirror, type RepoMirrorOptions,
 } from "./repo-mirror.js";
 
 export type Workspace = {
@@ -403,7 +403,10 @@ export const provisionWorkspace = async (
           cloneTarget = branch;
         }
         if (!await mirrorHasBranch(mirrorConfig, mirror, cloneTarget, mirrorEnv, execute)) {
-          throw new RepoMirrorError(mirror, `branch-absent:${cloneTarget}`);
+          // The mirror was pruned against the remote moments ago, so this is the
+          // remote's answer, not a mirror fault: the branch the run was told to
+          // start from does not exist.
+          throw new Error(`Branch ${cloneTarget} is absent from ${claim.repo.remoteUrl}`);
         }
         // Local clone: git hardlinks the object database instead of copying it,
         // which is what turns a two-minute transfer into a disk operation. The

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -343,19 +343,18 @@ export const provisionWorkspace = async (
     const target = claim.run.targetBranch ?? claim.repo.defaultBranch;
     const branch = claim.run.branch ?? `agentos/${claim.task.id}/run-${claim.run.runNumber}`;
     const pinnedBaseSha = claim.run.pinnedBaseSha;
-    // The mirror is daemon-owned and shared by every account on the machine, so
-    // its own git commands never run through the run-as prefix; only the
-    // workspace this function creates belongs to the launched account.
-    const mirrorConfig: RunnerConfig = { ...config, runAsPrefix: [] };
-    const mirrorEnv = workspaceEnvironment(mirrorConfig);
     // Dependencies are materialised after the mirror lock is released: `npm ci`
     // is bounded in half-hours, and holding a machine-wide lock across it would
     // serialise every other run on the host behind an install that never
     // touches the mirror.
+    //
+    // The mirror belongs to the account that runs the task, and `root` is what
+    // the daemon can chdir into before the run-as prefix takes over.
     const provisioned = await withRepoMirror(
-      mirrorConfig,
+      config,
       claim.repo.remoteUrl,
-      mirrorEnv,
+      root,
+      env,
       execute,
       { fetchRetryOptions: retryOptions, ...mirrorOptions },
       async (mirror): Promise<Workspace> => {
@@ -374,7 +373,7 @@ export const provisionWorkspace = async (
           // transfers only what the requested objects reach, never the mirror's
           // other refs.
           await ensureMirrorRevisions(
-            mirrorConfig, mirror, [implementationBaseSha, pinnedBaseSha], mirrorEnv, execute, retryOptions,
+            config, mirror, [implementationBaseSha, pinnedBaseSha], root, env, execute, retryOptions,
           );
           await execute(config, "git", ["init"], workspace, env);
           await execute(config, "git", ["remote", "add", "origin", claim.repo.remoteUrl], workspace, env);
@@ -399,10 +398,10 @@ export const provisionWorkspace = async (
         // the same answer `git ls-remote` used to make a round trip for.
         let cloneTarget = target;
         if (branch !== target && !claim.run.targetBranchPublished
-          && await mirrorHasBranch(mirrorConfig, mirror, branch, mirrorEnv, execute)) {
+          && await mirrorHasBranch(config, mirror, branch, root, env, execute)) {
           cloneTarget = branch;
         }
-        if (!await mirrorHasBranch(mirrorConfig, mirror, cloneTarget, mirrorEnv, execute)) {
+        if (!await mirrorHasBranch(config, mirror, cloneTarget, root, env, execute)) {
           // The mirror was pruned against the remote moments ago, so this is the
           // remote's answer, not a mirror fault: the branch the run was told to
           // start from does not exist.

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -7,9 +7,10 @@ import type { ClaimedTask } from "./api.js";
 import { defaultSessionConfigBaselineRoot, runnerProxyEnvironment, type RunnerConfig, type RunnerKind } from "./config.js";
 import { materializeWorkspaceDependencies, type DependencyCacheOptions } from "./dependency-cache.js";
 import { runCommand, type CommandOptions } from "./exec.js";
+import { type RetryOptions } from "./network-retry.js";
 import {
-  CLONE_COMMAND_TIMEOUT_MS, CLONE_OPERATION_BUDGET_MS, runWithNetworkRetry, type RetryOptions,
-} from "./network-retry.js";
+  ensureMirrorRevisions, mirrorHasBranch, withRepoMirror, RepoMirrorError, type RepoMirrorOptions,
+} from "./repo-mirror.js";
 
 export type Workspace = {
   path: string;
@@ -310,6 +311,7 @@ export const provisionWorkspace = async (
   execute: WorkspaceCommandExecutor = command,
   retryOptions: RetryOptions = {},
   dependencyCacheOptions: DependencyCacheOptions = {},
+  mirrorOptions: RepoMirrorOptions = {},
 ): Promise<Workspace> => {
   const root = resolve(config.workspaceRoot);
   const workspace = resolve(root, claim.run.id);
@@ -341,70 +343,86 @@ export const provisionWorkspace = async (
     const target = claim.run.targetBranch ?? claim.repo.defaultBranch;
     const branch = claim.run.branch ?? `agentos/${claim.task.id}/run-${claim.run.runNumber}`;
     const pinnedBaseSha = claim.run.pinnedBaseSha;
-    if (pinnedBaseSha) {
-      const implementationBaseSha = claim.run.implementationBaseSha;
-      if (!implementationBaseSha || claim.run.implementationHeadSha !== pinnedBaseSha) {
-        throw new Error(`Pinned run ${claim.run.id} is missing its immutable implementation range`);
-      }
-      // A branch clone would advertise and fetch the shared chain ref before a
-      // blind reviewer starts. Build an empty repository, fetch the immutable
-      // implementation range endpoints by object id, and stay detached at its
-      // head. With no fetch of the chain branch, successor commits and their
-      // report artifacts are not reachable from this object database.
-      //
-      // Into an empty object database this fetch transfers the same history a
-      // clone would, so it runs under the clone profile: a large repository is
-      // slow, not hung, and the 20s command ceiling built for incremental
-      // fetches kills every attempt on a slow link.
-      await execute(config, "git", ["init"], workspace, env);
-      await execute(config, "git", ["remote", "add", "origin", claim.repo.remoteUrl], workspace, env);
-      await runWithNetworkRetry("git", ["fetch"],
-        ({ timeoutMs }) => execute(
-          config,
-          "git",
-          ["fetch", "--no-tags", "origin", implementationBaseSha, pinnedBaseSha],
-          workspace,
-          env,
-          { timeoutMs },
-        ),
-        { commandTimeoutMs: CLONE_COMMAND_TIMEOUT_MS, budgetMs: CLONE_OPERATION_BUDGET_MS, ...retryOptions },
-      );
-      await execute(config, "git", ["checkout", "--detach", pinnedBaseSha], workspace, env);
-      const baseSha = await execute(config, "git", ["rev-parse", "HEAD"], workspace, env);
-      if (baseSha !== pinnedBaseSha) {
-        throw new Error(`Pinned workspace resolved ${baseSha}, expected ${pinnedBaseSha}`);
-      }
-      await materializeWorkspaceDependencies(config, workspace, env, execute, dependencyCacheOptions);
-      return { path: workspace, branch, baseSha, pinnedBaseSha };
-    }
-    // The publication ACK is fenced and immediate, but no database protocol can
-    // eliminate a crash between the remote accepting git push and that ACK.
-    // When the run's intended head already exists remotely, clone that durable
-    // truth instead of the stale fallback base. Derived chain heads are unique
-    // per project+chain, so this cannot accidentally adopt another chain.
-    let cloneTarget = target;
-    if (branch !== target && !claim.run.targetBranchPublished) {
-      try {
-        await runWithNetworkRetry("git", ["ls-remote"],
-          ({ timeoutMs }) => execute(config, "git", ["ls-remote", "--exit-code", "--heads", claim.repo.remoteUrl, `refs/heads/${branch}`], root, env, { timeoutMs }),
-          retryOptions,
-        );
-        cloneTarget = branch;
-      } catch {
-        // Exit 2 means the head is absent; clone the resolver-selected fallback.
-      }
-    }
-    // The clone profile, not delivery's: provisioning heartbeats keep the lease
-    // alive, so the ceiling only has to separate "hung" from "slow" — and a
-    // large repo is slow, not hung. See network-retry.ts for the derivation.
-    await runWithNetworkRetry("git", ["clone"],
-      ({ timeoutMs }) => execute(config, "git", ["clone", "--no-local", "--branch", cloneTarget, "--single-branch", claim.repo.remoteUrl, workspace], root, env, { timeoutMs }),
-      { commandTimeoutMs: CLONE_COMMAND_TIMEOUT_MS, budgetMs: CLONE_OPERATION_BUDGET_MS, ...retryOptions },
+    // The mirror is daemon-owned and shared by every account on the machine, so
+    // its own git commands never run through the run-as prefix; only the
+    // workspace this function creates belongs to the launched account.
+    const mirrorConfig: RunnerConfig = { ...config, runAsPrefix: [] };
+    const mirrorEnv = workspaceEnvironment(mirrorConfig);
+    // Dependencies are materialised after the mirror lock is released: `npm ci`
+    // is bounded in half-hours, and holding a machine-wide lock across it would
+    // serialise every other run on the host behind an install that never
+    // touches the mirror.
+    const provisioned = await withRepoMirror(
+      mirrorConfig,
+      claim.repo.remoteUrl,
+      mirrorEnv,
+      execute,
+      { fetchRetryOptions: retryOptions, ...mirrorOptions },
+      async (mirror): Promise<Workspace> => {
+        if (pinnedBaseSha) {
+          const implementationBaseSha = claim.run.implementationBaseSha;
+          if (!implementationBaseSha || claim.run.implementationHeadSha !== pinnedBaseSha) {
+            throw new Error(`Pinned run ${claim.run.id} is missing its immutable implementation range`);
+          }
+          // A branch clone would advertise and fetch the shared chain ref before
+          // a blind reviewer starts. Build an empty repository, fetch the
+          // immutable implementation range endpoints by object id, and stay
+          // detached at its head. With no fetch of the chain branch, successor
+          // commits and their report artifacts are not reachable from this
+          // object database — and fetching by object id keeps that true when the
+          // source is the mirror, which does carry the chain ref: a fetch
+          // transfers only what the requested objects reach, never the mirror's
+          // other refs.
+          await ensureMirrorRevisions(
+            mirrorConfig, mirror, [implementationBaseSha, pinnedBaseSha], mirrorEnv, execute, retryOptions,
+          );
+          await execute(config, "git", ["init"], workspace, env);
+          await execute(config, "git", ["remote", "add", "origin", claim.repo.remoteUrl], workspace, env);
+          // Local transport: slow on a large range, but it cannot hang on a
+          // network that is no longer in the path, so it carries no ceiling.
+          await execute(config, "git", ["fetch", "--no-tags", mirror, implementationBaseSha, pinnedBaseSha], workspace, env);
+          await execute(config, "git", ["checkout", "--detach", pinnedBaseSha], workspace, env);
+          const baseSha = await execute(config, "git", ["rev-parse", "HEAD"], workspace, env);
+          if (baseSha !== pinnedBaseSha) {
+            throw new Error(`Pinned workspace resolved ${baseSha}, expected ${pinnedBaseSha}`);
+          }
+          return { path: workspace, branch, baseSha, pinnedBaseSha };
+        }
+        // The publication ACK is fenced and immediate, but no database protocol
+        // can eliminate a crash between the remote accepting git push and that
+        // ACK. When the run's intended head already exists remotely, clone that
+        // durable truth instead of the stale fallback base. Derived chain heads
+        // are unique per project+chain, so this cannot accidentally adopt
+        // another chain.
+        //
+        // The mirror was pruned against the remote moments ago, so its refs are
+        // the same answer `git ls-remote` used to make a round trip for.
+        let cloneTarget = target;
+        if (branch !== target && !claim.run.targetBranchPublished
+          && await mirrorHasBranch(mirrorConfig, mirror, branch, mirrorEnv, execute)) {
+          cloneTarget = branch;
+        }
+        if (!await mirrorHasBranch(mirrorConfig, mirror, cloneTarget, mirrorEnv, execute)) {
+          throw new RepoMirrorError(mirror, `branch-absent:${cloneTarget}`);
+        }
+        // Local clone: git hardlinks the object database instead of copying it,
+        // which is what turns a two-minute transfer into a disk operation. The
+        // hardlinks survive the mirror repacking later, because unlinking a
+        // packfile the workspace also links does not free it. Where the kernel
+        // refuses the link — Linux protected_hardlinks, with the mirror owned by
+        // the daemon and the clone running as another account — git copies the
+        // file instead. That is still local disk, and still not the remote.
+        await execute(config, "git", ["clone", "--branch", cloneTarget, "--single-branch", mirror, workspace], root, env);
+        // Delivery pushes to `origin`; the mirror is a provisioning detail and
+        // must never become the run's publication target.
+        await execute(config, "git", ["remote", "set-url", "origin", claim.repo.remoteUrl], workspace, env);
+        const baseSha = await execute(config, "git", ["rev-parse", "HEAD"], workspace, env);
+        if (branch !== cloneTarget) await execute(config, "git", ["switch", "-c", branch], workspace, env);
+        return { path: workspace, branch, baseSha };
+      },
     );
-    const baseSha = await execute(config, "git", ["rev-parse", "HEAD"], workspace, env);
-    if (branch !== cloneTarget) await execute(config, "git", ["switch", "-c", branch], workspace, env);
     await materializeWorkspaceDependencies(config, workspace, env, execute, dependencyCacheOptions);
-    return { path: workspace, branch, baseSha };
+    return provisioned;
   } catch (error: unknown) {
     await cleanupWorkspace(config, workspace).catch(() => undefined);
     throw error;


### PR DESCRIPTION
Board card R4 (`cmt9bqj2t00kjmprul4ito1s5`), ruling in `records/BRIEF-zero-gate-rulings-20260825.md`.

## Why

The runner full-cloned the workspace from GitHub on every run. A measured clone took 125.9s against `CLONE_COMMAND_TIMEOUT_MS=120000`, and with flaky egress one chain on 2026-08-25 burned 3h04m at a 47% infrastructure failure rate. Leo ruled out relaxing the timeout: build the mirror instead.

## What

Every runner machine now keeps a persistent bare mirror under `<RUNNER_HOME>/.agentos/repo-mirrors` (override with `RUNNER_REPO_MIRROR_ROOT`). Workspaces are cloned from that mirror — a local clone hardlinks the object database instead of transferring it — and only the mirror's own incremental fetch talks to the remote, carrying the same `network-retry` timeout and retry budget the clone used to carry.

- The mirror belongs to the account that runs the tasks: every git and filesystem operation goes through `RUNNER_RUN_AS_PREFIX`, and git is addressed by `GIT_DIR` because the daemon uid cannot chdir into a 0700 home.
- The mirror fetches `+refs/heads/*:refs/heads/*` and tags, deliberately not GitHub's `refs/pull/*`, and sets `uploadpack.allowAnySHA1InWant` so pinned blind-review provisioning can fetch an exact object id out of it.
- The pinned path keeps its property: it fetches object ids, so successor commits stay unreachable. The clone path resets `origin` back to the GitHub URL, so delivery still pushes to the remote.
- A machine-local lock (atomic `mkdir` acquire, atomic `mv` steal, owner-token-checked release, 30s heartbeat) serialises concurrent runners on one machine. Dependency materialisation runs outside the lock.
- A damaged mirror fails loudly as `RepoMirrorError` with an identifiable condition; there is no silent fallback to a remote full clone. Absence on the remote is a plain error, not a mirror fault.

## Verification

- `node --import tsx --test packages/runner/src/*.test.ts` — 255 tests, 253 pass, 0 fail, 2 skipped
- runner typecheck and repo lint clean
- `MERGE GATE: PASS 55151d1024b882d4a5a3ba0c27f0d4e563974a40`
- Two codex review rounds; every finding re-verified independently before acting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)