### PR TITLE
refactor(db): give the merge-tail markers a module

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -87,23 +87,29 @@ import {
   type CandidateActivity,
   type CardRow,
   type DecisionRow,
-  asJsonObject,
   AUTHORITY_RESIGN_DEDUPE_PREFIX,
   AUTHORITY_RESIGN_OPEN_PREFIX,
   INDEPENDENT_REVIEW_OPEN_PREFIX,
   isMergeReadinessStep,
+  latestMarker,
   MAX_AUTHORITY_RESIGN_ROUNDS,
   MAX_BLOCKING_REVIEW_ROUNDS,
   MERGE_TAIL_KIND,
   MergeRecoveryStatus,
   mergeRecoveryPhase,
+  openReviewObligation,
   parseIndependentReviewDecision,
   parseRegressionVerdict,
   parseResolverResult,
+  readMarkerHistory,
+  readMarkers,
+  recoveryContext,
+  writeMarker,
   RELEASE_AUTHORITY_FILE,
   LEGACY_PRE_ADJUDICATION_TEMPLATE_PREFIX,
   type IndependentReviewFinding,
   type MergeRecoveryAttempt,
+  type RecoveryContext,
 } from "@agentos/db";
 import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
@@ -211,50 +217,6 @@ const isCandidateActivationFailure = (error: unknown): error is CandidateActivat
 
 const namedFailureReason = (error: CandidateActivationFailure): string => `${error.name}: ${error.message}`;
 
-type QueuedBaseDriftRecoveryContext = {
-  aggregateId: string;
-  attempt: number;
-  sourceStopId: string;
-  sourceRunId: string;
-  authorizationActivityId: string;
-  repository: string;
-  prNumber: number;
-  targetBranch: string;
-  authorizedHeadSha: string;
-  authorizedBaseSha: string;
-  observedBaseSha: string;
-  currentBaseSha: string;
-  readinessTaskId: string;
-  regressionTaskId: string;
-  integratorTaskId: string;
-  recoveryRunId: string;
-};
-
-const queuedRecoveryContext = (row: MergeRecoveryAttempt | null): QueuedBaseDriftRecoveryContext | null => {
-  if (!row?.boundSourceRunId || !row.authorizationActivityId || !row.recoveryRunId
-    || !row.readinessTaskId || !row.regressionTaskId || !row.repository
-    || row.prNumber === null || !row.targetBranch || !row.authorizedHeadSha
-    || !row.authorizedBaseSha || !row.observedBaseSha || !row.currentBaseSha) return null;
-  return {
-    aggregateId: row.id,
-    attempt: row.attempt,
-    sourceStopId: row.sourceStopId,
-    sourceRunId: row.boundSourceRunId,
-    authorizationActivityId: row.authorizationActivityId,
-    repository: row.repository,
-    prNumber: row.prNumber,
-    targetBranch: row.targetBranch,
-    authorizedHeadSha: row.authorizedHeadSha,
-    authorizedBaseSha: row.authorizedBaseSha,
-    observedBaseSha: row.observedBaseSha,
-    currentBaseSha: row.currentBaseSha,
-    readinessTaskId: row.readinessTaskId,
-    regressionTaskId: row.regressionTaskId,
-    integratorTaskId: row.integratorTaskId,
-    recoveryRunId: row.recoveryRunId,
-  };
-};
-
 const mergeRecoveryProjection = (row: MergeRecoveryAttempt | null) => row ? ({
   id: row.id,
   attempt: row.attempt,
@@ -272,7 +234,7 @@ const baseDriftRecoveryContext = async (
   regressionTaskId: string,
   recoveryRunId?: string,
   sourceStopId?: string,
-): Promise<QueuedBaseDriftRecoveryContext | null> => {
+): Promise<RecoveryContext | null> => {
   const row = await tx.mergeRecoveryAttempt.findFirst({
     where: {
       regressionTaskId,
@@ -282,12 +244,12 @@ const baseDriftRecoveryContext = async (
     },
     orderBy: [{ attempt: "desc" }, { id: "desc" }],
   });
-  return queuedRecoveryContext(row);
+  return recoveryContext(row);
 };
 
 const stopBaseDriftRecoveryTail = async (
   tx: DbTx,
-  context: QueuedBaseDriftRecoveryContext,
+  context: RecoveryContext,
   phase: "regression" | "independent-review",
   reason: string,
 ): Promise<void> => {
@@ -305,12 +267,10 @@ const stopBaseDriftRecoveryTail = async (
   await tx.inboxMessage.upsert({ where: { dedupeKey }, create: {
     from: "AGENT", taskId: context.regressionTaskId, kind: "TEXT", body, dedupeKey,
   }, update: {} });
-  const metadata = { ...context, kind: MERGE_TAIL_KIND.baseDriftRecovery, schemaVersion: 1,
-    state: "tail-stopped", phase, reason, dedupeKey } as Prisma.InputJsonObject;
-  await tx.taskActivity.createMany({ data: [
-    { taskId: context.integratorTaskId, actorType: "control-plane", body, metadata },
-    { taskId: context.regressionTaskId, actorType: "control-plane", body, metadata },
-  ] });
+  const metadata = { ...context, state: "tail-stopped", phase, reason, dedupeKey };
+  for (const taskId of [context.integratorTaskId, context.regressionTaskId]) {
+    await writeMarker(tx, taskId, "baseDriftRecovery", { actorType: "control-plane", body, metadata });
+  }
 };
 
 /**
@@ -380,19 +340,16 @@ const createReviewFollowUpCard = async (
     opensPullRequest: false,
     status: TaskStatus.BACKLOG,
   } });
-  await tx.taskActivity.create({ data: {
-    taskId: task.id,
+  await writeMarker(tx, task.id, "reviewObligation", {
     actorType: "control-plane",
     body: `Follow-up finding from independent review ${input.reviewTaskId} at ${input.headSha}`,
     metadata: {
-      kind: MERGE_TAIL_KIND.reviewObligation,
-      schemaVersion: 1,
       state: "follow-up",
       reviewTaskId: input.reviewTaskId,
       headSha: input.headSha,
       title: input.finding.title,
     },
-  } });
+  });
   return { taskId: task.id };
 };
 
@@ -532,34 +489,26 @@ const createMergeTailRepairTask = async (
     where: { id: repairRun.id },
     data: { branch: input.sourceRun.branch, targetBranch: input.sourceRun.branch },
   });
-  await tx.taskActivity.createMany({ data: [
-    {
-      taskId: regressionTask.id,
-      actorType: "control-plane",
-      body: `Automatic ${input.repairKind} attempt queued at chain head ${input.headSha} against ${input.baseHeadSha}`,
-      metadata: {
-        kind: MERGE_TAIL_KIND.repairAttempt,
-        schemaVersion: 1,
-        repairKind: input.repairKind,
-        repairTaskId: task.id,
-        headSha: input.headSha,
-        baseHeadSha: input.baseHeadSha,
-      },
+  await writeMarker(tx, regressionTask.id, "repairAttempt", {
+    actorType: "control-plane",
+    body: `Automatic ${input.repairKind} attempt queued at chain head ${input.headSha} against ${input.baseHeadSha}`,
+    metadata: {
+      repairKind: input.repairKind,
+      repairTaskId: task.id,
+      headSha: input.headSha,
+      baseHeadSha: input.baseHeadSha,
     },
-    {
-      taskId: task.id,
-      actorType: "control-plane",
-      body: `Automatic ${input.repairKind} attempt for regression task ${regressionTask.id}`,
-      metadata: {
-        kind: MERGE_TAIL_KIND.repairAttempt,
-        schemaVersion: 1,
-        repairKind: input.repairKind,
-        regressionTaskId: regressionTask.id,
-        headSha: input.headSha,
-        baseHeadSha: input.baseHeadSha,
-      },
+  });
+  await writeMarker(tx, task.id, "repairAttempt", {
+    actorType: "control-plane",
+    body: `Automatic ${input.repairKind} attempt for regression task ${regressionTask.id}`,
+    metadata: {
+      repairKind: input.repairKind,
+      regressionTaskId: regressionTask.id,
+      headSha: input.headSha,
+      baseHeadSha: input.baseHeadSha,
     },
-  ] });
+  });
   await tx.task.update({
     where: { id: regressionTask.id },
     data: { status: TaskStatus.REVIEW, failureReason: `${input.repairKind}: automatic repair ${task.id} queued at ${input.headSha}` },
@@ -588,12 +537,11 @@ export const handleRegressionCompletion = async (
       return "handled";
     }
     await tx.task.update({ where: { id: input.task.id }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-    await tx.taskActivity.create({ data: {
-      taskId: input.task.id,
+    await writeMarker(tx, input.task.id, "regression", {
       actorType: "control-plane",
       body: `Regression did not advance: ${reason}`,
-      metadata: { kind: MERGE_TAIL_KIND.regression, schemaVersion: 1, state: "stopped", reason },
-    } });
+      metadata: { state: "stopped", reason },
+    });
     await openMergeTailStopNotice(tx, { taskId: input.task.id, agentId: input.run.agentId, sessionId: input.run.sessionId, reason });
     return "handled";
   };
@@ -603,12 +551,11 @@ export const handleRegressionCompletion = async (
   if (effectiveHead !== verdict.headSha || output?.commitSha !== verdict.headSha) {
     return stop(`stale regression evidence: verdict ${verdict.headSha}, output ${output?.commitSha ?? "missing"}, run ${effectiveHead ?? "missing"}`);
   }
-  await tx.taskActivity.create({ data: {
-    taskId: input.task.id,
+  await writeMarker(tx, input.task.id, "regression", {
     actorType: "control-plane",
     body: `Regression ${verdict.outcome} recorded for chain head ${verdict.headSha} against target ${verdict.baseHeadSha}`,
-    metadata: { kind: MERGE_TAIL_KIND.regression, ...verdict },
-  } });
+    metadata: { ...verdict },
+  });
   if (verdict.outcome === "pass") {
     if (recovery) {
       await tx.mergeRecoveryAttempt.update({ where: { id: recovery.aggregateId }, data: {
@@ -649,27 +596,21 @@ export const handleRegressionCompletion = async (
       data: { status: TaskStatus.REVIEW, failureReason: `${AUTHORITY_RESIGN_OPEN_PREFIX}${verdict.headSha}` },
     });
     if (parked.count !== 1) {
-      await tx.taskActivity.create({ data: {
-        taskId: input.task.id,
+      await writeMarker(tx, input.task.id, "authorityResign", {
         actorType: "control-plane",
         body: `Release authority re-signature is required at ${verdict.headSha} but this step is no longer the tail's to park`,
         metadata: {
-          kind: MERGE_TAIL_KIND.authorityResign,
-          schemaVersion: 1,
           state: "park-skipped",
           headSha: verdict.headSha,
           summary: verdict.summary,
         },
-      } });
+      });
       return "handled";
     }
-    await tx.taskActivity.create({ data: {
-      taskId: input.task.id,
+    await writeMarker(tx, input.task.id, "authorityResign", {
       actorType: "control-plane",
       body: `Release authority re-signature requested at ${verdict.headSha}: ${verdict.summary}`,
       metadata: {
-        kind: MERGE_TAIL_KIND.authorityResign,
-        schemaVersion: 1,
         state: "open",
         headSha: verdict.headSha,
         baseHeadSha: verdict.baseHeadSha,
@@ -677,7 +618,7 @@ export const handleRegressionCompletion = async (
         round,
         summary: verdict.summary,
       },
-    } });
+    });
     await openAuthorityResignNotice(tx, {
       taskId: input.task.id,
       agentId: input.run.agentId,
@@ -710,17 +651,18 @@ export const handleRegressionCompletion = async (
     return "handled";
   }
 
-  const attempts = await tx.taskActivity.findMany({
-    where: { taskId: input.task.id }, select: { metadata: true }, orderBy: { createdAt: "asc" },
-  });
+  // The whole history, not the recent-state window: one automatic attempt per
+  // repair kind is the rule, and an attempt pushed past the window by later
+  // activity would license a second one.
+  const attempts = await readMarkerHistory(tx, input.task.id);
   const repairKind = verdict.outcome === "refresh-conflict"
     ? "refresh-conflict"
     : verdict.outcome === "review-fail" ? "review-fix" : "gate-fix";
-  const alreadyAttempted = attempts.some((row) => {
-    const metadata = asJsonObject(row.metadata);
-    if (metadata?.kind !== MERGE_TAIL_KIND.repairAttempt || metadata.repairKind !== repairKind) return false;
-    return repairKind !== "refresh-conflict" || metadata.headSha === verdict.headSha;
-  });
+  const alreadyAttempted = attempts.some((marker) => (
+    marker.kind === "repairAttempt"
+    && marker.repairKind === repairKind
+    && (repairKind !== "refresh-conflict" || marker.headSha === verdict.headSha)
+  ));
   if (alreadyAttempted) {
     return stop(repairKind === "refresh-conflict"
       ? `second refresh conflict on chain head ${verdict.headSha}`
@@ -5864,25 +5806,22 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       // envelope's verdict decides *whether* the failure was external; it does
       // not get to raise the ceiling on this step either.
       const mechanical = isIntegratorStep(run.task?.templateStep ?? null);
-      const tailRows = succeeded && run.task
-        && !run.task.templateId && !run.task.chainId
-        ? await tx.taskActivity.findMany({
-            where: { taskId: run.task.id },
-            select: { metadata: true },
-            orderBy: { createdAt: "desc" },
-            take: 20,
-          })
+      const refunded = external && !mechanical ? 1 : 0;
+      const budgetCeiling = run.maxRunsPerTask + refunded;
+      // One marker read for both completion outcomes; this handler used to
+      // declare `tailRows` twice and scan twice. The success path consults it
+      // only for a standalone auxiliary task — an automatic repair or an
+      // independent review, neither of which is a chain step — while the
+      // failure path consults it only for a failure that is not about to be
+      // retried, which is why the ceiling is computed above the read.
+      const failureIsFinal = !succeeded && !(retryable && run.runNumber < budgetCeiling);
+      const tailMarkers = run.task && (failureIsFinal || (succeeded && !run.task.templateId && !run.task.chainId))
+        ? await readMarkers(tx, run.task.id)
         : [];
-      const repairMarker = tailRows.map((row) => asJsonObject(row.metadata)).find((metadata) => (
-        metadata?.kind === MERGE_TAIL_KIND.repairAttempt && typeof metadata.regressionTaskId === "string"
-      ));
-      const reviewMarker = tailRows.map((row) => asJsonObject(row.metadata)).find((metadata) => (
-        metadata?.kind === MERGE_TAIL_KIND.reviewObligation
-        && metadata.state === "open"
-        && typeof metadata.readinessTaskId === "string"
-        && typeof metadata.regressionTaskId === "string"
-      ));
-      const repairRegression = typeof repairMarker?.regressionTaskId === "string"
+      const succeededMarkers = succeeded ? tailMarkers : [];
+      const repairMarker = latestMarker(succeededMarkers, "repairAttempt");
+      const reviewMarker = openReviewObligation(succeededMarkers);
+      const repairRegression = repairMarker?.regressionTaskId
         ? await tx.task.findUnique({
             where: { id: repairMarker.regressionTaskId },
             select: {
@@ -5894,7 +5833,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             },
           })
         : null;
-      const reviewRegression = typeof reviewMarker?.regressionTaskId === "string"
+      const reviewRegression = reviewMarker?.regressionTaskId
         ? await tx.task.findUnique({
             where: { id: reviewMarker.regressionTaskId },
             select: { projectId: true, repoId: true, templateId: true, chainId: true, targetBranch: true },
@@ -5926,14 +5865,13 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             select: { id: true },
           })
         : null;
-      const mergeTailAuxiliary = Boolean(repairMarker || reviewMarker);
-      const auxiliaryTargetTaskId = typeof repairMarker?.regressionTaskId === "string"
+      // An auxiliary task is one whose own marker names the Regression it serves.
+      const mergeTailAuxiliary = Boolean(
+        repairMarker?.regressionTaskId || (reviewMarker?.readinessTaskId && reviewMarker.regressionTaskId),
+      );
+      const auxiliaryTargetTaskId = repairMarker?.regressionTaskId
         ? repairDocumentationTask?.id ?? repairMarker.regressionTaskId
-        : typeof reviewMarker?.readinessTaskId === "string"
-          ? reviewMarker.readinessTaskId
-          : null;
-      const refunded = external && !mechanical ? 1 : 0;
-      const budgetCeiling = run.maxRunsPerTask + refunded;
+        : reviewMarker?.readinessTaskId ?? null;
       // The same refund, recorded apart from the ceiling it produced. The gates
       // an operator can reach read this rather than `maxRunsPerTask`, because
       // only this can still be told apart from the configured budget after that
@@ -6102,47 +6040,32 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         const budgetExhausted = !succeeded && retryable && !retryCreated;
         let canonicalOutputFailure: string | null = null;
         if (!succeeded && !retryCreated && run.task) {
-          const tailRows = await tx.taskActivity.findMany({
-            where: { taskId: run.taskId },
-            select: { metadata: true },
-            orderBy: { createdAt: "desc" },
-            take: 20,
-          });
-          const metadataRows = tailRows.map((row) => asJsonObject(row.metadata));
-          const repairMarker = metadataRows.find((metadata) => (
-            metadata?.kind === MERGE_TAIL_KIND.repairAttempt && typeof metadata.regressionTaskId === "string"
-          ));
-          const reviewMarker = metadataRows.find((metadata) => (
-            metadata?.kind === MERGE_TAIL_KIND.reviewObligation
-            && typeof metadata.readinessTaskId === "string"
-            && typeof metadata.regressionTaskId === "string"
-          ));
-          if (repairMarker && typeof repairMarker.regressionTaskId === "string") {
-            const reason = `${String(repairMarker.repairKind)} repair ${run.taskId} failed without closing the repair at ${String(repairMarker.headSha)}`;
-            await tx.task.update({ where: { id: repairMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-            await tx.taskActivity.create({ data: {
-              taskId: repairMarker.regressionTaskId,
+          // The same markers the success path above read, from the same scan.
+          // A failed auxiliary task closes the obligation it was carrying, so
+          // its review obligation counts in any state, not only `open`.
+          const failedRepair = latestMarker(tailMarkers, "repairAttempt");
+          const failedReview = latestMarker(tailMarkers, "reviewObligation");
+          if (failedRepair?.regressionTaskId) {
+            const reason = `${failedRepair.repairKind} repair ${run.taskId} failed without closing the repair at ${failedRepair.headSha}`;
+            await tx.task.update({ where: { id: failedRepair.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
+            await writeMarker(tx, failedRepair.regressionTaskId, "repairResult", {
               actorType: "control-plane",
-              body: `Automatic ${String(repairMarker.repairKind)} attempt failed: ${String(repairMarker.headSha)} -> ${body.headSha ?? "no-delivered-head"}`,
-              metadata: jsonValue({
-                kind: MERGE_TAIL_KIND.repairResult,
-                schemaVersion: 1,
-                repairKind: typeof repairMarker.repairKind === "string" ? repairMarker.repairKind : null,
+              body: `Automatic ${failedRepair.repairKind} attempt failed: ${failedRepair.headSha} -> ${body.headSha ?? "no-delivered-head"}`,
+              metadata: {
+                repairKind: failedRepair.repairKind,
                 repairTaskId: run.taskId,
-                startHeadSha: typeof repairMarker.headSha === "string" ? repairMarker.headSha : null,
-                targetHeadSha: typeof repairMarker.baseHeadSha === "string" ? repairMarker.baseHeadSha : null,
+                startHeadSha: failedRepair.headSha,
+                targetHeadSha: failedRepair.baseHeadSha,
                 resolvedHeadSha: body.headSha ?? null,
                 state: "failed",
-              }),
-            } });
-            await openMergeTailStopNotice(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
-          } else if (reviewMarker
-            && typeof reviewMarker.readinessTaskId === "string"
-            && typeof reviewMarker.regressionTaskId === "string") {
-            const reason = `independent review ${run.taskId} failed without an exact-head decision for ${String(reviewMarker.headSha)}`;
-            await tx.task.update({ where: { id: reviewMarker.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-            await tx.task.update({ where: { id: reviewMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-            await openMergeTailStopNotice(tx, { taskId: reviewMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+              },
+            });
+            await openMergeTailStopNotice(tx, { taskId: failedRepair.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
+          } else if (failedReview?.readinessTaskId && failedReview.regressionTaskId) {
+            const reason = `independent review ${run.taskId} failed without an exact-head decision for ${failedReview.headSha}`;
+            await tx.task.update({ where: { id: failedReview.readinessTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
+            await tx.task.update({ where: { id: failedReview.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
+            await openMergeTailStopNotice(tx, { taskId: failedReview.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
           }
         }
         // §4.0 outcome branching. The executor's own fenced write is the only
@@ -6260,14 +6183,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         } else if (succeeded && run.task && (run.task.chainId || mergeTailAuxiliary)) {
           let repairUnable = false;
           let reviewRejected = false;
-          if (reviewMarker
-            && typeof reviewMarker.readinessTaskId === "string"
-            && typeof reviewMarker.regressionTaskId === "string"
-            && typeof reviewMarker.headSha === "string") {
+          if (reviewMarker?.readinessTaskId && reviewMarker.regressionTaskId && reviewMarker.headSha) {
             const readinessTaskId = reviewMarker.readinessTaskId;
             const regressionTaskId = reviewMarker.regressionTaskId;
             const reviewHeadSha = reviewMarker.headSha;
-            const reviewBaseSha = typeof reviewMarker.baseSha === "string" ? reviewMarker.baseSha : null;
+            const reviewBaseSha = reviewMarker.baseSha;
             // Review evidence is run-scoped even though TaskStepOutput is not.
             // An earlier attempt's decision is not this attempt's decision, and
             // a decision not bound to the reviewed head is not evidence about
@@ -6329,40 +6249,34 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                 await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: reason } });
                 await stopTail(reason);
               } else {
-                await tx.taskActivity.create({ data: {
-                  taskId: readinessTaskId,
+                await writeMarker(tx, readinessTaskId, "reviewObligation", {
                   actorType: "control-plane",
                   body: followUpCardIds.length === 0
                     ? `Independent review approved exact head ${reviewHeadSha}`
                     : `Independent review accepted exact head ${reviewHeadSha} with ${followUpCardIds.length} follow-up card(s)`,
-                  metadata: jsonValue({
-                    kind: MERGE_TAIL_KIND.reviewObligation,
-                    schemaVersion: 1,
+                  metadata: {
                     state: parsedReview.decision.outcome,
                     reviewTaskId: run.taskId,
                     headSha: reviewHeadSha,
                     baseSha: reviewBaseSha,
                     followUpCardIds,
-                  }),
-                } });
+                  },
+                });
               }
             } else {
               reviewRejected = true;
               const summary = parsedReview.decision.blockingSummary;
-              const prior = await tx.taskActivity.findMany({
-                where: { taskId: readinessTaskId }, select: { metadata: true },
-              });
-              const round = prior.filter((row) => {
-                const metadata = asJsonObject(row.metadata);
-                return metadata?.kind === MERGE_TAIL_KIND.reviewObligation && metadata.state === "rejected";
-              }).length + 1;
-              await tx.taskActivity.create({ data: {
-                taskId: readinessTaskId,
+              // The whole history, not the recent-state window: the blocking-round
+              // ceiling counts every rejection this readiness ever took, and one
+              // pushed past the window by later activity would reset the count.
+              const prior = await readMarkerHistory(tx, readinessTaskId);
+              const round = prior.filter((marker) => (
+                marker.kind === "reviewObligation" && marker.state === "rejected"
+              )).length + 1;
+              await writeMarker(tx, readinessTaskId, "reviewObligation", {
                 actorType: "control-plane",
                 body: `Independent review rejected exact head ${reviewHeadSha} on blocking round ${round}`,
                 metadata: {
-                  kind: MERGE_TAIL_KIND.reviewObligation,
-                  schemaVersion: 1,
                   state: "rejected",
                   reviewTaskId: run.taskId,
                   headSha: reviewHeadSha,
@@ -6370,7 +6284,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                   summary,
                   blockingRound: round,
                 },
-              } });
+              });
               await tx.task.update({ where: { id: run.taskId }, data: {
                 status: TaskStatus.DONE,
                 failureReason: truncateFailureReason(`independent review rejected: ${summary}`, FAILURE_REASON_LIMIT),
@@ -6379,7 +6293,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                 tx,
                 regressionTaskId,
                 undefined,
-                typeof reviewMarker.recoverySourceStopId === "string" ? reviewMarker.recoverySourceStopId : "no-recovery-context",
+                reviewMarker.recoverySourceStopId ?? "no-recovery-context",
               );
               if (driftRecovery) {
                 await stopBaseDriftRecoveryTail(tx, driftRecovery, "independent-review", `rejected ${reviewHeadSha}: ${summary}`);
@@ -6409,18 +6323,15 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                 if (!lockedRegression) {
                   await stopTail(`independent review rejected ${reviewHeadSha} but its Regression task is gone`);
                 } else if (claimedPark.count !== 1) {
-                  await tx.taskActivity.create({ data: {
-                    taskId: readinessTaskId,
+                  await writeMarker(tx, readinessTaskId, "reviewObligation", {
                     actorType: "control-plane",
                     body: `Independent review rejected ${reviewHeadSha}, but readiness is no longer parked on that review; automatic repair was not started`,
                     metadata: {
-                      kind: MERGE_TAIL_KIND.reviewObligation,
-                      schemaVersion: 1,
                       state: "repair-skipped",
                       reviewTaskId: run.taskId,
                       headSha: reviewHeadSha,
                     },
-                  } });
+                  });
                 } else {
                   const repair = await createMergeTailRepairTask(tx, {
                     regressionTask: { id: regressionTaskId, ...lockedRegression },
@@ -6444,14 +6355,14 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
               }
             }
           }
-          if (repairMarker && typeof repairMarker.regressionTaskId === "string") {
+          if (repairMarker?.regressionTaskId) {
             const repairOutput = await tx.taskStepOutput.findUnique({ where: { taskId: run.taskId }, select: { body: true } });
             let reportedUnable = false;
             let resolvedHeadSha = body.headSha ?? null;
             if (repairMarker.repairKind === "refresh-conflict") {
               const parsedResolver = parseResolverResult(repairOutput?.body);
-              const expectedStart = typeof repairMarker.headSha === "string" ? repairMarker.headSha : null;
-              const expectedTarget = typeof repairMarker.baseHeadSha === "string" ? repairMarker.baseHeadSha : null;
+              const expectedStart = repairMarker.headSha;
+              const expectedTarget = repairMarker.baseHeadSha;
               const bindingError = parsedResolver.status === "invalid"
                 ? parsedResolver.reason
                 : parsedResolver.result.startHeadSha !== expectedStart || parsedResolver.result.targetHeadSha !== expectedTarget
@@ -6464,13 +6375,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                 const reason = `refresh-conflict repair ${run.taskId} returned invalid output: ${bindingError}`;
                 await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: reason } });
                 await tx.task.update({ where: { id: repairMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-                await tx.taskActivity.create({ data: {
-                  taskId: repairMarker.regressionTaskId,
+                await writeMarker(tx, repairMarker.regressionTaskId, "repairResult", {
                   actorType: "control-plane",
                   body: `Automatic refresh-conflict attempt stopped: ${reason}`,
-                  metadata: jsonValue({
-                    kind: MERGE_TAIL_KIND.repairResult,
-                    schemaVersion: 1,
+                  metadata: {
                     repairKind: "refresh-conflict",
                     repairTaskId: run.taskId,
                     startHeadSha: expectedStart,
@@ -6478,8 +6386,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
                     resolvedHeadSha: body.headSha ?? null,
                     state: "invalid-output",
                     reason: bindingError,
-                  }),
-                } });
+                  },
+                });
                 await openMergeTailStopNotice(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
               } else if (parsedResolver.status === "ok") {
                 reportedUnable = parsedResolver.result.outcome === "unable";
@@ -6495,20 +6403,17 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
               await tx.task.update({ where: { id: repairMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
               await openMergeTailStopNotice(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
             } else if (!repairUnable) {
-              await tx.taskActivity.create({ data: {
-                taskId: repairMarker.regressionTaskId,
+              await writeMarker(tx, repairMarker.regressionTaskId, "repairResult", {
                 actorType: "control-plane",
                 body: `Automatic ${String(repairMarker.repairKind)} attempt completed: ${String(repairMarker.headSha)} -> ${body.headSha ?? "missing-head"}`,
-                metadata: jsonValue({
-                  kind: MERGE_TAIL_KIND.repairResult,
-                  schemaVersion: 1,
-                  repairKind: typeof repairMarker.repairKind === "string" ? repairMarker.repairKind : null,
+                metadata: {
+                  repairKind: repairMarker.repairKind,
                   repairTaskId: run.taskId,
-                  startHeadSha: typeof repairMarker.headSha === "string" ? repairMarker.headSha : null,
-                  targetHeadSha: typeof repairMarker.baseHeadSha === "string" ? repairMarker.baseHeadSha : null,
+                  startHeadSha: repairMarker.headSha,
+                  targetHeadSha: repairMarker.baseHeadSha,
                   resolvedHeadSha,
-                }),
-              } });
+                },
+              });
               if (repairDocumentationTask) {
                 await tx.task.update({
                   where: { id: repairDocumentationTask.id },

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -8,12 +8,13 @@ import {
   applyInboxDecisionTx,
   enqueueTaskRun,
   MERGE_INTEGRATOR_KIND,
-  MERGE_TAIL_KIND,
   Prisma,
   PrismaClient,
   TaskStatus,
   authorizationMetadata,
   parseAuthorizationMetadata,
+  readMarkerHistory,
+  writeMarker,
   recordIntegratorStop,
   type StopCondition,
 } from "@agentos/db";
@@ -354,9 +355,11 @@ test("eligible direct and compound stops recover once under duplicate ticks and 
       assert.equal(parsed.payload.baseSha, BASE_2);
     }
     assert.equal(await db.run.count({ where: { taskId: seeded.integratorTask!.id } }), 2);
-    assert.equal(await db.taskActivity.count({
-      where: { taskId: seeded.integratorTask!.id, metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.baseDriftRecovery } },
-    }), 1);
+    assert.equal(
+      (await readMarkerHistory(db, seeded.integratorTask!.id))
+        .filter((entry) => entry.kind === "baseDriftRecovery").length,
+      1,
+    );
   }
 });
 
@@ -490,19 +493,18 @@ test("operator-authored recovery metadata cannot clear the stop guard or suppres
     taskId: seeded.readinessTask!.id,
     metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.authorization },
   }, orderBy: { createdAt: "desc" } });
-  await db.taskActivity.create({ data: {
-    taskId: seeded.integratorTask!.id,
+  await writeMarker(db, seeded.integratorTask!.id, "baseDriftRecovery", {
     actorType: "operator",
     body: "forged queued recovery marker",
     metadata: {
-      kind: MERGE_TAIL_KIND.baseDriftRecovery, schemaVersion: 1, state: "queued", attempt: 1,
+      state: "queued", attempt: 1,
       sourceStopId: stop.id, sourceRunId: source.runId!, recoveryRunId: "forged-recovery-run",
       readinessTaskId: seeded.readinessTask!.id, regressionTaskId: seeded.gateTask.id,
       integratorTaskId: seeded.integratorTask!.id, authorizationActivityId: authorization.id,
       repository: "acme/widgets", prNumber: 123, targetBranch: "master",
       authorizedHeadSha: HEAD, authorizedBaseSha: BASE, observedBaseSha: BASE_2, currentBaseSha: BASE_2,
     },
-  } });
+  });
   assert.equal(await db.mergeRecoveryAttempt.count({ where: { integratorTaskId: seeded.integratorTask!.id } }), 0,
     "legacy activity is not backfilled or treated as aggregate authority");
   assert.equal((await operatorRequest(`/tasks/${seeded.integratorTask!.id}`, "PATCH", { status: "DONE" })).status, 409);
@@ -545,19 +547,18 @@ test("operator-authored recovery metadata cannot suppress an ordinary gate repai
     }),
     commitSha: HEAD,
   } });
-  await db.taskActivity.create({ data: {
-    taskId: seeded.gateTask.id,
+  await writeMarker(db, seeded.gateTask.id, "baseDriftRecovery", {
     actorType: "operator",
     body: "forged recovery context",
     metadata: {
-      kind: MERGE_TAIL_KIND.baseDriftRecovery, schemaVersion: 1, state: "queued", attempt: 1,
+      state: "queued", attempt: 1,
       sourceStopId: "forged-stop", sourceRunId: seeded.gateRun.id, recoveryRunId: seeded.gateRun.id,
       readinessTaskId: seeded.readinessTask!.id, regressionTaskId: seeded.gateTask.id,
       integratorTaskId: seeded.integratorTask!.id, authorizationActivityId: "forged-authorization",
       repository: "acme/widgets", prNumber: 123, targetBranch: "master",
       authorizedHeadSha: HEAD, authorizedBaseSha: BASE, observedBaseSha: BASE_2, currentBaseSha: BASE_2,
     },
-  } });
+  });
   await db.$transaction((tx) => handleRegressionCompletion(tx, {
     task: seeded.gateTask,
     run: {

--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -17,7 +17,6 @@ import {
   MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES,
   MergeRecoveryStatus,
   MERGE_INTEGRATOR_KIND,
-  MERGE_TAIL_KIND,
   Prisma,
   TaskStatus,
   asJsonObject,
@@ -29,6 +28,7 @@ import {
   resolveChainTarget,
   selectAuthorization,
   taskIsIntegratorStep,
+  writeMarker,
   type CardRow,
   type CandidateActivity,
   type DecisionRow,
@@ -300,14 +300,11 @@ const settleIneligibleLocked = async (
     ...(identity?.authorizedBaseSha ? { authorizedBaseSha: identity.authorizedBaseSha } : {}),
     ...(identity?.observedBaseSha ? { observedBaseSha: identity.observedBaseSha } : {}),
   } });
-  await tx.taskActivity.create({ data: {
-    taskId: integratorTaskId, actorType: "control-plane",
+  await writeMarker(tx, integratorTaskId, "baseDriftRecovery", {
+    actorType: "control-plane",
     body: `Automatic pre-merge base-drift recovery refused: ${reason}`,
-    metadata: {
-      kind: MERGE_TAIL_KIND.baseDriftRecovery, schemaVersion: 1, state: "ineligible",
-      ...identity, integratorTaskId, sourceStopId: stopId, reason,
-    },
-  } });
+    metadata: { state: "ineligible", ...identity, integratorTaskId, sourceStopId: stopId, reason },
+  });
   const dedupeKey = `${RECOVERY_NOTIFICATION_PREFIX}:ineligible:${stopId}`;
   await tx.inboxMessage.upsert({ where: { dedupeKey }, create: {
     from: "AGENT", taskId: integratorTaskId, kind: "TEXT",
@@ -360,20 +357,17 @@ const recordClassificationRetry = async (
     where: { id: attempt.id },
     data: { validationAttempts: classificationAttempt, failureReason: reason },
   });
-  await tx.taskActivity.create({ data: {
-    taskId: integratorTaskId,
+  await writeMarker(tx, integratorTaskId, "baseDriftRecovery", {
     actorType: "control-plane",
     body: `Automatic pre-merge base-drift classification deferred (${classificationAttempt}/${MAX_BASE_DRIFT_CLASSIFICATION_RETRIES}): ${reason}`,
     metadata: {
-      kind: MERGE_TAIL_KIND.baseDriftRecovery,
-      schemaVersion: 1,
       state: "classification-retry",
       integratorTaskId,
       sourceStopId: stopId,
       classificationAttempt,
       reason,
     },
-  } });
+  });
   return "retryable";
 });
 
@@ -410,8 +404,6 @@ const queueRecovery = async (
   } });
   const attempt = aggregate.attempt;
   const common = {
-    kind: MERGE_TAIL_KIND.baseDriftRecovery,
-    schemaVersion: 1,
     sourceStopId: expected.stopId,
     sourceRunId: expected.sourceRunId,
     integratorTaskId: expected.integratorTaskId,
@@ -445,11 +437,11 @@ const queueRecovery = async (
       observedBaseSha: expected.observedBaseSha,
       currentBaseSha,
     } });
-    await tx.taskActivity.create({ data: {
-      taskId: expected.integratorTaskId, actorType: "control-plane",
+    await writeMarker(tx, expected.integratorTaskId, "baseDriftRecovery", {
+      actorType: "control-plane",
       body: `Automatic pre-merge base-drift recovery exhausted at attempt ${attempt}`,
       metadata: { ...common, state: "exhausted", reason },
-    } });
+    });
     const dedupeKey = `${RECOVERY_NOTIFICATION_PREFIX}:exhausted:${expected.stopId}`;
     await tx.inboxMessage.upsert({ where: { dedupeKey }, create: {
       from: "AGENT", taskId: expected.integratorTaskId, kind: "TEXT",
@@ -486,20 +478,17 @@ const queueRecovery = async (
     observedBaseSha: expected.observedBaseSha,
     currentBaseSha,
   } });
-  const metadata = { ...common, state: "queued", recoveryRunId: run.id,
-  };
-  await tx.taskActivity.createMany({ data: [
-    {
-      taskId: expected.integratorTaskId, actorType: "control-plane",
-      body: `Automatic base-drift recovery ${attempt} parked stop ${expected.stopId} and queued fresh regression`,
-      metadata,
-    },
-    {
-      taskId: expected.regressionTaskId, actorType: "control-plane",
-      body: `Automatic base-drift recovery ${attempt} verifies ${expected.authorizedHeadSha} against current base ${currentBaseSha}`,
-      metadata,
-    },
-  ] });
+  const metadata = { ...common, state: "queued", recoveryRunId: run.id };
+  await writeMarker(tx, expected.integratorTaskId, "baseDriftRecovery", {
+    actorType: "control-plane",
+    body: `Automatic base-drift recovery ${attempt} parked stop ${expected.stopId} and queued fresh regression`,
+    metadata,
+  });
+  await writeMarker(tx, expected.regressionTaskId, "baseDriftRecovery", {
+    actorType: "control-plane",
+    body: `Automatic base-drift recovery ${attempt} verifies ${expected.authorizedHeadSha} against current base ${currentBaseSha}`,
+    metadata,
+  });
   return "recovered";
 });
 

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -1,25 +1,9 @@
 import { execFile } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-import { asJsonObject, executionModeFor, MERGE_TAIL_KIND, type Prisma } from "@agentos/db";
+import { executionModeFor, latestMarker, openReviewObligation, readMarkers, type Prisma } from "@agentos/db";
 
 const mergeLeaseScript = fileURLToPath(new URL("../../../scripts/merge-lease.sh", import.meta.url));
-
-/** How far back the merge-tail markers are read, matching the completion path. */
-const mergeTailMarkerScan = 20;
-
-const markerRegressionTaskId = (
-  markers: Array<Record<string, unknown> | null>,
-  kind: string,
-  state?: string,
-): string | null => {
-  for (const metadata of markers) {
-    if (metadata?.kind !== kind) continue;
-    if (state !== undefined && metadata.state !== state) continue;
-    if (typeof metadata.regressionTaskId === "string") return metadata.regressionTaskId;
-  }
-  return null;
-};
 
 export type MergeLeaseReleaser = (chainId: string) => Promise<void>;
 
@@ -58,7 +42,9 @@ export const releaseMergeLeaseSafely = async (
  * only the mechanical merge step, the Regression step, and the merge-tail
  * auxiliary tasks (automatic repair attempts and independent reviews) ever run
  * under the lease, and an auxiliary task answers for the lease of the Regression
- * chain it serves rather than for a chain of its own.
+ * chain it serves rather than for a chain of its own. It reads the same marker
+ * window the completion path reads because it is the same question, which is
+ * why the window no longer needs restating here.
  */
 export const mergeTailLeaseChainId = async (
   tx: Prisma.TransactionClient,
@@ -77,14 +63,10 @@ export const mergeTailLeaseChainId = async (
     },
   });
   if (!task) return null;
-  const markers = (await tx.taskActivity.findMany({
-    where: { taskId },
-    select: { metadata: true },
-    orderBy: { createdAt: "desc" },
-    take: mergeTailMarkerScan,
-  })).map((row) => asJsonObject(row.metadata));
-  const auxiliaryRegressionTaskId = markerRegressionTaskId(markers, MERGE_TAIL_KIND.repairAttempt)
-    ?? markerRegressionTaskId(markers, MERGE_TAIL_KIND.reviewObligation, "open");
+  const markers = await readMarkers(tx, taskId);
+  const auxiliaryRegressionTaskId = latestMarker(markers, "repairAttempt")?.regressionTaskId
+    ?? openReviewObligation(markers)?.regressionTaskId
+    ?? null;
   const tail = executionModeFor(task.templateStep) === "mechanical"
     || task.templateStep?.outputKind === "regression-verification"
     || auxiliaryRegressionTaskId !== null;

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -15,7 +15,6 @@ import {
   LEGACY_PRE_ADJUDICATION_MERGE_READINESS_STEP_INDEX,
   LEGACY_PRE_ADJUDICATION_TEMPLATE_PREFIX,
   MERGE_READINESS_STEP_INDEX,
-  MERGE_TAIL_KIND,
   MergeRecoveryStatus,
   Prisma,
   RunnerPreference,
@@ -30,11 +29,15 @@ import {
   lockChainRows,
   lockTaskRow,
   parseRegressionVerdict,
+  readMarkerHistory,
+  recoveryContext,
   resolveChainTarget,
   resolutionTestTriggers,
   runnerFor,
+  writeMarker,
   type PrismaClient,
-  type MergeRecoveryAttempt,
+  type Marker,
+  type RecoveryContext,
 } from "@agentos/db";
 
 import { evidenceFromSnapshot } from "./merge-evidence-worker.js";
@@ -54,25 +57,6 @@ const READINESS_CLAIM_PREFIX = "merge-readiness-claim:";
 export const READINESS_READ_BUDGET_MS = 20_000;
 export const READINESS_CLAIM_LEASE_MS = 30_000;
 
-type RecoveryContext = {
-  aggregateId: string;
-  attempt: number;
-  sourceStopId: string;
-  sourceRunId: string;
-  authorizationActivityId: string;
-  repository: string;
-  prNumber: number;
-  targetBranch: string;
-  authorizedHeadSha: string;
-  authorizedBaseSha: string;
-  observedBaseSha: string;
-  currentBaseSha: string;
-  readinessTaskId: string;
-  regressionTaskId: string;
-  integratorTaskId: string;
-  recoveryRunId: string;
-};
-
 const lockTaskMutationRows = async (
   tx: Prisma.TransactionClient,
   taskId: string,
@@ -87,31 +71,6 @@ const lockTaskMutationRows = async (
   } else {
     await lockTaskRow(tx, taskId);
   }
-};
-
-const recoveryContext = (row: MergeRecoveryAttempt | null): RecoveryContext | null => {
-  if (!row?.boundSourceRunId || !row.authorizationActivityId || !row.recoveryRunId
-    || !row.readinessTaskId || !row.regressionTaskId || !row.repository
-    || row.prNumber === null || !row.targetBranch || !row.authorizedHeadSha
-    || !row.authorizedBaseSha || !row.observedBaseSha || !row.currentBaseSha) return null;
-  return {
-    aggregateId: row.id,
-    attempt: row.attempt,
-    sourceStopId: row.sourceStopId,
-    sourceRunId: row.boundSourceRunId,
-    authorizationActivityId: row.authorizationActivityId,
-    repository: row.repository,
-    prNumber: row.prNumber,
-    targetBranch: row.targetBranch,
-    authorizedHeadSha: row.authorizedHeadSha,
-    authorizedBaseSha: row.authorizedBaseSha,
-    observedBaseSha: row.observedBaseSha,
-    currentBaseSha: row.currentBaseSha,
-    readinessTaskId: row.readinessTaskId,
-    regressionTaskId: row.regressionTaskId,
-    integratorTaskId: row.integratorTaskId,
-    recoveryRunId: row.recoveryRunId,
-  };
 };
 
 const recoveryContextFor = async (
@@ -186,12 +145,11 @@ const stopReadiness = async (
         { taskId: input.regressionTaskId, actorType: "control-plane", body: recoveryBody!, metadata },
       ] });
     }
-    await tx.taskActivity.create({ data: {
-      taskId: input.regressionTaskId,
+    await writeMarker(tx, input.regressionTaskId, "readiness", {
       actorType: "control-plane",
       body: `Merge readiness stopped at regression: ${input.reason}`,
-      metadata: { kind: MERGE_TAIL_KIND.readiness, schemaVersion: 1, state: "stopped", reason: input.reason },
-    } });
+      metadata: { state: "stopped", reason: input.reason },
+    });
     await tx.inboxMessage.upsert({
       where: { dedupeKey },
       create: {
@@ -208,21 +166,21 @@ const stopReadiness = async (
   await releaseMergeLeaseSafely(releaseChainLease, chainId);
 };
 
+// The whole history, newest first: a review obligation for this exact head can
+// sit arbitrarily far back once the readiness task has accumulated activity,
+// and missing it would reopen a review that is already answered.
 const latestReviewState = async (
   db: PrismaClient | Prisma.TransactionClient,
   readinessTaskId: string,
   headSha: string,
   recoveryBaseSha: string | null,
-) => {
-  const rows = await db.taskActivity.findMany({ where: { taskId: readinessTaskId }, orderBy: { createdAt: "desc" }, select: { metadata: true } });
-  for (const row of rows) {
-    const metadata = row.metadata as Record<string, unknown> | null;
-    if (metadata?.kind === MERGE_TAIL_KIND.reviewObligation
-      && metadata.headSha === headSha
-      && (recoveryBaseSha === null || metadata.baseSha === recoveryBaseSha)) return metadata;
-  }
-  return null;
-};
+): Promise<Marker | null> => (
+  (await readMarkerHistory(db, readinessTaskId)).find((marker) => (
+    marker.kind === "reviewObligation"
+    && marker.headSha === headSha
+    && (recoveryBaseSha === null || marker.baseSha === recoveryBaseSha)
+  )) ?? null
+);
 
 const createReviewObligation = async (
   db: PrismaClient,
@@ -285,38 +243,33 @@ const createReviewObligation = async (
     model: "gpt-5.6-sol:medium",
     runner: runnerFor(RunnerPreference.CODEX, "gpt-5.6-sol:medium"),
   } });
-  await tx.taskActivity.createMany({ data: [
-    {
-      taskId: input.readinessTask.id,
-      actorType: "control-plane",
-      body: `Independent review obligation opened for ${input.headSha}`,
-      metadata: {
-        kind: MERGE_TAIL_KIND.reviewObligation,
-        schemaVersion: 1,
-        state: "open",
-        headSha: input.headSha,
-        baseSha: input.baseSha,
-        reviewTaskId: task.id,
-        triggers: input.triggers,
-        recoverySourceStopId: input.recovery?.sourceStopId ?? null,
-      },
+  // Two rows, deliberately not the same one. The readiness task's copy names
+  // the review task it is waiting on; the review task's copy names the tail it
+  // answers for, which is what the completion path reads back from it.
+  await writeMarker(tx, input.readinessTask.id, "reviewObligation", {
+    actorType: "control-plane",
+    body: `Independent review obligation opened for ${input.headSha}`,
+    metadata: {
+      state: "open",
+      headSha: input.headSha,
+      baseSha: input.baseSha,
+      reviewTaskId: task.id,
+      triggers: input.triggers,
+      recoverySourceStopId: input.recovery?.sourceStopId ?? null,
     },
-    {
-      taskId: task.id,
-      actorType: "control-plane",
-      body: `Blind review obligation for readiness task ${input.readinessTask.id}`,
-      metadata: {
-        kind: MERGE_TAIL_KIND.reviewObligation,
-        schemaVersion: 1,
-        state: "open",
-        readinessTaskId: input.readinessTask.id,
-        regressionTaskId: input.regressionTaskId,
-        headSha: input.headSha,
-        baseSha: input.baseSha,
-        recoverySourceStopId: input.recovery?.sourceStopId ?? null,
-      },
+  });
+  await writeMarker(tx, task.id, "reviewObligation", {
+    actorType: "control-plane",
+    body: `Blind review obligation for readiness task ${input.readinessTask.id}`,
+    metadata: {
+      state: "open",
+      readinessTaskId: input.readinessTask.id,
+      regressionTaskId: input.regressionTaskId,
+      headSha: input.headSha,
+      baseSha: input.baseSha,
+      recoverySourceStopId: input.recovery?.sourceStopId ?? null,
     },
-  ] });
+  });
   await tx.task.update({ where: { id: input.readinessTask.id }, data: {
     status: TaskStatus.REVIEW,
     failureReason: `${INDEPENDENT_REVIEW_OPEN_PREFIX}${task.id}:${input.headSha}`,
@@ -372,19 +325,16 @@ const requeueRegression = async (
         },
       ] });
     }
-    await tx.taskActivity.create({ data: {
-      taskId: input.regressionTaskId,
+    await writeMarker(tx, input.regressionTaskId, "readiness", {
       actorType: "control-plane",
       body: `Merge readiness returned to regression: ${input.reason}; ${input.staleBaseSha} -> ${input.currentBaseSha}`,
       metadata: {
-        kind: MERGE_TAIL_KIND.readiness,
-        schemaVersion: 1,
         state: "requeued-regression",
         reason: input.reason,
         staleBaseSha: input.staleBaseSha,
         currentBaseSha: input.currentBaseSha,
       },
-    } });
+    });
   });
 };
 
@@ -532,15 +482,16 @@ export const readinessTick = async (
         continue;
       }
       const triggers = defenseTriggers(diff.files);
-      const resolutionRows = await db.taskActivity.findMany({ where: { taskId: regression.id }, select: { metadata: true } });
-      for (const row of resolutionRows) {
-        const metadata = row.metadata as Record<string, unknown> | null;
-        if (metadata?.kind !== MERGE_TAIL_KIND.repairResult || metadata.repairKind !== "refresh-conflict") continue;
-        if (typeof metadata.startHeadSha !== "string" || typeof metadata.resolvedHeadSha !== "string") {
+      // Every refresh-conflict resolution this Regression ever recorded has to
+      // be re-proved, however far back it sits.
+      const resolutions = await readMarkerHistory(db, regression.id);
+      for (const marker of resolutions) {
+        if (marker.kind !== "repairResult" || marker.repairKind !== "refresh-conflict") continue;
+        if (!marker.startHeadSha || !marker.resolvedHeadSha) {
           triggers.push({ path: "<resolution-range>", reason: "existing-test-lines-unverifiable" });
           continue;
         }
-        const resolution = await reader.compareCommits(target.repository, metadata.startHeadSha, metadata.resolvedHeadSha, controller.signal);
+        const resolution = await reader.compareCommits(target.repository, marker.startHeadSha, marker.resolvedHeadSha, controller.signal);
         if (!resolution.filesComplete) {
           triggers.push({ path: "<resolution-range>", reason: "existing-test-lines-unverifiable" });
           continue;
@@ -635,12 +586,16 @@ export const readinessTick = async (
         });
         await tx.task.update({ where: { id: readiness.id }, data: { status: TaskStatus.DONE, failureReason: null } });
         await tx.task.update({ where: { id: regression.id }, data: { failureReason: null } });
-        await tx.taskActivity.create({ data: {
-          taskId: readiness.id,
+        await writeMarker(tx, readiness.id, "readiness", {
           actorType: "control-plane",
           body: `Merge readiness authorized exact head ${evidence.headSha}; merge execution queued`,
-          metadata: { kind: MERGE_TAIL_KIND.readiness, schemaVersion: 1, state: "authorized", headSha: evidence.headSha, authorizationActivityId: activity.id, recoverySourceStopId: recovery?.sourceStopId ?? null },
-        } });
+          metadata: {
+            state: "authorized",
+            headSha: evidence.headSha,
+            authorizationActivityId: activity.id,
+            recoverySourceStopId: recovery?.sourceStopId ?? null,
+          },
+        });
         if (recovery) {
           await activateRecoveryIntegratorSuccessor(tx, {
             readinessTaskId: readiness.id,

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -15,6 +15,9 @@ import {
   MERGE_TAIL_KIND,
   PrismaClient,
   TaskStatus,
+  latestMarker,
+  readMarkers,
+  writeMarker,
 } from "@agentos/db";
 
 import { handleRegressionCompletion } from "./app.js";
@@ -353,37 +356,35 @@ const rejectIndependentReviewAfterPass = async (
     body: outputBody,
     commitSha: HEAD,
   } });
-  await db.taskActivity.createMany({ data: [
-    {
-      taskId: readiness.id,
-      actorType: "control-plane",
-      body: `Independent review obligation opened for ${HEAD}`,
-      metadata: {
-        kind: "mergeTail.reviewObligation", schemaVersion: 1, state: "open",
-        reviewTaskId: review.id, headSha: HEAD, baseSha: BASE,
-      },
+  await writeMarker(db, readiness.id, "reviewObligation", {
+    actorType: "control-plane",
+    body: `Independent review obligation opened for ${HEAD}`,
+    metadata: { state: "open", reviewTaskId: review.id, headSha: HEAD, baseSha: BASE },
+  });
+  await writeMarker(db, review.id, "reviewObligation", {
+    actorType: "control-plane",
+    body: `Blind review obligation for readiness task ${readiness.id}`,
+    metadata: {
+      state: "open",
+      readinessTaskId: readiness.id,
+      regressionTaskId: seeded.regression.id,
+      headSha: HEAD,
+      baseSha: BASE,
     },
-    {
-      taskId: review.id,
-      actorType: "control-plane",
-      body: `Blind review obligation for readiness task ${readiness.id}`,
-      metadata: {
-        kind: "mergeTail.reviewObligation", schemaVersion: 1, state: "open",
-        readinessTaskId: readiness.id, regressionTaskId: seeded.regression.id,
-        headSha: HEAD, baseSha: BASE,
-      },
-    },
-  ] });
-  if (priorBlockingRounds > 0) await db.taskActivity.createMany({ data:
-    Array.from({ length: priorBlockingRounds }, (_unused, index) => ({
-      taskId: readiness.id,
+  });
+  for (let index = 0; index < priorBlockingRounds; index += 1) {
+    await writeMarker(db, readiness.id, "reviewObligation", {
       actorType: "control-plane",
       body: `Independent review rejected exact head ${HEAD} on blocking round ${String(index + 1)}`,
       metadata: {
-        kind: "mergeTail.reviewObligation", schemaVersion: 1, state: "rejected",
-        headSha: HEAD, baseSha: BASE, summary: blockingSummary, blockingRound: index + 1,
+        state: "rejected",
+        headSha: HEAD,
+        baseSha: BASE,
+        summary: blockingSummary,
+        blockingRound: index + 1,
       },
-    })) });
+    });
+  }
   await beforeCompletion({ readinessId: readiness.id, reviewTaskId: review.id, reviewRunId: reviewRun.id });
   const prior = process.env.RUNNER_TOKEN;
   process.env.RUNNER_TOKEN = "merge-tail-review-token";
@@ -424,11 +425,9 @@ test("a refresh conflict creates exactly one resolver and its completion re-runs
   }));
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } })).status, TaskStatus.TODO);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 2);
-  const result = await db.taskActivity.findFirstOrThrow({ where: {
-    taskId: seeded.regression.id,
-    metadata: { path: ["kind"], equals: "mergeTail.repairResult" },
-  } });
-  assert.match(result.body, new RegExp(`${HEAD}.*${RESOLVED}`));
+  const result = latestMarker(await readMarkers(db, seeded.regression.id), "repairResult");
+  assert.equal(result?.startHeadSha, HEAD);
+  assert.equal(result?.resolvedHeadSha, RESOLVED);
 
   assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
   assert.equal(await repairCount(seeded), 1);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -18,6 +18,7 @@ export * from "./deploy-barrier.js";
 export * from "./merge-integrator.js";
 export * from "./merge-integrator-db.js";
 export * from "./merge-tail.js";
+export * from "./merge-tail-markers.js";
 // Narrow on purpose: the release-authority module reads the filesystem at import
 // time, and only the attested file's name is wanted outside the release path.
 export { RELEASE_AUTHORITY_FILE } from "./release-authority.js";

--- a/packages/db/src/merge-tail-markers.test.ts
+++ b/packages/db/src/merge-tail-markers.test.ts
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MergeRecoveryStatus, type MergeRecoveryAttempt, type Prisma } from "@prisma/client";
+
+import { MERGE_TAIL_KIND } from "./merge-tail.js";
+import {
+  MERGE_TAIL_MARKER_SCAN,
+  latestMarker,
+  openReviewObligation,
+  readMarkerHistory,
+  readMarkers,
+  recoveryContext,
+  writeMarker,
+  type Marker,
+} from "./merge-tail-markers.js";
+
+type Row = { metadata: unknown };
+type FindManyArgs = { where: unknown; select: unknown; orderBy: unknown; take?: number };
+
+/**
+ * A transaction that records what was asked of it. The scan window and the
+ * ordering are the module's to own, so both are read back from here rather than
+ * inferred from a live database.
+ */
+const recordingTx = (rows: Row[]) => {
+  const reads: FindManyArgs[] = [];
+  const writes: Array<Record<string, unknown>> = [];
+  const tx = {
+    taskActivity: {
+      findMany: async (args: FindManyArgs) => {
+        reads.push(args);
+        return args.take === undefined ? rows : rows.slice(0, args.take);
+      },
+      create: async (args: { data: Record<string, unknown> }) => {
+        writes.push(args.data);
+        return args.data;
+      },
+    },
+  } as unknown as Prisma.TransactionClient;
+  return { tx, reads, writes };
+};
+
+const marker = (kind: keyof typeof MERGE_TAIL_KIND, extra: Record<string, unknown> = {}): Row => (
+  { metadata: { kind: MERGE_TAIL_KIND[kind], schemaVersion: 1, ...extra } }
+);
+
+test("the recent-state read owns the scan window and the ordering", async () => {
+  const rows = Array.from({ length: 40 }, (_, index) => marker("regression", { reason: `row-${index}` }));
+  const { tx, reads } = recordingTx(rows);
+  const markers = await readMarkers(tx, "task-1");
+
+  assert.equal(reads.length, 1);
+  assert.equal(reads[0]!.take, 20);
+  assert.equal(MERGE_TAIL_MARKER_SCAN, 20);
+  assert.deepEqual(reads[0]!.orderBy, [{ createdAt: "desc" }, { id: "desc" }]);
+  assert.deepEqual(reads[0]!.where, { taskId: "task-1" });
+  // The window is a row count, not a marker count: it is applied by the query,
+  // before the merge-tail rows are separated from every other activity.
+  assert.equal(markers.length, 20);
+  assert.equal(markers[0]!.raw.reason, "row-0");
+});
+
+test("the history read is unbounded and stays newest-first", async () => {
+  const rows = Array.from({ length: 40 }, (_, index) => marker("repairAttempt", { headSha: `head-${index}` }));
+  const { tx, reads } = recordingTx(rows);
+  const markers = await readMarkerHistory(tx, "task-1");
+
+  assert.equal(reads[0]!.take, undefined);
+  assert.equal(markers.length, 40);
+  assert.equal(markers[0]!.headSha, "head-0");
+  assert.equal(markers.at(-1)!.headSha, "head-39");
+});
+
+test("both reads keep only merge-tail markers and narrow their persisted fields", async () => {
+  const { tx } = recordingTx([
+    { metadata: null },
+    { metadata: ["not", "an", "object"] },
+    { metadata: { kind: "mergeIntegrator.result", outcome: "stopped" } },
+    { metadata: { kind: "mergeTail.reviewObligation", state: 7, headSha: null, regressionTaskId: "reg-1" } },
+  ]);
+  const markers = await readMarkers(tx, "task-1");
+
+  assert.equal(markers.length, 1);
+  const review = markers[0]!;
+  assert.equal(review.kind, "reviewObligation");
+  // A field whose persisted value is not a string reads as absent rather than
+  // reaching the caller as an unknown — this is the guard callers used to write.
+  assert.equal(review.state, null);
+  assert.equal(review.headSha, null);
+  assert.equal(review.regressionTaskId, "reg-1");
+  assert.equal(review.raw.state, 7);
+});
+
+test("latestMarker and openReviewObligation select from the newest end", () => {
+  const markers: Marker[] = [
+    { kind: "reviewObligation", state: "rejected", regressionTaskId: "reg-2", raw: {} } as Marker,
+    { kind: "repairAttempt", state: null, regressionTaskId: "reg-1", raw: {} } as Marker,
+    { kind: "reviewObligation", state: "open", regressionTaskId: "reg-0", raw: {} } as Marker,
+  ];
+
+  assert.equal(latestMarker(markers, "reviewObligation")?.state, "rejected");
+  assert.equal(latestMarker(markers, "reviewObligation", "open")?.regressionTaskId, "reg-0");
+  assert.equal(latestMarker(markers, "authorityResign"), null);
+  assert.equal(openReviewObligation(markers)?.regressionTaskId, "reg-0");
+});
+
+test("writeMarker owns the kind and the schema version", async () => {
+  const { tx, writes } = recordingTx([]);
+  await writeMarker(tx, "task-1", "repairResult", {
+    actorType: "control-plane",
+    body: "repair finished",
+    metadata: { kind: "mergeTail.notAKind", state: "failed", repairTaskId: "repair-1" },
+  });
+
+  assert.deepEqual(writes, [{
+    taskId: "task-1",
+    actorType: "control-plane",
+    body: "repair finished",
+    metadata: {
+      schemaVersion: 1,
+      kind: MERGE_TAIL_KIND.repairResult,
+      state: "failed",
+      repairTaskId: "repair-1",
+    },
+  }]);
+});
+
+const attemptRow = (overrides: Partial<MergeRecoveryAttempt> = {}): MergeRecoveryAttempt => ({
+  id: "attempt-1",
+  attempt: 2,
+  status: MergeRecoveryStatus.REPAIRING,
+  sourceStopId: "stop-1",
+  boundSourceRunId: "run-1",
+  authorizationActivityId: "activity-1",
+  repository: "owner/repo",
+  prNumber: 7,
+  targetBranch: "main",
+  authorizedHeadSha: "a".repeat(40),
+  authorizedBaseSha: "b".repeat(40),
+  observedBaseSha: "c".repeat(40),
+  currentBaseSha: "d".repeat(40),
+  readinessTaskId: "readiness-1",
+  regressionTaskId: "regression-1",
+  integratorTaskId: "integrator-1",
+  recoveryRunId: "recovery-run-1",
+  ...overrides,
+} as MergeRecoveryAttempt);
+
+test("recoveryContext refuses an attempt row that is missing any bound field", () => {
+  assert.equal(recoveryContext(null), null);
+  assert.equal(recoveryContext(attemptRow({ boundSourceRunId: null })), null);
+  assert.equal(recoveryContext(attemptRow({ recoveryRunId: null })), null);
+  assert.equal(recoveryContext(attemptRow({ prNumber: null })), null);
+  assert.equal(recoveryContext(attemptRow({ currentBaseSha: null })), null);
+
+  const context = recoveryContext(attemptRow());
+  assert.equal(context?.aggregateId, "attempt-1");
+  assert.equal(context?.sourceRunId, "run-1");
+  assert.equal(context?.prNumber, 7);
+  assert.equal(context?.integratorTaskId, "integrator-1");
+});
+
+// The seven converted call sites, by the property each one depends on. The
+// window and the order are not interchangeable between them: forcing the
+// history readers into the recent-state window is the regression this proves
+// against.
+
+test("completion-path sites read the recent-state window (app.ts success and failure paths)", async () => {
+  const rows = [
+    marker("repairAttempt", { regressionTaskId: "reg-1", repairKind: "gate-fix", headSha: "h1" }),
+    ...Array.from({ length: 30 }, () => marker("regression", {})),
+  ];
+  const { tx, reads } = recordingTx(rows);
+  const markers = await readMarkers(tx, "repair-task");
+
+  assert.equal(reads[0]!.take, MERGE_TAIL_MARKER_SCAN);
+  assert.equal(latestMarker(markers, "repairAttempt")?.regressionTaskId, "reg-1");
+});
+
+test("mergeTailLeaseChainId reads the same window as the completion path (merge-lease.ts)", async () => {
+  const { tx, reads } = recordingTx([
+    marker("reviewObligation", { state: "open", regressionTaskId: "reg-9" }),
+  ]);
+  const markers = await readMarkers(tx, "review-task");
+
+  assert.equal(reads[0]!.take, MERGE_TAIL_MARKER_SCAN);
+  assert.equal(
+    latestMarker(markers, "repairAttempt")?.regressionTaskId ?? openReviewObligation(markers)?.regressionTaskId,
+    "reg-9",
+  );
+});
+
+test("alreadyAttempted sees an attempt buried past the recent-state window (app.ts:639)", async () => {
+  const rows = [
+    ...Array.from({ length: 25 }, () => marker("regression", {})),
+    marker("repairAttempt", { repairKind: "gate-fix", headSha: "h1" }),
+  ];
+  const history = await readMarkerHistory(recordingTx(rows).tx, "regression-task");
+  const recent = await readMarkers(recordingTx(rows).tx, "regression-task");
+  const attempted = (markers: Marker[]) => markers.some((entry) => (
+    entry.kind === "repairAttempt" && entry.repairKind === "gate-fix"
+  ));
+
+  assert.equal(attempted(history), true);
+  // The failure this site's window exists to prevent: with take 20 the older
+  // attempt is invisible and a second automatic repair would be created.
+  assert.equal(attempted(recent), false);
+});
+
+test("alreadyRejected is order-independent over the full history (app.ts:6233)", async () => {
+  const rows = [
+    ...Array.from({ length: 25 }, () => marker("readiness", { state: "queued" })),
+    marker("reviewObligation", { state: "rejected", reviewTaskId: "review-1" }),
+  ];
+  const { tx, reads } = recordingTx(rows);
+  const history = await readMarkerHistory(tx, "readiness-task");
+
+  assert.equal(reads[0]!.take, undefined);
+  assert.equal(latestMarker(history, "reviewObligation", "rejected") !== null, true);
+  assert.equal(latestMarker([...history].reverse(), "reviewObligation", "rejected") !== null, true);
+});
+
+test("latestReviewState takes the newest matching obligation (merge-readiness-worker.ts:212)", async () => {
+  const rows = [
+    marker("reviewObligation", { state: "approved", headSha: "head-1", baseSha: "base-1" }),
+    marker("reviewObligation", { state: "open", headSha: "head-1", baseSha: "base-1" }),
+    marker("reviewObligation", { state: "open", headSha: "head-0", baseSha: "base-0" }),
+  ];
+  const { tx, reads } = recordingTx(rows);
+  const history = await readMarkerHistory(tx, "readiness-task");
+  const matching = history.find((entry) => (
+    entry.kind === "reviewObligation" && entry.headSha === "head-1" && entry.baseSha === "base-1"
+  ));
+
+  assert.equal(reads[0]!.take, undefined);
+  // Newest first, so the approval wins over the open row it answered.
+  assert.equal(matching?.state, "approved");
+});
+
+test("refresh-conflict resolutions are re-proved from the whole history (merge-readiness-worker.ts:509)", async () => {
+  const rows = [
+    ...Array.from({ length: 25 }, () => marker("regression", {})),
+    marker("repairResult", { repairKind: "refresh-conflict", startHeadSha: "s1", resolvedHeadSha: "r1" }),
+    marker("repairResult", { repairKind: "refresh-conflict", startHeadSha: 7, resolvedHeadSha: "r0" }),
+  ];
+  const { tx, reads } = recordingTx(rows);
+  const history = await readMarkerHistory(tx, "regression-task");
+  const resolutions = history.filter((entry) => (
+    entry.kind === "repairResult" && entry.repairKind === "refresh-conflict"
+  ));
+
+  assert.equal(reads[0]!.take, undefined);
+  assert.equal(resolutions.length, 2);
+  assert.deepEqual(resolutions.map((entry) => entry.startHeadSha), ["s1", null]);
+});

--- a/packages/db/src/merge-tail-markers.ts
+++ b/packages/db/src/merge-tail-markers.ts
@@ -1,0 +1,185 @@
+import type { MergeRecoveryAttempt, Prisma } from "@prisma/client";
+
+import { asJsonObject, MERGE_TAIL_KIND, MERGE_TAIL_SCHEMA_VERSION } from "./merge-tail.js";
+
+type Tx = Prisma.TransactionClient;
+
+/**
+ * How far back a recent-state marker read looks. The completion path fixed this
+ * number and `merge-lease.ts` used to restate it in a comment — "matching the
+ * completion path" — because there was nowhere else to say it. `TaskActivity`
+ * rows are live production data, so the window is part of the persisted read
+ * contract and not a tuning knob.
+ */
+export const MERGE_TAIL_MARKER_SCAN = 20;
+
+export type MarkerKind = keyof typeof MERGE_TAIL_KIND;
+
+/**
+ * A merge-tail marker with its persisted fields already narrowed. Callers read
+ * these instead of re-deriving them from `metadata`: the `typeof x === "string"`
+ * guard that used to follow every `asJsonObject` call lives here now. `raw` is
+ * the untouched object for the fields no reader has needed yet.
+ */
+export type Marker = {
+  kind: MarkerKind;
+  state: string | null;
+  regressionTaskId: string | null;
+  readinessTaskId: string | null;
+  reviewTaskId: string | null;
+  repairKind: string | null;
+  headSha: string | null;
+  baseHeadSha: string | null;
+  baseSha: string | null;
+  startHeadSha: string | null;
+  resolvedHeadSha: string | null;
+  recoverySourceStopId: string | null;
+  raw: Record<string, unknown>;
+};
+
+const KIND_BY_VALUE = new Map<string, MarkerKind>(
+  (Object.entries(MERGE_TAIL_KIND) as Array<[MarkerKind, string]>).map(([name, value]) => [value, name]),
+);
+
+const text = (raw: Record<string, unknown>, field: string): string | null => (
+  typeof raw[field] === "string" ? raw[field] : null
+);
+
+const asMarker = (metadata: Prisma.JsonValue | null | undefined): Marker | null => {
+  const raw = asJsonObject(metadata);
+  const kind = raw && typeof raw.kind === "string" ? KIND_BY_VALUE.get(raw.kind) : undefined;
+  if (!raw || !kind) return null;
+  return {
+    kind,
+    state: text(raw, "state"),
+    regressionTaskId: text(raw, "regressionTaskId"),
+    readinessTaskId: text(raw, "readinessTaskId"),
+    reviewTaskId: text(raw, "reviewTaskId"),
+    repairKind: text(raw, "repairKind"),
+    headSha: text(raw, "headSha"),
+    baseHeadSha: text(raw, "baseHeadSha"),
+    baseSha: text(raw, "baseSha"),
+    startHeadSha: text(raw, "startHeadSha"),
+    resolvedHeadSha: text(raw, "resolvedHeadSha"),
+    recoverySourceStopId: text(raw, "recoverySourceStopId"),
+    raw,
+  };
+};
+
+// A task's activity carries operator notes and other families of marker
+// (`mergeIntegrator.*`, evidence requests) alongside the merge tail's. Both
+// reads take rows first and keep the merge-tail ones second, which is what the
+// open-coded scans did and what makes the window a row count rather than a
+// marker count.
+const scan = async (tx: Tx, taskId: string, take?: number): Promise<Marker[]> => {
+  const rows = await tx.taskActivity.findMany({
+    where: { taskId },
+    select: { metadata: true },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    ...(take === undefined ? {} : { take }),
+  });
+  return rows.flatMap((row) => {
+    const marker = asMarker(row.metadata);
+    return marker ? [marker] : [];
+  });
+};
+
+/** The recent state of a task's merge tail: newest first, `MERGE_TAIL_MARKER_SCAN` rows deep. */
+export const readMarkers = async (tx: Tx, taskId: string): Promise<Marker[]> => (
+  scan(tx, taskId, MERGE_TAIL_MARKER_SCAN)
+);
+
+/**
+ * Every merge-tail marker a task ever recorded, newest first. This answers "has
+ * this ever happened", which the recent-state window cannot: an older
+ * `repairAttempt` pushed past row 20 would let a second automatic repair start
+ * where the tail stops today.
+ */
+export const readMarkerHistory = async (tx: Tx, taskId: string): Promise<Marker[]> => scan(tx, taskId);
+
+/** The newest marker of `kind`, optionally restricted to one `state`. */
+export const latestMarker = (markers: Marker[], kind: MarkerKind, state?: string): Marker | null => (
+  markers.find((marker) => marker.kind === kind && (state === undefined || marker.state === state)) ?? null
+);
+
+/** The independent review a task is still waiting on, if any. */
+export const openReviewObligation = (markers: Marker[]): Marker | null => (
+  latestMarker(markers, "reviewObligation", "open")
+);
+
+export type MarkerWrite = {
+  actorType: string;
+  body: string;
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Records one marker. `kind` and `schemaVersion` are the module's to write, so
+ * a caller cannot record a marker under a kind string that no reader matches.
+ */
+export const writeMarker = async (
+  tx: Tx,
+  taskId: string,
+  kind: MarkerKind,
+  payload: MarkerWrite,
+): Promise<void> => {
+  await tx.taskActivity.create({ data: {
+    taskId,
+    actorType: payload.actorType,
+    body: payload.body,
+    metadata: {
+      schemaVersion: MERGE_TAIL_SCHEMA_VERSION,
+      ...payload.metadata,
+      kind: MERGE_TAIL_KIND[kind],
+    } as Prisma.InputJsonObject,
+  } });
+};
+
+/**
+ * A base-drift recovery attempt that carries every field its tail needs. The
+ * columns are individually nullable, so a row that is missing one is not a
+ * recovery this code can act on — that is what the null return means.
+ */
+export type RecoveryContext = {
+  aggregateId: string;
+  attempt: number;
+  sourceStopId: string;
+  sourceRunId: string;
+  authorizationActivityId: string;
+  repository: string;
+  prNumber: number;
+  targetBranch: string;
+  authorizedHeadSha: string;
+  authorizedBaseSha: string;
+  observedBaseSha: string;
+  currentBaseSha: string;
+  readinessTaskId: string;
+  regressionTaskId: string;
+  integratorTaskId: string;
+  recoveryRunId: string;
+};
+
+export const recoveryContext = (row: MergeRecoveryAttempt | null): RecoveryContext | null => {
+  if (!row?.boundSourceRunId || !row.authorizationActivityId || !row.recoveryRunId
+    || !row.readinessTaskId || !row.regressionTaskId || !row.repository
+    || row.prNumber === null || !row.targetBranch || !row.authorizedHeadSha
+    || !row.authorizedBaseSha || !row.observedBaseSha || !row.currentBaseSha) return null;
+  return {
+    aggregateId: row.id,
+    attempt: row.attempt,
+    sourceStopId: row.sourceStopId,
+    sourceRunId: row.boundSourceRunId,
+    authorizationActivityId: row.authorizationActivityId,
+    repository: row.repository,
+    prNumber: row.prNumber,
+    targetBranch: row.targetBranch,
+    authorizedHeadSha: row.authorizedHeadSha,
+    authorizedBaseSha: row.authorizedBaseSha,
+    observedBaseSha: row.observedBaseSha,
+    currentBaseSha: row.currentBaseSha,
+    readinessTaskId: row.readinessTaskId,
+    regressionTaskId: row.regressionTaskId,
+    integratorTaskId: row.integratorTaskId,
+    recoveryRunId: row.recoveryRunId,
+  };
+};


### PR DESCRIPTION
Implements section **C6** of `BRIEF-architecture-deepening-20260825.md` (records
`cd9bd61`): give the merge-tail markers an owner.

## What moved

New module `packages/db/src/merge-tail-markers.ts`, re-exported from the
`@agentos/db` barrel. It takes a `Prisma.TransactionClient` and issues the query
itself; callers stop restating the scan, the ordering, the `asJsonObject` hop and
the `typeof x === "string"` narrowing that followed it.

```
readMarkers(tx, taskId)        // take 20, desc — recent state
readMarkerHistory(tx, taskId)  // unbounded, desc — "has this ever happened"
latestMarker(markers, kind, state?)
openReviewObligation(markers)
writeMarker(tx, taskId, kind, payload)   // owns kind + schemaVersion
recoveryContext(row)                     // pure mapper, the 43 duplicated lines once
```

`Marker` carries the persisted field names already narrowed — `state`,
`regressionTaskId`, `readinessTaskId`, `reviewTaskId`, `repairKind`, `headSha`,
`baseHeadSha`, `baseSha`, `startHeadSha`, `resolvedHeadSha`,
`recoverySourceStopId` — plus `raw` for the fields no reader has needed. Callers
write null checks on typed fields, not type guards.

Nothing about the persisted format changed: no kind renamed, no metadata field
renamed, no scan window moved.

## Two windows, not one

The 20 `taskActivity.findMany` sites are not one family. Verified breakdown:

- **3 sites** used the `take: 20` descending recent-state scan — `app.ts:5818`,
  `app.ts:6045`, `merge-lease.ts:80`. They now call `readMarkers`.
- **4 sites** scan the full history unbounded and ask a different question —
  `app.ts:639` (`alreadyAttempted`), `app.ts:6233` (`alreadyRejected`),
  `merge-readiness-worker.ts:212`, `:509`. They now call `readMarkerHistory`.
  Routing these through `take: 20` would be a live regression: `app.ts:639`
  would miss a `repairAttempt` pushed past row 20 and create a **second**
  automatic repair where the tail stops today. `merge-tail-markers.test.ts`
  asserts exactly that failure.
- **3 sites** are different queries — `regression-repair-handoff.ts:78`, `:136`,
  `:175` (DB-side `kind` filter plus `createdAt` bounds). Left open-coded and
  reported below. A fourth, `app.ts:473`, went away on main when
  `applyMergeTailOperatorDecision` was deleted.
- The rest are integrator/evidence markers — a different family, out of scope.

## The duplicate scan

`tailRows` was declared twice in the completion handler (`app.ts:5818` and
`:6045`), the second shadowing the first, so the success and failure paths each
scanned. There is now one read whose condition spans both paths, and both derive
their markers from it. The gating stayed exactly where it was: the success path
still only consults markers for a standalone auxiliary task, so
`mergeTailAuxiliary` cannot become true on a failed run — that would change which
completions release the merge lease.

## Verification

- `npm test -w @agentos/db` — 259 pass, 0 fail, including the new
  `merge-tail-markers.test.ts` (recording transaction adapter, no Postgres).
  The scan window and the ordering are assertions now, not a comment.
- `npm run test:db -w @agentos/api -- src/merge-tail-repair.dbtest.ts
  src/merge-base-drift-recovery.dbtest.ts src/merge-stop-state.dbtest.ts` — 70
  pass, 0 fail — plus `merge-tail-readiness`, `merge-lease-cancel-release`,
  `merge-evidence-protocol` and `merge-integrator-forgery` — 31 pass, 0 fail —
  all against a throwaway PostgreSQL.
- `npm run lint`, `tsc --noEmit` on `@agentos/api`.

## Follow-up, not in this change

- `mergeRecoveryTransitionAllowed` (`merge-tail.ts:53`) still has zero production
  callers while `MergeRecoveryStatus` is written at 11 sites. Routing those
  writers through the guard is real work and is deliberately not here. The guard
  is not deleted either; that is Leo's call.
- `asJsonObject` stays exported. It has consumers outside the marker readers:
  `merge-base-drift-worker.ts:198` (integrator intent rows),
  `regression-repair-handoff.ts:129` (parsing a review task's output body) and
  its three marker sites.
- The three different-query sites above still restate their own shape. Absorbing
  them needs a second read shape (DB-side kind filter + `createdAt` lower bound),
  which is a separate decision.
