### PR TITLE
feat(merge-tail): ask for the release-authority signature instead of negotiating it

### DIFF
--- a/agents/roles/regression-verifier.md
+++ b/agents/roles/regression-verifier.md
@@ -26,8 +26,16 @@ head-bound `review-fail` verdict with the unresolved IDs or new defect in its
 summary. The control plane owns returning
 that result to the fix path.
 
-Only after semantic verification passes, run the task prompt's one exact-head
-mechanical gate. Do not substitute another command, reuse evidence for another
+Before the gate, run the task prompt's release-authority check. A branch that
+moves attested release-path files invalidates the signed attestation, and the
+migration preflight then refuses the tree, so the gate cannot pass until the
+attestation is re-signed. You never re-sign it: the key is the operator's and is
+in no checkout. Report the condition through the prompt's `authority-resign`
+outcome and stop there; the control plane owns asking for the signature and
+resuming this step once it lands.
+
+Only after semantic verification passes and that check is clean, run the task
+prompt's one exact-head mechanical gate. Do not substitute another command, reuse evidence for another
 head or base, or treat a non-verdict exit as PASS or FAIL. Persist exactly one
 of the task prompt's versioned JSON outcomes as the AgentOS task output. Do not
 write or commit a report file.

--- a/agents/templates/compound-engineer-workflow/10-regression-verification.md
+++ b/agents/templates/compound-engineer-workflow/10-regression-verification.md
@@ -27,7 +27,18 @@ with its dispositions, and the documentation result from AgentOS step outputs.
 Review the full final diff as one unit, account for every finding id either
 report raised, and rerun relevant regressions. If an adopted finding remains
 open, a rejection is unsupported, or the fix introduces a defect, do not run the
-full gate; emit the `review-fail` output below. Only after semantic verification passes,
+full gate; emit the `review-fail` output below.
+
+Before the gate, run `npm run db:authority-check -w @agentos/db` once. Exit 0
+means the tracked `release-authority.json` still covers this tree. Exit 1 means
+this branch moved attested release-path files without re-signing it, so the
+migration preflight refuses this tree and the gate cannot pass: do not run the
+gate, and finish with the `authority-resign` output below, carrying the printed
+`RESIGN release-authority` lines in `summary`. Never re-sign it yourself — the
+signing key is the operator's and is in no checkout. Any other exit is a loud
+run failure.
+
+Only after semantic verification passes and that check is clean, run
 `scripts/gate-worker/gate-dispatch.sh <head-sha> --master <baseHeadSha>`.
 If dispatch exits 75 or 76 without a verdict, retry dispatch in place up to two
 more times. If all three attempts return a non-verdict exit, or dispatch returns
@@ -40,6 +51,7 @@ report file:
 - semantic FAIL: `{"schemaVersion":1,"outcome":"review-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","summary":"<unresolved finding IDs or newly discovered defect>"}`
 - gate FAIL: `{"schemaVersion":1,"outcome":"gate-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"FAIL","summary":"<named failing stage>"}`
 - refresh conflict: `{"schemaVersion":1,"outcome":"refresh-conflict","headSha":"<chain head before refresh>","baseHeadSha":"<target head>","summary":"<conflicted paths>"}`
+- release authority re-signature required: `{"schemaVersion":1,"outcome":"authority-resign","headSha":"<40 hex>","baseHeadSha":"<40 hex>","summary":"<the RESIGN release-authority lines>"}`
 
 No other output shape advances the chain. A non-verdict gate exit is neither
 PASS nor FAIL.

--- a/agents/templates/direct-engineer-workflow/05-regression-verification.md
+++ b/agents/templates/direct-engineer-workflow/05-regression-verification.md
@@ -27,7 +27,18 @@ implementation with its dispositions from AgentOS step outputs. Review the full
 fix diff as one unit, account for every finding id either report raised, and
 rerun relevant regressions. If an adopted finding remains open, a rejection is
 unsupported, or the fix introduces a defect, do not run the full gate; emit the
-`review-fail` output below. Only after semantic verification passes, run
+`review-fail` output below.
+
+Before the gate, run `npm run db:authority-check -w @agentos/db` once. Exit 0
+means the tracked `release-authority.json` still covers this tree. Exit 1 means
+this branch moved attested release-path files without re-signing it, so the
+migration preflight refuses this tree and the gate cannot pass: do not run the
+gate, and finish with the `authority-resign` output below, carrying the printed
+`RESIGN release-authority` lines in `summary`. Never re-sign it yourself — the
+signing key is the operator's and is in no checkout. Any other exit is a loud
+run failure.
+
+Only after semantic verification passes and that check is clean, run
 `scripts/gate-worker/gate-dispatch.sh <head-sha> --master <baseHeadSha>`.
 If dispatch exits 75 or 76 without a verdict, retry dispatch in place up to two
 more times. If all three attempts return a non-verdict exit, or dispatch returns
@@ -40,6 +51,7 @@ report file:
 - semantic FAIL: `{"schemaVersion":1,"outcome":"review-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","summary":"<unresolved finding IDs or newly discovered defect>"}`
 - gate FAIL: `{"schemaVersion":1,"outcome":"gate-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"FAIL","summary":"<named failing stage>"}`
 - refresh conflict: `{"schemaVersion":1,"outcome":"refresh-conflict","headSha":"<chain head before refresh>","baseHeadSha":"<target head>","summary":"<conflicted paths>"}`
+- release authority re-signature required: `{"schemaVersion":1,"outcome":"authority-resign","headSha":"<40 hex>","baseHeadSha":"<40 hex>","summary":"<the RESIGN release-authority lines>"}`
 
 No other output shape advances the chain. A non-verdict gate exit is neither
 PASS nor FAIL.

--- a/docs/public-snapshot.md
+++ b/docs/public-snapshot.md
@@ -101,6 +101,16 @@ else. `mintedArtifacts` is the manifest's mechanism for a snapshot input that is
 generated rather than tracked, and it is empty: nothing this repository
 publishes is minted-and-untracked today.
 
+**When a chain moves the migration set.** Any branch that adds a migration or
+edits a file `RELEASE_EVIDENCE_FILES` names invalidates the attestation, so the
+merge gate fails on the preflight's own dbtest. That is expected and the
+autonomous merge tail is built for it: regression verification runs
+`npm run db:authority-check -w @agentos/db` before the gate, and on a
+re-signature it parks itself and opens one inbox message carrying the exact
+commands above for that branch and head. Re-sign on the machine that holds the
+key, push, and the server re-queues regression verification on its own. Nothing
+in a chain ever signs, and no other chain waits on this one.
+
 **Then commit the attestation.** It is tracked, so it is reviewed and gated like
 the key that verifies it, and re-signing it is a commit like any other:
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -88,6 +88,7 @@ import {
   type CardRow,
   type DecisionRow,
   asJsonObject,
+  AUTHORITY_RESIGN_DEDUPE_PREFIX,
   AUTHORITY_RESIGN_OPEN_PREFIX,
   INDEPENDENT_REVIEW_OPEN_PREFIX,
   isMergeReadinessStep,
@@ -421,6 +422,14 @@ const openMergeTailStopNotice = async (
  * filled in by hand. Nothing else in the chain is blocked while it waits, and
  * the resign worker resumes this step on its own once the signature is pushed.
  */
+/**
+ * A branch name may legally contain `$`, a backtick or a semicolon, and this
+ * message is written to be pasted into a shell that will be holding the release
+ * signing key. Every interpolated value is quoted, including the embedded single
+ * quote a refname may also carry.
+ */
+const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
+
 const openAuthorityResignNotice = async (
   tx: DbTx,
   input: {
@@ -440,21 +449,21 @@ const openAuthorityResignNotice = async (
     [
       "Run this in the checkout that holds the private revalidation document, with the signing key at hand:",
       "",
-      `  git fetch origin ${input.branch}`,
-      `  git switch --detach ${input.headSha}`,
+      `  git fetch origin ${shellQuote(input.branch)}`,
+      `  git switch --detach ${shellQuote(input.headSha)}`,
       "  RELEASE_AUTHORITY_KEY=~/.agentos-keys/release-authority.ed25519 \\",
       `  GOAL5A0_MASTER_SHA="$(node -p "require('./${RELEASE_AUTHORITY_FILE}').masterSha")" \\`,
       `  GOAL5A0_CONTROL_PLANE_A_SHA="$(node -p "require('./${RELEASE_AUTHORITY_FILE}').controlPlaneASha")" \\`,
       "    npm run snapshot:authority",
       `  npm run db:authority-check -w @agentos/db`,
       `  git add ${RELEASE_AUTHORITY_FILE}`,
-      `  git commit -m "chore(release): re-sign the release authority for ${input.branch}"`,
-      `  git push origin HEAD:${input.branch}`,
+      `  git commit -m ${shellQuote(`chore(release): re-sign the release authority for ${input.branch}`)}`,
+      `  git push origin ${shellQuote(`HEAD:${input.branch}`)}`,
     ].join("\n"),
     `Nothing else is needed. The server watches the pull request and re-runs regression verification as soon as the re-signed ${RELEASE_AUTHORITY_FILE} is on ${input.branch}.`,
   ].join("\n\n");
   await tx.inboxMessage.upsert({
-    where: { dedupeKey: `authority-resign:${input.taskId}:${input.headSha}` },
+    where: { dedupeKey: `${AUTHORITY_RESIGN_DEDUPE_PREFIX}${input.taskId}:${input.headSha}` },
     create: {
       from: "AGENT",
       agentId: input.agentId,
@@ -462,7 +471,7 @@ const openAuthorityResignNotice = async (
       taskId: input.taskId,
       kind: "TEXT",
       body,
-      dedupeKey: `authority-resign:${input.taskId}:${input.headSha}`,
+      dedupeKey: `${AUTHORITY_RESIGN_DEDUPE_PREFIX}${input.taskId}:${input.headSha}`,
     },
     update: {},
   });
@@ -610,48 +619,50 @@ export const handleRegressionCompletion = async (
     return "advance";
   }
 
-  if (recovery) {
-    await stopBaseDriftRecoveryTail(
-      tx,
-      recovery,
-      "regression",
-      verdict.outcome === "refresh-conflict"
-        ? `refresh conflict at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`
-        : verdict.outcome === "review-fail"
-          ? `semantic regression FAIL at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`
-          : verdict.outcome === "authority-resign"
-            ? `release authority re-signature required at ${verdict.headSha}: ${verdict.summary}`
-            : `merge gate FAIL at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`,
-    );
-    return "handled";
-  }
-
   if (verdict.outcome === "authority-resign") {
-    // The park is owned by the resign worker, which returns this step to TODO
-    // once the re-signed attestation is on the branch. Counting only `open`
-    // rounds is the anti-thrash bound: a repeat means the last signature did
-    // not cover this tree, and a chain that keeps asking is not progressing.
-    const priorRounds = (await tx.taskActivity.findMany({
-      where: { taskId: input.task.id }, select: { metadata: true },
-    })).filter((row) => {
-      const metadata = asJsonObject(row.metadata);
-      return metadata?.kind === MERGE_TAIL_KIND.authorityResign && metadata.state === "open";
-    }).length;
-    const round = priorRounds + 1;
-    if (round > MAX_AUTHORITY_RESIGN_ROUNDS) {
-      return stop(truncateFailureReason(
-        `release authority re-signature round ${round} exceeds ${MAX_AUTHORITY_RESIGN_ROUNDS} at ${verdict.headSha}: ${verdict.summary}`,
-        FAILURE_REASON_LIMIT,
-      ));
-    }
-    if (!input.run.branch) {
-      return stop(`release authority re-signature is required at ${verdict.headSha} but this run names no chain branch`);
-    }
+    // Rounds are counted from the notices this function itself wrote, not from
+    // the activity log: `actorType` and `metadata` are caller-supplied on the
+    // activity route, and an inbox `dedupeKey` is written nowhere else. The
+    // bound is anti-thrash — a repeat means the last signature did not cover
+    // this tree, and a chain that keeps asking is not progressing.
+    const round = await tx.inboxMessage.count({
+      where: { taskId: input.task.id, dedupeKey: { startsWith: `${AUTHORITY_RESIGN_DEDUPE_PREFIX}${input.task.id}:` } },
+    }) + 1;
+    const exhausted = round > MAX_AUTHORITY_RESIGN_ROUNDS;
     const branch = input.run.branch;
-    await tx.task.update({ where: { id: input.task.id }, data: {
-      status: TaskStatus.REVIEW,
-      failureReason: `${AUTHORITY_RESIGN_OPEN_PREFIX}${verdict.headSha}`,
-    } });
+    if (exhausted || !branch) {
+      const reason = exhausted
+        ? `release authority re-signature round ${round} exceeds ${MAX_AUTHORITY_RESIGN_ROUNDS} at ${verdict.headSha}: ${verdict.summary}`
+        : `release authority re-signature is required at ${verdict.headSha} but this run names no chain branch`;
+      const bounded = truncateFailureReason(reason, FAILURE_REASON_LIMIT);
+      if (recovery) {
+        await stopBaseDriftRecoveryTail(tx, recovery, "regression", bounded);
+        return "handled";
+      }
+      return stop(bounded);
+    }
+    // A step an operator has already taken over is not re-parked under it: the
+    // completion holds the chain mutex only from here, so the row is claimed
+    // rather than overwritten.
+    const parked = await tx.task.updateMany({
+      where: { id: input.task.id, status: { in: [TaskStatus.TODO, TaskStatus.DOING] } },
+      data: { status: TaskStatus.REVIEW, failureReason: `${AUTHORITY_RESIGN_OPEN_PREFIX}${verdict.headSha}` },
+    });
+    if (parked.count !== 1) {
+      await tx.taskActivity.create({ data: {
+        taskId: input.task.id,
+        actorType: "control-plane",
+        body: `Release authority re-signature is required at ${verdict.headSha} but this step is no longer the tail's to park`,
+        metadata: {
+          kind: MERGE_TAIL_KIND.authorityResign,
+          schemaVersion: 1,
+          state: "park-skipped",
+          headSha: verdict.headSha,
+          summary: verdict.summary,
+        },
+      } });
+      return "handled";
+    }
     await tx.taskActivity.create({ data: {
       taskId: input.task.id,
       actorType: "control-plane",
@@ -676,6 +687,26 @@ export const handleRegressionCompletion = async (
       summary: verdict.summary,
       round,
     });
+    // A base-drift recovery that reaches this needs the same signature as any
+    // other chain, and the resign worker resumes the same step for it. The
+    // recovery aggregate keeps its own state; nothing about it is decided here.
+    return "handled";
+  }
+
+  if (recovery) {
+    await stopBaseDriftRecoveryTail(
+      tx,
+      recovery,
+      "regression",
+      truncateFailureReason(
+        verdict.outcome === "refresh-conflict"
+          ? `refresh conflict at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`
+          : verdict.outcome === "review-fail"
+            ? `semantic regression FAIL at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`
+            : `merge gate FAIL at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`,
+        FAILURE_REASON_LIMIT,
+      ),
+    );
     return "handled";
   }
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -88,8 +88,10 @@ import {
   type CardRow,
   type DecisionRow,
   asJsonObject,
+  AUTHORITY_RESIGN_OPEN_PREFIX,
   INDEPENDENT_REVIEW_OPEN_PREFIX,
   isMergeReadinessStep,
+  MAX_AUTHORITY_RESIGN_ROUNDS,
   MAX_BLOCKING_REVIEW_ROUNDS,
   MERGE_TAIL_KIND,
   MergeRecoveryStatus,
@@ -97,6 +99,7 @@ import {
   parseIndependentReviewDecision,
   parseRegressionVerdict,
   parseResolverResult,
+  RELEASE_AUTHORITY_FILE,
   LEGACY_PRE_ADJUDICATION_TEMPLATE_PREFIX,
   type IndependentReviewFinding,
   type MergeRecoveryAttempt,
@@ -407,6 +410,64 @@ const openMergeTailStopNotice = async (
   } });
 };
 
+/**
+ * The one operator action the autonomous merge tail asks for, and the reason it
+ * cannot ask an agent instead: `release-authority.json` is signed with a key
+ * that lives outside every checkout, so a chain that moves an attested
+ * release-path file can only be unblocked by whoever holds it.
+ *
+ * The message is written to be run, not interpreted: the two recorded SHAs come
+ * out of the attestation already in the checkout, so nothing here has to be
+ * filled in by hand. Nothing else in the chain is blocked while it waits, and
+ * the resign worker resumes this step on its own once the signature is pushed.
+ */
+const openAuthorityResignNotice = async (
+  tx: DbTx,
+  input: {
+    taskId: string;
+    agentId: string;
+    sessionId?: string;
+    branch: string;
+    headSha: string;
+    summary: string;
+    round: number;
+  },
+): Promise<void> => {
+  const body = [
+    `Autonomous merge tail: ${RELEASE_AUTHORITY_FILE} must be re-signed before this chain can merge.`,
+    `Branch ${input.branch} moved attested release-path files at head ${input.headSha}, so the migration preflight refuses this tree and the merge gate cannot pass. The signing key never enters a chain, so this is yours to run (request ${input.round} of ${MAX_AUTHORITY_RESIGN_ROUNDS}).`,
+    `What moved:\n${input.summary}`,
+    [
+      "Run this in the checkout that holds the private revalidation document, with the signing key at hand:",
+      "",
+      `  git fetch origin ${input.branch}`,
+      `  git switch --detach ${input.headSha}`,
+      "  RELEASE_AUTHORITY_KEY=~/.agentos-keys/release-authority.ed25519 \\",
+      `  GOAL5A0_MASTER_SHA="$(node -p "require('./${RELEASE_AUTHORITY_FILE}').masterSha")" \\`,
+      `  GOAL5A0_CONTROL_PLANE_A_SHA="$(node -p "require('./${RELEASE_AUTHORITY_FILE}').controlPlaneASha")" \\`,
+      "    npm run snapshot:authority",
+      `  npm run db:authority-check -w @agentos/db`,
+      `  git add ${RELEASE_AUTHORITY_FILE}`,
+      `  git commit -m "chore(release): re-sign the release authority for ${input.branch}"`,
+      `  git push origin HEAD:${input.branch}`,
+    ].join("\n"),
+    `Nothing else is needed. The server watches the pull request and re-runs regression verification as soon as the re-signed ${RELEASE_AUTHORITY_FILE} is on ${input.branch}.`,
+  ].join("\n\n");
+  await tx.inboxMessage.upsert({
+    where: { dedupeKey: `authority-resign:${input.taskId}:${input.headSha}` },
+    create: {
+      from: "AGENT",
+      agentId: input.agentId,
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      taskId: input.taskId,
+      kind: "TEXT",
+      body,
+      dedupeKey: `authority-resign:${input.taskId}:${input.headSha}`,
+    },
+    update: {},
+  });
+};
+
 const createMergeTailRepairTask = async (
   tx: DbTx,
   input: {
@@ -558,8 +619,63 @@ export const handleRegressionCompletion = async (
         ? `refresh conflict at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`
         : verdict.outcome === "review-fail"
           ? `semantic regression FAIL at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`
-          : `merge gate FAIL at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`,
+          : verdict.outcome === "authority-resign"
+            ? `release authority re-signature required at ${verdict.headSha}: ${verdict.summary}`
+            : `merge gate FAIL at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`,
     );
+    return "handled";
+  }
+
+  if (verdict.outcome === "authority-resign") {
+    // The park is owned by the resign worker, which returns this step to TODO
+    // once the re-signed attestation is on the branch. Counting only `open`
+    // rounds is the anti-thrash bound: a repeat means the last signature did
+    // not cover this tree, and a chain that keeps asking is not progressing.
+    const priorRounds = (await tx.taskActivity.findMany({
+      where: { taskId: input.task.id }, select: { metadata: true },
+    })).filter((row) => {
+      const metadata = asJsonObject(row.metadata);
+      return metadata?.kind === MERGE_TAIL_KIND.authorityResign && metadata.state === "open";
+    }).length;
+    const round = priorRounds + 1;
+    if (round > MAX_AUTHORITY_RESIGN_ROUNDS) {
+      return stop(truncateFailureReason(
+        `release authority re-signature round ${round} exceeds ${MAX_AUTHORITY_RESIGN_ROUNDS} at ${verdict.headSha}: ${verdict.summary}`,
+        FAILURE_REASON_LIMIT,
+      ));
+    }
+    if (!input.run.branch) {
+      return stop(`release authority re-signature is required at ${verdict.headSha} but this run names no chain branch`);
+    }
+    const branch = input.run.branch;
+    await tx.task.update({ where: { id: input.task.id }, data: {
+      status: TaskStatus.REVIEW,
+      failureReason: `${AUTHORITY_RESIGN_OPEN_PREFIX}${verdict.headSha}`,
+    } });
+    await tx.taskActivity.create({ data: {
+      taskId: input.task.id,
+      actorType: "control-plane",
+      body: `Release authority re-signature requested at ${verdict.headSha}: ${verdict.summary}`,
+      metadata: {
+        kind: MERGE_TAIL_KIND.authorityResign,
+        schemaVersion: 1,
+        state: "open",
+        headSha: verdict.headSha,
+        baseHeadSha: verdict.baseHeadSha,
+        branch,
+        round,
+        summary: verdict.summary,
+      },
+    } });
+    await openAuthorityResignNotice(tx, {
+      taskId: input.task.id,
+      agentId: input.run.agentId,
+      sessionId: input.run.sessionId,
+      branch,
+      headSha: verdict.headSha,
+      summary: verdict.summary,
+      round,
+    });
     return "handled";
   }
 
@@ -1565,6 +1681,18 @@ const activateMergeTailTarget = async (
         ? "Independent review resolved; readiness target returned to the server worker"
         : "Merge-tail readiness target queued for server worker",
       metadata: { kind: MERGE_TAIL_KIND.readiness, schemaVersion: 1, state: "queued" },
+    } });
+    return;
+  }
+  if (target.status === TaskStatus.REVIEW && target.failureReason?.startsWith(AUTHORITY_RESIGN_OPEN_PREFIX)) {
+    // A park the resign worker owns. Re-queueing this step now would spend a
+    // gate on a tree the migration preflight still refuses, and would lose the
+    // park the operator's inbox message points at.
+    await tx.taskActivity.create({ data: {
+      taskId,
+      actorType: "control-plane",
+      body: "Merge-tail target is held by an open release authority re-signature",
+      metadata: { kind: MERGE_TAIL_KIND.authorityResign, schemaVersion: 1, state: "held" },
     } });
     return;
   }

--- a/packages/api/src/authority-resign-worker.ts
+++ b/packages/api/src/authority-resign-worker.ts
@@ -1,0 +1,183 @@
+/**
+ * The other side of the release-authority park.
+ *
+ * `handleRegressionCompletion` parks a regression-verification step and opens
+ * an inbox message when the branch moved attested release-path files without
+ * re-signing `release-authority.json`. The signature is the operator's to
+ * produce, so nothing in the chain can resolve that park — but nothing has to
+ * ask the operator to press a button either. This worker watches the pull
+ * request and returns the step to the queue the moment the re-signed
+ * attestation is on the branch. Whether the new signature is actually good is
+ * not decided here: the re-run gate decides it, and a signature that still does
+ * not cover the tree parks the step again, up to `MAX_AUTHORITY_RESIGN_ROUNDS`.
+ */
+import {
+  AUTHORITY_RESIGN_OPEN_PREFIX,
+  InboxStatus,
+  MERGE_TAIL_KIND,
+  Prisma,
+  RELEASE_AUTHORITY_FILE,
+  TaskStatus,
+  asJsonObject,
+  enqueueTaskRun,
+  lockChainRows,
+  lockTaskRow,
+  resolveChainTarget,
+  type PrismaClient,
+} from "@agentos/db";
+
+import { createGitHubReader, type GitHubReader } from "./github-read.js";
+
+/**
+ * Slower than the readiness poll on purpose: what this waits for is a person
+ * fetching a branch and running a signing command, so a tighter loop would only
+ * spend GitHub reads to learn the same thing.
+ */
+export const authorityResignPollIntervalMs = (): number => {
+  const raw = Number(process.env.AUTHORITY_RESIGN_POLL_INTERVAL_MS);
+  return Number.isFinite(raw) && raw >= 1_000 ? Math.floor(raw) : 30_000;
+};
+
+export const AUTHORITY_RESIGN_READ_BUDGET_MS = 20_000;
+
+export type AuthorityResignTickResult = { resumed: number; waiting: number; unwatchable: number };
+
+type ParkedRequest = { headSha: string; baseHeadSha: string; branch: string; round: number };
+
+const latestOpenRequest = (rows: Array<{ metadata: Prisma.JsonValue | null }>): ParkedRequest | null => {
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const metadata = asJsonObject(rows[index]?.metadata ?? null);
+    if (metadata?.kind !== MERGE_TAIL_KIND.authorityResign || metadata.state !== "open") continue;
+    if (typeof metadata.headSha !== "string" || typeof metadata.baseHeadSha !== "string"
+      || typeof metadata.branch !== "string" || typeof metadata.round !== "number") return null;
+    return {
+      headSha: metadata.headSha,
+      baseHeadSha: metadata.baseHeadSha,
+      branch: metadata.branch,
+      round: metadata.round,
+    };
+  }
+  return null;
+};
+
+export const authorityResignTick = async (
+  db: PrismaClient,
+  reader: GitHubReader | null = createGitHubReader(),
+  now = new Date(),
+  limit = 5,
+): Promise<AuthorityResignTickResult> => {
+  const result: AuthorityResignTickResult = { resumed: 0, waiting: 0, unwatchable: 0 };
+  const parked = await db.task.findMany({
+    where: {
+      status: TaskStatus.REVIEW,
+      failureReason: { startsWith: AUTHORITY_RESIGN_OPEN_PREFIX },
+      templateStep: { outputKind: "regression-verification" },
+    },
+    include: { repo: { select: { defaultBranch: true } } },
+    orderBy: { createdAt: "asc" },
+    take: limit,
+  });
+  for (const task of parked) {
+    const parkReason = task.failureReason;
+    if (!parkReason) continue;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    try {
+      const activities = await db.taskActivity.findMany({
+        where: { taskId: task.id }, select: { metadata: true }, orderBy: { createdAt: "asc" },
+      });
+      const request = latestOpenRequest(activities);
+      if (!request) {
+        // The park and the request that explains it are written in one
+        // transaction, so this cannot happen without something having rewritten
+        // the history. Say so instead of guessing a head to watch.
+        console.error(`Authority resign park on task ${task.id} has no open request activity`);
+        result.unwatchable += 1;
+        continue;
+      }
+      if (!reader?.compareCommits) {
+        console.error(`Authority resign park on task ${task.id} cannot be watched: no GitHub comparison reader`);
+        result.unwatchable += 1;
+        continue;
+      }
+      const target = await db.$transaction((tx) => resolveChainTarget(tx, task));
+      if (!target.resolved) {
+        console.error(`Authority resign park on task ${task.id} cannot be watched: pull-request target is ${target.unresolvable}`);
+        result.unwatchable += 1;
+        continue;
+      }
+      const controller = new AbortController();
+      timer = setTimeout(() => controller.abort(), AUTHORITY_RESIGN_READ_BUDGET_MS);
+      const snapshot = await reader.readPullRequest(target.repository, target.prNumber, task.repo?.defaultBranch ?? "main", controller.signal);
+      if (!snapshot.headRefOid || snapshot.headRefOid === request.headSha) {
+        result.waiting += 1;
+        continue;
+      }
+      if (!snapshot.baseSha) {
+        result.waiting += 1;
+        continue;
+      }
+      const diff = await reader.compareCommits(target.repository, snapshot.baseSha, snapshot.headRefOid, controller.signal);
+      // The whole range, not the new commits: the attestation has to be
+      // re-signed relative to the base this branch merges into, and a truncated
+      // file list cannot show that it was.
+      if (!diff.filesComplete || !diff.files.some((file) => file.filename === RELEASE_AUTHORITY_FILE)) {
+        result.waiting += 1;
+        continue;
+      }
+      const resumedHead = snapshot.headRefOid;
+      const resumed = await db.$transaction(async (tx) => {
+        const identity = await tx.task.findUnique({ where: { id: task.id }, select: { projectId: true, chainId: true } });
+        if (!identity) return false;
+        if (identity.chainId) await lockChainRows(tx, { projectId: identity.projectId, chainId: identity.chainId });
+        else await lockTaskRow(tx, task.id);
+        const claimed = await tx.task.updateMany({
+          where: { id: task.id, status: TaskStatus.REVIEW, failureReason: parkReason },
+          data: { status: TaskStatus.TODO, failureReason: null },
+        });
+        if (claimed.count !== 1) return false;
+        await enqueueTaskRun(tx, task.id, now);
+        await tx.taskActivity.create({ data: {
+          taskId: task.id,
+          actorType: "control-plane",
+          body: `Re-signed ${RELEASE_AUTHORITY_FILE} observed on ${request.branch}; regression verification re-queued at ${resumedHead}`,
+          metadata: {
+            kind: MERGE_TAIL_KIND.authorityResign,
+            schemaVersion: 1,
+            state: "resumed",
+            parkedHeadSha: request.headSha,
+            headSha: resumedHead,
+            branch: request.branch,
+            round: request.round,
+          },
+        } });
+        await tx.inboxMessage.updateMany({
+          where: { dedupeKey: `authority-resign:${task.id}:${request.headSha}`, status: InboxStatus.OPEN },
+          data: { status: InboxStatus.CLOSED, answeredAt: now },
+        });
+        return true;
+      });
+      if (resumed) result.resumed += 1;
+      else result.waiting += 1;
+    } catch (error: unknown) {
+      // One unreadable pull request must not starve the other parks in this
+      // tick. The park is left exactly as it is and the next tick tries again;
+      // a condition that never clears keeps saying so, once per tick.
+      console.error(`Authority resign park on task ${task.id} could not be evaluated`, error);
+      result.unwatchable += 1;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+  return result;
+};
+
+export const startAuthorityResignWorker = (
+  db: PrismaClient,
+  reader: GitHubReader | null = createGitHubReader(),
+): ReturnType<typeof setInterval> => {
+  const timer = setInterval(() => {
+    void authorityResignTick(db, reader).catch((error: unknown) => console.error("Authority resign tick failed", error));
+  }, authorityResignPollIntervalMs());
+  timer.unref?.();
+  return timer;
+};

--- a/packages/api/src/authority-resign-worker.ts
+++ b/packages/api/src/authority-resign-worker.ts
@@ -12,6 +12,7 @@
  * not cover the tree parks the step again, up to `MAX_AUTHORITY_RESIGN_ROUNDS`.
  */
 import {
+  AUTHORITY_RESIGN_DEDUPE_PREFIX,
   AUTHORITY_RESIGN_OPEN_PREFIX,
   InboxStatus,
   MERGE_TAIL_KIND,
@@ -64,7 +65,6 @@ export const authorityResignTick = async (
   db: PrismaClient,
   reader: GitHubReader | null = createGitHubReader(),
   now = new Date(),
-  limit = 5,
 ): Promise<AuthorityResignTickResult> => {
   const result: AuthorityResignTickResult = { resumed: 0, waiting: 0, unwatchable: 0 };
   const parked = await db.task.findMany({
@@ -75,7 +75,6 @@ export const authorityResignTick = async (
     },
     include: { repo: { select: { defaultBranch: true } } },
     orderBy: { createdAt: "asc" },
-    take: limit,
   });
   for (const task of parked) {
     const parkReason = task.failureReason;
@@ -112,14 +111,20 @@ export const authorityResignTick = async (
         result.waiting += 1;
         continue;
       }
-      if (!snapshot.baseSha) {
+      // From the parked head, not from the base: what has to be proven is that
+      // the attestation moved *after* this park. A base-relative comparison
+      // would also match the re-signature of an earlier round, and would resume
+      // a step whose own migration is still unattested.
+      const diff = await reader.compareCommits(target.repository, request.headSha, snapshot.headRefOid, controller.signal);
+      // `behind` or `diverged` means the parked head is not an ancestor of what
+      // is on the branch now: the file list no longer describes "what was added
+      // since the park", so it cannot answer the question either.
+      if (diff.status !== "ahead" && diff.status !== "identical") {
         result.waiting += 1;
         continue;
       }
-      const diff = await reader.compareCommits(target.repository, snapshot.baseSha, snapshot.headRefOid, controller.signal);
-      // The whole range, not the new commits: the attestation has to be
-      // re-signed relative to the base this branch merges into, and a truncated
-      // file list cannot show that it was.
+      // A truncated list cannot show the attestation is absent, only that it was
+      // not among the first 300 paths.
       if (!diff.filesComplete || !diff.files.some((file) => file.filename === RELEASE_AUTHORITY_FILE)) {
         result.waiting += 1;
         continue;
@@ -151,7 +156,7 @@ export const authorityResignTick = async (
           },
         } });
         await tx.inboxMessage.updateMany({
-          where: { dedupeKey: `authority-resign:${task.id}:${request.headSha}`, status: InboxStatus.OPEN },
+          where: { dedupeKey: `${AUTHORITY_RESIGN_DEDUPE_PREFIX}${task.id}:${request.headSha}`, status: InboxStatus.OPEN },
           data: { status: InboxStatus.CLOSED, answeredAt: now },
         });
         return true;

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -424,6 +424,11 @@ const canonicalOutputSchemas: Record<string, z.ZodType> = {
       baseHeadSha: commitSha,
       summary: nonEmptyString,
     }),
+    canonicalEnvelope.extend({
+      outcome: z.literal("authority-resign"),
+      baseHeadSha: commitSha,
+      summary: nonEmptyString,
+    }),
   ]),
   documentation: canonicalEnvelope.extend({
     summary: nonEmptyString,

--- a/packages/api/src/chain.dbtest.ts
+++ b/packages/api/src/chain.dbtest.ts
@@ -7,6 +7,7 @@ import {
   activateChainSuccessor,
   applyInboxDecisionTx,
   CHAIN_AUTO_RESUME_KIND,
+  AUTHORITY_RESIGN_OPEN_PREFIX,
   INDEPENDENT_REVIEW_OPEN_PREFIX,
   MAX_AUTOMATIC_SUCCESSOR_RESUMES,
   COMPOUND_IMPLEMENTATION_ASSIGNEE_ERROR_CODE,
@@ -1198,6 +1199,21 @@ test("a stalled REVIEW successor is automatically returned to the queue", { time
   assert.equal(await db.taskActivity.count({ where: {
     taskId: successor.id, metadata: { path: ["kind"], equals: CHAIN_AUTO_RESUME_KIND },
   } }), 1);
+});
+
+test("a successor held by an open release authority re-signature is left to the resign worker", { timeout: 20_000 }, async () => {
+  const { predecessor, successor } = await seedExecutableChain();
+  await db.task.update({ where: { id: successor.id }, data: {
+    status: "REVIEW", failureReason: `${AUTHORITY_RESIGN_OPEN_PREFIX}${"a".repeat(40)}`,
+  } });
+  await activateOnParkedSuccessor(predecessor);
+  const held = await db.task.findUniqueOrThrow({ where: { id: successor.id } });
+  assert.equal(held.status, "REVIEW");
+  assert.equal(await db.run.count({ where: { taskId: successor.id } }), 0);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: successor.id, metadata: { path: ["kind"], equals: CHAIN_AUTO_RESUME_KIND },
+  } }), 0);
+  assert.match(await latestActivity(successor.id), /held by an open release authority re-signature/u);
 });
 
 test("a successor held by an open independent review is left to that review", { timeout: 20_000 }, async () => {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -30,6 +30,7 @@ let schedulerTimer: ReturnType<typeof setInterval> | null = null;
 let evidenceTimer: ReturnType<typeof setInterval> | null = null;
 let readinessTimer: ReturnType<typeof setInterval> | null = null;
 let baseDriftRecoveryTimer: ReturnType<typeof setInterval> | null = null;
+let authorityResignTimer: ReturnType<typeof setInterval> | null = null;
 let prisma: (typeof import("@agentos/db"))["prisma"] | undefined;
 let cleanupPromise: Promise<void> | undefined;
 let requestedSignal: NodeJS.Signals | undefined;
@@ -71,6 +72,8 @@ const cleanup = (exitCode: number): Promise<void> => {
     readinessTimer = null;
     if (baseDriftRecoveryTimer) clearInterval(baseDriftRecoveryTimer);
     baseDriftRecoveryTimer = null;
+    if (authorityResignTimer) clearInterval(authorityResignTimer);
+    authorityResignTimer = null;
     await closeServer().catch((error: unknown) => failures.push(error));
     if (prisma) await prisma.$disconnect().catch((error: unknown) => failures.push(error));
     // After the listener is closed and the client is disconnected, and not
@@ -166,6 +169,7 @@ const main = async (): Promise<void> => {
     { startEvidenceWorker },
     { startReadinessWorker },
     { startBaseDriftRecoveryWorker },
+    { startAuthorityResignWorker },
     files,
     { serve },
   ] = await Promise.all([
@@ -176,6 +180,7 @@ const main = async (): Promise<void> => {
     import("./merge-evidence-worker.js"),
     import("./merge-readiness-worker.js"),
     import("./merge-base-drift-worker.js"),
+    import("./authority-resign-worker.js"),
     import("./files/config.js"),
     import("@hono/node-server"),
   ]);
@@ -220,6 +225,7 @@ const main = async (): Promise<void> => {
   evidenceTimer = startEvidenceWorker(prisma);
   readinessTimer = startReadinessWorker(prisma);
   baseDriftRecoveryTimer = startBaseDriftRecoveryWorker(prisma);
+  authorityResignTimer = startAuthorityResignWorker(prisma);
   startupBusy = false;
 };
 

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { after, before, beforeEach, test } from "node:test";
 
 import {
+  AUTHORITY_RESIGN_OPEN_PREFIX,
   AUTHORIZED_MERGE_METHOD,
   applyInboxDecisionTx,
   enqueueTaskRun,
@@ -569,6 +570,37 @@ test("operator-authored recovery metadata cannot suppress an ordinary gate repai
   assert.equal(await db.inboxMessage.count({ where: {
     dedupeKey: { startsWith: "merge-base-drift-recovery-tail-stop:" },
   } }), 0);
+});
+
+test("a recovery regression that needs a re-signature parks and asks instead of stopping the tail", async () => {
+  const seeded = await seedStopped("canonical-compound-readiness", "tail-resign");
+  await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)));
+  const run = await db.run.findFirstOrThrow({ where: { taskId: seeded.gateTask.id }, orderBy: { runNumber: "desc" } });
+  const body = {
+    schemaVersion: 1, outcome: "authority-resign", headSha: HEAD, baseHeadSha: BASE_2,
+    summary: "added packages/db/prisma/migrations/20260826000000_probe/migration.sql",
+  };
+  await db.taskStepOutput.upsert({ where: { taskId: seeded.gateTask.id }, create: {
+    taskId: seeded.gateTask.id, runId: run.id, kind: "regression-verification", body: JSON.stringify(body), commitSha: HEAD,
+  }, update: { runId: run.id, body: JSON.stringify(body), commitSha: HEAD } });
+
+  await db.$transaction((tx) => handleRegressionCompletion(tx, {
+    task: seeded.gateTask,
+    run: { id: run.id, agentId: run.agentId, branch: "agentos/chain/demo", headSha: HEAD, sessionId: seeded.gateSession.id },
+    now: new Date(),
+  }));
+
+  // A recovery needs the same signature as any other chain, and the resign
+  // worker resumes the same step for it: this is not a dead end.
+  const gate = await db.task.findUniqueOrThrow({ where: { id: seeded.gateTask.id } });
+  assert.equal(gate.status, TaskStatus.REVIEW);
+  assert.equal(gate.failureReason, `${AUTHORITY_RESIGN_OPEN_PREFIX}${HEAD}`);
+  const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.gateTask.id } });
+  assert.match(notice.body, /must be re-signed/u);
+  assert.equal(await db.task.count({ where: { name: { startsWith: "Autonomous merge tail:" } } }), 0);
+  assert.equal((await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  })).status, "REPAIRING");
 });
 
 test("a recovery regression conflict, semantic failure, or gate failure stops without an auxiliary repair task", async () => {

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -8,11 +8,17 @@ import { promisify } from "node:util";
 
 import {
   AssigneeType,
+  AUTHORITY_RESIGN_OPEN_PREFIX,
+  InboxStatus,
+  MAX_AUTHORITY_RESIGN_ROUNDS,
+  MERGE_TAIL_KIND,
   PrismaClient,
   TaskStatus,
 } from "@agentos/db";
 
 import { handleRegressionCompletion } from "./app.js";
+import { authorityResignTick } from "./authority-resign-worker.js";
+import type { GitHubReader, PullRequestSnapshot } from "./github-read.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
@@ -106,17 +112,34 @@ const seedRegression = async (options: { withLibrarian?: boolean } = {}) => {
   return { project, template, repo, regressionAgent, reviewAgent, readinessStep, regression, librarian, fix, run, session };
 };
 
-const verdict = (outcome: "refresh-conflict" | "review-fail" | "gate-fail") => JSON.stringify(outcome === "refresh-conflict"
+const RESIGN_SUMMARY = "added packages/db/prisma/migrations/20260826000000_probe/migration.sql";
+
+const verdict = (outcome: RegressionOutcome) => JSON.stringify(outcome === "refresh-conflict"
   ? { schemaVersion: 1, outcome, headSha: HEAD, baseHeadSha: BASE, summary: "merge conflict" }
   : outcome === "review-fail"
     ? { schemaVersion: 1, outcome, headSha: HEAD, baseHeadSha: BASE, summary: "MF-2 remains open" }
-    : { schemaVersion: 1, outcome, headSha: HEAD, baseHeadSha: BASE, gateVerdict: "FAIL", summary: "suite failed" });
+    : outcome === "authority-resign"
+      ? { schemaVersion: 1, outcome, headSha: HEAD, baseHeadSha: BASE, summary: RESIGN_SUMMARY }
+      : { schemaVersion: 1, outcome, headSha: HEAD, baseHeadSha: BASE, gateVerdict: "FAIL", summary: "suite failed" });
+
+type RegressionOutcome = "refresh-conflict" | "review-fail" | "gate-fail" | "authority-resign";
 
 const exercise = async (
-  outcome: "refresh-conflict" | "review-fail" | "gate-fail",
-  options: { withLibrarian?: boolean } = {},
+  outcome: RegressionOutcome,
+  options: { withLibrarian?: boolean; priorResignRounds?: number } = {},
 ) => {
   const seeded = await seedRegression(options);
+  for (let round = 1; round <= (options.priorResignRounds ?? 0); round += 1) {
+    await db.taskActivity.create({ data: {
+      taskId: seeded.regression.id,
+      actorType: "control-plane",
+      body: `Release authority re-signature requested (round ${round})`,
+      metadata: {
+        kind: MERGE_TAIL_KIND.authorityResign, schemaVersion: 1, state: "open",
+        headSha: HEAD, baseHeadSha: BASE, branch: BRANCH, round,
+      },
+    } });
+  }
   await db.taskStepOutput.create({ data: {
     taskId: seeded.regression.id, runId: seeded.run.id, kind: "regression-verification",
     body: verdict(outcome), commitSha: HEAD,
@@ -830,4 +853,171 @@ test("a stale branch is mechanically refreshed before exact-head PASS advances",
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test("an authority re-signature request parks the step and opens one runnable inbox message", async () => {
+  const seeded = await exercise("authority-resign");
+
+  const regression = await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } });
+  assert.equal(regression.status, TaskStatus.REVIEW);
+  assert.equal(regression.failureReason, `${AUTHORITY_RESIGN_OPEN_PREFIX}${HEAD}`);
+  // No agent can close this, so no agent is asked to.
+  assert.equal(await repairCount(seeded), 0);
+
+  const messages = await db.inboxMessage.findMany({ where: { taskId: seeded.regression.id } });
+  assert.equal(messages.length, 1);
+  const message = messages[0]!;
+  assert.equal(message.kind, "TEXT");
+  assert.equal(message.status, InboxStatus.OPEN);
+  assert.equal(message.dedupeKey, `authority-resign:${seeded.regression.id}:${HEAD}`);
+  for (const fragment of [
+    RESIGN_SUMMARY,
+    `git switch --detach ${HEAD}`,
+    "npm run snapshot:authority",
+    "npm run db:authority-check -w @agentos/db",
+    `git push origin HEAD:${BRANCH}`,
+    "release-authority.json",
+  ]) assert.ok(message.body.includes(fragment), `${fragment} is missing from the inbox message`);
+  // The one-liner must be runnable, so nothing in it may be a placeholder.
+  assert.equal(/<[a-z-]+>/u.test(message.body), false, message.body);
+
+  const opened = await db.taskActivity.findMany({ where: { taskId: seeded.regression.id } });
+  const request = opened.map((row) => row.metadata as Record<string, unknown> | null)
+    .filter((metadata) => metadata?.kind === MERGE_TAIL_KIND.authorityResign && metadata.state === "open");
+  assert.equal(request.length, 1);
+  assert.deepEqual(
+    { headSha: request[0]!.headSha, branch: request[0]!.branch, round: request[0]!.round },
+    { headSha: HEAD, branch: BRANCH, round: 1 },
+  );
+});
+
+test("a re-signature request past the round ceiling stops the tail instead of asking again", async () => {
+  const seeded = await exercise("authority-resign", { priorResignRounds: MAX_AUTHORITY_RESIGN_ROUNDS });
+
+  const regression = await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } });
+  assert.equal(regression.status, TaskStatus.REVIEW);
+  assert.equal(regression.failureReason?.startsWith(AUTHORITY_RESIGN_OPEN_PREFIX), false);
+  assert.match(regression.failureReason ?? "", /re-signature round 4 exceeds 3/u);
+  const notices = await db.inboxMessage.findMany({ where: { taskId: seeded.regression.id } });
+  assert.equal(notices.length, 1);
+  assert.match(notices[0]!.body, /Autonomous merge tail stopped/u);
+});
+
+test("a repair completion does not restart a step parked for a re-signature", async () => {
+  const seeded = await exercise("gate-fail");
+  const repair = await repairFor(seeded, "gate-fix");
+  await db.task.update({ where: { id: seeded.regression.id }, data: {
+    status: TaskStatus.REVIEW, failureReason: `${AUTHORITY_RESIGN_OPEN_PREFIX}${HEAD}`,
+  } });
+
+  await completeRepair(seeded, repair.id, "repair completed", HEAD);
+
+  const regression = await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } });
+  assert.equal(regression.status, TaskStatus.REVIEW);
+  assert.equal(regression.failureReason, `${AUTHORITY_RESIGN_OPEN_PREFIX}${HEAD}`);
+  assert.equal(await db.run.count({ where: { taskId: seeded.regression.id, status: "QUEUED" } }), 0);
+  assert.equal(await db.taskActivity.count({
+    where: { taskId: seeded.regression.id, body: { contains: "held by an open release authority re-signature" } },
+  }), 1);
+});
+
+const PR_NUMBER = 41;
+const RESIGNED = "d".repeat(40);
+
+const resignReader = (headRefOid: string, filenames: string[]): GitHubReader => {
+  const pullRequest: PullRequestSnapshot = {
+    repository: "acme/widgets",
+    number: PR_NUMBER,
+    state: "OPEN",
+    isDraft: false,
+    merged: false,
+    mergeable: "MERGEABLE",
+    mergeStateStatus: "CLEAN",
+    baseRefName: "main",
+    headRefOid,
+    baseSha: BASE,
+    autoMergeRequest: null,
+    mergeQueueEntry: null,
+    repositoryMergeQueue: null,
+    mergedBy: null,
+    mergeCommit: null,
+    requiredCheckNames: [],
+    checkContexts: [],
+    headCommitOid: headRefOid,
+    readAt: new Date().toISOString(),
+  };
+  return {
+    readPullRequest: async () => pullRequest,
+    compareCommits: async () => ({
+      status: "ahead",
+      behindBy: 0,
+      filesComplete: true,
+      files: filenames.map((filename) => ({ filename, previousFilename: null, patch: null })),
+    }),
+  };
+};
+
+const parkedForResign = async () => {
+  const seeded = await exercise("authority-resign");
+  await db.run.update({
+    where: { id: seeded.run.id },
+    data: {
+      pullRequestNumber: PR_NUMBER,
+      pullRequestUrl: `https://github.com/acme/widgets/pull/${PR_NUMBER}`,
+    },
+  });
+  return seeded;
+};
+
+test("the resign worker returns the step once the re-signed attestation is on the branch", async () => {
+  const seeded = await parkedForResign();
+
+  const result = await authorityResignTick(db, resignReader(RESIGNED, ["release-authority.json", "packages/db/prisma/migrations/20260826000000_probe/migration.sql"]));
+
+  assert.deepEqual(result, { resumed: 1, waiting: 0, unwatchable: 0 });
+  const regression = await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } });
+  assert.equal(regression.status, TaskStatus.TODO);
+  assert.equal(regression.failureReason, null);
+  assert.equal(await db.run.count({ where: { taskId: seeded.regression.id, status: "QUEUED" } }), 1);
+  const resumedActivity = (await db.taskActivity.findMany({ where: { taskId: seeded.regression.id } }))
+    .map((row) => row.metadata as Record<string, unknown> | null)
+    .filter((metadata) => metadata?.kind === MERGE_TAIL_KIND.authorityResign && metadata.state === "resumed");
+  assert.equal(resumedActivity.length, 1);
+  assert.equal(resumedActivity[0]!.headSha, RESIGNED);
+  const message = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
+  assert.equal(message.status, InboxStatus.CLOSED);
+});
+
+test("a push that does not carry the attestation leaves the park exactly as it was", async () => {
+  const seeded = await parkedForResign();
+
+  const result = await authorityResignTick(db, resignReader(RESIGNED, ["packages/api/src/app.ts"]));
+
+  assert.deepEqual(result, { resumed: 0, waiting: 1, unwatchable: 0 });
+  const regression = await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } });
+  assert.equal(regression.status, TaskStatus.REVIEW);
+  assert.equal(regression.failureReason, `${AUTHORITY_RESIGN_OPEN_PREFIX}${HEAD}`);
+  assert.equal(await db.run.count({ where: { taskId: seeded.regression.id, status: "QUEUED" } }), 0);
+  const message = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
+  assert.equal(message.status, InboxStatus.OPEN);
+});
+
+test("the head that was parked is never mistaken for the re-signed one", async () => {
+  await parkedForResign();
+
+  // The attestation is in the range because the branch has always carried one;
+  // only a head that actually moved can be the operator's signature.
+  const result = await authorityResignTick(db, resignReader(HEAD, ["release-authority.json"]));
+
+  assert.deepEqual(result, { resumed: 0, waiting: 1, unwatchable: 0 });
+});
+
+test("a park whose pull request cannot be resolved is reported, not resumed and not lost", async () => {
+  const seeded = await exercise("authority-resign");
+
+  const result = await authorityResignTick(db, resignReader(RESIGNED, ["release-authority.json"]));
+
+  assert.deepEqual(result, { resumed: 0, waiting: 0, unwatchable: 1 });
+  const regression = await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } });
+  assert.equal(regression.failureReason, `${AUTHORITY_RESIGN_OPEN_PREFIX}${HEAD}`);
 });

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 
 import {
   AssigneeType,
+  AUTHORITY_RESIGN_DEDUPE_PREFIX,
   AUTHORITY_RESIGN_OPEN_PREFIX,
   InboxStatus,
   MAX_AUTHORITY_RESIGN_ROUNDS,
@@ -33,8 +34,13 @@ const BRANCH = "agentos/repair-test";
 const RESOLVED = "c".repeat(40);
 const exec = promisify(execFile);
 
+let seedCounter = 0;
+
 const seedRegression = async (options: { withLibrarian?: boolean } = {}) => {
-  const project = await db.project.create({ data: { name: "Repair", slug: `repair-${Date.now()}` } });
+  // A test may seed several chains in one millisecond, and both the slug and the
+  // chain id have to stay distinct across them.
+  const seedId = `${Date.now()}-${(seedCounter += 1)}`;
+  const project = await db.project.create({ data: { name: "Repair", slug: `repair-${seedId}` } });
   const environment = await db.environment.create({ data: { projectId: project.id, name: "local", allowedHosts: [] } });
   const makeAgent = (name: string) => db.agent.create({ data: {
     projectId: project.id, environmentId: environment.id, name, title: name,
@@ -83,7 +89,7 @@ const seedRegression = async (options: { withLibrarian?: boolean } = {}) => {
       assigneeAgentId: librarianAgent.id, prompt: "document", approvalGate: false, outputKind: "documentation",
     } }) : null,
   ]);
-  const chainId = `chain-${Date.now()}`;
+  const chainId = `chain-${seedId}`;
   const fix = await db.task.create({ data: {
     projectId: project.id, repoId: repo.id, templateId: template.id, templateStepId: fixStep.id,
     name: "Fix", description: "fix", assigneeType: AssigneeType.AGENT, assigneeAgentId: fixAgent.id,
@@ -126,18 +132,19 @@ type RegressionOutcome = "refresh-conflict" | "review-fail" | "gate-fail" | "aut
 
 const exercise = async (
   outcome: RegressionOutcome,
-  options: { withLibrarian?: boolean; priorResignRounds?: number } = {},
+  options: { withLibrarian?: boolean; priorResignRounds?: number; branch?: string } = {},
 ) => {
   const seeded = await seedRegression(options);
+  // Rounds are counted from the notices themselves, so a prior round is seeded
+  // as the notice it was, dedupe key and all.
   for (let round = 1; round <= (options.priorResignRounds ?? 0); round += 1) {
-    await db.taskActivity.create({ data: {
+    await db.inboxMessage.create({ data: {
+      from: "AGENT",
+      agentId: seeded.regressionAgent.id,
       taskId: seeded.regression.id,
-      actorType: "control-plane",
+      kind: "TEXT",
       body: `Release authority re-signature requested (round ${round})`,
-      metadata: {
-        kind: MERGE_TAIL_KIND.authorityResign, schemaVersion: 1, state: "open",
-        headSha: HEAD, baseHeadSha: BASE, branch: BRANCH, round,
-      },
+      dedupeKey: `${AUTHORITY_RESIGN_DEDUPE_PREFIX}${seeded.regression.id}:${"e".repeat(39)}${round}`,
     } });
   }
   await db.taskStepOutput.create({ data: {
@@ -146,7 +153,10 @@ const exercise = async (
   } });
   const input = {
     task: seeded.regression,
-    run: { id: seeded.run.id, agentId: seeded.regressionAgent.id, branch: BRANCH, headSha: HEAD, sessionId: seeded.session.id },
+    run: {
+      id: seeded.run.id, agentId: seeded.regressionAgent.id,
+      branch: options.branch ?? BRANCH, headSha: HEAD, sessionId: seeded.session.id,
+    },
     now: new Date(),
   };
   assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, input)), "handled");
@@ -869,13 +879,13 @@ test("an authority re-signature request parks the step and opens one runnable in
   const message = messages[0]!;
   assert.equal(message.kind, "TEXT");
   assert.equal(message.status, InboxStatus.OPEN);
-  assert.equal(message.dedupeKey, `authority-resign:${seeded.regression.id}:${HEAD}`);
+  assert.equal(message.dedupeKey, `${AUTHORITY_RESIGN_DEDUPE_PREFIX}${seeded.regression.id}:${HEAD}`);
   for (const fragment of [
     RESIGN_SUMMARY,
-    `git switch --detach ${HEAD}`,
+    `git switch --detach '${HEAD}'`,
     "npm run snapshot:authority",
     "npm run db:authority-check -w @agentos/db",
-    `git push origin HEAD:${BRANCH}`,
+    `git push origin 'HEAD:${BRANCH}'`,
     "release-authority.json",
   ]) assert.ok(message.body.includes(fragment), `${fragment} is missing from the inbox message`);
   // The one-liner must be runnable, so nothing in it may be a placeholder.
@@ -899,8 +909,10 @@ test("a re-signature request past the round ceiling stops the tail instead of as
   assert.equal(regression.failureReason?.startsWith(AUTHORITY_RESIGN_OPEN_PREFIX), false);
   assert.match(regression.failureReason ?? "", /re-signature round 4 exceeds 3/u);
   const notices = await db.inboxMessage.findMany({ where: { taskId: seeded.regression.id } });
-  assert.equal(notices.length, 1);
-  assert.match(notices[0]!.body, /Autonomous merge tail stopped/u);
+  // The three prior rounds and one stop notice: no fourth request was written.
+  assert.equal(notices.length, MAX_AUTHORITY_RESIGN_ROUNDS + 1);
+  assert.equal(notices.filter((notice) => /Autonomous merge tail stopped/u.test(notice.body)).length, 1);
+  assert.equal(notices.filter((notice) => /must be re-signed/u.test(notice.body)).length, 0);
 });
 
 test("a repair completion does not restart a step parked for a re-signature", async () => {
@@ -924,7 +936,13 @@ test("a repair completion does not restart a step parked for a re-signature", as
 const PR_NUMBER = 41;
 const RESIGNED = "d".repeat(40);
 
-const resignReader = (headRefOid: string, filenames: string[]): GitHubReader => {
+type ResignReader = GitHubReader & { comparisons: Array<{ base: string; head: string }> };
+
+const resignReader = (
+  headRefOid: string,
+  filenames: string[],
+  status: "ahead" | "behind" | "diverged" | "identical" = "ahead",
+): ResignReader => {
   const pullRequest: PullRequestSnapshot = {
     repository: "acme/widgets",
     number: PR_NUMBER,
@@ -946,14 +964,19 @@ const resignReader = (headRefOid: string, filenames: string[]): GitHubReader => 
     headCommitOid: headRefOid,
     readAt: new Date().toISOString(),
   };
+  const comparisons: Array<{ base: string; head: string }> = [];
   return {
+    comparisons,
     readPullRequest: async () => pullRequest,
-    compareCommits: async () => ({
-      status: "ahead",
-      behindBy: 0,
-      filesComplete: true,
-      files: filenames.map((filename) => ({ filename, previousFilename: null, patch: null })),
-    }),
+    compareCommits: async (_repository, base, head) => {
+      comparisons.push({ base, head });
+      return {
+        status,
+        behindBy: 0,
+        filesComplete: true,
+        files: filenames.map((filename) => ({ filename, previousFilename: null, patch: null })),
+      };
+    },
   };
 };
 
@@ -1010,6 +1033,75 @@ test("the head that was parked is never mistaken for the re-signed one", async (
   const result = await authorityResignTick(db, resignReader(HEAD, ["release-authority.json"]));
 
   assert.deepEqual(result, { resumed: 0, waiting: 1, unwatchable: 0 });
+});
+
+test("the re-signature is looked for after the parked head, not after the pull request base", async () => {
+  await parkedForResign();
+  const reader = resignReader(RESIGNED, ["release-authority.json"]);
+
+  assert.deepEqual(await authorityResignTick(db, reader), { resumed: 1, waiting: 0, unwatchable: 0 });
+  // A base-anchored comparison would also match a re-signature from an earlier
+  // round, and would resume a step whose own migration is still unattested.
+  assert.deepEqual(reader.comparisons, [{ base: HEAD, head: RESIGNED }]);
+});
+
+test("a branch that no longer descends from the parked head is not read as a re-signature", async () => {
+  const seeded = await parkedForResign();
+
+  const result = await authorityResignTick(db, resignReader(RESIGNED, ["release-authority.json"], "diverged"));
+
+  assert.deepEqual(result, { resumed: 0, waiting: 1, unwatchable: 0 });
+  const regression = await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } });
+  assert.equal(regression.failureReason, `${AUTHORITY_RESIGN_OPEN_PREFIX}${HEAD}`);
+});
+
+test("every park is scanned, not just the oldest few", async () => {
+  const parks = [];
+  for (let index = 0; index < 6; index += 1) parks.push(await parkedForResign());
+
+  const result = await authorityResignTick(db, resignReader(RESIGNED, ["release-authority.json"]));
+
+  assert.deepEqual(result, { resumed: 6, waiting: 0, unwatchable: 0 });
+  for (const seeded of parks) {
+    assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } })).status, TaskStatus.TODO);
+  }
+});
+
+test("a hostile branch name cannot escape the shell command the operator is asked to run", async () => {
+  const branch = "feat/'; rm -rf $HOME #";
+  const seeded = await exercise("authority-resign", { branch });
+
+  const message = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
+  assert.ok(message.body.includes(`git fetch origin 'feat/'\\''; rm -rf $HOME #'`), message.body);
+  assert.ok(message.body.includes(`git push origin 'HEAD:feat/'\\''; rm -rf $HOME #'`), message.body);
+  // Every argument is one single-quoted word, with the branch's own quote escaped.
+  assert.ok(message.body.includes(`git commit -m 'chore(release): re-sign the release authority for feat/'\\''; rm -rf $HOME #'`), message.body);
+});
+
+test("a step that is no longer the tail's to park is reported instead of overwritten", async () => {
+  const seeded = await seedRegression();
+  await db.taskStepOutput.create({ data: {
+    taskId: seeded.regression.id, runId: seeded.run.id, kind: "regression-verification",
+    body: verdict("authority-resign"), commitSha: HEAD,
+  } });
+  // An operator took the step over between the run finishing and this handler
+  // reaching the row.
+  await db.task.update({ where: { id: seeded.regression.id }, data: {
+    status: TaskStatus.REVIEW, failureReason: "operator holds this step",
+  } });
+
+  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, {
+    task: seeded.regression,
+    run: { id: seeded.run.id, agentId: seeded.regressionAgent.id, branch: BRANCH, headSha: HEAD, sessionId: seeded.session.id },
+    now: new Date(),
+  })), "handled");
+
+  const regression = await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } });
+  assert.equal(regression.failureReason, "operator holds this step");
+  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 0);
+  assert.equal(await db.taskActivity.count({
+    where: { taskId: seeded.regression.id, metadata: { path: ["state"], equals: "park-skipped" } },
+  }), 1);
 });
 
 test("a park whose pull request cannot be resolved is reported, not resumed and not lost", async () => {

--- a/packages/api/src/regression-repair-handoff.ts
+++ b/packages/api/src/regression-repair-handoff.ts
@@ -52,6 +52,10 @@ export const regressionRepairHandoffForClaim = async (
     reason: `regression repair handoff is invalid: ${reason}`,
   });
 
+  // A re-signature request creates no repair task, so there is no repair run to
+  // hand the prior verdict to. The re-run reads the tree itself.
+  if (parsed.verdict.outcome === "authority-resign") return { status: "none" };
+
   let trigger: RegressionRepairHandoff["trigger"];
   let repairKind: RegressionRepairKind;
   let evidenceAt = priorOutput.updatedAt;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -31,6 +31,7 @@
     "db:migrate:release": "tsx prisma/release-migrate.ts",
     "db:migrate-status": "dotenv -e ../../.env -- prisma migrate status",
     "db:drift-check": "node scripts/check-drift.mjs",
+    "db:authority-check": "node --import tsx prisma/check-release-authority.ts",
     "db:preflight-goal-execution": "dotenv -e ../../.env -- tsx prisma/preflight-goal-execution.ts",
     "db:migrate-goal-execution": "npm run db:preflight-goal-execution && dotenv -e ../../.env -- prisma migrate deploy",
     "db:verify-starter-onboarding": "dotenv -e ../../.env -- tsx prisma/verify-starter-onboarding.ts",

--- a/packages/db/prisma/check-release-authority.ts
+++ b/packages/db/prisma/check-release-authority.ts
@@ -1,0 +1,77 @@
+/**
+ * `npm run db:authority-check` — does the tracked attestation still cover this
+ * tree?
+ *
+ * The signature over `release-authority.json` binds every release-path file and
+ * the whole migration set. A branch that adds a migration, or edits any of the
+ * files `RELEASE_EVIDENCE_FILES` names, therefore invalidates it: the migration
+ * preflight refuses that tree, and the merge gate fails on the preflight's own
+ * dbtest. Nothing in a chain can repair that, because the signing key is the
+ * operator's and never enters a run.
+ *
+ * So the chain asks this question before it spends a gate on the answer. The
+ * comparison itself is `attestationCoverage`; this script is the tree-reading
+ * and exit-code shell around it.
+ *
+ * Exit codes are the contract:
+ *   0  the attestation covers this tree
+ *   1  a re-signature is required; the moved paths are printed
+ *   2  the question could not be answered here
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { attestationCoverage } from "../src/release-authority-coverage.js";
+import {
+  parseReleaseAuthority,
+  readFileManifest,
+  readMigrationSet,
+  RELEASE_AUTHORITY_FILE,
+} from "../src/release-authority.js";
+
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url)).replace(/\/+$/u, "");
+
+const unanswerable = (detail: string): never => {
+  console.error(`STOP release-authority-check ${detail}`);
+  process.exit(2);
+};
+
+const main = (): void => {
+  const attestationPath = join(repositoryRoot, RELEASE_AUTHORITY_FILE);
+  if (!existsSync(attestationPath)) {
+    unanswerable(`${RELEASE_AUTHORITY_FILE} is absent from this checkout`);
+  }
+  const parsed = parseReleaseAuthority(readFileSync(attestationPath, "utf8"));
+  if (!parsed.ok) {
+    unanswerable(`${RELEASE_AUTHORITY_FILE} ${parsed.reason}`);
+    return;
+  }
+  const { authority } = parsed;
+
+  let manifest;
+  let migrations;
+  try {
+    manifest = readFileManifest(repositoryRoot);
+    migrations = readMigrationSet(repositoryRoot);
+  } catch {
+    unanswerable("this tree has no migration set to hash");
+    return;
+  }
+  if (manifest.unreadable.length > 0) {
+    unanswerable(`this checkout is missing release-path file(s): ${manifest.unreadable.join(", ")}`);
+    return;
+  }
+
+  const coverage = attestationCoverage({ authority, manifest: manifest.entries, migrations });
+  if (coverage.covered) {
+    console.log(`release-authority-check ok commit=${authority.commit} files=${authority.files.length} migrations=${migrations.count}/${migrations.terminal}`);
+    return;
+  }
+
+  console.error(`RESIGN release-authority ${RELEASE_AUTHORITY_FILE} does not cover this tree`);
+  for (const detail of coverage.moved) console.error(`RESIGN release-authority   ${detail}`);
+  process.exit(1);
+};
+
+main();

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -18,6 +18,10 @@ export * from "./deploy-barrier.js";
 export * from "./merge-integrator.js";
 export * from "./merge-integrator-db.js";
 export * from "./merge-tail.js";
+// Narrow on purpose: the release-authority module reads the filesystem at import
+// time, and only the attested file's name is wanted outside the release path.
+export { RELEASE_AUTHORITY_FILE } from "./release-authority.js";
+export * from "./release-authority-coverage.js";
 export * from "./workflow.js";
 export * from "./usage.js";
 export * from "./cost.js";

--- a/packages/db/src/merge-tail.test.ts
+++ b/packages/db/src/merge-tail.test.ts
@@ -188,3 +188,18 @@ test("a decision with more findings than one range can carry, or an over-long fi
   const long = { ...followUp, detail: "d".repeat(MAX_REVIEW_FINDING_TEXT + 1) };
   assert.equal(parseIndependentReviewDecision(reviewBody([long]), A).status, "invalid");
 });
+
+test("an authority-resign verdict is a first-class outcome and still needs its summary", () => {
+  const parsed = parseRegressionVerdict(JSON.stringify({
+    schemaVersion: 1, outcome: "authority-resign", headSha: A, baseHeadSha: B,
+    summary: "added packages/db/prisma/migrations/20260826000000_x/migration.sql",
+  }));
+  assert.equal(parsed.status, "ok");
+  assert.equal(parsed.status === "ok" ? parsed.verdict.outcome : null, "authority-resign");
+  assert.equal(parseRegressionVerdict(JSON.stringify({
+    schemaVersion: 1, outcome: "authority-resign", headSha: A, baseHeadSha: B, summary: "   ",
+  })).status, "invalid");
+  assert.equal(parseRegressionVerdict(JSON.stringify({
+    schemaVersion: 1, outcome: "authority-resign", headSha: A, baseHeadSha: B,
+  })).status, "invalid");
+});

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -25,6 +25,7 @@ export const MERGE_TAIL_KIND = {
   repairResult: "mergeTail.repairResult",
   reviewObligation: "mergeTail.reviewObligation",
   readiness: "mergeTail.readiness",
+  authorityResign: "mergeTail.authorityResign",
 } as const;
 
 /**
@@ -33,6 +34,22 @@ export const MERGE_TAIL_KIND = {
  * generic recovery has to be able to recognise it.
  */
 export const INDEPENDENT_REVIEW_OPEN_PREFIX = "independent-review-open:";
+
+/**
+ * The failure reason a regression-verification step carries while it waits for
+ * the operator to re-sign `release-authority.json`. Like the review park it is
+ * owned and resolved by a specific mechanism — here the resign worker — so
+ * generic recovery must leave it alone rather than re-queue the step under it.
+ */
+export const AUTHORITY_RESIGN_OPEN_PREFIX = "authority-resign-open:";
+
+/**
+ * How many times one chain may be sent back for a re-signature before the tail
+ * stops instead. Re-signing is an operator action, so a repeat means the last
+ * signature did not in fact cover this tree; a third one is a loop, not
+ * progress.
+ */
+export const MAX_AUTHORITY_RESIGN_ROUNDS = 3;
 
 export const MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES = 2;
 export const MAX_BASE_DRIFT_CLASSIFICATION_RETRIES = 30;
@@ -81,12 +98,19 @@ export type RegressionVerdict =
   | { schemaVersion: 1; outcome: "pass"; headSha: string; baseHeadSha: string; gateVerdict: "PASS" }
   | { schemaVersion: 1; outcome: "review-fail"; headSha: string; baseHeadSha: string; summary: string }
   | { schemaVersion: 1; outcome: "gate-fail"; headSha: string; baseHeadSha: string; gateVerdict: "FAIL"; summary: string }
-  | { schemaVersion: 1; outcome: "refresh-conflict"; headSha: string; baseHeadSha: string; summary: string };
+  | { schemaVersion: 1; outcome: "refresh-conflict"; headSha: string; baseHeadSha: string; summary: string }
+  /**
+   * The tree moved attested release-path files without re-signing
+   * `release-authority.json`, so the migration preflight refuses it and the
+   * gate cannot pass. Reported instead of a gate run: no agent can close it,
+   * because the signing key is the operator's and never enters a run.
+   */
+  | { schemaVersion: 1; outcome: "authority-resign"; headSha: string; baseHeadSha: string; summary: string };
 
 export type RegressionRepairHandoff = {
   schemaVersion: 1;
   trigger:
-    | { kind: "regression-verdict"; verdict: Exclude<RegressionVerdict, { outcome: "pass" }> }
+    | { kind: "regression-verdict"; verdict: Exclude<RegressionVerdict, { outcome: "pass" | "authority-resign" }> }
     | {
       kind: "independent-review-rejection";
       verdict: Extract<RegressionVerdict, { outcome: "pass" }>;
@@ -143,6 +167,9 @@ export const parseRegressionVerdict = (body: string | null | undefined): Regress
     return { status: "ok", verdict: value as RegressionVerdict };
   }
   if (value.outcome === "refresh-conflict" && typeof value.summary === "string" && value.summary.length > 0) {
+    return { status: "ok", verdict: value as RegressionVerdict };
+  }
+  if (value.outcome === "authority-resign" && typeof value.summary === "string" && value.summary.trim().length > 0) {
     return { status: "ok", verdict: value as RegressionVerdict };
   }
   return { status: "invalid", reason: "regression outcome and gateVerdict disagree or required summary is absent" };

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -44,6 +44,14 @@ export const INDEPENDENT_REVIEW_OPEN_PREFIX = "independent-review-open:";
 export const AUTHORITY_RESIGN_OPEN_PREFIX = "authority-resign-open:";
 
 /**
+ * The dedupe key prefix of the inbox message that carries a re-signature
+ * request: `authority-resign:<taskId>:<headSha>`. Only the control plane can
+ * write a dedupe key, so counting these keys is how many rounds a task has
+ * actually been sent back — a number no run can inflate.
+ */
+export const AUTHORITY_RESIGN_DEDUPE_PREFIX = "authority-resign:";
+
+/**
  * How many times one chain may be sent back for a re-signature before the tail
  * stops instead. Re-signing is an operator action, so a repeat means the last
  * signature did not in fact cover this tree; a third one is a loop, not

--- a/packages/db/src/release-authority-coverage.test.ts
+++ b/packages/db/src/release-authority-coverage.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { attestationCoverage } from "./release-authority-coverage.js";
+import {
+  parseReleaseAuthority,
+  readFileManifest,
+  readMigrationSet,
+  RELEASE_AUTHORITY_FILE,
+  type FileEntry,
+  type MigrationSet,
+} from "./release-authority.js";
+
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url)).replace(/\/+$/u, "");
+
+const digest = (seed: string): string => seed.repeat(64).slice(0, 64);
+const entry = (path: string, seed: string): FileEntry => ({ path, sha256: digest(seed), blob: seed.repeat(40).slice(0, 40) });
+const migrations: MigrationSet = { count: 2, terminal: "20260101000000_two", sha256: digest("m") };
+const files = [entry("packages/db/prisma/schema.prisma", "1"), entry("release-authority.pub", "2")];
+
+test("a tree that matches the attestation is covered", () => {
+  assert.deepEqual(
+    attestationCoverage({ authority: { files, migrations }, manifest: [...files], migrations }),
+    { covered: true },
+  );
+});
+
+test("an edited, added or removed attested file is named in both directions", () => {
+  const edited = attestationCoverage({
+    authority: { files, migrations },
+    manifest: [entry("packages/db/prisma/schema.prisma", "9"), files[1]!],
+    migrations,
+  });
+  assert.deepEqual(edited, { covered: false, moved: ["edited packages/db/prisma/schema.prisma"] });
+
+  const added = attestationCoverage({
+    authority: { files, migrations },
+    manifest: [...files, entry("packages/db/prisma/migrations/20260102000000_three/migration.sql", "3")],
+    migrations,
+  });
+  assert.deepEqual(added, {
+    covered: false,
+    moved: ["added packages/db/prisma/migrations/20260102000000_three/migration.sql"],
+  });
+
+  const removed = attestationCoverage({ authority: { files, migrations }, manifest: [files[0]!], migrations });
+  assert.deepEqual(removed, { covered: false, moved: ["removed release-authority.pub"] });
+});
+
+test("a moved migration set is reported even when every attested file still matches", () => {
+  const moved = attestationCoverage({
+    authority: { files, migrations },
+    manifest: [...files],
+    migrations: { count: 3, terminal: "20260102000000_three", sha256: digest("n") },
+  });
+  assert.deepEqual(moved, {
+    covered: false,
+    moved: ["migration set 2/20260101000000_two -> 3/20260102000000_three"],
+  });
+});
+
+test("this repository's tracked attestation covers this tree", () => {
+  // The condition the chain checks before every gate, asserted here so a
+  // re-signature that was forgotten fails by name rather than inside the
+  // migration preflight's own dbtest.
+  const parsed = parseReleaseAuthority(readFileSync(`${repositoryRoot}/${RELEASE_AUTHORITY_FILE}`, "utf8"));
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  const manifest = readFileManifest(repositoryRoot);
+  assert.deepEqual(manifest.unreadable, []);
+  assert.deepEqual(
+    attestationCoverage({
+      authority: parsed.authority,
+      manifest: manifest.entries,
+      migrations: readMigrationSet(repositoryRoot),
+    }),
+    { covered: true },
+  );
+});

--- a/packages/db/src/release-authority-coverage.ts
+++ b/packages/db/src/release-authority-coverage.ts
@@ -1,0 +1,50 @@
+/**
+ * Does a signed attestation still describe the tree in front of it?
+ *
+ * This is the question a chain has to answer before it spends a merge gate:
+ * moving any attested release-path file, or any migration, invalidates the
+ * signature, and only the key holder can restore it. It is deliberately not an
+ * authority check — the signature, the recorded SHAs, the ancestry and the
+ * private evidence are checked by `verifyReleaseAuthority`, which is what the
+ * migration preflight calls and what decides whether a tree may migrate. This
+ * says only which attested paths moved, so the request for a new signature can
+ * name them.
+ *
+ * It lives outside `release-authority.ts` because that file is itself attested:
+ * editing it to add a diagnostic would invalidate the very attestation the
+ * diagnostic reports on.
+ */
+import type { FileEntry, MigrationSet, ReleaseAuthority } from "./release-authority.js";
+
+export type AttestationCoverage = { covered: true } | { covered: false; moved: string[] };
+
+/**
+ * `moved` is sorted and reads as a report: `added|edited|removed <path>` for the
+ * file manifest, and one `migration set` line when the digest of the migration
+ * set as a whole changed. Both directions are checked — a file the attestation
+ * names and the tree no longer holds is as much a re-signature as a new one.
+ */
+export const attestationCoverage = (input: {
+  authority: Pick<ReleaseAuthority, "files" | "migrations">;
+  manifest: FileEntry[];
+  migrations: MigrationSet;
+}): AttestationCoverage => {
+  const attested = new Map(input.authority.files.map((entry) => [entry.path, entry.sha256]));
+  const present = new Map(input.manifest.map((entry) => [entry.path, entry.sha256]));
+  const moved: string[] = [];
+  for (const [path, sha256] of present) {
+    const before = attested.get(path);
+    if (before === undefined) moved.push(`added ${path}`);
+    else if (before !== sha256) moved.push(`edited ${path}`);
+  }
+  for (const path of attested.keys()) {
+    if (!present.has(path)) moved.push(`removed ${path}`);
+  }
+  moved.sort();
+  const before = input.authority.migrations;
+  const after = input.migrations;
+  if (before.count !== after.count || before.terminal !== after.terminal || before.sha256 !== after.sha256) {
+    moved.push(`migration set ${before.count}/${before.terminal} -> ${after.count}/${after.terminal}`);
+  }
+  return moved.length === 0 ? { covered: true } : { covered: false, moved };
+};

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -43,7 +43,7 @@ import {
   resolveChainTarget,
   stopStateFor,
 } from "./merge-integrator-db.js";
-import { INDEPENDENT_REVIEW_OPEN_PREFIX, isMergeReadinessStep, MERGE_TAIL_KIND } from "./merge-tail.js";
+import { AUTHORITY_RESIGN_OPEN_PREFIX, INDEPENDENT_REVIEW_OPEN_PREFIX, isMergeReadinessStep, MERGE_TAIL_KIND } from "./merge-tail.js";
 
 type Tx = Prisma.TransactionClient;
 
@@ -1478,6 +1478,20 @@ const activateChainSuccessorInternal = async (
         taskId: successor.id,
         actorType: "control-plane",
         body: "Predecessor layer completed; successor is held by an open independent review",
+      } });
+      continue;
+    }
+    // The same reasoning for the other owned park: the resign worker returns a
+    // regression step to the queue once the re-signed attestation is on the
+    // branch, and resuming it before then only buys a gate the migration
+    // preflight will refuse.
+    const resignOwnedPark = successor.status === TaskStatus.REVIEW
+      && (successor.failureReason?.startsWith(AUTHORITY_RESIGN_OPEN_PREFIX) ?? false);
+    if (resignOwnedPark) {
+      await tx.taskActivity.create({ data: {
+        taskId: successor.id,
+        actorType: "control-plane",
+        body: "Predecessor layer completed; successor is held by an open release authority re-signature",
       } });
       continue;
     }


### PR DESCRIPTION
A chain that adds or edits a migration invalidates the ed25519 attestation in `release-authority.json`, so the migration preflight refuses the tree and the merge gate fails on the preflight's own dbtest. Only the key holder can repair that, and until now the chain discovered it as a wall: a gate failure that had to be negotiated on the spot.

This turns the wall into an expected step.

- `npm run db:authority-check` (`packages/db/prisma/check-release-authority.ts`) answers "does the tracked attestation still cover this tree" deterministically before a gate is spent on the answer. The comparison lives in a new `release-authority-coverage.ts` because `release-authority.ts` is itself attested. Exit 0 covered, 1 re-signature required with the moved paths named, 2 unanswerable here.
- The regression-verification contract gained an `authority-resign` verdict. On it, the step parks under `authority-resign-open:<head>` and one inbox message opens with the exact command sequence to run - fetch, detach, `snapshot:authority`, `db:authority-check`, commit, push - every interpolated value single-quoted. The signing key never enters a chain or a runner; there is no switch that skips verification.
- `authority-resign-worker.ts` watches the pull request and returns the step to the queue as soon as the re-signed attestation is on the branch, comparing the parked head against the current head so an earlier round's signature cannot satisfy this park. No other chain is blocked meanwhile, and repeat requests are bounded at `MAX_AUTHORITY_RESIGN_ROUNDS`, counted from inbox dedupe keys that no run can write.
- Both park guards (`activateMergeTailTarget`, `activateChainSuccessorInternal`) leave a resign-owned park alone, as they already do for the review-owned one.

Merge gate: PASS at 4873002 against baseline cd4374e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
