### PR TITLE
refactor(gate): give the gate's shell layer an interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "verify:compose-binding": "node scripts/compose-binding.mjs",
     "test:compose-binding": "node --test scripts/compose-binding.test.mjs",
     "test:frozen-docs": "node --test scripts/check-frozen-docs.test.mjs",
-    "test:gate-worker": "node --test scripts/gate-worker/gate-worker.test.mjs scripts/gate-worker/gate-dispatch.test.mjs",
+    "test:gate-worker": "node --test scripts/gate-worker/gate-env.test.mjs scripts/gate-worker/gate-worker.test.mjs scripts/gate-worker/gate-dispatch.test.mjs",
     "test:auto-deploy": "node --test scripts/deploy/quiet-window-deploy.test.mjs",
     "snapshot:authority": "npm run snapshot:authority -w @agentos/db",
     "snapshot:authority-keygen": "npm run snapshot:authority-keygen -w @agentos/db --",

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -122,6 +122,7 @@
     { "glob": "scripts/gate-worker/provision.sh", "purpose": "gate worker: worker-wide toolchain provisioning, dry-run by default" },
     { "glob": "scripts/gate-worker/remote-gate.sh", "purpose": "gate worker: one synchronous ssh call that brings a verdict home" },
     { "glob": "scripts/gate-worker/run-gate.sh", "purpose": "gate worker: the worker-side harness that checks a commit out of the mirror and gates it" },
+    { "glob": "scripts/gate-worker/step-engine.sh", "purpose": "gate worker: the merge gate's step engine — what a step is, what a group of them is, and what the run learned" },
     { "glob": "scripts/goal-5a0-dependency-gate.sh", "purpose": "migration dependency-gate supervisor" },
     { "glob": "scripts/goal-5a0-dependency-gate.test.mjs", "purpose": "migration dependency-gate regression tests" },
     { "glob": "scripts/goal-5a0-evidence-destination.sh", "purpose": "migration evidence destination containment" },

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -116,6 +116,8 @@
     { "glob": "scripts/gate-worker/bench-postgres.sh", "purpose": "gate worker: throwaway-postgres settings benchmark over one fixed commit" },
     { "glob": "scripts/gate-worker/gate-dispatch.sh", "purpose": "gate worker: slot-rationed dispatch across the local machine and the worker" },
     { "glob": "scripts/gate-worker/gate-dispatch.test.mjs", "purpose": "gate worker and merge lease: slot-lock concurrency, dispatcher retry and exit-code behavior, and origin-ref lease regression tests" },
+    { "glob": "scripts/gate-worker/gate-env.mjs", "purpose": "gate worker: what the gate reads out of the environment, and which of it a fixture may inherit" },
+    { "glob": "scripts/gate-worker/gate-env.test.mjs", "purpose": "gate worker: fixture-environment guard and the coverage test that keeps the inherited list closed" },
     { "glob": "scripts/gate-worker/gate-worker.test.mjs", "purpose": "gate worker: credential red-line parity, remote-value allowlists, exact-ref transport retries and run-gate no-verdict regression tests" },
     { "glob": "scripts/gate-worker/lib.sh", "purpose": "gate worker: shared repository-name derivation for the local-side scripts" },
     { "glob": "scripts/gate-worker/mirror-push.sh", "purpose": "gate worker: mirror push, the only path code reaches the worker by" },

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -44,6 +44,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import nodeTest from "node:test";
 import { fileURLToPath } from "node:url";
+import { fixtureEnv } from "./gate-env.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const libPath = join(here, "lib.sh");
@@ -52,42 +53,11 @@ const mergeLeasePath = join(here, "..", "merge-lease.sh");
 
 const test = (name, body) => nodeTest(name, { concurrency: true }, body);
 
-// The dispatcher and the gate read their topology and their sizing out of the
-// environment: `AGENTOS_GATE_SERVER` alone collapses the dispatcher to a single
-// server with an empty fallback (gate-dispatch.sh), which turns a case that
-// pre-fills the desktop slots into a wait for a slot that cannot open. A
-// session configured to reach a real gate worker exports that variable, so a
-// fixture that inherits the host environment tests the host's topology instead
-// of the one it declares. The host's Git identity was already neutralised here
-// for the same reason; behaviour belongs on the same list. The dispatcher's own
-// namespace is stripped by prefix so a variable added to it later cannot
-// reintroduce the leak.
-const HOST_GATE_PREFIXES = ["AGENTOS_GATE_", "GATE_DISPATCH_"];
-// run-gate.sh's two are not prefixed but are read the same way: GATE_HOME
-// relocates the whole gate directory a fixture built for itself — at the real
-// worker's mirror, worktrees and logs — and STALE_WORKTREE_MINUTES decides what
-// its sweep reclaims. XDG_CACHE_HOME is deliberately NOT on this list: every
-// case that needs it sets it, and removing it would point a dispatcher at the
-// real slot locks under $HOME/.cache instead.
-const HOST_GATE_NAMES = ["GATE_HOME", "STALE_WORKTREE_MINUTES"];
-const isHostGateConfig = (key) =>
-  HOST_GATE_PREFIXES.some((prefix) => key.startsWith(prefix)) || HOST_GATE_NAMES.includes(key);
-
-const hostNeutralEnv = Object.fromEntries(
-  Object.entries(process.env).filter(([key]) => !isHostGateConfig(key)),
-);
-
-const FIXTURE_ENV = {
-  ...hostNeutralEnv,
-  GIT_CONFIG_GLOBAL: "/dev/null",
-  GIT_CONFIG_SYSTEM: "/dev/null",
-  GIT_AUTHOR_NAME: "gate-dispatch-fixture",
-  GIT_AUTHOR_EMAIL: "gate-dispatch-fixture",
-  GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
-  GIT_COMMITTER_NAME: "gate-dispatch-fixture",
-  GIT_COMMITTER_EMAIL: "gate-dispatch-fixture",
-  GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z",
-};
+// What the gate reads out of the environment, and which of it a fixture may
+// inherit, is one question with one answer; it used to be 26 identical lines
+// here and 26 more in the sibling fixture file, and one of the three commits
+// that edited them landed in only one of the two.
+const FIXTURE_ENV = fixtureEnv("gate-dispatch-fixture");
 
 const scratch = (t) => {
   const root = mkdtempSync(join(tmpdir(), "gate-dispatch-test-"));
@@ -397,16 +367,6 @@ const busyCache = (t, busySlots = []) => {
 
 const dispatch = (t, repo, args, env = {}, busySlots = []) =>
   runDispatch(repo, busyCache(t, busySlots), args, env);
-
-test("the fixture environment carries no host gate configuration", () => {
-  // The guard for the leak itself. Nothing below states which servers exist or
-  // how long to wait unless it says so, so a host that is configured to reach a
-  // real gate worker cannot silently rewrite the topology these cases assert
-  // on — which is how this suite once blocked for the dispatcher's full hour
-  // instead of failing.
-  const leaked = Object.keys(FIXTURE_ENV).filter(isHostGateConfig);
-  assert.deepEqual(leaked, [], `host gate configuration reached the fixtures: ${leaked.join(", ")}`);
-});
 
 test("an explicitly enabled local PASS comes back as 0 with the gate's own verdict line", (t) => {
   const repo = fixtureRepo(t, {});

--- a/scripts/gate-worker/gate-env.mjs
+++ b/scripts/gate-worker/gate-env.mjs
@@ -1,0 +1,64 @@
+// The fixture's view of the gate's environment: which variables the gate reads,
+// and which of them a fixture may inherit from the host it runs on.
+//
+// The dispatcher and the gate read their topology and their sizing out of the
+// environment: `AGENTOS_GATE_SERVER` alone collapses the dispatcher to a single
+// server with an empty fallback (gate-dispatch.sh), which turns a case that
+// pre-fills the desktop slots into a wait for a slot that cannot open. A
+// session configured to reach a real gate worker exports that variable, so a
+// fixture that inherits the host environment tests the host's topology instead
+// of the one it declares — which is how that suite once blocked for the
+// dispatcher's full hour instead of failing. The host's Git identity was
+// already neutralised for the same reason; behaviour belongs on the same list.
+// The dispatcher's own namespace is stripped by prefix so a variable added to
+// it later cannot reintroduce the leak.
+//
+// This was 26 identical lines in gate-worker.test.mjs and gate-dispatch.test.mjs.
+// Three commits edited them by hand — 1a855ae, 4087264, d360238 — and 4087264
+// landed in only one of the two, so the guard it added was missing from the
+// other file until the commit after it. That is what this module is for: not
+// that the list appeared twice, but that the reason did.
+
+export const GATE_ENV_PREFIXES = ["AGENTOS_GATE_", "GATE_DISPATCH_"];
+
+// run-gate.sh's two are not prefixed but are read the same way: GATE_HOME
+// relocates the whole gate directory a fixture built for itself — at the real
+// worker's mirror, worktrees and logs — and STALE_WORKTREE_MINUTES decides what
+// its sweep reclaims.
+export const GATE_ENV_NAMES = ["GATE_HOME", "STALE_WORKTREE_MINUTES"];
+
+// The other half of the same question, and the reason for each entry. Every
+// name the gate scripts read is either stripped by isHostGateConfig or stated
+// here; gate-env.test.mjs holds that closed, so a variable added to the gate
+// cannot silently start reaching the fixtures the way one already did.
+export const GATE_ENV_INHERITED = {
+  XDG_CACHE_HOME:
+    "every case that needs it sets it, and removing it would point a dispatcher at the real slot locks under $HOME/.cache",
+  HOME: "the fixture's own account; every case that needs a private home hands the script one",
+  TMPDIR: "where the fixtures put their own scratch roots in the first place",
+  RANDOM: "bash's own generator, not a name anything exports",
+  AGENTOS_MASTER_OID:
+    "read only by merge-gate.sh, and no fixture runs the real gate: every case that reaches it substitutes a stub",
+  ESBUILD_BINARY_PATH: "read only by merge-gate.sh, and no fixture runs the real gate",
+  NODE_OPTIONS: "read only by merge-gate.sh, and no fixture runs the real gate",
+  TEST_DATABASE_URL: "read only by merge-gate.sh, and no fixture runs the real gate",
+};
+
+export const isHostGateConfig = (key) =>
+  GATE_ENV_PREFIXES.some((prefix) => key.startsWith(prefix)) || GATE_ENV_NAMES.includes(key);
+
+export const hostNeutralEnv = () =>
+  Object.fromEntries(Object.entries(process.env).filter(([key]) => !isHostGateConfig(key)));
+
+// `identity` is the one thing that differed between the two fixture files.
+export const fixtureEnv = (identity) => ({
+  ...hostNeutralEnv(),
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_AUTHOR_NAME: identity,
+  GIT_AUTHOR_EMAIL: identity,
+  GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
+  GIT_COMMITTER_NAME: identity,
+  GIT_COMMITTER_EMAIL: identity,
+  GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z",
+});

--- a/scripts/gate-worker/gate-env.test.mjs
+++ b/scripts/gate-worker/gate-env.test.mjs
@@ -1,0 +1,120 @@
+// Fixtures for gate-env.mjs, the fixture environment gate-worker.test.mjs and
+// gate-dispatch.test.mjs both build from.
+//
+// The guard below used to be stated once in each of those files, because each
+// built its own environment. The coverage test after it is the one that could
+// not be stated in either: it asks whether the list is still the whole list.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import nodeTest from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  GATE_ENV_INHERITED,
+  GATE_ENV_NAMES,
+  GATE_ENV_PREFIXES,
+  fixtureEnv,
+  hostNeutralEnv,
+  isHostGateConfig,
+} from "./gate-env.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const test = (name, body) => nodeTest(name, { concurrency: true }, body);
+
+test("the fixture environment carries no host gate configuration", () => {
+  // The guard for the leak itself: a host configured to reach a real gate
+  // worker must not be able to rewrite what the cases run against. Nothing in
+  // either fixture file states which servers exist or how long to wait unless
+  // it says so, and a host that could silently rewrite the topology is how one
+  // of those suites once blocked for the dispatcher's full hour instead of
+  // failing.
+  const leaked = Object.keys(fixtureEnv("gate-env-fixture")).filter(isHostGateConfig);
+  assert.deepEqual(leaked, [], `host gate configuration reached the fixtures: ${leaked.join(", ")}`);
+});
+
+test("the fixture environment pins the Git identity it was asked for", () => {
+  const env = fixtureEnv("some-fixture");
+  assert.equal(env.GIT_AUTHOR_NAME, "some-fixture");
+  assert.equal(env.GIT_COMMITTER_EMAIL, "some-fixture");
+  // The host's own Git configuration is the other thing a fixture must not read.
+  assert.equal(env.GIT_CONFIG_GLOBAL, "/dev/null");
+  assert.equal(env.GIT_CONFIG_SYSTEM, "/dev/null");
+});
+
+test("hostNeutralEnv strips the gate's configuration and keeps the rest", () => {
+  const neutral = hostNeutralEnv();
+  assert.deepEqual(Object.keys(neutral).filter(isHostGateConfig), []);
+  // Reading process.env is the point of the function; a fixture still needs a
+  // PATH to spawn anything with.
+  assert.equal(neutral.PATH, process.env.PATH);
+});
+
+// --- the list is still the whole list ----------------------------------------
+
+// The gate scripts a fixture spawns. provision.sh and the two bench-*.sh are
+// deliberately outside it: no fixture runs them, so what they read out of an
+// operator's environment is not a question about this environment.
+const GATE_SCRIPTS = [
+  join(here, "..", "merge-gate.sh"),
+  ...["lib.sh", "step-engine.sh", "run-gate.sh", "gate-dispatch.sh", "mirror-push.sh", "remote-gate.sh"].map((name) =>
+    join(here, name),
+  ),
+];
+
+// A shell script reads an environment variable by defaulting it —
+// `NAME="${NAME:-...}"`, `${NAME:+...}` — or by using a name it never assigns.
+// A name whose first plain assignment in some script gives it a value of that
+// script's own is that script's variable, not the environment's.
+const gateEnvNamesRead = () => {
+  const used = new Set();
+  const ownedBySomeScript = new Set();
+  for (const path of GATE_SCRIPTS) {
+    const source = readFileSync(path, "utf8");
+    for (const [, name] of source.matchAll(/\$\{([A-Z][A-Z0-9_]*)[-+:=}]/g)) used.add(name);
+    const firstAssignment = new Map();
+    for (const [, name, value] of source.matchAll(/^[ \t]*([A-Z][A-Z0-9_]*)=(.*)$/gm)) {
+      // `NAME=literal cmd ...` sets a variable for one command rather than for
+      // the script, so it says nothing about whose variable the name is.
+      if (/^(?:''|""|[A-Za-z0-9_.:@\/-]*)\s+\S/.test(value)) continue;
+      if (!firstAssignment.has(name)) firstAssignment.set(name, value.trim());
+    }
+    for (const [name, value] of firstAssignment) {
+      if (!new RegExp(`^"?\\$\\{${name}[-:+]`).test(value)) ownedBySomeScript.add(name);
+    }
+  }
+  return [...used].filter((name) => !ownedBySomeScript.has(name)).sort();
+};
+
+test("every environment variable the gate reads is either stripped or has a stated reason to stay", () => {
+  // The test the two fixture files could not hold between them. `4087264` added
+  // a guard to one of them by hand and missed the other; a list that has to be
+  // remembered is a list that gets edited once. This fails the moment the gate
+  // starts reading a variable nobody stripped and nobody gave a reason for.
+  const unclassified = gateEnvNamesRead().filter(
+    (name) => !isHostGateConfig(name) && !Object.hasOwn(GATE_ENV_INHERITED, name),
+  );
+  assert.deepEqual(
+    unclassified,
+    [],
+    `the gate reads these and gate-env.mjs neither strips them nor says why they stay: ${unclassified.join(", ")}`,
+  );
+});
+
+test("the scan finds the variables it was built for", () => {
+  // A scan that matched nothing would pass the test above in silence. These are
+  // the four the two fixture files named, one from each shape the scan has to
+  // recognise.
+  const read = gateEnvNamesRead();
+  for (const name of ["AGENTOS_GATE_SERVER", "GATE_DISPATCH_POLL_SECONDS", ...GATE_ENV_NAMES, "XDG_CACHE_HOME"]) {
+    assert.ok(read.includes(name), `the scan no longer finds ${name}, which the gate reads`);
+  }
+});
+
+test("nothing is stripped and inherited at once, and every reason is a reason", () => {
+  for (const [name, reason] of Object.entries(GATE_ENV_INHERITED)) {
+    assert.equal(isHostGateConfig(name), false, `${name} is both stripped and inherited`);
+    assert.ok(reason.length > 20, `${name} is inherited without a stated reason`);
+  }
+  assert.ok(GATE_ENV_PREFIXES.every((prefix) => prefix.endsWith("_")), "a prefix that is not a namespace matches names nobody meant");
+});

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -43,6 +43,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import nodeTest from "node:test";
 import { fileURLToPath } from "node:url";
+import { fixtureEnv } from "./gate-env.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const libPath = join(here, "lib.sh");
@@ -54,42 +55,11 @@ const runbookPath = join(here, "..", "..", "docs", "runbooks", "gate-worker.md")
 
 const test = (name, body) => nodeTest(name, { concurrency: true }, body);
 
-// The dispatcher and the gate read their topology and their sizing out of the
-// environment: `AGENTOS_GATE_SERVER` alone collapses the dispatcher to a single
-// server with an empty fallback (gate-dispatch.sh), which turns a case that
-// pre-fills the desktop slots into a wait for a slot that cannot open. A
-// session configured to reach a real gate worker exports that variable, so a
-// fixture that inherits the host environment tests the host's topology instead
-// of the one it declares. The host's Git identity was already neutralised here
-// for the same reason; behaviour belongs on the same list. The dispatcher's own
-// namespace is stripped by prefix so a variable added to it later cannot
-// reintroduce the leak.
-const HOST_GATE_PREFIXES = ["AGENTOS_GATE_", "GATE_DISPATCH_"];
-// run-gate.sh's two are not prefixed but are read the same way: GATE_HOME
-// relocates the whole gate directory a fixture built for itself — at the real
-// worker's mirror, worktrees and logs — and STALE_WORKTREE_MINUTES decides what
-// its sweep reclaims. XDG_CACHE_HOME is deliberately NOT on this list: every
-// case that needs it sets it, and removing it would point a dispatcher at the
-// real slot locks under $HOME/.cache instead.
-const HOST_GATE_NAMES = ["GATE_HOME", "STALE_WORKTREE_MINUTES"];
-const isHostGateConfig = (key) =>
-  HOST_GATE_PREFIXES.some((prefix) => key.startsWith(prefix)) || HOST_GATE_NAMES.includes(key);
-
-const hostNeutralEnv = Object.fromEntries(
-  Object.entries(process.env).filter(([key]) => !isHostGateConfig(key)),
-);
-
-const FIXTURE_ENV = {
-  ...hostNeutralEnv,
-  GIT_CONFIG_GLOBAL: "/dev/null",
-  GIT_CONFIG_SYSTEM: "/dev/null",
-  GIT_AUTHOR_NAME: "gate-worker-fixture",
-  GIT_AUTHOR_EMAIL: "gate-worker-fixture",
-  GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
-  GIT_COMMITTER_NAME: "gate-worker-fixture",
-  GIT_COMMITTER_EMAIL: "gate-worker-fixture",
-  GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z",
-};
+// What the gate reads out of the environment, and which of it a fixture may
+// inherit, is one question with one answer; it used to be 26 identical lines
+// here and 26 more in the sibling fixture file, and one of the three commits
+// that edited them landed in only one of the two.
+const FIXTURE_ENV = fixtureEnv("gate-worker-fixture");
 
 const scratch = (t) => {
   const root = mkdtempSync(join(tmpdir(), "gate-worker-test-"));
@@ -518,14 +488,6 @@ const runGate = (home, args, env = {}) =>
     timeout: 120_000,
     env: { ...FIXTURE_ENV, ...env },
   });
-
-test("the fixture environment carries no host gate configuration", () => {
-  // The guard for the leak: a host configured to reach a real gate worker must
-  // not be able to rewrite what these cases run against. Stated in both
-  // gate-worker fixture files because each builds its own environment.
-  const leaked = Object.keys(FIXTURE_ENV).filter(isHostGateConfig);
-  assert.deepEqual(leaked, [], `host gate configuration reached the fixtures: ${leaked.join(", ")}`);
-});
 
 test("a gate that passes is reported as the gate's own verdict", (t) => {
   const fixture = gateHome(t);

--- a/scripts/gate-worker/step-engine.sh
+++ b/scripts/gate-worker/step-engine.sh
@@ -1,0 +1,288 @@
+# The gate's step engine: what it means to run a step, to run a group of steps
+# at once, and what the run's outcome is when it ends. Sourced by merge-gate.sh
+# and by scripts/merge-gate-parallel.test.mjs. Not executable on its own.
+#
+# Two things the caller owes this file. It must have sourced lib.sh first, for
+# GATE_EXIT_NO_VERDICT. And it must define `say` and `note`, the two output
+# helpers a step announces itself through; they are the gate's log format, not
+# the engine's, and the fixtures supply their own.
+#
+# Not here: which steps the gate runs, in what order, and in which group. That
+# is the plan, it lives in merge-gate.sh where an operator reads it, and this
+# file knows nothing about it.
+#
+# Deliberately not in lib.sh. lib.sh is installed on the worker beside
+# run-gate.sh and carries the verdict's wire format, which run-gate.sh and
+# gate-dispatch.sh read. Neither of them runs a step, and neither should be
+# shipped the gate's state machine to find that out. merge-gate.sh is the
+# opposite case: run-gate.sh creates a worktree from the mirror at the
+# candidate oid and runs scripts/merge-gate.sh inside it, so what merge-gate.sh
+# sources out of the repository tree arrives with the commit. This file
+# therefore travels with the commit and is not installed on the worker.
+
+# The engine's state. Every one of these is read back through gate_steps_report
+# and gate_steps_outcome; nothing outside this file needs to know they exist.
+gate_steps_begin() {
+  # What each step reported: one preformatted line per step, in the order the
+  # steps were submitted.
+  STEP_REPORT=()
+  # Where the gate is. Set on entry to a step and cleared when it passes, so a
+  # run that dies anywhere still names the step it died in.
+  FAILED_STEP=""
+  # Set only when the run was stopped rather than decided. It is what turns the
+  # last line into GATE NOT RUN instead of a FAIL nothing formed.
+  NO_VERDICT_REASON=""
+  NO_VERDICT_EXIT="${GATE_EXIT_NO_VERDICT}"
+  # Named the moment a step is seen to have failed on its own, which is earlier
+  # than its group's accounting: a signal arriving while a later member is still
+  # stuck must not erase a failure this run already observed.
+  GATE_REAL_FAILURE=""
+  # The members a parallel group has in flight. See gate_steps_stop_running.
+  GATE_GROUP_PIDS=()
+}
+
+# A step that was stopped from outside against one that failed on its own. The
+# first set is what an operator, a supervisor or the OOM killer sends: nothing
+# was learned about the commit, so the run has no verdict to give. A crash the
+# step produced itself (SIGSEGV, SIGABRT, SIGBUS, SIGFPE) is the code under test
+# behaving badly and stays a FAIL, which is the direction this is allowed to be
+# wrong in: it never converts a real failure into an errand.
+stopped_from_outside() {
+  case "$1" in
+    129 | 130 | 131 | 137 | 143) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+record_stop() {
+  NO_VERDICT_REASON="${1} was stopped before it could be judged"
+  NO_VERDICT_EXIT="${GATE_EXIT_NO_VERDICT}"
+}
+
+record_real_failure() {
+  GATE_REAL_FAILURE="${GATE_REAL_FAILURE:+${GATE_REAL_FAILURE}, }${1}"
+}
+
+step() {
+  local label="$1"; shift
+  say "${label}"
+  local started; started=$(date +%s)
+  FAILED_STEP="${label}"
+  local status=0
+  ( cd "${REPO_ROOT}" && "$@" ) || status=$?
+  if [ "${status}" -ne 0 ]; then
+    if stopped_from_outside "${status}"; then
+      STEP_REPORT+=("STOP  ${label}")
+      record_stop "${label}"
+    else
+      STEP_REPORT+=("FAIL  ${label}")
+      record_real_failure "${label}"
+    fi
+    return 1
+  fi
+  STEP_REPORT+=("$(printf 'ok    %-42s %4ss' "${label}" "$(( $(date +%s) - started ))")")
+  FAILED_STEP=""
+}
+
+# Run independent steps at the same time.
+#
+# Members are separated by `::`: each one is a label followed by the command it
+# runs, exactly as `step` takes them. Nothing about what a step proves changes
+# here — only how many of them are in flight at once. The gate is a chain of
+# eighteen serial steps on a worker with twelve cores, and for most of a run
+# eleven of them have nothing to do.
+#
+# Two properties this has to keep, because a parallel group is where both are
+# normally lost:
+#
+# Output stays readable. Each member writes to its own file and the files are
+# replayed in submission order after the group finishes, so the log reads like
+# the serial steps it replaced instead of interleaved fragments from a dozen
+# processes. `parallel_lint` already worked this way; this is that pattern with
+# more than two members.
+#
+# Every failure is named, not just the first. A group that stopped at the
+# earliest non-zero status would send someone back for a second gate to find
+# the second problem, and running these together is precisely what makes it
+# cheap to learn all of them in one pass. Each member is waited for, each keeps
+# its own duration, and the verdict line lists all of them.
+GATE_STEP_SEPARATOR="::"
+
+# The members a parallel group has in flight. cleanup has to be able to reach
+# them: it deletes GATE_TMP, releases the worktree lock and removes the
+# postgres container, and each of those is a statement that this gate has
+# stopped working. `kill` on this script alone interrupts the parent's `wait`
+# without touching the members, so the teardown would run while a build is
+# still writing dist/ and the next gate would take the lock this one just
+# released. The serial layout this replaced had one child at a time and no log
+# of its own to delete; nine at once is worth the accounting.
+
+# Signalling the member alone is not enough, and the shape of the miss is easy
+# to reproduce: the member is a subshell, the work it runs is a process below
+# that, and `npm ci` or `tsc` is a process below *that*. Killing the member
+# leaves the rest orphaned and running. So members are started under `set -m`,
+# which makes each one a process-group leader, and the whole group is signalled
+# at once.
+gate_steps_stop_running() {
+  [ "${#GATE_GROUP_PIDS[@]}" -gt 0 ] || return 0
+  local group alive attempt
+  printf '\n   interrupted: stopping %s step(s) still running\n' "${#GATE_GROUP_PIDS[@]}"
+  for group in "${GATE_GROUP_PIDS[@]}"; do kill -TERM -"${group}" 2>/dev/null || true; done
+  # Five seconds to end on their own, then stop asking. Waiting without a
+  # deadline hands a member that ignores TERM the power to hang the gate
+  # forever, which is worse than the leak this is closing.
+  for ((attempt=0; attempt<50; attempt++)); do
+    alive=0
+    for group in "${GATE_GROUP_PIDS[@]}"; do kill -0 -"${group}" 2>/dev/null && alive=1; done
+    [ "${alive}" -eq 0 ] && break
+    sleep 0.1
+  done
+  for group in "${GATE_GROUP_PIDS[@]}"; do kill -KILL -"${group}" 2>/dev/null || true; done
+  # Reaped, not just signalled: returning while they are still dying is the
+  # race this exists to close.
+  for group in "${GATE_GROUP_PIDS[@]}"; do wait "${group}" 2>/dev/null || true; done
+  GATE_GROUP_PIDS=()
+}
+
+parallel_steps() {
+  local title="$1"; shift
+  local -a labels=() serialized=() pids=() statuses=() logs=() current=() failures=() stopped=()
+  local token index slot seconds
+
+  for token in "$@" "${GATE_STEP_SEPARATOR}"; do
+    if [ "${token}" = "${GATE_STEP_SEPARATOR}" ]; then
+      if [ "${#current[@]}" -gt 0 ]; then
+        [ "${#current[@]}" -ge 2 ] \
+          || { printf 'parallel_steps: member "%s" names no command\n' "${current[0]}" >&2; return 1; }
+        labels+=("${current[0]}")
+        # %q quoting is produced by bash for bash, so the eval below restores
+        # exactly this argument vector. Every member here is a literal in this
+        # file; none of it comes from the commit being gated.
+        serialized+=("$(printf '%q ' "${current[@]:1}")")
+        current=()
+      fi
+      continue
+    fi
+    current+=("${token}")
+  done
+  [ "${#labels[@]}" -gt 0 ] || { printf 'parallel_steps: %s has no members\n' "${title}" >&2; return 1; }
+
+  # Set before anything is spawned: if this group dies without reaching its own
+  # accounting, the verdict still names where the gate was.
+  FAILED_STEP="${title}"
+  say "${title} (${#labels[@]} steps at once)"
+
+  for ((index=0; index<${#labels[@]}; index++)); do
+    slot="$(printf '%s' "${labels[index]}" | tr -c '[:alnum:]' '-')"
+    logs[index]="${GATE_TMP}/group-${index}-${slot}.log"
+    # The member times itself. Timing it from here would charge each member for
+    # however long the parent happened to wait on the members before it.
+    # Job control, on for the spawn only: it is what puts the member and
+    # everything it starts into one process group gate_steps_stop_running can
+    # reach. It changes nothing on the normal path -- exit codes still arrive
+    # through `wait`, and a group that ends on its own prints nothing.
+    set -m
+    (
+      cd "${REPO_ROOT}" || exit 1
+      __started=$(date +%s)
+      eval "${serialized[index]}"
+      __status=$?
+      printf '%s\n' "$(( $(date +%s) - __started ))" > "${logs[index]}.seconds"
+      exit "${__status}"
+    ) >"${logs[index]}" 2>&1 &
+    pids[index]=$!
+    GATE_GROUP_PIDS+=("$!")
+    set +m
+    note "started ${labels[index]}"
+  done
+
+  # The member's own status, not a flattened 1: 128+N is how a member that was
+  # killed is told apart from one that ran and failed, and the difference is
+  # whether this group has a verdict at all.
+  for ((index=0; index<${#labels[@]}; index++)); do
+    if wait "${pids[index]}"; then statuses[index]=0; else statuses[index]=$?; fi
+    # Recorded here rather than in the accounting below, which a signal arriving
+    # while a later member is still stuck would never reach.
+    if [ "${statuses[index]}" -ne 0 ] && ! stopped_from_outside "${statuses[index]}"; then
+      record_real_failure "${labels[index]}"
+    fi
+  done
+  GATE_GROUP_PIDS=()
+
+  for ((index=0; index<${#labels[@]}; index++)); do
+    printf '\n--- %s ---\n' "${labels[index]}"
+    cat "${logs[index]}" 2>/dev/null || true
+  done
+
+  for ((index=0; index<${#labels[@]}; index++)); do
+    # A member killed before it could write its own duration reports `?` rather
+    # than a number this run did not measure.
+    seconds="$(cat "${logs[index]}.seconds" 2>/dev/null || printf '?')"
+    [ -n "${seconds}" ] || seconds="?"
+    if [ "${statuses[index]}" -eq 0 ]; then
+      STEP_REPORT+=("$(printf 'ok    %-42s %4ss' "${labels[index]}" "${seconds}")")
+    elif stopped_from_outside "${statuses[index]}"; then
+      STEP_REPORT+=("$(printf 'STOP  %-42s %4ss' "${labels[index]}" "${seconds}")")
+      stopped+=("${labels[index]}")
+    else
+      STEP_REPORT+=("$(printf 'FAIL  %-42s %4ss' "${labels[index]}" "${seconds}")")
+      failures+=("${labels[index]}")
+    fi
+  done
+
+  # A member that ran and failed is a judgement about the commit and outranks a
+  # member that was stopped: the gate did learn something, and burying that
+  # under "no verdict" would let a real FAIL be re-dispatched as an errand.
+  if [ "${#failures[@]}" -gt 0 ]; then
+    FAILED_STEP="$(printf '%s, ' "${failures[@]}")"
+    FAILED_STEP="${FAILED_STEP%, }"
+    return 1
+  fi
+  if [ "${#stopped[@]}" -gt 0 ]; then
+    FAILED_STEP="$(printf '%s, ' "${stopped[@]}")"
+    FAILED_STEP="${FAILED_STEP%, }"
+    record_stop "${FAILED_STEP}"
+    return 1
+  fi
+  FAILED_STEP=""
+}
+
+# What a signal that stopped the gate is, recorded rather than judged: whether
+# it outranks anything is gate_steps_outcome's question and is answered there
+# once. The caller keeps its trap handlers, because a trap has to exit in the
+# gate's own process.
+gate_steps_note_signal() {
+  NO_VERDICT_REASON="the gate was stopped by SIG${1}${FAILED_STEP:+ during ${FAILED_STEP}}"
+  NO_VERDICT_EXIT="$2"
+}
+
+# Every step's result, in submission order, ready to print.
+gate_steps_report() {
+  [ "${#STEP_REPORT[@]}" -gt 0 ] || return 0
+  local line
+  for line in "${STEP_REPORT[@]}"; do printf '   %s\n' "${line}"; done
+}
+
+# What this run learned about the commit, as one line:
+#
+#   pass
+#   fail <step>[, <step>...]
+#   no-verdict <exit> <reason>
+#
+# The order of these three branches is the engine's whole rule and is stated
+# here and nowhere else. A failure the run actually observed is a judgement
+# about the commit, and neither a signal arriving afterwards nor a member that
+# was stopped unmakes it — that is the direction this is allowed to be wrong
+# in, because the opposite lets a real FAIL be re-dispatched as an errand. Only
+# a run that learned nothing reports the absence of a verdict.
+gate_steps_outcome() {
+  if [ -n "${GATE_REAL_FAILURE}" ]; then
+    printf 'fail %s\n' "${GATE_REAL_FAILURE}"
+  elif [ -n "${NO_VERDICT_REASON}" ]; then
+    printf 'no-verdict %s %s\n' "${NO_VERDICT_EXIT}" "${NO_VERDICT_REASON}"
+  elif [ -n "${FAILED_STEP}" ]; then
+    printf 'fail %s\n' "${FAILED_STEP}"
+  else
+    printf 'pass\n'
+  fi
+}

--- a/scripts/merge-gate-parallel.test.mjs
+++ b/scripts/merge-gate-parallel.test.mjs
@@ -12,9 +12,12 @@
 // was in, so a reviewer reading that line recorded a judgement about the commit
 // that nothing had formed. Nothing about it is visible on a green run either.
 //
-// The function is extracted from merge-gate.sh and run for real. Re-typing it
-// into a fixture would test a copy, and the copy is the one thing that cannot
-// drift into disagreeing with the gate while still passing.
+// The engine is sourced from scripts/gate-worker/step-engine.sh and run for
+// real. Re-typing it into a fixture would test a copy, and the copy is the one
+// thing that cannot drift into disagreeing with the gate while still passing.
+// It used to be sliced out of merge-gate.sh by string offsets, which needed
+// four guard assertions to notice when the slicing stopped matching; a file
+// the gate itself sources needs none of them.
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -29,50 +32,28 @@ const gatePath = fileURLToPath(new URL("./merge-gate.sh", import.meta.url));
 // that re-typed them would keep passing while the gate's real output changed
 // underneath it — which is the whole reason the module exists.
 const libPath = fileURLToPath(new URL("./gate-worker/lib.sh", import.meta.url));
+// The engine itself. What a step is, what a group of them is, and what the run
+// learned are all behind this one interface, so a fixture declares its inputs
+// and nothing else.
+const enginePath = fileURLToPath(new URL("./gate-worker/step-engine.sh", import.meta.url));
 
 const test = (name, body) => nodeTest(name, { concurrency: true }, body);
 
-// The extraction is bounded by two literals that exist in merge-gate.sh for
-// this purpose. If either stops matching, the tests fail loudly here instead of
-// silently exercising nothing.
-const extractParallelSteps = () => {
-  const source = readFileSync(gatePath, "utf8");
-  // From the stop classifier rather than from the separator: what a member's
-  // exit status means is part of what this group reports, so the fixture must
-  // run the gate's own classification and not a copy of it.
-  const start = source.indexOf("\nstopped_from_outside() {");
-  assert.notEqual(start, -1, "merge-gate.sh no longer defines stopped_from_outside");
-  assert.notEqual(
-    source.indexOf('GATE_STEP_SEPARATOR="::"', start),
-    -1,
-    "merge-gate.sh no longer defines GATE_STEP_SEPARATOR after the stop classifier",
-  );
-  const bodyStart = source.indexOf("\nparallel_steps() {", start);
-  assert.notEqual(bodyStart, -1, "merge-gate.sh no longer defines parallel_steps");
-  const end = source.indexOf("\n}\n", bodyStart);
-  assert.notEqual(end, -1, "parallel_steps has no terminating brace");
-  return source.slice(start, end + 3);
-};
-
-const PARALLEL_STEPS = extractParallelSteps();
-
-// Enough of the gate for the function under test to run: the two output helpers,
-// the report array it appends to, the temp root it writes member logs into, and
-// the working directory it runs members in. Nothing here stands in for the
-// behaviour being tested.
-const HARNESS = `
+// Enough of the gate for the engine to run: the two output helpers it owes the
+// engine, the temp root it writes member logs into, and the working directory
+// it runs members in. Nothing here stands in for the behaviour being tested.
+const ENGINE = `
 set -uo pipefail
 say() { printf '\\n== %s\\n' "$1"; }
 note() { printf '   %s\\n' "$1"; }
 . ${JSON.stringify(libPath)}
-STEP_REPORT=()
-FAILED_STEP=""
-NO_VERDICT_REASON=""
-NO_VERDICT_EXIT="$GATE_EXIT_NO_VERDICT"
-GATE_REAL_FAILURE=""
+. ${JSON.stringify(enginePath)}
+gate_steps_begin
+`;
+
+const HARNESS = `${ENGINE}
 GATE_TMP="$1"
 REPO_ROOT="$2"
-${PARALLEL_STEPS}
 `;
 
 // Runs one group and reports what the gate would have: the exit status, the
@@ -209,6 +190,58 @@ test("PARALLEL-USAGE refuses a member with no command", () => {
   assert.match(run.stderr, /names no command/);
 });
 
+// --- what the run learned ---------------------------------------------------
+
+// gate_steps_outcome is the one place the engine's precedence rule is written:
+// a failure the run observed outranks a signal that arrived afterwards, and
+// only a run that learned nothing reports the absence of a verdict. Until it
+// existed the rule could only be observed through the line cleanup printed,
+// which is why the same `if` had to be repeated in cleanup and in the signal
+// handler and why one of the two was wrong.
+const runOutcome = (scenario) => {
+  const root = mkdtempSync(join(tmpdir(), "merge-gate-outcome."));
+  try {
+    const script = join(root, "outcome.sh");
+    writeFileSync(script, `${HARNESS}\n${scenario}\ngate_steps_outcome\n`);
+    const result = spawnSync("bash", [script, root, root], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    return (result.stdout ?? "").trim().split("\n").at(-1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test("OUTCOME a run in which nothing failed is a pass", () => {
+  assert.equal(runOutcome(`step "fine" true`), "pass");
+});
+
+test("OUTCOME a step that failed on its own names itself", () => {
+  assert.equal(runOutcome(`step "bad" false || :`), "fail bad");
+});
+
+test("OUTCOME a step stopped from outside is no verdict, with the code that says so", () => {
+  assert.equal(
+    runOutcome(`step "killed" sh -c 'kill -TERM $$; sleep 30' || :`),
+    "no-verdict 76 killed was stopped before it could be judged",
+  );
+});
+
+test("OUTCOME a signal after a real failure does not unmake the failure", () => {
+  // The rule, asked directly rather than through the printed line. The signal
+  // is recorded either way; which one outranks is answered here and only here.
+  assert.equal(
+    runOutcome(`step "bad" false || :\ngate_steps_note_signal TERM 143`),
+    "fail bad",
+  );
+});
+
+test("OUTCOME a signal with nothing learned is no verdict under the signal's own code", () => {
+  assert.equal(
+    runOutcome(`FAILED_STEP="the suites"\ngate_steps_note_signal TERM 143`),
+    "no-verdict 143 the gate was stopped by SIGTERM during the suites",
+  );
+});
+
 // --- the verdict cleanup prints ---------------------------------------------
 
 // cleanup() and the signal handlers, run for real against stubbed teardown. The
@@ -225,23 +258,13 @@ const extractVerdict = () => {
   return source.slice(start, end + endMarker.length);
 };
 
-const VERDICT_HARNESS = `
-set -uo pipefail
-say() { printf '\\n== %s\\n' "$1"; }
-note() { printf '   %s\\n' "$1"; }
-terminate_group_steps() { :; }
+const VERDICT_HARNESS = `${ENGINE}
 discard_gate_tmp() { :; }
 release_lock() { :; }
 KEEP_POSTGRES=0
 POSTGRES_STARTED=0
 CONTAINER=stub
-STEP_REPORT=()
-FAILED_STEP=""
 GATED_HEAD=abc123
-. ${JSON.stringify(libPath)}
-NO_VERDICT_REASON=""
-NO_VERDICT_EXIT="$GATE_EXIT_NO_VERDICT"
-GATE_REAL_FAILURE=""
 ${extractVerdict()}
 `;
 
@@ -296,29 +319,17 @@ test("VERDICT a clean run still passes and still names its commit", () => {
 });
 
 // A group and the verdict together, which is the only way to observe what a
-// signal arriving mid-group actually prints. Both extractions are the gate's
-// own source; cleanup's teardown is stubbed for the same reason as above.
-const COMBINED_HARNESS = `
-set -uo pipefail
-say() { printf '\\n== %s\\n' "$1"; }
-note() { printf '   %s\\n' "$1"; }
+// signal arriving mid-group actually prints. The engine is the gate's own file
+// and cleanup is the gate's own source; cleanup's teardown is stubbed for the
+// same reason as above.
+const COMBINED_HARNESS = `${HARNESS}
 discard_gate_tmp() { :; }
 release_lock() { :; }
 KEEP_POSTGRES=0
 POSTGRES_STARTED=0
 CONTAINER=stub
-STEP_REPORT=()
-FAILED_STEP=""
 GATED_HEAD=abc123
-. ${JSON.stringify(libPath)}
-NO_VERDICT_REASON=""
-NO_VERDICT_EXIT="$GATE_EXIT_NO_VERDICT"
-GATE_REAL_FAILURE=""
-GATE_GROUP_PIDS=()
-GATE_TMP="$1"
-REPO_ROOT="$2"
 ${extractVerdict()}
-${PARALLEL_STEPS}
 `;
 
 // Runs a group, waits until the member that is meant to block has reported its
@@ -394,7 +405,7 @@ test("PARALLEL-INTERRUPT stops members still running before the gate tears down"
     writeFileSync(
       script,
       `${HARNESS}\n` +
-        `trap 'terminate_group_steps; exit 143' TERM\n` +
+        `trap 'gate_steps_stop_running; exit 143' TERM\n` +
         `parallel_steps "a group" "long" sh -c 'printf %s "$$" > "$0"; exec sleep 30' ${JSON.stringify(memberPidFile)}\n`,
     );
     const harness = spawn("bash", [script, root, root], { stdio: "ignore" });
@@ -437,7 +448,7 @@ test("PARALLEL-INTERRUPT stops the members before cleanup removes what they use"
   // and the lock is released closes nothing.
   const source = readFileSync(gatePath, "utf8");
   const cleanup = source.slice(source.indexOf("\ncleanup() {"));
-  const stop = cleanup.indexOf("terminate_group_steps");
+  const stop = cleanup.indexOf("gate_steps_stop_running");
   const discard = cleanup.indexOf("discard_gate_tmp");
   const release = cleanup.indexOf("release_lock");
   assert.ok(stop !== -1, "cleanup no longer stops in-flight members");

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -1254,7 +1254,7 @@ export AGENTOS_ALLOW_SCRATCH_DATABASES=1
 parallel_steps "dependencies and the install-free suites" \
   "npm ci" install_dependencies :: \
   "frozen-record checker fixtures" node --test scripts/check-frozen-docs.test.mjs :: \
-  "gate worker harness and slot fixtures" node --test scripts/gate-worker/gate-worker.test.mjs scripts/gate-worker/gate-dispatch.test.mjs :: \
+  "gate worker harness and slot fixtures" node --test scripts/gate-worker/gate-env.test.mjs scripts/gate-worker/gate-worker.test.mjs scripts/gate-worker/gate-dispatch.test.mjs :: \
   "parallel-group fixtures" node --test scripts/merge-gate-parallel.test.mjs :: \
   "build layer fixtures" node --test scripts/build-layers.test.mjs
 

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -166,6 +166,12 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
 # needs one writer.
 # shellcheck source=scripts/gate-worker/lib.sh
 . "${SCRIPT_DIR}/gate-worker/lib.sh"
+# What it means to run a step, to run a group of them at once, and what this
+# run's outcome is. It travels with the commit rather than being installed on
+# the worker: run-gate.sh gates a worktree checked out of the mirror, so
+# everything merge-gate.sh sources out of the repository tree is already there.
+# shellcheck source=scripts/gate-worker/step-engine.sh
+. "${SCRIPT_DIR}/gate-worker/step-engine.sh"
 CONTAINER="agentos-merge-gate-$$"
 # The lock lives in the worktree because the worktree is what is being contended:
 # two checkouts of the same repository may gate at the same time, two gates in one
@@ -177,16 +183,7 @@ GATE_TMP=""
 POSTGRES_STARTED=0
 GATED_HEAD=""
 GATE_PROFILE="full"
-FAILED_STEP=""
-STEP_REPORT=()
-# Set only when the run was stopped rather than decided. It is what turns the
-# last line into GATE NOT RUN instead of a FAIL nothing formed.
-NO_VERDICT_REASON=""
-NO_VERDICT_EXIT="${GATE_EXIT_NO_VERDICT}"
-# Named the moment a step is seen to have failed on its own, which is earlier
-# than its group's accounting: a signal arriving while a later member is still
-# stuck must not erase a failure this run already observed.
-GATE_REAL_FAILURE=""
+gate_steps_begin
 
 # --- plumbing ---------------------------------------------------------------
 
@@ -270,7 +267,7 @@ cleanup() {
   local cleanup_error=""
 
   # Before anything below is torn down, not after.
-  terminate_group_steps
+  gate_steps_stop_running
 
   discard_gate_tmp || cleanup_error="the temporary directory could not be removed"
   release_lock || cleanup_error="${cleanup_error:+${cleanup_error}; }the merge gate lock could not be released"
@@ -286,23 +283,32 @@ cleanup() {
   fi
 
   printf '\n'
-  if [ "${#STEP_REPORT[@]}" -gt 0 ]; then
-    for line in "${STEP_REPORT[@]}"; do printf '   %s\n' "${line}"; done
-  fi
+  gate_steps_report
 
-  # Before the FAIL branch, because a run that was stopped reaches it with a
-  # non-zero status and a FAILED_STEP naming wherever it happened to be, and
-  # would otherwise print a judgement about the commit that nothing formed.
-  if [ -n "${NO_VERDICT_REASON}" ]; then
-    printf '\n'
-    gate_verdict_not_run "${NO_VERDICT_REASON}${cleanup_error:+; ${cleanup_error}}"
-    printf 'Nothing judged %s. Re-run the gate; this is not a FAIL.\n' "${GATED_HEAD:-this commit}"
-    exit "${NO_VERDICT_EXIT}"
-  fi
+  # What this run learned, asked once. Which of a failure, a stop and a signal
+  # outranks which is the step engine's rule and is stated there; this reads
+  # the answer and picks the line that carries it.
+  local outcome; outcome="$(gate_steps_outcome)"
+  case "${outcome}" in
+    'no-verdict '*)
+      outcome="${outcome#no-verdict }"
+      printf '\n'
+      gate_verdict_not_run "${outcome#* }${cleanup_error:+; ${cleanup_error}}"
+      printf 'Nothing judged %s. Re-run the gate; this is not a FAIL.\n' "${GATED_HEAD:-this commit}"
+      exit "${outcome%% *}"
+      ;;
+    'fail '*)
+      printf '\n'
+      gate_verdict_fail "${outcome#fail }"
+      exit "${GATE_EXIT_FAIL}"
+      ;;
+  esac
 
-  if [ "${status}" -ne 0 ] || [ -n "${FAILED_STEP}" ]; then
+  # No step failed and none was stopped, and the script still ended non-zero:
+  # something outside the plan did, and the gate has no name for it.
+  if [ "${status}" -ne 0 ]; then
     printf '\n'
-    gate_verdict_fail "${FAILED_STEP:-unknown}"
+    gate_verdict_fail "unknown"
     exit "${GATE_EXIT_FAIL}"
   fi
   if [ -n "${cleanup_error}" ]; then
@@ -339,226 +345,11 @@ trap cleanup EXIT
 # did not fail; it never finished. Naming the signal here is what lets the EXIT
 # trap say so.
 interrupted() {
-  # A failure this run already saw is a judgement about the commit, and a signal
-  # arriving afterwards does not unmake it. Only a run that learned nothing
-  # reports the absence of a verdict.
-  if [ -n "${GATE_REAL_FAILURE}" ]; then
-    FAILED_STEP="${GATE_REAL_FAILURE}"
-  else
-    NO_VERDICT_REASON="the gate was stopped by SIG${1}${FAILED_STEP:+ during ${FAILED_STEP}}"
-    NO_VERDICT_EXIT="$2"
-  fi
+  gate_steps_note_signal "$1" "$2"
   exit "$2"
 }
 trap 'interrupted INT 130' INT
 trap 'interrupted TERM 143' TERM
-
-# A step that was stopped from outside against one that failed on its own. The
-# first set is what an operator, a supervisor or the OOM killer sends: nothing
-# was learned about the commit, so the run has no verdict to give. A crash the
-# step produced itself (SIGSEGV, SIGABRT, SIGBUS, SIGFPE) is the code under test
-# behaving badly and stays a FAIL, which is the direction this is allowed to be
-# wrong in: it never converts a real failure into an errand.
-stopped_from_outside() {
-  case "$1" in
-    129 | 130 | 131 | 137 | 143) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-record_stop() {
-  NO_VERDICT_REASON="${1} was stopped before it could be judged"
-  NO_VERDICT_EXIT="${GATE_EXIT_NO_VERDICT}"
-}
-
-record_real_failure() {
-  GATE_REAL_FAILURE="${GATE_REAL_FAILURE:+${GATE_REAL_FAILURE}, }${1}"
-}
-
-step() {
-  local label="$1"; shift
-  say "${label}"
-  local started; started=$(date +%s)
-  FAILED_STEP="${label}"
-  local status=0
-  ( cd "${REPO_ROOT}" && "$@" ) || status=$?
-  if [ "${status}" -ne 0 ]; then
-    if stopped_from_outside "${status}"; then
-      STEP_REPORT+=("STOP  ${label}")
-      record_stop "${label}"
-    else
-      STEP_REPORT+=("FAIL  ${label}")
-      record_real_failure "${label}"
-    fi
-    return 1
-  fi
-  STEP_REPORT+=("$(printf 'ok    %-42s %4ss' "${label}" "$(( $(date +%s) - started ))")")
-  FAILED_STEP=""
-}
-
-# Run independent steps at the same time.
-#
-# Members are separated by `::`: each one is a label followed by the command it
-# runs, exactly as `step` takes them. Nothing about what a step proves changes
-# here — only how many of them are in flight at once. The gate is a chain of
-# eighteen serial steps on a worker with twelve cores, and for most of a run
-# eleven of them have nothing to do.
-#
-# Two properties this has to keep, because a parallel group is where both are
-# normally lost:
-#
-# Output stays readable. Each member writes to its own file and the files are
-# replayed in submission order after the group finishes, so the log reads like
-# the serial steps it replaced instead of interleaved fragments from a dozen
-# processes. `parallel_lint` already worked this way; this is that pattern with
-# more than two members.
-#
-# Every failure is named, not just the first. A group that stopped at the
-# earliest non-zero status would send someone back for a second gate to find
-# the second problem, and running these together is precisely what makes it
-# cheap to learn all of them in one pass. Each member is waited for, each keeps
-# its own duration, and the verdict line lists all of them.
-GATE_STEP_SEPARATOR="::"
-
-# The members a parallel group has in flight. cleanup has to be able to reach
-# them: it deletes GATE_TMP, releases the worktree lock and removes the
-# postgres container, and each of those is a statement that this gate has
-# stopped working. `kill` on this script alone interrupts the parent's `wait`
-# without touching the members, so the teardown would run while a build is
-# still writing dist/ and the next gate would take the lock this one just
-# released. The serial layout this replaced had one child at a time and no log
-# of its own to delete; nine at once is worth the accounting.
-GATE_GROUP_PIDS=()
-
-# Signalling the member alone is not enough, and the shape of the miss is easy
-# to reproduce: the member is a subshell, the work it runs is a process below
-# that, and `npm ci` or `tsc` is a process below *that*. Killing the member
-# leaves the rest orphaned and running. So members are started under `set -m`,
-# which makes each one a process-group leader, and the whole group is signalled
-# at once.
-terminate_group_steps() {
-  [ "${#GATE_GROUP_PIDS[@]}" -gt 0 ] || return 0
-  local group alive attempt
-  printf '\n   interrupted: stopping %s step(s) still running\n' "${#GATE_GROUP_PIDS[@]}"
-  for group in "${GATE_GROUP_PIDS[@]}"; do kill -TERM -"${group}" 2>/dev/null || true; done
-  # Five seconds to end on their own, then stop asking. Waiting without a
-  # deadline hands a member that ignores TERM the power to hang the gate
-  # forever, which is worse than the leak this is closing.
-  for ((attempt=0; attempt<50; attempt++)); do
-    alive=0
-    for group in "${GATE_GROUP_PIDS[@]}"; do kill -0 -"${group}" 2>/dev/null && alive=1; done
-    [ "${alive}" -eq 0 ] && break
-    sleep 0.1
-  done
-  for group in "${GATE_GROUP_PIDS[@]}"; do kill -KILL -"${group}" 2>/dev/null || true; done
-  # Reaped, not just signalled: returning while they are still dying is the
-  # race this exists to close.
-  for group in "${GATE_GROUP_PIDS[@]}"; do wait "${group}" 2>/dev/null || true; done
-  GATE_GROUP_PIDS=()
-}
-
-parallel_steps() {
-  local title="$1"; shift
-  local -a labels=() serialized=() pids=() statuses=() logs=() current=() failures=() stopped=()
-  local token index slot seconds
-
-  for token in "$@" "${GATE_STEP_SEPARATOR}"; do
-    if [ "${token}" = "${GATE_STEP_SEPARATOR}" ]; then
-      if [ "${#current[@]}" -gt 0 ]; then
-        [ "${#current[@]}" -ge 2 ] \
-          || { printf 'parallel_steps: member "%s" names no command\n' "${current[0]}" >&2; return 1; }
-        labels+=("${current[0]}")
-        # %q quoting is produced by bash for bash, so the eval below restores
-        # exactly this argument vector. Every member here is a literal in this
-        # file; none of it comes from the commit being gated.
-        serialized+=("$(printf '%q ' "${current[@]:1}")")
-        current=()
-      fi
-      continue
-    fi
-    current+=("${token}")
-  done
-  [ "${#labels[@]}" -gt 0 ] || { printf 'parallel_steps: %s has no members\n' "${title}" >&2; return 1; }
-
-  # Set before anything is spawned: if this group dies without reaching its own
-  # accounting, the verdict still names where the gate was.
-  FAILED_STEP="${title}"
-  say "${title} (${#labels[@]} steps at once)"
-
-  for ((index=0; index<${#labels[@]}; index++)); do
-    slot="$(printf '%s' "${labels[index]}" | tr -c '[:alnum:]' '-')"
-    logs[index]="${GATE_TMP}/group-${index}-${slot}.log"
-    # The member times itself. Timing it from here would charge each member for
-    # however long the parent happened to wait on the members before it.
-    # Job control, on for the spawn only: it is what puts the member and
-    # everything it starts into one process group terminate_group_steps can
-    # reach. It changes nothing on the normal path -- exit codes still arrive
-    # through `wait`, and a group that ends on its own prints nothing.
-    set -m
-    (
-      cd "${REPO_ROOT}" || exit 1
-      __started=$(date +%s)
-      eval "${serialized[index]}"
-      __status=$?
-      printf '%s\n' "$(( $(date +%s) - __started ))" > "${logs[index]}.seconds"
-      exit "${__status}"
-    ) >"${logs[index]}" 2>&1 &
-    pids[index]=$!
-    GATE_GROUP_PIDS+=("$!")
-    set +m
-    note "started ${labels[index]}"
-  done
-
-  # The member's own status, not a flattened 1: 128+N is how a member that was
-  # killed is told apart from one that ran and failed, and the difference is
-  # whether this group has a verdict at all.
-  for ((index=0; index<${#labels[@]}; index++)); do
-    if wait "${pids[index]}"; then statuses[index]=0; else statuses[index]=$?; fi
-    # Recorded here rather than in the accounting below, which a signal arriving
-    # while a later member is still stuck would never reach.
-    if [ "${statuses[index]}" -ne 0 ] && ! stopped_from_outside "${statuses[index]}"; then
-      record_real_failure "${labels[index]}"
-    fi
-  done
-  GATE_GROUP_PIDS=()
-
-  for ((index=0; index<${#labels[@]}; index++)); do
-    printf '\n--- %s ---\n' "${labels[index]}"
-    cat "${logs[index]}" 2>/dev/null || true
-  done
-
-  for ((index=0; index<${#labels[@]}; index++)); do
-    # A member killed before it could write its own duration reports `?` rather
-    # than a number this run did not measure.
-    seconds="$(cat "${logs[index]}.seconds" 2>/dev/null || printf '?')"
-    [ -n "${seconds}" ] || seconds="?"
-    if [ "${statuses[index]}" -eq 0 ]; then
-      STEP_REPORT+=("$(printf 'ok    %-42s %4ss' "${labels[index]}" "${seconds}")")
-    elif stopped_from_outside "${statuses[index]}"; then
-      STEP_REPORT+=("$(printf 'STOP  %-42s %4ss' "${labels[index]}" "${seconds}")")
-      stopped+=("${labels[index]}")
-    else
-      STEP_REPORT+=("$(printf 'FAIL  %-42s %4ss' "${labels[index]}" "${seconds}")")
-      failures+=("${labels[index]}")
-    fi
-  done
-
-  # A member that ran and failed is a judgement about the commit and outranks a
-  # member that was stopped: the gate did learn something, and burying that
-  # under "no verdict" would let a real FAIL be re-dispatched as an errand.
-  if [ "${#failures[@]}" -gt 0 ]; then
-    FAILED_STEP="$(printf '%s, ' "${failures[@]}")"
-    FAILED_STEP="${FAILED_STEP%, }"
-    return 1
-  fi
-  if [ "${#stopped[@]}" -gt 0 ]; then
-    FAILED_STEP="$(printf '%s, ' "${stopped[@]}")"
-    FAILED_STEP="${FAILED_STEP%, }"
-    record_stop "${FAILED_STEP}"
-    return 1
-  fi
-  FAILED_STEP=""
-}
 
 sha256() { shasum -a 256 | awk '{print $1}'; }
 


### PR DESCRIPTION
C2 of the architecture-deepening brief. Two modules, one per commit, A first.

## A — the step engine (`2f7587c`)

`step`, `parallel_steps`, `terminate_group_steps`, `GATE_STEP_SEPARATOR`, the
STOP-vs-FAIL classifier and the six state globals move out of `merge-gate.sh`
into `scripts/gate-worker/step-engine.sh`, behind:

    gate_steps_begin
    step <label> <cmd...>
    parallel_steps <title> <label> <cmd...> :: ...
    gate_steps_stop_running          # was terminate_group_steps
    gate_steps_note_signal <name> <exit>
    gate_steps_report
    gate_steps_outcome               # pass | fail <step> | no-verdict <exit> <reason>

`gate_steps_outcome` is the point of it. The rule that *a real failure seen
before a signal survives it* — the subject of `f287ecc` — used to be stated
twice, once in `interrupted` and once as a second `if` in `cleanup`. It is now
stated once, in `gate_steps_outcome`, and `cleanup` stops reading five globals
and asks one question. `interrupted` is a two-line shim: record the signal,
exit — a trap handler has to exit in the gate's own process.

**Not in `lib.sh`**: `lib.sh` is installed on the worker beside `run-gate.sh`
and carries the verdict's wire format, which `run-gate.sh` and
`gate-dispatch.sh` read back. Neither of them runs a step. `step-engine.sh`
travels with the commit instead — `run-gate.sh` gates a worktree checked out
of the mirror — so `mirror-push.sh`'s install loop is deliberately untouched.

## B — the fixture's view of the gate environment (`16b2080`)

The 26-line preamble was byte-identical in `gate-worker.test.mjs` and
`gate-dispatch.test.mjs`. Three commits edited it by hand — `1a855ae`,
`4087264`, `d360238` — and `4087264` landed in only one of the two, so the
guard it added was missing from the other file until the next commit. The
argument is not that the list appeared twice; it is that the reason did.

`scripts/gate-worker/gate-env.mjs` owns `GATE_ENV_PREFIXES`, `GATE_ENV_NAMES`,
`GATE_ENV_INHERITED`, `isHostGateConfig`, `hostNeutralEnv()` and
`fixtureEnv(identity)`. The identity string was the only difference between the
two files and stays a parameter. No shell-side twin: `GATE_HOME` legitimately
means three different things across `provision.sh`, `mirror-push.sh` and
`run-gate.sh`.

## What the fixtures stopped restating

`merge-gate-parallel.test.mjs` no longer string-slices the engine out of the
script. `extractParallelSteps()` and its four `assert.notEqual(..., -1, ...)`
guards are gone: the harnesses source `step-engine.sh`, which is what the gate
does, so there is nothing left to fail loudly about.

Rebuilt globals, before → after:

| harness            | before | after |
| ------------------ | -----: | ----: |
| `HARNESS`          |      8 |     2 |
| `VERDICT_HARNESS`  |     15 |     4 |
| `COMBINED_HARNESS` |     17 |     6 |

What remains is genuine per-case input: `GATE_TMP` and `REPO_ROOT` for the
engine, and `KEEP_POSTGRES` / `POSTGRES_STARTED` / `CONTAINER` / `GATED_HEAD`
for `cleanup`'s stubbed teardown. The two `say`/`note` stubs stay: they are the
gate's log format, not the engine's, and the engine says so at the top of the
file.

`extractVerdict()` **stays**. It slices `cleanup` and the two signal traps,
which are the gate's own and not the engine's; the verdict cases still need
`cleanup` run for real to observe which last line and which exit code it
prints. That is exactly as much of it as survives.

## Tests

- **Survive** — all 23 cases in `merge-gate-parallel.test.mjs` pass with every
  assertion unchanged, and all 76 in the two gate-worker fixtures.
- **Appear** — five cases asking `gate_steps_outcome` its three shapes
  directly, including the precedence rule, which until now could only be
  observed through `cleanup`'s printed line; and in `gate-env.test.mjs` the
  coverage test: it scans the gate scripts a fixture spawns for every name they
  read out of the environment and asserts each is either stripped by
  `isHostGateConfig` or named in `GATE_ENV_INHERITED` with a reason. Twenty
  names are classified today; eight are inherited on purpose, `XDG_CACHE_HOME`
  with its original reason carried across verbatim.
- **Move** — the duplicated guard test, out of both fixture files into
  `gate-env.test.mjs`.

## What did not change, and two things that did

The plan is byte-identical in its steps, its grouping and its comments, with
one exception: `scripts/gate-worker/gate-env.test.mjs` is added to the "gate
worker harness and slot fixtures" member and to `npm run test:gate-worker`,
because a coverage test the gate never runs is not a coverage test. That is the
only plan line this branch touches.

**The six hand-assigned `FAILED_STEP` sites are left alone**, and the brief
allows for it. None of them can become a `step` without changing what the gate
reports:

- `worktree lock` — `acquire_lock` sets `LOCK_HELD` in the current shell;
  `step` runs its command in a subshell, so the lock would be taken and
  immediately forgotten.
- `authoritative default branch` — sets `MASTER_OID` and `MASTER_SOURCE` the
  same way.
- `docker preflight` — its two checks end in `die`, which must exit the gate;
  from a subshell it would exit the subshell and the verdict would name the
  wrong thing.

All three would also gain a `==` heading and a report line the gate does not
print today. They keep assigning `FAILED_STEP`, which `gate_steps_outcome`
still reads.

`step-engine.sh` reads no gate configuration variable of its own: `GATE_TMP`,
`REPO_ROOT` and `GATE_EXIT_NO_VERDICT` are all set by its caller in the same
process, so the note in the brief about the harnesses spawning `bash` without
an environment scrub is still not a live leak.

## Verification

`npm run lint` (both halves), `node --test scripts/merge-gate-parallel.test.mjs`,
`npm run test:gate-worker`, `npm run snapshot:scan`, and a `merge-gate.sh` run
driven into the `die` path to confirm `cleanup` still prints
`MERGE GATE: FAIL (preflight)` and releases the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)