### PR TITLE
feat(merge-tail): give repair tasks the chain's context and a second attempt

### DIFF
--- a/apps/web/src/components/task-card.tsx
+++ b/apps/web/src/components/task-card.tsx
@@ -2,7 +2,7 @@ import { type DragEvent, type MouseEvent, type ReactNode, memo, useEffect, useSt
 
 import { chainPositionMarker } from "../lib/chain";
 import { duration, money, timeAgo, usageCostLabel } from "../lib/format";
-import { moveTargets, retryable, scheduleLabel, statusLabel } from "../lib/board";
+import { chainBinding, chainBindingLabel, moveTargets, retryable, scheduleLabel, statusLabel } from "../lib/board";
 import { type Translate, useT } from "../lib/i18n";
 import { mergeBadge } from "../lib/merge-outcome";
 import { navigate } from "../lib/router";
@@ -171,7 +171,9 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
   const taskCostLabel = usageCostLabel(task.taskCost);
   const hasTokenFallback = task.taskCost !== null && task.taskCost.costUsd === null;
   const title = cardTitle(task);
-  const chainName = task.chainName ?? (task.chainId === null ? null : task.chainId.slice(0, 8));
+  const chain = chainBinding(task);
+  const chainLabel = chain === null ? null : chainBindingLabel(chain);
+  const repair = task.repairOf ?? null;
   return <article
     data-card={task.id}
     className={TASK_CARD}
@@ -209,25 +211,33 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
           </span>
         </div>
       ) : null}
-      {/* No placeholder for a chain-less card (K4). */}
-      {task.chainProgress ? (
+      {/* No placeholder for a chain-less card (K4). A merge-tail repair task is
+          chain-less in its own columns but not in fact, so the row is driven by
+          the binding rather than by the chain progress a detached task has none
+          of — otherwise the repair card sits on the board with nothing saying
+          which chain it belongs to. */}
+      {chainLabel === null ? null : (
         <div className={cn(TASK_META_ROW, "overflow-hidden text-ellipsis whitespace-nowrap")}>
-          {chainName === null ? null : (
-            <button
-              type="button"
-              className="max-w-full overflow-hidden text-ellipsis rounded-full border border-border bg-secondary px-[7px] py-[1px] text-secondary-foreground hover:text-foreground"
-              title={chainName}
-              aria-label={t("tasks.card.filterChain", { name: chainName })}
-              onClick={(event) => { event.stopPropagation(); actions.onFilterChain(task); }}
-            >
-              {chainName}
-            </button>
-          )}
+          <button
+            type="button"
+            className="max-w-full overflow-hidden text-ellipsis rounded-full border border-border bg-secondary px-[7px] py-[1px] text-secondary-foreground hover:text-foreground"
+            title={chainLabel}
+            aria-label={t("tasks.card.filterChain", { name: chainLabel })}
+            onClick={(event) => { event.stopPropagation(); actions.onFilterChain(task); }}
+          >
+            {chainLabel}
+          </button>
+          {/* Which repair this is, in the chain's own row: a repair card carries
+              no step ordinal, and the kind is the only thing that distinguishes
+              two repairs of the same chain. */}
+          {repair === null
+            ? null
+            : <Pill tone="amber" className={TASK_PILL}>{t("tasks.pill.repair", { kind: repair.repairKind })}</Pill>}
           {/* The marker keeps the card's node ordinal and the API-derived dense
               execution-layer progress together, without recomputing either. */}
           <span>{chainPositionMarker(task.chainProgress)}</span>
         </div>
-      ) : null}
+      )}
       <div className={TASK_META_ROW}>{runLabel(task, t)}</div>
       {task.assigneeAgent === null ? null : (
         <div className={TASK_META_ROW}>

--- a/apps/web/src/lib/board.ts
+++ b/apps/web/src/lib/board.ts
@@ -46,6 +46,30 @@ export const defaultTab = (counts: Counts): TaskStatus => {
   return STATUSES.filter((status) => status !== "DONE").find((status) => counts[status] > 0) ?? DEFAULT_STATUS;
 };
 
+/* ---------------------------------------------------------------- the chain */
+
+export type ChainBinding = { id: string; name: string | null };
+
+/**
+ * Which chain a board card belongs to.
+ *
+ * Read through this rather than off `chainId`, because an autonomous merge-tail
+ * repair task has no chain columns at all — it is created chain-detached so the
+ * chain stays a static, linear, once-through structure — and the API resolves
+ * its chain from the repair marker instead. Both answers are the same fact, and
+ * the filter, the card badge and the page's filter control all have to give the
+ * same one.
+ */
+export const chainBinding = (task: Pick<BoardTask, "chainId" | "chainName" | "repairOf">): ChainBinding | null => {
+  if (task.chainId !== null) return { id: task.chainId, name: task.chainName };
+  const repair = task.repairOf ?? null;
+  return repair === null ? null : { id: repair.chainId, name: repair.chainName };
+};
+
+/** What the chain is called on screen: its name where the API could derive one,
+ *  and a short form of its id where it could not. */
+export const chainBindingLabel = (binding: ChainBinding): string => binding.name ?? binding.id.slice(0, 8);
+
 /* ------------------------------------------------------------- the schedule */
 
 export type ScheduleSubject = Pick<

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -377,6 +377,11 @@ export type BoardTask = {
   /** §SF-1, bound to `latestRun`: null whenever the newest run is not the run
    *  that recorded the outcome. */
   mergeOutcome?: MergeOutcome | null;
+  /** The chain an autonomous merge-tail repair task repairs. A repair task is
+   *  chain-detached by design, so this is the only thing that puts its card with
+   *  the chain it belongs to. Null on every other card, absent for older board
+   *  responses. */
+  repairOf?: { chainId: string; chainName: string | null; repairKind: string } | null;
 };
 
 export type UsageCost = {

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -825,6 +825,7 @@ export const en = {
   "tasks.notice.copyFailed": "The browser refused clipboard access; open the task to read the error",
   "tasks.pill.approval": "Approval",
   "tasks.pill.cron": "cron",
+  "tasks.pill.repair": "Repair {kind}",
   "tasks.pill.template": "Template",
   "tasks.pill.webhook": "webhook",
   "tasks.schedule.AT": "at",

--- a/apps/web/src/locales/zh.ts
+++ b/apps/web/src/locales/zh.ts
@@ -818,6 +818,7 @@ export const zh = {
   "tasks.notice.copyFailed": "浏览器拒绝访问剪贴板；请打开任务查看完整错误",
   "tasks.pill.approval": "需审批",
   "tasks.pill.cron": "cron",
+  "tasks.pill.repair": "修复 {kind}",
   "tasks.pill.template": "模板",
   "tasks.pill.webhook": "webhook",
   "tasks.schedule.AT": "定时",

--- a/apps/web/src/pages/Tasks.tsx
+++ b/apps/web/src/pages/Tasks.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "../lib/api";
-import { COLUMNS, type Counts, countByStatus, defaultTab, focusAfterMove, parseStatus, statusLabel, tabKey } from "../lib/board";
+import { COLUMNS, type Counts, chainBinding, chainBindingLabel, countByStatus, defaultTab, focusAfterMove, parseStatus, statusLabel, tabKey } from "../lib/board";
 import { formatT } from "../lib/format";
 import { useAction, useMediaQuery, usePoll } from "../lib/hooks";
 import { useT } from "../lib/i18n";
@@ -46,8 +46,11 @@ export const archiveDoneNotice = (result: { archived: number; skipped: number })
     ? formatT("tasks.archiveDone.some", result)
     : formatT("tasks.archiveDone.all", result));
 
+/** Every card the chain owns, which includes the merge-tail repair tasks the
+ *  chain produced — those carry no chain columns of their own, so filtering on
+ *  `chainId` alone dropped them out of the group they belong to. */
 export const tasksForChain = (tasks: readonly BoardTask[], chainId: string | null): BoardTask[] =>
-  (chainId === null ? [...tasks] : tasks.filter((task) => task.chainId === chainId));
+  (chainId === null ? [...tasks] : tasks.filter((task) => chainBinding(task)?.id === chainId));
 
 export const ChainFilterControl = ({ name, onClear }: { name: string; onClear: () => void }): ReactNode => {
   const t = useT();
@@ -329,7 +332,8 @@ export const TasksPage = (): ReactNode => {
     onDelete: remove,
     onCopyError: copyError,
     onFilterChain: (task) => {
-      if (task.chainId !== null) setChainFilter({ id: task.chainId, name: task.chainName ?? task.chainId });
+      const chain = chainBinding(task);
+      if (chain !== null) setChainFilter({ id: chain.id, name: chainBindingLabel(chain) });
     },
   }), [move, retry, archive, remove, copyError]);
 

--- a/apps/web/src/tests/board.test.tsx
+++ b/apps/web/src/tests/board.test.tsx
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  chainParked, clampScroll, columnStep, countByStatus, defaultTab, edgeState, focusAfterMove,
-  moveTargets, parseStatus, retryable, sameEdges, scheduleLabel, statusLabel, storedScroll,
+  chainBinding, chainBindingLabel, chainParked, clampScroll, columnStep, countByStatus, defaultTab, edgeState,
+  focusAfterMove, moveTargets, parseStatus, retryable, sameEdges, scheduleLabel, statusLabel, storedScroll,
 } from "../lib/board";
 import type { BoardTask, ChainProgress } from "../lib/types";
 
@@ -27,6 +27,24 @@ const step = (position: number, overrides: Partial<BoardTask> = {}): BoardTask =
     chainId: "c1", done: 1, total: 9, activeStepName: "Implementation", activeStatus: "doing", currentLayer: 2, layerCount: 7, position,
   } satisfies ChainProgress,
   ...overrides,
+});
+
+/* ------------------------------------------------------------- the binding */
+
+test("a merge-tail repair task binds to a chain it has no columns for", () => {
+  assert.deepEqual(chainBinding(step(4, { chainName: "Release" })), { id: "c1", name: "Release" });
+  assert.equal(chainBinding(task()), null);
+  // Chain-detached by design: the binding is the API's resolution of the
+  // repair marker, and it is the only thing that puts the card with its chain.
+  const repair = task({ repairOf: { chainId: "c1", chainName: "Release", repairKind: "gate-fix" } });
+  assert.deepEqual(chainBinding(repair), { id: "c1", name: "Release" });
+  assert.equal(chainBindingLabel(chainBinding(repair)!), "Release");
+  // A chain with no step of its own on the page has no derived name, so the
+  // card names it by a short id rather than by nothing at all.
+  assert.equal(
+    chainBindingLabel(chainBinding(task({ repairOf: { chainId: "cmt38t30u000fmpru2uc4emc9", chainName: null, repairKind: "review-fix" } }))!),
+    "cmt38t30",
+  );
 });
 
 /* --------------------------------------------------------- schedule labels */

--- a/apps/web/src/tests/tasks-board.test.tsx
+++ b/apps/web/src/tests/tasks-board.test.tsx
@@ -274,6 +274,38 @@ test("chain badges filter to one chain, can be cleared, and titles drop the shar
   assert.match(control, />Clear filter<\/button>/);
 });
 
+test("a merge-tail repair task renders under the chain it repairs, with its kind", () => {
+  // The repair task is created chain-detached — no chainId, chainIndex or
+  // templateId — so before the API resolved its `repairAttempt` marker the board
+  // drew it as a loose card with nothing saying which chain it belonged to.
+  const step = task({ id: "s", name: "Release: Regression", displayName: "Regression", chainId: "c1", chainName: "Release", chainProgress: progress() });
+  const repair = task({
+    id: "r", name: "Autonomous merge tail: gate-fix", displayName: "Autonomous merge tail: gate-fix",
+    status: "DOING",
+    repairOf: { chainId: "c1", chainName: "Release", repairKind: "gate-fix" },
+  });
+  const other = task({ id: "o", name: "Unrelated", displayName: "Unrelated" });
+  assert.deepEqual(tasksForChain([step, repair, other], "c1").map(({ id }) => id), ["s", "r"]);
+
+  const markup = card(repair);
+  assert.match(markup, /aria-label="Show only chain Release"/);
+  assert.match(markup, new RegExp(en("tasks.pill.repair", { kind: "gate-fix" })));
+  // It carries no step ordinal of its own, and must not borrow one.
+  assert.doesNotMatch(markup, /step \d+\//);
+  // A chain step is not a repair.
+  assert.doesNotMatch(card(step), new RegExp(en("tasks.pill.repair", { kind: "gate-fix" })));
+  assert.doesNotMatch(card(other), /Show only chain/);
+});
+
+test("a repair card names the chain by a short id when the API derived no name", () => {
+  const markup = card({
+    id: "r", name: "Autonomous merge tail: review-fix", displayName: "Autonomous merge tail: review-fix",
+    repairOf: { chainId: "cmt38t30u000fmpru2uc4emc9", chainName: null, repairKind: "review-fix" },
+  });
+  assert.match(markup, /aria-label="Show only chain cmt38t30"/);
+  assert.match(markup, new RegExp(en("tasks.pill.repair", { kind: "review-fix" })));
+});
+
 test("a non-template chain uses the API-derived badge and short card title", () => {
   const direct = task({
     name: "Release: Build", displayName: "Build", chainId: "direct-chain", chainName: "Release",

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -1968,7 +1968,13 @@ test("partitionArchivable keeps the busy tasks out of the archive set and counts
 
 /** A stub with just enough of `task` for `GET /tasks` to answer: the board row
  *  page, the chain-progress page, and the recurring groupBy the full shape adds. */
-const boardDatabase = (rows: Array<Record<string, unknown>>): PrismaClient => {
+/** `related` answers the by-id lookups the board makes for rows that are not on
+ *  the page — a bound task's predecessor and a repair task's regression task —
+ *  and `activity` the merge-tail markers that name the latter. */
+const boardDatabase = (
+  rows: Array<Record<string, unknown>>,
+  extras: { related?: Array<Record<string, unknown>>; activity?: Array<Record<string, unknown>> } = {},
+): PrismaClient => {
   let call = 0;
   const taskRows = [...rows].sort((left, right) => (
     (right.createdAt as Date).getTime() - (left.createdAt as Date).getTime()
@@ -1977,12 +1983,14 @@ const boardDatabase = (rows: Array<Record<string, unknown>>): PrismaClient => {
   return {
     task: {
       findMany: async (args: Record<string, unknown> | undefined) => {
+        if ((args?.where as Record<string, unknown> | undefined)?.id !== undefined) return extras.related ?? [];
         if (call++ !== 0) return [];
         assert.deepEqual(args?.orderBy, [{ createdAt: "desc" }, { id: "asc" }]);
         return taskRows;
       },
       groupBy: async () => [],
     },
+    taskActivity: { findMany: async () => extras.activity ?? [] },
   } as unknown as PrismaClient;
 };
 
@@ -2037,6 +2045,31 @@ test("the board derives a shared title and badge for API-created chains", async 
       { id: "build", name: "Release: Build", displayName: "Build", chainName: "Release" },
       { id: "review", name: "Release: Review", displayName: "Review", chainName: "Release" },
     ]);
+  });
+});
+
+test("the board binds a chain-detached repair task to the chain its marker names", async () => {
+  await withTokens(async () => {
+    const response = await getTasks(boardDatabase(
+      [
+        taskRow({ id: "regression", chainId: "c1", chainIndex: 1, name: "Release: Regression", templateStep: { name: "Regression" } }),
+        taskRow({ id: "repair", name: "Autonomous merge tail: gate-fix", templateStep: null }),
+      ],
+      {
+        related: [{ id: "regression", chainId: "c1" }],
+        activity: [{ taskId: "repair", metadata: {
+          schemaVersion: 1, kind: "mergeTail.repairAttempt", repairKind: "gate-fix", regressionTaskId: "regression",
+        } }],
+      },
+    ), "?view=board");
+    assert.equal(response.status, 200);
+    const body = await response.json() as Array<{ id: string; chainId: string | null; repairOf: unknown }>;
+    const repair = body.find((card) => card.id === "repair")!;
+    // The repair task stays chain-detached on the wire — the binding is the
+    // read side's answer to where the card belongs, not a chain column.
+    assert.equal(repair.chainId, null);
+    assert.deepEqual(repair.repairOf, { chainId: "c1", chainName: "Release", repairKind: "gate-fix" });
+    assert.equal(body.find((card) => card.id === "regression")!.repairOf, null);
   });
 });
 

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -2056,7 +2056,7 @@ test("the board binds a chain-detached repair task to the chain its marker names
         taskRow({ id: "repair", name: "Autonomous merge tail: gate-fix", templateStep: null }),
       ],
       {
-        related: [{ id: "regression", chainId: "c1" }],
+        related: [{ id: "regression", projectId: "p1", chainId: "c1" }],
         activity: [{ taskId: "repair", metadata: {
           schemaVersion: 1, kind: "mergeTail.repairAttempt", repairKind: "gate-fix", regressionTaskId: "regression",
         } }],
@@ -2070,6 +2070,44 @@ test("the board binds a chain-detached repair task to the chain its marker names
     assert.equal(repair.chainId, null);
     assert.deepEqual(repair.repairOf, { chainId: "c1", chainName: "Release", repairKind: "gate-fix" });
     assert.equal(body.find((card) => card.id === "regression")!.repairOf, null);
+  });
+});
+
+test("a global board keeps two projects' same-named chains apart when it binds their repairs", async () => {
+  await withTokens(async () => {
+    // `chainId` is unique per project, not globally, so a board that spans
+    // projects can hold the same one twice. A repair card must be named by its
+    // own project's chain, not by whichever came first on the page.
+    const response = await getTasks(boardDatabase(
+      [
+        taskRow({ id: "regression-1", chainId: "c1", chainIndex: 1, name: "Release: Regression", templateStep: { name: "Regression" } }),
+        taskRow({ id: "repair-1", name: "Autonomous merge tail: gate-fix", templateStep: null }),
+        taskRow({ id: "regression-2", projectId: "p2", chainId: "c1", chainIndex: 1, name: "Hotfix: Regression", templateStep: { name: "Regression" } }),
+        taskRow({ id: "repair-2", projectId: "p2", name: "Autonomous merge tail: review-fix", templateStep: null }),
+      ],
+      {
+        related: [
+          { id: "regression-1", projectId: "p1", chainId: "c1" },
+          { id: "regression-2", projectId: "p2", chainId: "c1" },
+        ],
+        activity: [
+          { taskId: "repair-1", metadata: {
+            schemaVersion: 1, kind: "mergeTail.repairAttempt", repairKind: "gate-fix", regressionTaskId: "regression-1",
+          } },
+          { taskId: "repair-2", metadata: {
+            schemaVersion: 1, kind: "mergeTail.repairAttempt", repairKind: "review-fix", regressionTaskId: "regression-2",
+          } },
+        ],
+      },
+    ), "?view=board");
+    assert.equal(response.status, 200);
+    const body = await response.json() as Array<{ id: string; repairOf: unknown }>;
+    assert.deepEqual(body.find((card) => card.id === "repair-1")!.repairOf, {
+      chainId: "c1", chainName: "Release", repairKind: "gate-fix",
+    });
+    assert.deepEqual(body.find((card) => card.id === "repair-2")!.repairOf, {
+      chainId: "c1", chainName: "Hotfix", repairKind: "review-fix",
+    });
   });
 });
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -5,6 +5,7 @@ import {
   AssigneeType,
   agentArchiveBlocker,
   applyInboxDecision,
+  asJsonObject,
   catalogRunnerForModel,
   CleanupStatus,
   CodexServiceTier,
@@ -55,6 +56,7 @@ import {
   runOwnsMergeOutcome,
   INTEGRATOR_AGENT_NAME,
   MERGE_INTEGRATOR_KIND,
+  MERGE_TAIL_KIND,
   latestTargetCorrection,
   loadIntegratorTask,
   observedChainPullRequests,
@@ -78,7 +80,7 @@ import { getMimeType } from "hono/utils/mime";
 import { z } from "zod";
 
 import { authenticate, principalMayAccess, type Principal } from "./auth.js";
-import { boardCard, chainDisplayByTask, etagFor, etagMatches, serializeUsageCost } from "./board.js";
+import { boardCard, chainDisplayByTask, etagFor, etagMatches, repairBinding, serializeUsageCost, type RepairBinding } from "./board.js";
 import { isValidBranchName } from "./branch-name.js";
 import { chainExecutionOwner } from "./chain-execution-owner.js";
 import { FAILURE_REASON_LIMIT, failureReasonText } from "./failure-reason.js";
@@ -2313,11 +2315,56 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         });
         for (const predecessor of predecessors) predecessorById.set(predecessor.id, predecessor);
       }
+      // A merge-tail repair task is chain-detached by design, so nothing on its
+      // own row says which chain it repairs — the board drew it as a loose card
+      // beside the work that produced it. Its `repairAttempt` marker names the
+      // regression task, and that task's chain is where the card belongs. One
+      // extra query over the page's chain-less rows, skipped entirely when a
+      // page has none, and a second only when a repair card is actually on it.
+      const detachedIds = rows.filter((row) => row.chainId === null).map((row) => row.id);
+      const repairMarkers = detachedIds.length === 0 ? [] : await db.taskActivity.findMany({
+        where: {
+          taskId: { in: detachedIds },
+          actorType: "control-plane",
+          metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.repairAttempt },
+        },
+        select: { taskId: true, metadata: true },
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      });
+      const repairByTask = new Map<string, RepairBinding>();
+      if (repairMarkers.length > 0) {
+        const regressionIds = [...new Set(repairMarkers.flatMap((marker) => {
+          const value = asJsonObject(marker.metadata)?.regressionTaskId;
+          return typeof value === "string" ? [value] : [];
+        }))];
+        const regressionTasks = await db.task.findMany({
+          where: { id: { in: regressionIds }, ...(projectId ? { projectId } : {}) },
+          select: { id: true, chainId: true },
+        });
+        // The chain's display name is already derived once for this page. A
+        // chain with no step of its own on the page has none, and the card falls
+        // back to naming it by id exactly as a chain step's card does.
+        const chainNameById = new Map<string, string | null>();
+        for (const row of rows) {
+          if (row.chainId === null || chainNameById.has(row.chainId)) continue;
+          chainNameById.set(row.chainId, displayByTask.get(row.id)?.chainName ?? null);
+        }
+        const chainOfRegressionTask = (taskId: string): { chainId: string; chainName: string | null } | null => {
+          const chainId = regressionTasks.find((task) => task.id === taskId)?.chainId ?? null;
+          return chainId === null ? null : { chainId, chainName: chainNameById.get(chainId) ?? null };
+        };
+        for (const marker of repairMarkers) {
+          if (repairByTask.has(marker.taskId)) continue;
+          const binding = repairBinding(asJsonObject(marker.metadata), chainOfRegressionTask);
+          if (binding !== null) repairByTask.set(marker.taskId, binding);
+        }
+      }
       return validated(context, rows.map((row) => boardCard(
         row,
         progressFor(row),
         displayByTask.get(row.id),
         row.dispatchAfterTaskId === null ? null : predecessorById.get(row.dispatchAfterTaskId) ?? null,
+        repairByTask.get(row.id) ?? null,
       )));
     }
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -2339,19 +2339,29 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         }))];
         const regressionTasks = await db.task.findMany({
           where: { id: { in: regressionIds }, ...(projectId ? { projectId } : {}) },
-          select: { id: true, chainId: true },
+          select: { id: true, projectId: true, chainId: true },
         });
-        // The chain's display name is already derived once for this page. A
-        // chain with no step of its own on the page has none, and the card falls
-        // back to naming it by id exactly as a chain step's card does.
-        const chainNameById = new Map<string, string | null>();
+        const chainOfTask = new Map<string, { key: string; chainId: string }>();
+        for (const task of regressionTasks) {
+          if (task.chainId === null) continue;
+          chainOfTask.set(task.id, { key: chainKey({ projectId: task.projectId, chainId: task.chainId }), chainId: task.chainId });
+        }
+        // The chain's display name is already derived once for this page. Keyed
+        // by `chainKey` rather than `chainId` for the same reason the page's own
+        // grouping is: a global board carries several projects, and two of them
+        // may hold the same chain id. A chain with no step of its own on the
+        // page has no name here, and the card falls back to naming it by id
+        // exactly as a chain step's card does.
+        const chainNameByKey = new Map<string, string | null>();
         for (const row of rows) {
-          if (row.chainId === null || chainNameById.has(row.chainId)) continue;
-          chainNameById.set(row.chainId, displayByTask.get(row.id)?.chainName ?? null);
+          if (row.chainId === null) continue;
+          const key = chainKey({ projectId: row.projectId, chainId: row.chainId });
+          if (chainNameByKey.has(key)) continue;
+          chainNameByKey.set(key, displayByTask.get(row.id)?.chainName ?? null);
         }
         const chainOfRegressionTask = (taskId: string): { chainId: string; chainName: string | null } | null => {
-          const chainId = regressionTasks.find((task) => task.id === taskId)?.chainId ?? null;
-          return chainId === null ? null : { chainId, chainName: chainNameById.get(chainId) ?? null };
+          const chain = chainOfTask.get(taskId);
+          return chain === undefined ? null : { chainId: chain.chainId, chainName: chainNameByKey.get(chain.key) ?? null };
         };
         for (const marker of repairMarkers) {
           if (repairByTask.has(marker.taskId)) continue;

--- a/packages/api/src/board.test.ts
+++ b/packages/api/src/board.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { Prisma } from "@agentos/db";
 
-import { type BoardRow, boardCard, chainDisplayByTask, etagFor, etagMatches, taskChainName } from "./board.js";
+import { type BoardRow, boardCard, chainDisplayByTask, etagFor, etagMatches, repairBinding, taskChainName } from "./board.js";
 
 const session = (overrides: Partial<NonNullable<BoardRow["runs"][number]["session"]>> = {}): NonNullable<BoardRow["runs"][number]["session"]> => ({
   costUsd: null, inputTokens: null, cachedInputTokens: null, outputTokens: null, startedAt: null, endedAt: null, ...overrides,
@@ -40,9 +40,31 @@ test("the board card carries every field the board renders and nothing else", ()
   // deliberate act with a payload cost, so it has to be added here too.
   assert.deepEqual(Object.keys(boardCard(row(), null)).sort(), [
     "approvalGate", "assigneeAgent", "blockedOn", "chainId", "chainIndex", "chainName", "chainProgress", "cron", "displayName",
-    "failureReason", "id", "latestRun", "mergeOutcome", "name", "runAt", "scheduleKind", "source", "status", "taskCost",
-    "templateId", "timezone", "updatedAt",
+    "failureReason", "id", "latestRun", "mergeOutcome", "name", "repairOf", "runAt", "scheduleKind", "source", "status",
+    "taskCost", "templateId", "timezone", "updatedAt",
   ]);
+});
+
+test("a repair task is bound to the chain of the regression task its marker names", () => {
+  const chain = (): { chainId: string; chainName: string | null } => ({ chainId: "c1", chainName: "Release" });
+  assert.deepEqual(
+    repairBinding({ schemaVersion: 1, kind: "mergeTail.repairAttempt", repairKind: "gate-fix", regressionTaskId: "reg-1" }, chain),
+    { chainId: "c1", chainName: "Release", repairKind: "gate-fix" },
+  );
+  // The regression side of the same marker names the repair task, not a chain
+  // this card could be put under, so it is not this card's binding.
+  assert.equal(
+    repairBinding({ schemaVersion: 1, kind: "mergeTail.repairAttempt", repairKind: "gate-fix", repairTaskId: "fix-1" }, chain),
+    null,
+  );
+  // A regression task that is itself chain-detached binds nothing.
+  assert.equal(repairBinding({ repairKind: "review-fix", regressionTaskId: "reg-1" }, () => null), null);
+  assert.equal(repairBinding(null, chain), null);
+  assert.equal(boardCard(row(), null).repairOf, null);
+  assert.deepEqual(
+    boardCard(row(), null, undefined, null, { chainId: "c1", chainName: "Release", repairKind: "review-fix" }).repairOf,
+    { chainId: "c1", chainName: "Release", repairKind: "review-fix" },
+  );
 });
 
 test("blockedOn is projected from the resolved predecessor without storing its status", () => {
@@ -80,6 +102,7 @@ test("blockedOn is projected from the resolved predecessor without storing its s
     latestRun: null,
     taskCost: null,
     mergeOutcome: null,
+    repairOf: null,
   });
 });
 

--- a/packages/api/src/board.ts
+++ b/packages/api/src/board.ts
@@ -58,7 +58,21 @@ export type BoardCard = {
    * post-merge incident as a green Done. This is what the card renders instead.
    */
   mergeOutcome: MergeOutcomeProjection | null;
+  /**
+   * The chain a merge-tail repair task repairs.
+   *
+   * A repair task is deliberately chain-detached — no `chainId`, `chainIndex` or
+   * `templateId` — so its own columns say nothing about where it came from, and
+   * the board drew it as a loose card beside the chain that produced it. The
+   * `repairAttempt` marker it carries names the regression task, and that task's
+   * chain is what this reports. Null for every card that is not a repair task.
+   */
+  repairOf: RepairBinding | null;
 };
+
+/** What a repair card needs to sit with its chain: the chain it belongs to and
+ *  which kind of repair it is. */
+export type RepairBinding = { chainId: string; chainName: string | null; repairKind: string };
 
 /** The Prisma row shape `boardCard` needs — declared structurally so the route
  *  can `select` exactly these columns and nothing else. */
@@ -171,6 +185,7 @@ export const boardCard = (
   chainProgress: (ChainProgress & { position: number | null }) | null,
   display: ChainDisplay = { chainName: taskChainName(row), displayName: row.name },
   predecessor: BoardBlockedOnTask | null = null,
+  repairOf: RepairBinding | null = null,
 ): BoardCard => {
   const run = row.runs[0];
   const taskCost = sumUsageCosts(row.runs.flatMap((item) => item.session === null
@@ -216,7 +231,28 @@ export const boardCard = (
     mergeOutcome: run !== undefined && runOwnsMergeOutcome(row.stepOutput, run.id, run.id)
       ? projectMergeOutcome(row.stepOutput)
       : null,
+    repairOf,
   };
+};
+
+/**
+ * The chain binding a `repairAttempt` marker carries, or null when the marker is
+ * not the repair task's own side of one.
+ *
+ * The same kind is written on both sides of a repair: the regression task names
+ * the repair task, and the repair task names the regression task. Only the
+ * second names a chain this card can be put under, so a marker without a
+ * `regressionTaskId` is not this card's binding rather than a broken one.
+ */
+export const repairBinding = (
+  metadata: Record<string, unknown> | null,
+  chainOfRegressionTask: (regressionTaskId: string) => { chainId: string; chainName: string | null } | null,
+): RepairBinding | null => {
+  const regressionTaskId = typeof metadata?.regressionTaskId === "string" ? metadata.regressionTaskId : null;
+  const repairKind = typeof metadata?.repairKind === "string" ? metadata.repairKind : null;
+  if (regressionTaskId === null || repairKind === null) return null;
+  const chain = chainOfRegressionTask(regressionTaskId);
+  return chain === null ? null : { chainId: chain.chainId, chainName: chain.chainName, repairKind };
 };
 
 /**

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -8,6 +8,7 @@ import {
   lockAgentRepoGrant,
   lockAgentRow,
   MAX_AUTHORITY_RESIGN_ROUNDS,
+  MAX_MERGE_TAIL_REPAIR_ATTEMPTS,
   MergeRecoveryStatus,
   parseRegressionVerdict,
   Prisma,
@@ -240,7 +241,7 @@ export const openAuthorityResignNotice = async (
 export const createMergeTailRepairTask = async (
   tx: DbTx,
   input: {
-    regressionTask: { id: string; projectId: string; repoId: string | null; templateId: string | null; chainId: string | null; targetBranch: string | null };
+    regressionTask: { id: string; projectId: string; repoId: string | null; templateId: string | null; chainId: string | null; chainIndex: number | null; targetBranch: string | null };
     sourceRun: { id: string; branch: string | null };
     agentName: string;
     repairKind: "refresh-conflict" | "gate-fix" | "review-fix";
@@ -251,8 +252,11 @@ export const createMergeTailRepairTask = async (
   },
 ): Promise<{ taskId: string } | { refusal: string }> => {
   const { regressionTask } = input;
-  if (!regressionTask.repoId || !regressionTask.chainId || !regressionTask.templateId || !input.sourceRun.branch) {
-    return { refusal: "repair task cannot resolve its chain repository and shared branch" };
+  if (
+    !regressionTask.repoId || !regressionTask.chainId || regressionTask.chainIndex === null
+    || !regressionTask.templateId || !input.sourceRun.branch
+  ) {
+    return { refusal: "repair task cannot resolve its chain position, repository, and shared branch" };
   }
   const agent = await tx.agent.findFirst({
     where: { projectId: regressionTask.projectId, name: input.agentName, archivedAt: null },
@@ -263,17 +267,42 @@ export const createMergeTailRepairTask = async (
   });
   if (!grant) return { refusal: `required repair agent ${input.agentName} has no repository grant` };
 
-  const prompt = input.repairKind === "refresh-conflict"
+  // A repair task is deliberately chain-detached, so the claim path's own
+  // prior-output lookup (which keys off chainId and chainIndex) never fires for
+  // it. Without this the repair agent sees only the verdict summary and no
+  // Feature brief, acceptance criteria, or review reports, and the narrowest
+  // reading of that summary is the whole job it can do. Same query, ordering,
+  // and rendering as a chain step's: what the chain steps could see, the repair
+  // for those steps sees too.
+  const priorOutputs = await tx.taskStepOutput.findMany({
+    where: { task: {
+      projectId: regressionTask.projectId,
+      chainId: regressionTask.chainId,
+      chainIndex: { lt: regressionTask.chainIndex },
+    } },
+    select: { kind: true, body: true, task: { select: { name: true, chainIndex: true } } },
+    orderBy: { task: { chainIndex: "asc" } },
+  });
+  const chainContext = priorOutputs.length > 0
     ? [
-      `Resolve the refresh conflict between chain head ${input.headSha} and target head ${input.baseHeadSha}.`,
-      input.summary,
-      `Re-run the merge, preserve both intents under the merge-resolver role contract, commit the resolution, and persist the role's versioned JSON bound to start ${input.headSha} and target ${input.baseHeadSha}.`,
+      "Persisted outputs from prior template steps:",
+      ...priorOutputs.map((output) => `## ${output.task.name} (${output.kind})\n${output.body}`),
     ].join("\n\n")
-    : [
-      `Repair the autonomous merge tail failure at ${input.headSha} against target ${input.baseHeadSha}.`,
-      input.summary,
-      "Make exactly the changes needed to close this failure, run affected suites, commit, and persist the result as task output.",
-    ].join("\n\n");
+    : null;
+  const prompt = [
+    ...(input.repairKind === "refresh-conflict"
+      ? [
+        `Resolve the refresh conflict between chain head ${input.headSha} and target head ${input.baseHeadSha}.`,
+        input.summary,
+        `Re-run the merge, preserve both intents under the merge-resolver role contract, commit the resolution, and persist the role's versioned JSON bound to start ${input.headSha} and target ${input.baseHeadSha}.`,
+      ]
+      : [
+        `Repair the autonomous merge tail failure at ${input.headSha} against target ${input.baseHeadSha}.`,
+        input.summary,
+        "Make exactly the changes needed to close this failure, run affected suites, commit, and persist the result as task output. Before changing any shared type, schema, or route contract, enumerate its callers across every workspace, including apps/web, and update or test each one in the same change.",
+      ]),
+    ...(chainContext ? [chainContext] : []),
+  ].join("\n\n");
   const task = await tx.task.create({ data: {
     projectId: regressionTask.projectId,
     repoId: regressionTask.repoId,
@@ -322,7 +351,7 @@ export const createMergeTailRepairTask = async (
 export const handleRegressionCompletion = async (
   tx: DbTx,
   input: {
-    task: { id: string; projectId: string; repoId: string | null; templateId: string | null; chainId: string | null; targetBranch: string | null };
+    task: { id: string; projectId: string; repoId: string | null; templateId: string | null; chainId: string | null; chainIndex: number | null; targetBranch: string | null };
     run: { id: string; agentId: string; branch: string | null; headSha: string | null; sessionId: string };
     now: Date;
   },
@@ -454,24 +483,29 @@ export const handleRegressionCompletion = async (
     return "handled";
   }
 
-  // The whole history, not the recent-state window: one automatic attempt per
-  // repair kind is the rule, and an attempt pushed past the window by later
-  // activity would license a second one.
+  // The whole history, not the recent-state window: the automatic attempt
+  // budget per repair kind is the rule, and an attempt pushed past the window
+  // by later activity would license an extra one.
   const attempts = await readMarkerHistory(tx, input.task.id);
   const repairKind = verdict.outcome === "refresh-conflict"
     ? "refresh-conflict"
     : verdict.outcome === "review-fail" ? "review-fix" : "gate-fix";
-  const alreadyAttempted = attempts.some((marker) => (
+  const priorAttempts = attempts.filter((marker) => (
     marker.kind === "repairAttempt"
     && marker.repairKind === repairKind
     && (repairKind !== "refresh-conflict" || marker.headSha === verdict.headSha)
-  ));
-  if (alreadyAttempted) {
+  )).length;
+  // A refresh conflict is a merge of two fixed trees: a second resolver run on
+  // the same head has nothing new to work with. A semantic or gate FAIL does —
+  // the first repair moved the tree, and the verdict it now fails on is a
+  // different one — so those get a second attempt before the tail stops.
+  const attemptLimit = repairKind === "refresh-conflict" ? 1 : MAX_MERGE_TAIL_REPAIR_ATTEMPTS;
+  if (priorAttempts >= attemptLimit) {
     return stop(repairKind === "refresh-conflict"
       ? `second refresh conflict on chain head ${verdict.headSha}`
       : repairKind === "review-fix"
-        ? `second semantic regression FAIL on chain head ${verdict.headSha}`
-        : `second merge gate FAIL on chain head ${verdict.headSha}`);
+        ? `semantic regression FAIL on chain head ${verdict.headSha} after ${priorAttempts} automatic repair attempts`
+        : `merge gate FAIL on chain head ${verdict.headSha} after ${priorAttempts} automatic repair attempts`);
   }
   let agentName = "merge-resolver";
   if (repairKind === "gate-fix" || repairKind === "review-fix") {

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -485,7 +485,10 @@ export const handleRegressionCompletion = async (
 
   // The whole history, not the recent-state window: the automatic attempt
   // budget per repair kind is the rule, and an attempt pushed past the window
-  // by later activity would license an extra one.
+  // by later activity would license an extra one. The count includes the
+  // review-fix repairs the independent-review rejection path opened on this
+  // task, which is what makes a chain that has already been repaired reach this
+  // ceiling sooner; that path keeps its own separate round ceiling.
   const attempts = await readMarkerHistory(tx, input.task.id);
   const repairKind = verdict.outcome === "refresh-conflict"
     ? "refresh-conflict"

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -39,6 +39,13 @@ const exec = promisify(execFile);
 
 let seedCounter = 0;
 
+// A real chain reaches Regression with the brief, the acceptance criteria, and
+// both review reports already persisted. The repair task is chain-detached, so
+// these are the bodies it can only see if the repair prompt carries them.
+const IMPLEMENTATION_BODY = "Feature brief: reject unregistered graphs at every entry point. Acceptance: the webhook and manual fire paths refuse them too.";
+const SOL_FINDINGS_BODY = "sol-findings: MF-2 the HTTP layer validates but the webhook path calls the executor directly.";
+const BLIND_FINDINGS_BODY = "blind-findings: the manual fire path repeats the same bypass and the board reads the retired field.";
+
 const seedRegression = async (options: { withLibrarian?: boolean } = {}) => {
   // A test may seed several chains in one millisecond, and both the slug and the
   // chain id have to stay distinct across them.
@@ -98,6 +105,37 @@ const seedRegression = async (options: { withLibrarian?: boolean } = {}) => {
     name: "Fix", description: "fix", assigneeType: AssigneeType.AGENT, assigneeAgentId: fixAgent.id,
     status: TaskStatus.DONE, chainId, chainIndex: fixIndex, chainLayer: fixLayer, targetBranch: "main",
   } });
+  for (const prior of options.withLibrarian
+    ? [
+      { index: 4, name: "Implementation", kind: "implementation", body: IMPLEMENTATION_BODY },
+      { index: 5, name: "Sol review", kind: "sol-findings", body: SOL_FINDINGS_BODY },
+      { index: 6, name: "Blind review", kind: "blind-findings", body: BLIND_FINDINGS_BODY },
+    ]
+    : [
+      { index: 0, name: "Implementation", kind: "implementation", body: IMPLEMENTATION_BODY },
+      { index: 1, name: "Sol review", kind: "sol-findings", body: SOL_FINDINGS_BODY },
+      { index: 2, name: "Blind review", kind: "blind-findings", body: BLIND_FINDINGS_BODY },
+    ]) {
+    const step = await db.taskTemplateStep.create({ data: {
+      taskTemplateId: template.id, stepIndex: prior.index, layer: prior.index, name: prior.name,
+      assigneeType: AssigneeType.AGENT, assigneeAgentId: fixAgent.id, prompt: prior.name.toLowerCase(),
+      approvalGate: false, outputKind: prior.kind,
+    } });
+    const priorTask = await db.task.create({ data: {
+      projectId: project.id, repoId: repo.id, templateId: template.id, templateStepId: step.id,
+      name: prior.name, description: prior.name, assigneeType: AssigneeType.AGENT, assigneeAgentId: fixAgent.id,
+      status: TaskStatus.DONE, chainId, chainIndex: prior.index, chainLayer: prior.index, targetBranch: "main",
+    } });
+    const priorRun = await db.run.create({ data: {
+      projectId: project.id, taskId: priorTask.id, agentId: fixAgent.id, repoId: repo.id,
+      runNumber: 1, dedupeKey: `task:${priorTask.id}:run:1`, runner: "CODEX", model: fixAgent.model,
+      promptHash: "hash", status: "SUCCEEDED", branch: BRANCH, pushedBranch: BRANCH,
+      targetBranch: "main", headSha: HEAD,
+    } });
+    await db.taskStepOutput.create({ data: {
+      taskId: priorTask.id, runId: priorRun.id, kind: prior.kind, body: prior.body, commitSha: HEAD,
+    } });
+  }
   const librarian = librarianStep ? await db.task.create({ data: {
     projectId: project.id, repoId: repo.id, templateId: template.id, templateStepId: librarianStep.id,
     name: "Librarian", description: "document", assigneeType: AssigneeType.AGENT, assigneeAgentId: librarianAgent.id,
@@ -434,20 +472,26 @@ test("a refresh conflict creates exactly one resolver and its completion re-runs
   assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 1);
 });
 
-test("a gate FAIL creates one fix-agent task and a second FAIL escalates with both heads in activity", async () => {
+test("a gate FAIL is repaired twice and the third FAIL escalates with both heads in activity", async () => {
   const seeded = await exercise("gate-fail");
   const repair = await repairFor(seeded, "gate-fix");
   assert.equal((await db.agent.findUniqueOrThrow({ where: { id: repair.assigneeAgentId! } })).name, "senior-dev");
   await completeRepair(seeded, repair.id, "Fixed the failing regression and reran the affected suite.");
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 2);
+  // The first repair moved the tree, so the second FAIL is a verdict on a
+  // different tree and buys one more automatic attempt rather than a stop.
   assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
-  assert.equal(await repairCount(seeded), 1);
-  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 1);
+  assert.equal(await repairCount(seeded), 2);
+  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 0);
+  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
+  assert.equal(await repairCount(seeded), 2);
+  const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
+  assert.match(notice.body, /after 2 automatic repair attempts/u);
   const trail = await db.taskActivity.findMany({ where: { taskId: seeded.regression.id }, select: { body: true } });
   assert.match(trail.map(({ body }) => body).join("\n"), new RegExp(`${HEAD}.*${BASE}`, "s"));
 });
 
-test("a semantic FAIL skips the gate path and creates one review-fix task", async () => {
+test("a semantic FAIL skips the gate path and is repaired twice before it escalates", async () => {
   const seeded = await exercise("review-fail");
   const repair = await repairFor(seeded, "review-fix");
   assert.equal((await db.agent.findUniqueOrThrow({ where: { id: repair.assigneeAgentId! } })).name, "senior-dev");
@@ -455,8 +499,43 @@ test("a semantic FAIL skips the gate path and creates one review-fix task", asyn
   await completeRepair(seeded, repair.id, "Closed MF-2 and reran its focused regression.");
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 2);
   assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
-  assert.equal(await repairCount(seeded), 1);
-  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 1);
+  assert.equal(await repairCount(seeded), 2);
+  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 0);
+  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
+  assert.equal(await repairCount(seeded), 2);
+  const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
+  assert.match(notice.body, /after 2 automatic repair attempts/u);
+});
+
+test("a repair task carries the chain's persisted outputs its own detached row cannot reach", async () => {
+  for (const outcome of ["review-fail", "gate-fail", "refresh-conflict"] as const) {
+    await resetTestDb(db);
+    const seeded = await exercise(outcome);
+    const repair = await repairFor(seeded, outcome === "review-fail" ? "review-fix" : outcome === "gate-fail" ? "gate-fix" : "refresh-conflict");
+    // Chain-detached by design: the claim path's prior-output lookup cannot
+    // fire for this row, so the prompt is the only carrier.
+    assert.equal(repair.chainId, null, outcome);
+    assert.equal(repair.chainIndex, null, outcome);
+    assert.match(repair.description, /Persisted outputs from prior template steps:/u, outcome);
+    assert.ok(repair.description.includes(IMPLEMENTATION_BODY), outcome);
+    assert.ok(repair.description.includes(SOL_FINDINGS_BODY), outcome);
+    assert.ok(repair.description.includes(BLIND_FINDINGS_BODY), outcome);
+    // Chain order, and nothing from the Regression step that opened the repair.
+    assert.ok(
+      repair.description.indexOf(IMPLEMENTATION_BODY) < repair.description.indexOf(SOL_FINDINGS_BODY),
+      outcome,
+    );
+    assert.ok(!repair.description.includes("regression-verification"), outcome);
+  }
+});
+
+test("a review-fix prompt names the blast radius a summary-literal repair would miss", async () => {
+  const seeded = await exercise("review-fail");
+  const repair = await repairFor(seeded, "review-fix");
+  assert.match(repair.description, /enumerate its callers across every workspace, including apps\/web/u);
+  const conflict = await exercise("refresh-conflict");
+  const resolver = await repairFor(conflict, "refresh-conflict");
+  assert.doesNotMatch(resolver.description, /enumerate its callers/u);
 });
 
 test("a Full Assurance repair revalidates documentation before Regression", async () => {

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -35,6 +35,7 @@ const HEAD = "a".repeat(40);
 const BASE = "b".repeat(40);
 const BRANCH = "agentos/repair-test";
 const RESOLVED = "c".repeat(40);
+const REPAIRED = "d".repeat(40);
 const exec = promisify(execFile);
 
 let seedCounter = 0;
@@ -161,13 +162,13 @@ const seedRegression = async (options: { withLibrarian?: boolean } = {}) => {
 
 const RESIGN_SUMMARY = "added packages/db/prisma/migrations/20260826000000_probe/migration.sql";
 
-const verdict = (outcome: RegressionOutcome) => JSON.stringify(outcome === "refresh-conflict"
-  ? { schemaVersion: 1, outcome, headSha: HEAD, baseHeadSha: BASE, summary: "merge conflict" }
+const verdict = (outcome: RegressionOutcome, headSha: string = HEAD) => JSON.stringify(outcome === "refresh-conflict"
+  ? { schemaVersion: 1, outcome, headSha, baseHeadSha: BASE, summary: "merge conflict" }
   : outcome === "review-fail"
-    ? { schemaVersion: 1, outcome, headSha: HEAD, baseHeadSha: BASE, summary: "MF-2 remains open" }
+    ? { schemaVersion: 1, outcome, headSha, baseHeadSha: BASE, summary: "MF-2 remains open" }
     : outcome === "authority-resign"
-      ? { schemaVersion: 1, outcome, headSha: HEAD, baseHeadSha: BASE, summary: RESIGN_SUMMARY }
-      : { schemaVersion: 1, outcome, headSha: HEAD, baseHeadSha: BASE, gateVerdict: "FAIL", summary: "suite failed" });
+      ? { schemaVersion: 1, outcome, headSha, baseHeadSha: BASE, summary: RESIGN_SUMMARY }
+      : { schemaVersion: 1, outcome, headSha, baseHeadSha: BASE, gateVerdict: "FAIL", summary: "suite failed" });
 
 type RegressionOutcome = "refresh-conflict" | "review-fail" | "gate-fail" | "authority-resign";
 
@@ -211,6 +212,38 @@ const repairFor = (
   projectId: seeded.project.id,
   name: `Autonomous merge tail: ${repairKind}`,
 } });
+
+/**
+ * The next turn of the repair loop, as the tail actually runs it: the queued
+ * Regression Run the last repair completion created publishes its own verdict,
+ * bound to that Run and to the head the repair produced, and completes.
+ *
+ * Re-invoking the first completion would exercise the attempt counter without
+ * exercising the loop it bounds.
+ */
+const failRegressionAgain = async (
+  seeded: Awaited<ReturnType<typeof exercise>>,
+  outcome: RegressionOutcome,
+  runNumber: number,
+  headSha: string,
+) => {
+  const run = await db.run.findFirstOrThrow({ where: { taskId: seeded.regression.id, runNumber } });
+  await db.run.update({ where: { id: run.id }, data: {
+    status: "SUCCEEDED", branch: BRANCH, pushedBranch: BRANCH, targetBranch: "main", headSha,
+  } });
+  const session = await db.session.create({ data: {
+    runId: run.id, projectId: seeded.project.id, agentId: seeded.regressionAgent.id, taskId: seeded.regression.id,
+    runner: "CODEX", executionStatus: "SUCCEEDED",
+  } });
+  await db.taskStepOutput.update({ where: { taskId: seeded.regression.id }, data: {
+    runId: run.id, body: verdict(outcome, headSha), commitSha: headSha,
+  } });
+  return db.$transaction((tx) => handleRegressionCompletion(tx, {
+    task: seeded.regression,
+    run: { id: run.id, agentId: seeded.regressionAgent.id, branch: BRANCH, headSha, sessionId: session.id },
+    now: new Date(),
+  }));
+};
 
 const repairCount = (seeded: Awaited<ReturnType<typeof exercise>>) => db.task.count({ where: {
   projectId: seeded.project.id,
@@ -474,16 +507,22 @@ test("a refresh conflict creates exactly one resolver and its completion re-runs
 
 test("a gate FAIL is repaired twice and the third FAIL escalates with both heads in activity", async () => {
   const seeded = await exercise("gate-fail");
-  const repair = await repairFor(seeded, "gate-fix");
-  assert.equal((await db.agent.findUniqueOrThrow({ where: { id: repair.assigneeAgentId! } })).name, "senior-dev");
-  await completeRepair(seeded, repair.id, "Fixed the failing regression and reran the affected suite.");
+  const first = await repairFor(seeded, "gate-fix");
+  assert.equal((await db.agent.findUniqueOrThrow({ where: { id: first.assigneeAgentId! } })).name, "senior-dev");
+  await completeRepair(seeded, first.id, "Fixed the failing regression and reran the affected suite.", RESOLVED);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 2);
-  // The first repair moved the tree, so the second FAIL is a verdict on a
-  // different tree and buys one more automatic attempt rather than a stop.
-  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
+  // The first repair moved the tree, so this FAIL is a verdict on a different
+  // head and buys one more automatic attempt rather than a stop.
+  assert.equal(await failRegressionAgain(seeded, "gate-fail", 2, RESOLVED), "handled");
   assert.equal(await repairCount(seeded), 2);
   assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 0);
-  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
+  const second = await db.task.findFirstOrThrow({
+    where: { projectId: seeded.project.id, name: "Autonomous merge tail: gate-fix" },
+    orderBy: { createdAt: "desc" },
+  });
+  await completeRepair(seeded, second.id, "Fixed the remaining failure and reran the affected suite.", REPAIRED);
+  assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 3);
+  assert.equal(await failRegressionAgain(seeded, "gate-fail", 3, REPAIRED), "handled");
   assert.equal(await repairCount(seeded), 2);
   const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
   assert.match(notice.body, /after 2 automatic repair attempts/u);
@@ -493,15 +532,23 @@ test("a gate FAIL is repaired twice and the third FAIL escalates with both heads
 
 test("a semantic FAIL skips the gate path and is repaired twice before it escalates", async () => {
   const seeded = await exercise("review-fail");
-  const repair = await repairFor(seeded, "review-fix");
-  assert.equal((await db.agent.findUniqueOrThrow({ where: { id: repair.assigneeAgentId! } })).name, "senior-dev");
-  assert.match(repair.description, /MF-2 remains open/u);
-  await completeRepair(seeded, repair.id, "Closed MF-2 and reran its focused regression.");
+  const first = await repairFor(seeded, "review-fix");
+  assert.equal((await db.agent.findUniqueOrThrow({ where: { id: first.assigneeAgentId! } })).name, "senior-dev");
+  assert.match(first.description, /MF-2 remains open/u);
+  await completeRepair(seeded, first.id, "Closed MF-2 and reran its focused regression.", RESOLVED);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 2);
-  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
+  assert.equal(await failRegressionAgain(seeded, "review-fail", 2, RESOLVED), "handled");
   assert.equal(await repairCount(seeded), 2);
   assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 0);
-  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, seeded.input)), "handled");
+  const second = await db.task.findFirstOrThrow({
+    where: { projectId: seeded.project.id, name: "Autonomous merge tail: review-fix" },
+    orderBy: { createdAt: "desc" },
+  });
+  // The second repair carries the chain's context too, not only the first one.
+  assert.ok(second.description.includes(SOL_FINDINGS_BODY));
+  await completeRepair(seeded, second.id, "Closed the remaining finding and reran its focused regression.", REPAIRED);
+  assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 3);
+  assert.equal(await failRegressionAgain(seeded, "review-fail", 3, REPAIRED), "handled");
   assert.equal(await repairCount(seeded), 2);
   const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
   assert.match(notice.body, /after 2 automatic repair attempts/u);

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -882,7 +882,7 @@ export const completeRun = async (
               // or target branch cannot hand off to the fresh Regression run.
               const lockedRegression = await tx.task.findUnique({
                 where: { id: regressionTaskId },
-                select: { projectId: true, repoId: true, templateId: true, chainId: true, targetBranch: true },
+                select: { projectId: true, repoId: true, templateId: true, chainId: true, chainIndex: true, targetBranch: true },
               });
               // Claiming the park this review owns is what makes the repair
               // automatic without overruling anyone: an operator who moved

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -60,6 +60,14 @@ export const AUTHORITY_RESIGN_DEDUPE_PREFIX = "authority-resign:";
  */
 export const MAX_AUTHORITY_RESIGN_ROUNDS = 3;
 
+/**
+ * How many automatic repairs one chain gets per repair kind before the tail
+ * stops. A semantic or gate FAIL after a repair is a different verdict against
+ * a different tree, so one more attempt is progress rather than a loop; a
+ * refresh conflict is not covered by this and stays at one attempt per head.
+ */
+export const MAX_MERGE_TAIL_REPAIR_ATTEMPTS = 2;
+
 export const MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES = 2;
 export const MAX_BASE_DRIFT_CLASSIFICATION_RETRIES = 30;
 


### PR DESCRIPTION
Implements all five items of `BRIEF-merge-tail-repair-context-fix.md` (2026-08-26; brief at `scratchpad/BRIEF-merge-tail-repair-context-fix.md` in the dispatching session).

## Why

A merge-tail repair task is chain-detached by design — no `chainId`, `chainIndex`, or `templateId` — so `run-claim.ts`'s prior-output lookup, which keys off exactly those columns, never fires for it. The repair agent's whole prompt was three lines: a head declaration, the verdict summary, and one instruction. No Feature brief, no acceptance criteria, no `sol-findings` / `blind-findings`, no `fixed-implementation`. The narrowest reading of that summary was the whole job it could do — PR #134's repair closed the HTTP zod layer and missed the webhook and manual-fire paths that reached the same executor directly, and broke the web UI on the way.

The design ruling behind this change is that the repair task stays chain-detached (writing it into the chain would mean touching three `run-claim` predicates, `chainProgress`, and the chain-completion test for a dynamic loop the chain does not model). Context travels by explicit prompt instead.

## What

1. **Chain context in the repair prompt** — `createMergeTailRepairTask` reads the chain's persisted step outputs ahead of the regression step and appends them, using the same query, ordering, and rendering (`## <task name> (<kind>)`) a chain step's claim would get. No filtering and no truncation: what the chain steps could see, the repair for those steps sees. Both the `refresh-conflict` and the `review-fix` / `gate-fix` branches get it. `regressionTask` gained `chainIndex`, and a null one now refuses loudly rather than dispatching a blind repair.
2. **Blast radius in the review-fix prompt** — "Before changing any shared type, schema, or route contract, enumerate its callers across every workspace, including apps/web, and update or test each one in the same change."
3. **dbtest coverage** — the `merge-tail-repair` fixture now seeds the chain's earlier steps and their outputs, and asserts the repair task's description carries the brief body and both review reports, in chain order, while its own `chainId` / `chainIndex` stay null.
4. **Board read side** — a repair card binds to the chain its `repairAttempt` marker names (`BoardCard.repairOf`), so it renders with that chain and shows its repair kind instead of sitting on the board as a loose card. Read-only: no schema, migration, or write-path change.
5. **Two automatic attempts** — semantic and gate FAILs get two repairs before the tail stops (`MAX_MERGE_TAIL_REPAIR_ATTEMPTS`); a refresh conflict still gets one per head, since a second resolver run on the same two fixed trees has nothing new to work with.

## Review

Reviewed with `codex exec -m gpt-5.6-sol` at `xhigh` over the whole diff. Round 1 raised three findings; round 2 came back clean.

- Fixed: the board's repair binding keyed its chain-name lookup by `chainId` alone while the page's own grouping keys by `(projectId, chainId)`, so a global board spanning two projects that hold the same chain id could name a repair card after the wrong chain. Now keyed by `chainKey`, with a test.
- Fixed: the attempt-limit tests re-invoked the first regression completion, exercising the marker counter without the loop it bounds. They now settle each queued Regression Run, publish a verdict bound to that run and the repaired head, and complete it.
- Not restructured, deliberately: the independent-review rejection path opens `review-fix` repairs without consulting this budget. Both loops were already separately bounded before this change (that path keeps its own `MAX_BLOCKING_REVIEW_ROUNDS` ceiling and stop notice), the interaction is pre-existing, and the brief scoped item 5 to the regression-verdict stop condition. The cross-path counting is now stated where it is read. Round 2 confirmed no unbounded creation, thrash, or non-stopping trace.

## Verification

Rebased onto `main` @ 91e3fda and re-run there:

- `npm run lint` — pass
- `npm run typecheck` — pass, all workspaces
- `npm test -w @agentos/api` — 506 pass, 1 skipped
- `npm test -w @agentos/web` — 401 pass
- `npm test -w @agentos/db` — 259 pass
- `npm run test:db -w @agentos/api` over `merge-tail-repair`, `merge-base-drift-recovery`, `board-blocked-on`, `tasks`, `run-completion` — 123 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)