### PR TITLE
fix(merge-tail): hold the merge lease only where the lock is load-bearing

### DIFF
--- a/docs/adr/0001-merge-lease-hold-window.md
+++ b/docs/adr/0001-merge-lease-hold-window.md
@@ -1,6 +1,6 @@
 # 0001 - Narrow the merge lease hold window
 
-Status: proposed
+Status: accepted (2026-08-26)
 
 ## Context
 
@@ -214,29 +214,56 @@ extending the name-plus-ordinal predicates, and moving
 That asymmetry decides the sequencing below: control-plane fixes ship on their
 own, prompt fixes ride the next rollover.
 
-## Decision (proposed - awaiting a ruling)
+## Decision
 
-### R1. Release across the independent review; readiness re-acquires
+The defect the four findings share is an asymmetry: **release is entirely
+code and acquire is entirely a prompt.** Nine control-plane call sites give the
+lease back; one model, following a sentence in a template, takes it. A mutual
+exclusion protocol half-executed by something that does not have to follow the
+protocol produces exactly finding C - a release nobody asked for, issued after
+the push on the same shell line had already failed, with no exit code checked.
 
-When the readiness worker parks on an open review obligation, release the lease
-using the releaser it already holds. When the review clears and readiness is
-handed back, acquire once before validating the pull-request snapshot; on
-failure leave the step parked and retry on a later tick rather than blocking the
-2-second poll loop. `merge-lease.sh acquire --timeout-minutes 0` already gives a
-single-attempt acquire that exits 75 on contention, so no change to
-`scripts/merge-lease.sh` is required. Rate-limit the retry to roughly the
-script's own poll interval so a parked step does not push to `origin` every
-tick.
+Closing the asymmetry completely would mean the control plane acquiring for the
+regression run. That is worse, not better: the control plane cannot see inside a
+run, so a lease taken for the run covers the whole run, including the 39m35s of
+semantic verification. Correct granularity there needs the regression step split
+in two, which is a template shape change. So the asymmetry closes at the one
+point where the lock is actually load-bearing.
 
-This also closes finding C's blast radius: with readiness acquiring before it
-authorizes, a stray agent-side release costs a re-acquire instead of an
-unleased merge.
+### R1. The control plane takes the lease where the lock is load-bearing
 
-Scope: `packages/api/src/merge-readiness-worker.ts` only. This is a merge
-automation path on the defense list, so it needs `senior-dev` and an explicit
-authorization to touch it.
+The segment that has to be serialised is the one `AGENTS.md` describes and no
+larger: from the base an authorization pins to the merge that consumes it. That
+segment is entirely inside the control plane, and it is about twenty seconds
+long. So:
 
-### R2. Rides the next template rollover
+- When readiness parks on an open review obligation, it releases. The review
+  reads a diff on GitHub; it neither produces nor consumes the proof.
+- Before it writes an authorization, readiness acquires - one attempt, never a
+  poll, since a tick cannot block on a lock another line may hold for minutes.
+  `merge-lease.sh acquire --timeout-minutes 0` already exits 75 on contention,
+  so `scripts/merge-lease.sh` is not touched. A tick that cannot take the lease
+  leaves its step claimed; the claim expires after
+  `READINESS_CLAIM_LEASE_MS` and a later tick tries again, which rate-limits the
+  retry to roughly the script's own poll interval for free.
+- Because the acquire is a network round trip spent inside the claim's lease,
+  the authorization transaction re-affirms the claim before it writes anything.
+  Without that, a worker that lost its step while acquiring could queue a second
+  merge execution.
+
+Acquire is idempotent for one task id, so in the ordinary case - no drift, no
+stray release - readiness's acquire finds the lease already held for the same
+chain and changes nothing.
+
+This also closes finding C's blast radius: with readiness taking the lease
+before the only action that consumes the proof, a stray agent-side release costs
+a re-acquire instead of an unleased merge.
+
+Scope: `packages/api/src/merge-lease.ts` and
+`packages/api/src/merge-readiness-worker.ts`. This is a merge automation path on
+the defense list; it was authorized explicitly on 2026-08-26.
+
+### R2. Not a project of its own; rides the next template rollover
 
 1. State the release contract in both regression prompts: the control plane owns
    release; the run never calls `release` or `steal`. (Fixes C at the source.)
@@ -270,6 +297,10 @@ would only paper over findings A and E.
   Worth reconsidering after R1.
 - **Fix C with a prompt-only edit.** Blocked by the frozen-prompt rule above.
   R1 defuses it instead, and R2 fixes it properly at the next rollover.
+- **Give the control plane the acquire as well, for the regression run.** The
+  symmetric-looking answer, and the wrong one: it widens the lock to the whole
+  run rather than narrowing it, because the control plane cannot see the point
+  inside the run where the base gets pinned.
 
 ## Consequences
 

--- a/docs/adr/0001-merge-lease-hold-window.md
+++ b/docs/adr/0001-merge-lease-hold-window.md
@@ -1,0 +1,260 @@
+# 0001 - Narrow the merge lease hold window
+
+Status: proposed
+
+## Context
+
+`scripts/merge-lease.sh` serialises the final merge window on `main` through one
+ref on `origin`. `AGENTS.md` states its purpose precisely: the lease "keeps an
+exact-head gate proof valid from the moment its baseline is fixed until that
+proof is consumed by the merge". The segment that must be held is therefore
+`fix the baseline -> run the gate -> merge`. Nothing else in the tail produces
+or consumes that proof.
+
+The autonomous chain tail holds it far wider than that. On 2026-08-26 two
+delivery lines ran concurrently and the lease became the throughput bottleneck.
+
+### Observed timeline (2026-08-26, UTC)
+
+Chain `af3c73f5` (*Run duration display*, PR #138):
+
+| Time | Event |
+| --- | --- |
+| 10:57:30 | regression run 7 acquires the lease, refreshes onto `origin/main` `0cb8f3c`, merge commit `d532af7` |
+| 11:00:44 | semantic verification passes (3m14s) |
+| 11:05:05 | `MERGE GATE: PASS` at `d532af7`; the run's own activity records "Merge lease released" |
+| 11:06:34 | regression PASS recorded; readiness queued |
+| 11:06:40 | independent review obligation opened |
+| 11:59:13 | independent review approved (52m33s) |
+| 11:59:18 | mechanical authorization |
+| 11:59:32 | merged as `f1d6cf6` |
+
+Chain `ff7a6904` (*Rollover and seed hardening*):
+
+| Time | Event |
+| --- | --- |
+| 10:31:58 | regression run 1 acquires the lease |
+| 10:50:23 | refresh onto `0cb8f3c` conflicts |
+| 10:50:54 | `refresh-conflict` recorded, repair queued, control plane releases the lease |
+| 11:13:28 | refresh-conflict repair completes (22m34s, unleased - correct) |
+| 11:17:35 | regression run 2 acquires the lease (`acquiredAt` on the lease blob) |
+| 11:18:08 | refresh onto `0cb8f3c`: already up to date |
+| 11:57:43 | semantic verification complete (39m35s, in-lock) |
+| 12:00:57 | release-authority check exit 0 |
+| 12:01:23 | regression PASS recorded against base `0cb8f3c` |
+| 12:01:27 | readiness: "target base advanced after regression PASS" `0cb8f3c` -> `f1d6cf6`; regression requeued |
+| 12:02:56 | regression run 3 re-acquires (same task id, idempotent), refreshes onto `f1d6cf6` |
+| 12:11:43 | regression PASS recorded at `9335539` |
+| 12:11:48 | independent review obligation opened |
+| 12:19:54 | independent review rejected, blocking round 1; review-fix repair queued; control plane releases the lease |
+| 12:20:05 | chain `65d229d6` acquires the lease |
+
+`ff7a6904` held the lease continuously for 62m19s (11:17:35 - 12:19:54) and
+merged nothing. Of that window, 39m35s was semantic verification, 8m06s was an
+independent review, and roughly 12 minutes was the gate plus the
+release-authority check. `65d229d6` had been polling since about 12:17:33 and
+was released only by the other chain's failure, not by its success.
+
+### Where the lease is taken and given back
+
+Acquire happens in exactly one place, and it is a prompt, not code:
+
+- `agents/templates/direct-engineer-workflow/05-regression-verification.md:16`
+- `agents/templates/compound-engineer-workflow/10-regression-verification.md:16`
+
+Both say: "before the first fetch, acquire the chain merge lease with
+`scripts/merge-lease.sh acquire --task {{chainId}} ...`". Acquire is idempotent
+for one task id, so every later regression run of the same chain re-acquires
+without contending with itself.
+
+Release is control-plane only, always `--task <chainId>`:
+
+- `packages/api/src/run-completion.ts:557` - a merge-tail run fails terminally with no retry
+- `packages/api/src/run-completion.ts:596` - the mechanical merge step succeeded
+- `packages/api/src/run-completion.ts:671` - canonical output refused on a regression step
+- `packages/api/src/run-completion.ts:698` - regression completed but did not advance
+- `packages/api/src/run-completion.ts:950` - a repair reported unable, or the independent review rejected
+- `packages/api/src/merge-readiness-worker.ts:151` - `stopReadiness`
+- `packages/api/src/reconcile.ts:379` - leases stranded by cancelled or lost runs
+- `packages/api/src/app.ts:3689`, `:4201`, `:4398` - run settlement and cancellation
+
+Two paths deliberately do not release: regression advancing to readiness, and
+readiness requeueing regression after base drift. `steal` has no caller in the
+repository; it is operator-only.
+
+The lock therefore spans `regression acquire -> merge execution`, with a release
+at every stop or bounce, and includes both agent-reasoning phases in the tail.
+
+## Findings
+
+### A. The independent review is inside the lock, by design
+
+`merge-readiness-worker.ts:createReviewObligation` creates the review task and
+parks readiness with `INDEPENDENT_REVIEW_OPEN_PREFIX` without releasing.
+`merge-lease.ts:mergeTailLeaseChainId` enumerates independent reviews as tasks
+that run under the lease, so this is intended behaviour, not an oversight. The
+review neither produces nor consumes the gate proof: it reads
+`baseSha..headSha` on GitHub and returns findings. Its duration is an agent
+session's duration - 8m06s in one observation, 52m33s in the other - and all of
+it is charged to every other delivery line's queue.
+
+The review's cost is bounded three times over: up to
+`MAX_BLOCKING_REVIEW_ROUNDS = 3` blocking rounds, each round adding a review-fix
+repair session, a full regression run, and another review, all inside the lock.
+
+The lease is not what makes the merge exact-head correct. Three independent
+checks already are:
+
+- readiness requeues regression when the PR head moved
+  (`merge-readiness-worker.ts:398`) or when
+  `snapshot.baseSha !== verdict.baseHeadSha` (`:433`);
+- the server-side ancestry check refuses anything but `ahead`/`identical` with
+  `behind_by == 0` (`:457`);
+- the merge executor re-verifies every precondition against the live pull
+  request and the exact-head authorization before merging.
+
+The requeue at 12:01:27 above is that safety net firing correctly. So the lease
+buys efficiency - it stops a gate run from being wasted - not safety.
+
+The price of releasing across the review is therefore bounded and known: if
+`main` advances while the review runs, readiness requeues regression, and the
+chain pays one full regression run. That is more than one gate run, because the
+step's prompt re-does semantic verification on every run: 3m14s for `af3c73f5`,
+39m35s for `ff7a6904`.
+
+### B. Acquire-before-integrate ordering: no defect found
+
+Only three places state the ordering, and all three agree with `AGENTS.md`:
+
+- `AGENTS.md:101` - acquire "before beginning the final sequence of integrating
+  the latest `main`, running the merge gate, and performing the merge";
+- both regression prompts, at line 16 - acquire "before the first fetch".
+
+No code acquires the lease, so no call site can contradict them, and
+`docs/runbooks/merge-delivery.md` does not mention the lease at all. The live
+evidence matches: every regression run above acquired first and fetched second.
+There is nothing to correct here.
+
+The ordering is, however, what pulls the refresh and the whole semantic
+verification phase inside the lock - see finding E.
+
+### C. A regression agent released the lease itself
+
+At 11:05:05 chain `af3c73f5`'s regression run recorded: "Gate PASS at `d532af7`
+against baseline `0cb8f3c`; release-authority check exit 0. Merge lease
+released, branch pushed fast-forward, pass output persisted."
+
+Nothing asked it to. Neither regression prompt nor `agents/roles/regression-verifier.md`
+mentions release; the release contract exists only in control-plane code, so it
+is invisible to the agent, while `AGENTS.md:102` ("Release it immediately after
+the delivery lands or fails") reads as an instruction to release whenever it
+reaches a chain agent's context.
+
+The consequence is the expensive one in this incident. `af3c73f5` then ran its
+52-minute review, authorized, and merged PR #138 at 11:59:30 holding no lease at
+all - while `ff7a6904` held it. `main` advanced under a held lease, which voided
+`ff7a6904`'s baseline and made its entire 11:17:35 - 12:01:27 hold, including
+39m35s of semantic verification and a full gate run, produce nothing.
+
+### D. Thresholds are calibrated for a narrower window than the code produces
+
+`STALE_SECONDS` is 45 minutes and `MERGE_LEASE_TIMEOUT_MINUTES` defaults to 60.
+A lawful 62-minute hold is machine-stealable for its last 17 minutes and starves
+a waiter just before it ends. No automatic caller of `steal` exists today, so
+this is latent rather than active, but the numbers describe a window the tail no
+longer fits in.
+
+### E. Semantic verification is also inside the lock, and costs more than the review
+
+The regression prompt orders the run as: acquire, fetch, merge base, semantic
+verification, release-authority check, gate. Semantic verification is a full
+agent reading of the fix diff. It neither produces nor consumes the gate proof,
+and it was the single largest in-lock segment observed (39m35s versus roughly 12
+minutes for the authority check and gate together). Any fix here is a prompt
+change - see the cost note below.
+
+### Cost note: prompt fixes are not cheap
+
+`docs/runbooks/chain-template-changes.md` is explicit: once any task has been
+created from a step, `sync-canonical-prompts.ts` refuses to change that step's
+prompt at all. On a template with live history there is no prompt-only change; a
+prompt rewrite must ride a shape change that rolls the canonical row over, which
+means registering the outgoing graph in `canonical-template-transition.ts`,
+extending the name-plus-ordinal predicates, and moving
+`template-sources.ts`/`seed.ts` with it.
+
+That asymmetry decides the sequencing below: control-plane fixes ship on their
+own, prompt fixes ride the next rollover.
+
+## Decision (proposed - awaiting a ruling)
+
+### R1. Release across the independent review; readiness re-acquires
+
+When the readiness worker parks on an open review obligation, release the lease
+using the releaser it already holds. When the review clears and readiness is
+handed back, acquire once before validating the pull-request snapshot; on
+failure leave the step parked and retry on a later tick rather than blocking the
+2-second poll loop. `merge-lease.sh acquire --timeout-minutes 0` already gives a
+single-attempt acquire that exits 75 on contention, so no change to
+`scripts/merge-lease.sh` is required. Rate-limit the retry to roughly the
+script's own poll interval so a parked step does not push to `origin` every
+tick.
+
+This also closes finding C's blast radius: with readiness acquiring before it
+authorizes, a stray agent-side release costs a re-acquire instead of an
+unleased merge.
+
+Scope: `packages/api/src/merge-readiness-worker.ts` only. This is a merge
+automation path on the defense list, so it needs `senior-dev` and an explicit
+authorization to touch it.
+
+### R2. Rides the next template rollover
+
+1. State the release contract in both regression prompts: the control plane owns
+   release; the run never calls `release` or `steal`. (Fixes C at the source.)
+2. Move the acquire from "before the first fetch" to immediately before gate
+   dispatch, after semantic verification and the release-authority check pass,
+   and add a post-acquire re-check that the base head has not moved since the
+   refresh - re-fetch and re-merge if it has. (Fixes E.)
+3. Amend `AGENTS.md:101` in the same change, since (2) contradicts its current
+   wording for the chain tail.
+
+### R3. Revisit `STALE_SECONDS` and the acquire timeout after R1
+
+With R1 and R2 the tail's hold drops to roughly gate plus authorization plus
+merge. Re-derive the thresholds from measured holds then; changing them now
+would only paper over findings A and E.
+
+## Alternatives considered
+
+- **Do nothing; raise the thresholds (R3 alone).** Cheapest, changes no
+  behaviour, and leaves the queueing exactly as observed. Rejected as a
+  standalone answer: it treats the symptom.
+- **Move the independent review before the gate.** Not possible. The review
+  reviews `baseSha..headSha` on the refreshed head, which does not exist until
+  the refresh, and its value is that it is bound to the exact head that will be
+  merged.
+- **Run the review concurrently with the gate.** Attractive on wall clock - the
+  tail becomes `max(review, gate)` instead of the sum - but it requires the
+  control plane to learn the refreshed head before the regression run finishes,
+  which today it only learns from the run's final output. Larger change, and
+  orthogonal to the lease: it shortens the tail without narrowing the lock.
+  Worth reconsidering after R1.
+- **Fix C with a prompt-only edit.** Blocked by the frozen-prompt rule above.
+  R1 defuses it instead, and R2 fixes it properly at the next rollover.
+
+## Consequences
+
+- Base drift during an independent review becomes likely rather than rare, so
+  the requeue path in `merge-readiness-worker.ts` moves from a rarely-exercised
+  safety net to an ordinary path. It costs the drifting chain one full
+  regression run, semantic verification included.
+- The exact-head correctness argument is unchanged: it never rested on the
+  lease. R1 removes an efficiency guarantee over one segment, not a safety one.
+- Concurrent delivery lines stop paying each other's agent-session time. Under
+  the observed incident, `65d229d6` would have acquired at about 12:11:48
+  instead of 12:20:05, and `ff7a6904`'s wasted 44-minute hold would not have
+  happened at all, because `af3c73f5` would have had to acquire before merging
+  PR #138.
+- Until R2 lands, semantic verification stays inside the lock, so holds shorten
+  but do not become minimal.

--- a/docs/adr/0001-merge-lease-hold-window.md
+++ b/docs/adr/0001-merge-lease-hold-window.md
@@ -22,10 +22,15 @@ Chain `af3c73f5` (*Run duration display*, PR #138):
 | --- | --- |
 | 10:57:30 | regression run 7 acquires the lease, refreshes onto `origin/main` `0cb8f3c`, merge commit `d532af7` |
 | 11:00:44 | semantic verification passes (3m14s) |
-| 11:05:05 | `MERGE GATE: PASS` at `d532af7`; the run's own activity records "Merge lease released" |
+| 11:03:51 | the run issues `git push ... ; scripts/merge-lease.sh release --task af3c73f5-... ; echo "EXIT=$?"` |
+| 11:04:08 | the push fails (`SSL_ERROR_SYSCALL`); the release runs anyway and reports `MERGE LEASE: released` |
+| 11:04:14 | the run retries the push and it succeeds |
+| 11:05:05 | `MERGE GATE: PASS` at `d532af7`; the run reports "branch pushed fast-forward" |
 | 11:06:34 | regression PASS recorded; readiness queued |
-| 11:06:40 | independent review obligation opened |
-| 11:59:13 | independent review approved (52m33s) |
+| 11:06:40 | independent review obligation opened; review run 1 starts |
+| 11:36:51 | review run 1 declared `lost` (runner heartbeat starved) after 30m10s |
+| 11:51:53 | review run 2 declared `lost` after 15m01s |
+| 11:59:13 | review run 3 approves after 7m18s (52m33s wall clock across three runs) |
 | 11:59:18 | mechanical authorization |
 | 11:59:32 | merged as `f1d6cf6` |
 
@@ -94,9 +99,13 @@ parks readiness with `INDEPENDENT_REVIEW_OPEN_PREFIX` without releasing.
 `merge-lease.ts:mergeTailLeaseChainId` enumerates independent reviews as tasks
 that run under the lease, so this is intended behaviour, not an oversight. The
 review neither produces nor consumes the gate proof: it reads
-`baseSha..headSha` on GitHub and returns findings. Its duration is an agent
-session's duration - 8m06s in one observation, 52m33s in the other - and all of
-it is charged to every other delivery line's queue.
+`baseSha..headSha` on GitHub and returns findings. All of its duration is charged to every other
+delivery line's queue, and that duration is not bounded by review effort. In the
+`af3c73f5` observation the obligation was open for 52m33s across three runs: two
+were declared `lost` to runner heartbeat starvation after 30m10s and 15m01s, and
+only the third did the review, in 7m18s. The in-lock window is therefore set by
+runner-loss detection and retry count, not by how long a review takes. The other
+observation, `ff7a6904`, took 8m06s in a single run.
 
 The review's cost is bounded three times over: up to
 `MAX_BLOCKING_REVIEW_ROUNDS = 3` blocking rounds, each round adding a review-fix
@@ -140,15 +149,34 @@ verification phase inside the lock - see finding E.
 
 ### C. A regression agent released the lease itself
 
-At 11:05:05 chain `af3c73f5`'s regression run recorded: "Gate PASS at `d532af7`
-against baseline `0cb8f3c`; release-authority check exit 0. Merge lease
-released, branch pushed fast-forward, pass output persisted."
+The session transcript for chain `af3c73f5`'s regression run 7 is unambiguous.
+At 11:03:51 it ran, as one shell line:
 
-Nothing asked it to. Neither regression prompt nor `agents/roles/regression-verifier.md`
-mentions release; the release contract exists only in control-plane code, so it
-is invisible to the agent, while `AGENTS.md:102` ("Release it immediately after
-the delivery lands or fails") reads as an instruction to release whenever it
-reaches a chain agent's context.
+```sh
+git push origin HEAD:fix/run-duration-display 2>&1 | tail -3; \
+scripts/merge-lease.sh release --task af3c73f5-... 2>&1 | tail -3; echo "EXIT=$?"
+```
+
+and at 11:04:08 got back:
+
+```
+fatal: unable to access 'https://github.com/mosonlab/agentos.git/': LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443
+merge-lease: released refs/merge-lease/holder (1c9e90d...)
+```
+
+No cancellation and no lost run occurred anywhere between 11:04 and 11:17:35,
+so this release, and not a control-plane path, is what freed the ref.
+
+Two things went wrong on that one line. The release was never authorized:
+neither regression prompt nor `agents/roles/regression-verifier.md` mentions
+release, the release contract exists only in control-plane code and is invisible
+to the agent, and `AGENTS.md:102` ("Release it immediately after the delivery
+lands or fails") reads as an instruction to release whenever it reaches a chain
+agent's context. And the release ran after the push had already failed, because
+`;` ignores the push's status and `EXIT=$?` reports the exit of `tail -3` rather
+than of either real command - so the run had no failure signal at all where the
+prompt requires it to fail loudly. The branch reached `origin` only on a retry at
+11:04:14, a minute after the global lock had been handed away.
 
 The consequence is the expensive one in this incident. `af3c73f5` then ran its
 52-minute review, authorized, and merged PR #138 at 11:59:30 holding no lease at
@@ -258,3 +286,10 @@ would only paper over findings A and E.
   PR #138.
 - Until R2 lands, semantic verification stays inside the lock, so holds shorten
   but do not become minimal.
+
+## Out of scope, reported not fixed
+
+Two independent review runs were lost to runner heartbeat starvation on
+2026-08-26 (30m10s and 15m01s before detection). That is a runner reliability
+question, not a lease question, and it is recorded here only because it is what
+made one in-lock window seven times longer than the work inside it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,5 +11,6 @@ consequences. Status is one of proposed, accepted, or superseded (with a
 pointer to the superseding record). Decisions made during card intake or
 grill sessions that outlive the card belong here, not on the card.
 
-No records exist yet; the first accepted decision starts the sequence at
-`0001`.
+`0001` is proposed and awaiting a ruling; a proposed record holds its number
+from the moment it is written, so the next record starts at `0002` whether or
+not `0001` is accepted.

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -155,3 +155,50 @@ export const mergeTailLeaseChainId = async (
   });
   return regression?.chainId ?? null;
 };
+
+/**
+ * What one `merge-lease.sh acquire --timeout-minutes 0` did. Unlike release,
+ * the exit code alone separates these, so there is no machine line to read: 0
+ * means this chain holds the lease -- freshly taken, or already held for the
+ * same task id, which is what its own regression run leaves behind -- and 75
+ * means somebody else holds it. Anything else never got far enough to say.
+ */
+export type MergeLeaseAcquisition =
+  | { outcome: "acquired" }
+  | { outcome: "contended" }
+  | { outcome: "unreachable"; detail: string };
+
+export type MergeLeaseAcquirer = (chainId: string) => Promise<MergeLeaseAcquisition>;
+
+const CONTENDED_EXIT = 75;
+
+/**
+ * One attempt, never a poll. The caller is the readiness tick, which cannot
+ * block on a lock another delivery line may hold for minutes; a tick that
+ * cannot take the lease leaves its step claimed and comes back. The reason
+ * string matches the one the chain's own regression run writes, so an operator
+ * reading `merge-lease.sh status` sees the same lease either way.
+ */
+export const acquireMergeLease: MergeLeaseAcquirer = async (chainId) => {
+  try {
+    const { stdout, stderr } = await execFileAsync("bash", [
+      mergeLeaseScript,
+      "acquire",
+      "--task",
+      chainId,
+      "--reason",
+      `chain merge tail ${chainId}`,
+      "--timeout-minutes",
+      "0",
+    ], { timeout: 30_000, encoding: "utf8" });
+    const detail = `${stdout}${stderr}`.trim();
+    if (detail) console.log(detail);
+    return { outcome: "acquired" };
+  } catch (error: unknown) {
+    const failure = error as { code?: number; stdout?: string; stderr?: string };
+    if (failure.code === CONTENDED_EXIT) return { outcome: "contended" };
+    const detail = `${failure.stdout ?? ""}${failure.stderr ?? ""}`.trim();
+    console.error(`Merge lease acquire failed for chain ${chainId}${detail ? `: ${detail}` : ""}`);
+    return { outcome: "unreachable", detail: detail || String(error) };
+  }
+};

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -43,9 +43,11 @@ import { lockTaskMutationRows } from "./task-write.js";
 import { evidenceFromSnapshot } from "./merge-evidence-worker.js";
 import { createGitHubReader, type GitHubReader } from "./github-read.js";
 import {
+  acquireMergeLease,
   releaseMergeLease,
   releaseMergeLeaseSafely,
   reportMergeLeaseAnomaly,
+  type MergeLeaseAcquirer,
   type MergeLeaseReleaser,
 } from "./merge-lease.js";
 
@@ -264,6 +266,26 @@ const createReviewObligation = async (
 
 export type ReadinessTickResult = { claimed: number; authorized: number; reviewing: number; requeued: number; stopped: number };
 
+/**
+ * Hand the lease back for the length of an independent review. The review
+ * neither produces nor consumes the exact-head gate proof -- it reads a diff on
+ * GitHub -- so holding the lease across it charges an agent session, and
+ * however many runner losses and retries that session takes, to every other
+ * delivery line's queue. `not-held` and `skipped` are ordinary answers here:
+ * this path has to leave the lock free, not prove it was the one holding it.
+ * Only "nobody knows" is worth saying out loud.
+ */
+const releaseForReview = async (
+  releaseChainLease: MergeLeaseReleaser,
+  chainId: string | null,
+): Promise<void> => {
+  const release = await releaseMergeLeaseSafely(releaseChainLease, chainId);
+  if (release?.outcome !== "unreachable") return;
+  console.error(
+    `Merge lease anomaly: the release for chain ${chainId ?? "unknown"} before its independent review could not be carried out: ${release.detail}. The merge window on main may stay locked for the length of that review.`,
+  );
+};
+
 const requeueRegression = async (
   db: PrismaClient,
   input: {
@@ -329,6 +351,7 @@ export const readinessTick = async (
   now = new Date(),
   limit = 5,
   releaseChainLease: MergeLeaseReleaser = async () => ({ outcome: "not-held" }),
+  acquireChainLease: MergeLeaseAcquirer = async () => ({ outcome: "acquired" }),
 ): Promise<ReadinessTickResult> => {
   const result: ReadinessTickResult = { claimed: 0, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 };
   const candidates = await db.task.findMany({
@@ -497,15 +520,17 @@ export const readinessTick = async (
           // written. Between the read above and here the review can have
           // completed and handed this step back; parking on that stale read
           // would strand a step no review is coming back for.
-          await db.$transaction(async (tx) => {
+          const parked = await db.$transaction(async (tx) => {
             await lockTaskMutationRows(tx, readiness.id);
             const current = await latestReviewState(tx, readiness.id, verdict.verdict.headSha, recovery ? snapshot.baseSha : null);
-            if (current?.state !== "open") return;
-            await tx.task.updateMany({
+            if (current?.state !== "open") return false;
+            const reparked = await tx.task.updateMany({
               where: { id: readiness.id, status: TaskStatus.DOING, failureReason: claimReason },
               data: { status: TaskStatus.REVIEW, failureReason: `${INDEPENDENT_REVIEW_OPEN_PREFIX}${String(current.reviewTaskId)}` },
             });
+            return reparked.count === 1;
           });
+          if (parked) await releaseForReview(releaseChainLease, readiness.chainId);
           result.reviewing += 1;
           continue;
         }
@@ -530,6 +555,7 @@ export const readinessTick = async (
           claimReason,
         });
         if (opened.ok) {
+          await releaseForReview(releaseChainLease, readiness.chainId);
           result.reviewing += 1;
         } else if ("lost" in opened) {
           // Another worker owns this readiness step now. Leaving its state
@@ -547,8 +573,27 @@ export const readinessTick = async (
         result.stopped += 1;
         continue;
       }
-      await db.$transaction(async (tx) => {
+      // The lock belongs here and only here. From the base this authorization
+      // pins to the merge that consumes it, `main` must not move; everything
+      // earlier in the tail -- the refresh, the semantic verification, the
+      // review -- can be redone if it does. An acquire that loses leaves the
+      // step claimed, so its claim expires and a later tick tries again, rather
+      // than authorizing a merge whose window nobody is holding open.
+      if (readiness.chainId) {
+        const acquisition = await acquireChainLease(readiness.chainId);
+        if (acquisition.outcome !== "acquired") continue;
+      }
+      const authorized = await db.$transaction(async (tx) => {
         await lockTaskMutationRows(tx, readiness.id);
+        // The claim is evidence until it is re-read under the mutex, and the
+        // acquire above is a network round trip spent inside the claim's lease.
+        // A worker that lost the step while acquiring must write nothing here:
+        // two authorizations would queue two merge executions.
+        const held = await tx.task.updateMany({
+          where: { id: readiness.id, status: TaskStatus.DOING, failureReason: claimReason },
+          data: { status: TaskStatus.DONE, failureReason: null },
+        });
+        if (held.count !== 1) return false;
         // Every exact-head/current-base cycle gets a distinct binding. The
         // obsolete authorization remains append-only evidence and cannot make a
         // refreshed authorization ambiguous or be reused by the executor.
@@ -570,7 +615,6 @@ export const readinessTick = async (
           create: { taskId: readiness.id, kind: "merge-authorization", body: JSON.stringify({ authorizationActivityId: activity.id, headSha: evidence.headSha }), commitSha: evidence.headSha },
           update: { kind: "merge-authorization", body: JSON.stringify({ authorizationActivityId: activity.id, headSha: evidence.headSha }), commitSha: evidence.headSha },
         });
-        await tx.task.update({ where: { id: readiness.id }, data: { status: TaskStatus.DONE, failureReason: null } });
         await tx.task.update({ where: { id: regression.id }, data: { failureReason: null } });
         await writeMarker(tx, readiness.id, "readiness", {
           actorType: "control-plane",
@@ -593,8 +637,9 @@ export const readinessTick = async (
         } else {
           await activateChainSuccessor(tx, readiness, {}, now);
         }
+        return true;
       });
-      result.authorized += 1;
+      if (authorized) result.authorized += 1;
     } catch (error: unknown) {
       await stopReadiness(db, { readinessTaskId: readiness.id, regressionTaskId: regression.id, reason: `readiness evaluation failed: ${error instanceof Error ? error.message : String(error)}`, recovery }, releaseChainLease);
       result.stopped += 1;
@@ -610,7 +655,8 @@ export const startReadinessWorker = (
   reader: GitHubReader | null = createGitHubReader(),
 ): ReturnType<typeof setInterval> => {
   const timer = setInterval(() => {
-    void readinessTick(db, reader, new Date(), 5, releaseMergeLease).catch((error: unknown) => console.error("Merge readiness tick failed", error));
+    void readinessTick(db, reader, new Date(), 5, releaseMergeLease, acquireMergeLease)
+      .catch((error: unknown) => console.error("Merge readiness tick failed", error));
   }, readinessPollIntervalMs());
   timer.unref?.();
   return timer;

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -10,7 +10,7 @@ import {
 } from "@agentos/db";
 
 import type { GitHubReader, PullRequestSnapshot } from "./github-read.js";
-import type { MergeLeaseReleaser } from "./merge-lease.js";
+import type { MergeLeaseAcquirer, MergeLeaseReleaser } from "./merge-lease.js";
 import { readinessTick } from "./merge-readiness-worker.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
@@ -329,4 +329,40 @@ test("manual start cannot turn server-owned readiness into a model run", async (
     if (prior === undefined) delete process.env.OPERATOR_TOKEN;
     else process.env.OPERATOR_TOKEN = prior;
   }
+});
+
+test("the merge lease is handed back for the length of an independent review", async () => {
+  const seeded = await seedReadiness();
+  const guarded = reader([{ filename: "scripts/merge-gate.sh", previousFilename: null, patch: "@@ -1 +1 @@\n-old\n+new" }]);
+  assert.deepEqual(await readinessTick(db, guarded, new Date(), 5, releaseChainLease), { claimed: 1, authorized: 0, reviewing: 1, requeued: 0, stopped: 0 });
+  assert.deepEqual(releasedChainLeases, [seeded.readiness.chainId]);
+});
+
+test("a contended lease leaves readiness for a later tick instead of authorizing", async () => {
+  const seeded = await seedReadiness();
+  const asked: string[] = [];
+  const contended: MergeLeaseAcquirer = async (chainId) => {
+    asked.push(chainId);
+    return { outcome: "contended" };
+  };
+  const started = new Date();
+  assert.deepEqual(
+    await readinessTick(db, reader(), started, 5, releaseChainLease, contended),
+    { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 },
+  );
+  assert.deepEqual(asked, [seeded.readiness.chainId]);
+  assert.equal(await db.taskStepOutput.count({ where: { taskId: seeded.readiness.id } }), 0);
+  assert.equal(await db.run.count({ where: { taskId: seeded.integrator.id } }), 0);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.DOING);
+  assert.deepEqual(releasedChainLeases, []);
+
+  // The claim, not a retry counter, is what brings it back: once the claim
+  // expires the next tick re-evaluates and takes the lease it could not get.
+  const acquired: MergeLeaseAcquirer = async () => ({ outcome: "acquired" });
+  assert.deepEqual(
+    await readinessTick(db, reader(), new Date(started.getTime() + 60_000), 5, releaseChainLease, acquired),
+    { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 },
+  );
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.DONE);
+  assert.equal(await db.run.count({ where: { taskId: seeded.integrator.id } }), 1);
 });

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -59,6 +59,7 @@
     { "glob": "docs/release/v0.1.0-support-matrix.md", "purpose": "the authoritative support statement: what is Verified, Maintainer-verified, Experimental, Unverified and Unsupported, with the evidence boundary for each row" },
     { "glob": "docs/release/v0.2.0-release-notes.md", "purpose": "the release notes for v0.2.0, and the source text for the GitHub Release body of the same tag" },
     { "glob": "docs/adr/README.md", "purpose": "architecture decision record convention: naming, numbering, and how specs reference ADRs" },
+    { "glob": "docs/adr/0001-merge-lease-hold-window.md", "purpose": "diagnosis of the merge-lease hold window and the proposed narrowing of it" },
     { "glob": "docs/runbooks/card-intake.md", "purpose": "how a raw idea becomes a runnable backlog card before chain dispatch" },
     { "glob": "docs/runbooks/chain-template-changes.md", "purpose": "how a chain template change is authored, registered as a legacy shape, gated and deployed" },
     { "glob": "docs/runbooks/gate-worker.md", "purpose": "the offshore merge-gate worker and gate dispatcher runbook: slot model, red lines, deployment, troubleshooting" },

--- a/scripts/public-snapshot-scan.test.mjs
+++ b/scripts/public-snapshot-scan.test.mjs
@@ -370,6 +370,7 @@ test("the docs surface is closed and named one file at a time", () => {
   // unrelated plans, reviews, specifications, or unlisted runbooks alongside it.
   assert.deepEqual(docs.sort(), [
     "docs/BRIEF-TEMPLATE.md",
+    "docs/adr/0001-merge-lease-hold-window.md",
     "docs/adr/README.md",
     "docs/demos/templates-release-demo.md",
     "docs/demos/templates-release-evidence.schema.json",


### PR DESCRIPTION
Narrows the autonomous merge tail's hold on `scripts/merge-lease.sh` to the
segment that is actually load-bearing. Diagnosis, evidence and the alternatives
are in `docs/adr/0001-merge-lease-hold-window.md`.

## What was wrong

The tail took the lease in the regression step's prompt and gave it back only
when it stopped or merged. An independent review therefore ran inside the lock.
On 2026-08-26, chain `ff7a6904` held it continuously for 62m19s and merged
nothing; 39m35s of that was semantic verification and 8m06s an independent
review, against roughly 12 minutes of gate and release-authority check.

Underneath that: release is nine control-plane call sites, acquire was one
sentence in a template. Chain `af3c73f5`'s regression run ran, as one shell
line, `git push ... ; merge-lease.sh release ... ; echo "EXIT=$?"`. The push
failed on a TLS error, the `;` released the lease anyway, and `EXIT=$?` reported
`tail -3`. Its tail then authorized and merged `main` holding no lease, under
another chain's held lease, voiding that chain's baseline.

## What changed

`packages/api/src/merge-lease.ts`
- `acquireMergeLease`: one attempt (`--timeout-minutes 0`), never a poll. Exit 0
  is acquired (including "already held for task"), 75 is contended, anything
  else is unreachable. `scripts/merge-lease.sh` is not touched.

`packages/api/src/merge-readiness-worker.ts`
- releases when readiness parks on an open review obligation, on both park
  paths, and only when the park actually took;
- acquires before writing an authorization; a contended acquire leaves the step
  claimed so the claim expiry paces the retry;
- the authorization transaction re-affirms the claim before writing, because the
  acquire is a network round trip spent inside the claim's lease. Without it a
  worker that lost its step while acquiring could queue a second merge
  execution.

## Cost

Base drift during a review becomes ordinary rather than rare. Readiness already
requeues regression for it. That costs the drifting chain one regression run
instead of charging every other delivery line for the length of the review.

## Verification

- `npm run test:db -w @agentos/api -- src/merge-tail-readiness.dbtest.ts` 12/12,
  including two new tests: the lease is handed back for the length of a review,
  and a contended lease leaves readiness for a later tick then authorizes once
  it can acquire.
- `npm run test:db -w @agentos/api -- src/merge-base-drift-recovery.dbtest.ts` 18/18.
- `npm test -w @agentos/api` 503 pass, 1 skipped.
- `npm run lint`, `npm run typecheck` clean.
- The `exit 75` contract is already asserted twice in
  `scripts/merge-lease.test.mjs`; that `execFile` surfaces it as a numeric
  `error.code` was verified directly.

## Not in this change

Semantic verification still runs inside the lock, and the prompts still say the
run acquires. Both are prompt changes, and a step with live history has no
prompt-only change (`docs/runbooks/chain-template-changes.md`), so they ride the
next template rollover. Recorded as R2 in the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
