### PR TITLE
fix(merge-tail): let a repeat stop settle instead of poisoning the claim queue

### DIFF
--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -1378,6 +1378,8 @@ test("claim query filters archived agents before take so active work cannot star
     let claimedId: string | undefined;
     const tx = {
       $queryRaw: async () => [{ granted: true }],
+      // The claim loop brackets every candidate in a savepoint.
+      $executeRawUnsafe: async () => 0,
       run: {
         findMany: async ({ where, take }: { where: Record<string, any>; take: number }) => {
           claimWhere = where;

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -33,19 +33,31 @@ import { FAILURE_REASON_LIMIT, truncateFailureReason } from "./failure-reason.js
 
 type DbTx = Prisma.TransactionClient;
 
+/**
+ * The notice the tail writes when it stops, keyed by task and reason.
+ *
+ * Stopping twice for the same reason is a legitimate event: an operator retry
+ * re-queues the run, the claim path judges the same handoff invalid again, and
+ * the stop path runs again. Under `create` that repeat raised P2002 inside the
+ * caller's transaction, which rolled the whole stop back -- and in the claim
+ * path took every other queued run's claim down with it. The notice is a
+ * digest, not a log: one row per (task, reason) is the intended state, so a
+ * repeat leaves the existing row alone.
+ */
 export const openMergeTailStopNotice = async (
   tx: DbTx,
   input: { taskId: string; agentId: string; sessionId?: string; reason: string },
 ): Promise<void> => {
-  await tx.inboxMessage.create({ data: {
+  const dedupeKey = `merge-tail-stop:${input.taskId}:${createHash("sha256").update(input.reason).digest("hex")}`;
+  await tx.inboxMessage.upsert({ where: { dedupeKey }, create: {
     from: "AGENT",
     agentId: input.agentId,
     ...(input.sessionId ? { sessionId: input.sessionId } : {}),
     taskId: input.taskId,
     kind: "TEXT",
     body: `Autonomous merge tail stopped: ${input.reason}`,
-    dedupeKey: `merge-tail-stop:${input.taskId}:${createHash("sha256").update(input.reason).digest("hex")}`,
-  } });
+    dedupeKey,
+  }, update: {} });
 };
 
 export const baseDriftRecoveryContext = async (

--- a/packages/api/src/merge-tail-stop-notice.dbtest.ts
+++ b/packages/api/src/merge-tail-stop-notice.dbtest.ts
@@ -1,0 +1,251 @@
+import "./test-workspace-root.js";
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { after, before, beforeEach, test } from "node:test";
+
+import {
+  AssigneeType,
+  enqueueTaskRun,
+  FailureClass,
+  PrismaClient,
+  RunStatus,
+  TaskStatus,
+} from "@agentos/db";
+
+import { createApp } from "./test-app.js";
+import { resetTestDb, setupTestDb } from "./testdb.js";
+
+const RUNNER_TOKEN = "merge-tail-stop-notice-runner";
+const HEAD = "a".repeat(40);
+const BASE = "b".repeat(40);
+const BRANCH = "agentos/stop-notice-test";
+const STOP_REASON = "regression repair handoff is invalid: no successful gate-fix result binds "
+  + `${HEAD} to ${BASE}`;
+const STOP_DEDUPE_PREFIX = "merge-tail-stop:";
+
+const priorRunnerToken = process.env.RUNNER_TOKEN;
+let db: PrismaClient;
+let seedCounter = 0;
+
+before(() => {
+  process.env.RUNNER_TOKEN = RUNNER_TOKEN;
+  db = setupTestDb();
+});
+beforeEach(async () => { await resetTestDb(db); });
+after(async () => {
+  await db.$disconnect();
+  if (priorRunnerToken === undefined) delete process.env.RUNNER_TOKEN;
+  else process.env.RUNNER_TOKEN = priorRunnerToken;
+});
+
+const claim = (client: PrismaClient, runnerId: string) => createApp(client).request("/runner/tasks/claim", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${RUNNER_TOKEN}`, "Content-Type": "application/json" },
+  body: JSON.stringify({ runnerId, leaseSeconds: 60 }),
+});
+
+/**
+ * A Regression step whose only prior evidence is a negative verdict with no
+ * repair result behind it: the claim path judges its handoff invalid, stops the
+ * tail, and writes the stop notice. Re-queueing it reproduces the incident,
+ * because the second stop carries the same task and the same reason.
+ */
+const seedInvalidHandoffRegression = async () => {
+  const seedId = `${Date.now()}-${(seedCounter += 1)}`;
+  const project = await db.project.create({ data: { name: "Stop notice", slug: `stop-notice-${seedId}` } });
+  const environment = await db.environment.create({ data: {
+    projectId: project.id, name: "local", allowedHosts: [],
+  } });
+  const agent = await db.agent.create({ data: {
+    projectId: project.id,
+    environmentId: environment.id,
+    name: "review-coordinator-sol",
+    title: "Regression",
+    model: "claude",
+    foundationalPrompt: "foundation",
+    rolePrompt: "role",
+  } });
+  const repo = await db.repo.create({ data: {
+    projectId: project.id,
+    name: "widgets",
+    remoteUrl: "https://example.test/widgets.git",
+    mountPath: "/repo",
+    defaultBranch: "main",
+  } });
+  await db.agentRepoAccess.create({ data: {
+    projectId: project.id, agentId: agent.id, repoId: repo.id, mountPath: "/repo", permissions: "GIT_WRITE",
+  } });
+  const template = await db.taskTemplate.create({ data: {
+    projectId: project.id, name: `stop-notice-workflow-${seedId}`, description: "tail", variables: [],
+  } });
+  const regressionStep = await db.taskTemplateStep.create({ data: {
+    taskTemplateId: template.id,
+    stepIndex: 5,
+    layer: 4,
+    name: "Regression",
+    assigneeType: AssigneeType.AGENT,
+    assigneeAgentId: agent.id,
+    prompt: "verify",
+    approvalGate: false,
+    outputKind: "regression-verification",
+  } });
+  const regression = await db.task.create({ data: {
+    projectId: project.id,
+    repoId: repo.id,
+    templateId: template.id,
+    templateStepId: regressionStep.id,
+    name: "Regression",
+    description: "verify",
+    assigneeType: AssigneeType.AGENT,
+    assigneeAgentId: agent.id,
+    status: TaskStatus.TODO,
+    targetBranch: BRANCH,
+  } });
+  const firstRun = await db.$transaction((tx) => enqueueTaskRun(tx as never, regression.id));
+  await db.run.update({
+    where: { id: firstRun.id },
+    data: { status: RunStatus.SUCCEEDED, branch: BRANCH, headSha: HEAD, endedAt: new Date() },
+  });
+  await db.taskStepOutput.create({ data: {
+    taskId: regression.id,
+    runId: firstRun.id,
+    kind: "regression-verification",
+    commitSha: HEAD,
+    body: JSON.stringify({
+      schemaVersion: 1,
+      outcome: "gate-fail",
+      gateVerdict: "FAIL",
+      headSha: HEAD,
+      baseHeadSha: BASE,
+      summary: "merge gate FAIL on the chain head",
+    }),
+  } });
+  return { project, environment, agent, repo, regression };
+};
+
+/** The re-queue an operator performs after the chain stops. */
+const requeueRegression = async (
+  seeded: Awaited<ReturnType<typeof seedInvalidHandoffRegression>>,
+  readyAt: Date,
+) => {
+  await db.task.update({
+    where: { id: seeded.regression.id },
+    data: { status: TaskStatus.TODO, failureReason: null },
+  });
+  const run = await db.$transaction((tx) => enqueueTaskRun(tx as never, seeded.regression.id, readyAt));
+  await db.run.update({ where: { id: run.id }, data: { branch: BRANCH } });
+  return run;
+};
+
+const seedUnrelatedQueuedRun = async (
+  seeded: Awaited<ReturnType<typeof seedInvalidHandoffRegression>>,
+  readyAt: Date,
+) => {
+  const task = await db.task.create({ data: {
+    projectId: seeded.project.id,
+    repoId: seeded.repo.id,
+    name: "Unrelated queued work",
+    description: "unrelated",
+    assigneeType: AssigneeType.AGENT,
+    assigneeAgentId: seeded.agent.id,
+    status: TaskStatus.TODO,
+  } });
+  return db.$transaction((tx) => enqueueTaskRun(tx as never, task.id, readyAt));
+};
+
+const assertStopSettled = async (
+  seeded: Awaited<ReturnType<typeof seedInvalidHandoffRegression>>,
+  runId: string,
+) => {
+  const [run, task, notices] = await Promise.all([
+    db.run.findUniqueOrThrow({ where: { id: runId } }),
+    db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } }),
+    db.inboxMessage.findMany({
+      where: { taskId: seeded.regression.id, dedupeKey: { startsWith: STOP_DEDUPE_PREFIX } },
+    }),
+  ]);
+  assert.equal(run.status, RunStatus.FAILED);
+  assert.equal(run.failureClass, FailureClass.TASK_FAILED);
+  assert.equal(run.failureReason, STOP_REASON);
+  assert.equal(run.retryable, false);
+  assert.equal(task.status, TaskStatus.REVIEW);
+  assert.equal(task.failureReason, STOP_REASON);
+  // One row per (task, reason) is the intended state of a digest, so the repeat
+  // stop settles against the row the first one wrote instead of colliding.
+  assert.equal(notices.length, 1);
+  assert.equal(
+    notices[0]!.dedupeKey,
+    `${STOP_DEDUPE_PREFIX}${seeded.regression.id}:${createHash("sha256").update(STOP_REASON).digest("hex")}`,
+  );
+  assert.equal(notices[0]!.body, `Autonomous merge tail stopped: ${STOP_REASON}`);
+};
+
+test("a repeated same-reason merge-tail stop settles its run and leaves the queue claimable", async () => {
+  const seeded = await seedInvalidHandoffRegression();
+  const firstStopped = await requeueRegression(seeded, new Date("2026-01-01T00:00:00.000Z"));
+
+  assert.equal((await claim(db, "first-stop-runner")).status, 204);
+  await assertStopSettled(seeded, firstStopped.id);
+
+  // The operator retry, racing ahead of an unrelated queued run so the poisoned
+  // candidate is the head of the queue this poll observes.
+  const secondStopped = await requeueRegression(seeded, new Date("2026-01-01T00:00:01.000Z"));
+  const unrelated = await seedUnrelatedQueuedRun(seeded, new Date("2026-01-01T00:00:02.000Z"));
+
+  const response = await claim(db, "repeat-stop-runner");
+  assert.equal(response.status, 200);
+  const claimed = await response.json() as { run: { id: string } };
+  assert.equal(claimed.run.id, unrelated.id);
+  await assertStopSettled(seeded, secondStopped.id);
+});
+
+test("a candidate that raises is isolated from the rest of the claim queue", async () => {
+  const seeded = await seedInvalidHandoffRegression();
+  const poisoned = await requeueRegression(seeded, new Date("2026-01-01T00:00:00.000Z"));
+  const unrelated = await seedUnrelatedQueuedRun(seeded, new Date("2026-01-01T00:00:01.000Z"));
+  const failingDb = db.$extends({
+    query: {
+      inboxMessage: {
+        async upsert() {
+          throw new Error("stop-notice-write-failed");
+        },
+      },
+    },
+  }) as unknown as PrismaClient;
+
+  const response = await claim(failingDb, "isolation-runner");
+  assert.equal(response.status, 200);
+  const claimed = await response.json() as { run: { id: string } };
+  assert.equal(claimed.run.id, unrelated.id);
+
+  // The poisoned candidate's own writes are rolled back to its savepoint, so it
+  // is left exactly as it was found rather than half settled.
+  const [poisonedRun, task, notices] = await Promise.all([
+    db.run.findUniqueOrThrow({ where: { id: poisoned.id } }),
+    db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } }),
+    db.inboxMessage.count({ where: { taskId: seeded.regression.id } }),
+  ]);
+  assert.equal(poisonedRun.status, RunStatus.QUEUED);
+  assert.equal(poisonedRun.failureReason, null);
+  assert.equal(task.status, TaskStatus.TODO);
+  assert.equal(notices, 0);
+});
+
+test("an isolated candidate error surfaces when the poll claims nothing", async () => {
+  const seeded = await seedInvalidHandoffRegression();
+  const poisoned = await requeueRegression(seeded, new Date("2026-01-01T00:00:00.000Z"));
+  const failingDb = db.$extends({
+    query: {
+      inboxMessage: {
+        async upsert() {
+          throw new Error("stop-notice-write-failed");
+        },
+      },
+    },
+  }) as unknown as PrismaClient;
+
+  assert.equal((await claim(failingDb, "surfacing-runner")).status, 500);
+  const poisonedRun = await db.run.findUniqueOrThrow({ where: { id: poisoned.id } });
+  assert.equal(poisonedRun.status, RunStatus.QUEUED);
+});

--- a/packages/api/src/run-claim.ts
+++ b/packages/api/src/run-claim.ts
@@ -47,6 +47,9 @@ const isCandidateActivationFailure = (error: unknown): error is CandidateActivat
 
 const namedFailureReason = (error: CandidateActivationFailure): string => `${error.name}: ${error.message}`;
 
+const SKIP = { outcome: "skip" } as const;
+const HALT = { outcome: "halt" } as const;
+
 export type ClaimRunInput = {
   body: ClaimInput;
   claimantClass: ClaimantClass;
@@ -109,8 +112,11 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
       take: 20,
     });
     const executorRunnerIds = mergeExecutorRunnerIds();
-    for (const candidate of candidates) {
-      if (!candidate.task || !candidate.repo) continue;
+    // One candidate's decision, taken as its own unit of work so the loop can
+    // isolate it. `skip` moves to the next candidate, `halt` ends the whole
+    // claim without one, `claimed` carries the run handed to the runner.
+    const activateCandidate = async (candidate: (typeof candidates)[number]) => {
+      if (!candidate.task || !candidate.repo) return SKIP;
       if (!candidate.agent.repoAccess.some((grant) => grant.repoId === candidate.repoId && grant.projectId === candidate.projectId)) {
         const reason = "repository-grant-missing: restore the agent Repo grant, then retry this run";
         const stranded = await tx.run.updateMany({
@@ -137,31 +143,31 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
           // in the chain. End the transaction here: scanning another
           // candidate could next wait on a sibling Run while its claimant
           // already holds that Run and waits for this chain mutex.
-          if (parked.ok && parked.chainLocked) return null;
+          if (parked.ok && parked.chainLocked) return HALT;
         }
-        continue;
+        return SKIP;
       }
       // §D-P4. A candidate whose (agent, step) binding is invalid is *skipped*,
       // not claimed: a mis-bound step-12 row must never be handed to anything,
       // and the sentinel Agent on an ordinary step must never reach an adapter.
-      if (integratorBindingRefusal(candidate.agent.name, candidate.task.templateStep)) continue;
+      if (integratorBindingRefusal(candidate.agent.name, candidate.task.templateStep)) return SKIP;
       // Readiness is server-owned. Even if an old/manual path materializes a
       // Run row for it, no model runner or merge executor may claim it; the
       // readiness worker consumes the TODO task row directly.
-      if (isMergeReadinessStep(candidate.task.templateStep)) continue;
+      if (isMergeReadinessStep(candidate.task.templateStep)) return SKIP;
       const executionMode = executionModeFor(candidate.task.templateStep);
       // §D-P1 rule 3, symmetric and fail-closed: only the independently
       // authenticated merge-executor principal is offered an integrator run,
       // and it is offered nothing else. With `MERGE_EXECUTOR_RUNNER_IDS`
       // empty — the shipped default — or with `MERGE_EXECUTOR_TOKEN` unset or
       // aliased onto the runner token, no integrator run is claimable at all.
-      if (!claimantMayTake(executionMode, claimantClass, body.runnerId, executorRunnerIds)) continue;
+      if (!claimantMayTake(executionMode, claimantClass, body.runnerId, executorRunnerIds)) return SKIP;
       // The backend circuit breaker tracks model-CLI health. A mechanical run
       // spawns no CLI, so an open CLI circuit is not evidence about it; the
       // `runner` on its row is an inert artifact of the sentinel Agent.
       if (executionMode === "agent") {
         const backend = await tx.runnerBackendState.findUnique({ where: { runner: candidate.runner } });
-        if (readStoredCliAvailability(backend?.capabilities)?.available === false || backend?.circuitOpen) continue;
+        if (readStoredCliAvailability(backend?.capabilities)?.available === false || backend?.circuitOpen) return SKIP;
       }
       if (executionMode === "mechanical") {
         const targetBranch = candidate.task.targetBranch ?? candidate.repo.defaultBranch;
@@ -173,7 +179,7 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
         const [targetLock] = await tx.$queryRaw<Array<{ locked: boolean }>>`
           SELECT pg_try_advisory_xact_lock(hashtextextended(${lockKey}, 0)) AS "locked"
         `;
-        if (targetLock?.locked !== true) continue;
+        if (targetLock?.locked !== true) return SKIP;
         const activePeers = await tx.run.findMany({
           where: {
             id: { not: candidate.id },
@@ -187,7 +193,7 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
             } },
           },
         });
-        if (activePeers.some((peer) => taskIsIntegratorStep(peer.task))) continue;
+        if (activePeers.some((peer) => taskIsIntegratorStep(peer.task))) return SKIP;
       }
       const regressionRepairHandoff = await regressionRepairHandoffForClaim(tx, {
         taskId: candidate.task.id,
@@ -236,9 +242,9 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
             ...(sourceSession ? { sessionId: sourceSession.id } : {}),
             reason: regressionRepairHandoff.reason,
           });
-          if (parked.ok && parked.chainLocked) return null;
+          if (parked.ok && parked.chainLocked) return HALT;
         }
-        continue;
+        return SKIP;
       }
       const grants = [
         ...candidate.agent.environment.secrets,
@@ -303,9 +309,9 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
             },
             update: {},
           });
-          if (parked.ok && parked.chainLocked) return null;
+          if (parked.ok && parked.chainLocked) return HALT;
         }
-        continue;
+        return SKIP;
       }
       const generation = candidate.leaseGeneration + 1;
       const fencingToken = makeFencingToken(candidate.id, generation);
@@ -327,7 +333,7 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
           sessionTokenRevokedAt: null,
         },
       });
-      if (won.count !== 1) continue;
+      if (won.count !== 1) return SKIP;
       await lockTaskMutationRows(tx, candidate.task.id);
       const priorResume = candidate.session?.resumeInput && candidate.session.providerConversationId ? {
         providerConversationId: candidate.session.providerConversationId,
@@ -423,38 +429,77 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
         select: { id: true },
       }) !== null;
       return {
-        task: candidate.task,
-        agent: candidate.agent,
-        repo: candidate.repo,
-        // Server-computed from the template step. Nothing a client sends
-        // participates, and the ordinary runner refuses `mechanical` before it
-        // constructs a workspace, a prompt, or a child environment.
-        executionMode,
-        // A later chain run targets the shared head, so its own targetBranch
-        // cannot tell delivery which integration line the chain started
-        // from. Carry the first run's durable base separately for PR create.
-        run: {
-          ...run,
-          targetBranchPublished,
-          pullRequestBase: chainFirstRun?.targetBranch ?? candidate.repo.defaultBranch,
-          pinnedBaseSha: candidate.task.templateStep?.baseFromStepIndex == null ? null : run.targetBranch,
-          implementationBaseSha: implementationRange?.implementationBaseSha ?? null,
-          implementationHeadSha: implementationRange?.implementationHeadSha ?? null,
+        outcome: "claimed" as const,
+        claim: {
+          task: candidate.task,
+          agent: candidate.agent,
+          repo: candidate.repo,
+          // Server-computed from the template step. Nothing a client sends
+          // participates, and the ordinary runner refuses `mechanical` before it
+          // constructs a workspace, a prompt, or a child environment.
+          executionMode,
+          // A later chain run targets the shared head, so its own targetBranch
+          // cannot tell delivery which integration line the chain started
+          // from. Carry the first run's durable base separately for PR create.
+          run: {
+            ...run,
+            targetBranchPublished,
+            pullRequestBase: chainFirstRun?.targetBranch ?? candidate.repo.defaultBranch,
+            pinnedBaseSha: candidate.task.templateStep?.baseFromStepIndex == null ? null : run.targetBranch,
+            implementationBaseSha: implementationRange?.implementationBaseSha ?? null,
+            implementationHeadSha: implementationRange?.implementationHeadSha ?? null,
+          },
+          session,
+          runner: candidate.runner,
+          fencingToken,
+          sessionToken: sessionCredential.token,
+          secrets,
+          priorOutputs,
+          previousRunHandoff,
+          regressionRepairHandoff: regressionRepairHandoff.status === "ok"
+            ? regressionRepairHandoff.handoff
+            : null,
+          resume: priorResume,
+          nextEventSeq: (latestEvent._max.seq ?? -1) + 1,
         },
-        session,
-        runner: candidate.runner,
-        fencingToken,
-        sessionToken: sessionCredential.token,
-        secrets,
-        priorOutputs,
-        previousRunHandoff,
-        regressionRepairHandoff: regressionRepairHandoff.status === "ok"
-          ? regressionRepairHandoff.handoff
-          : null,
-        resume: priorResume,
-        nextEventSeq: (latestEvent._max.seq ?? -1) + 1,
       };
+    };
+
+    // Per-candidate isolation. A candidate that raises inside the shared claim
+    // transaction used to abort it whole: the poisoned head of the queue rolled
+    // back its own settlement *and* starved every other queued run, because the
+    // transaction was already aborted by the time the loop reached them. Each
+    // candidate now runs against its own savepoint, so its partial writes are
+    // undone and the transaction stays usable for the rest of the queue.
+    //
+    // A serialization failure or deadlock is not isolatable: Postgres aborts the
+    // whole transaction, `ROLLBACK TO SAVEPOINT` would fail too, and the outer
+    // six-attempt retry is the correct response. It is re-raised untouched.
+    let isolated: unknown = null;
+    for (const [index, candidate] of candidates.entries()) {
+      const savepoint = `claim_candidate_${index}`;
+      await tx.$executeRawUnsafe(`SAVEPOINT ${savepoint}`);
+      let decided: Awaited<ReturnType<typeof activateCandidate>>;
+      try {
+        decided = await activateCandidate(candidate);
+      } catch (error: unknown) {
+        if (isSerializationConflict(error)) throw error;
+        await tx.$executeRawUnsafe(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+        console.error(`Claim candidate ${candidate.id} failed and was isolated from the claim`, error);
+        isolated ??= error;
+        continue;
+      }
+      await tx.$executeRawUnsafe(`RELEASE SAVEPOINT ${savepoint}`);
+      // A chained park that committed ends the claim here on purpose (lock
+      // order), and it outranks an earlier candidate's isolated error.
+      if (decided.outcome === "halt") return null;
+      if (decided.outcome === "claimed") return decided.claim;
     }
+    // Isolation keeps one poisoned candidate from starving the others; it does
+    // not make its failure disappear. With nothing claimed there is no work to
+    // report and no reason to swallow it, so the first isolated error is the
+    // answer this poll gives.
+    if (isolated !== null) throw isolated;
     return null;
   }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
   let claimed: Awaited<ReturnType<typeof claimOnce>> = null;

--- a/packages/api/src/runners.test.ts
+++ b/packages/api/src/runners.test.ts
@@ -66,6 +66,8 @@ const makeDatabase = (
 ): PrismaClient => {
   const tx = {
     $queryRaw: async () => [{ granted: barrierGranted }],
+    // The claim loop brackets every candidate in a savepoint.
+    $executeRawUnsafe: async () => 0,
     run: {
       findMany: async () => { onCandidateRead(); return candidates; },
       findFirst: async () => null,


### PR DESCRIPTION
Card `cmta4syuc043jmpllit7d9gm3`.

## The incident

2026-08-26 13:02-13:17: every runner claim poll failed with `409 Unique constraint violated` (184 occurrences in the runner error log) and no QUEUED run on the board could be claimed. Reproduced live on task `cmt9t4j1k000fmpjzdbpdodd3` run 4.

`openMergeTailStopNotice` wrote its notice with `inboxMessage.create` under `dedupeKey = merge-tail-stop:{taskId}:{sha256(reason)}`. After a chain stop an operator retry re-queued the regression run; `regressionRepairHandoffForClaim` judged the handoff invalid again for the same reason, the stop path ran again, and the `create` collided with the notice the earlier stop had written. P2002 aborted the whole claim transaction — rolling back the run's own `FAILED` settlement and the task park — and because the transaction was already aborted, every other candidate in the same poll was starved too. The poisoned head of the queue therefore blocked the entire fleet. The interim mitigation was renaming the stale notice's dedupe key by hand; the code was unchanged, so any same-reason repeat stop would paralyze claiming again.

## The fix, both layers

1. **`openMergeTailStopNotice` is an upsert on its dedupe key** (`packages/api/src/merge-tail-actions.ts`). Stopping twice for the same reason is a legitimate event, and the notice is a digest, not a log: one row per (task, reason) is the intended state, so the repeat leaves the existing row alone.

2. **Per-candidate error isolation in the claim loop** (`packages/api/src/run-claim.ts`). The loop body is extracted into `activateCandidate`, which returns `skip` / `halt` / `claimed`, and each candidate runs against its own `SAVEPOINT`. A candidate that raises has its partial writes rolled back to that savepoint and the transaction stays usable for the rest of the queue. Two deliberate carve-outs:
   - A serialization failure or deadlock is re-raised untouched — Postgres aborts the whole transaction, `ROLLBACK TO SAVEPOINT` would fail too, and the existing six-attempt retry is the correct response.
   - Isolation does not swallow the failure: when the poll claims nothing, the first isolated error is re-thrown, so a genuinely broken candidate still surfaces as a 500 rather than a silent 204. A committed chained park outranks it and still ends the claim on its own (lock order).

## Tests

New `packages/api/src/merge-tail-stop-notice.dbtest.ts`:

- a re-queued handoff-invalid regression stops a second time for the same reason: the second run settles `FAILED`, the task lands in `REVIEW`, exactly one stop notice exists under the shared dedupe key, and an unrelated QUEUED run is claimed in the same poll;
- a candidate whose stop write raises is isolated: the unrelated run is still claimed, and the poisoned run and task are left exactly as found;
- an isolated error still surfaces as a 500 when the poll claims nothing.

## Verification

- `npm run lint` (biome + eslint), `npm run typecheck`: clean.
- `npm run test:db -w @agentos/api` over `merge-tail-stop-notice`, `claim-activation-isolation`, `merge-tail-repair`, `merge-stop-state`, `blind-claim`, `run-completion`, `merge-base-drift-recovery`, `chain`, `dispatch-activation`, `run-fence`, `deploy-barrier`, `merge-integrator-binding`, `merge-integrator-seed`, `chain-branch`, `active-run-cancellation`: 243 pass, 0 fail.
- `npm run snapshot:scan`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)