### PR TITLE
feat(api): centralize refusal HTTP mapping

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -8,16 +8,11 @@ import {
   catalogRunnerForModel,
   CleanupStatus,
   CodexServiceTier,
-  COMPOUND_IMPLEMENTATION_ASSIGNEE_ERROR_CODE,
   deriveRunConfig,
   FailureClass,
   GoalStatus,
   enqueueTaskRun,
   InboxStatus,
-  isArchivedAssigneeError,
-  isArchivedTaskError,
-  isCompoundImplementationAssigneeError,
-  isIntegratorStoppedError,
   lockAgentRepoGrant,
   lockAgentRepoGrantForRevocation,
   lockAgentRow,
@@ -48,7 +43,6 @@ import {
   isMergeExecutorRunnerId,
   mechanicalPrincipalRefusal,
   executionModeFor,
-  isMergeConfirmationError,
   integratorBindingRefusal,
   integratorBindingRefusalFor,
   projectMergeOutcome,
@@ -120,6 +114,13 @@ import {
 } from "./execution.js";
 import { createArchivedRunNoticeScheduler, noteArchivedQueuedRuns, reconcileDatabaseRuns } from "./reconcile.js";
 import {
+  type Refusal,
+  type RefusalDetail,
+  type RefusalReason,
+  refusalFor,
+  refusalResponse,
+} from "./refusal.js";
+import {
   acknowledgeReclaimSalvage, publishReclaimIntents, recordReclaimOutcomes, repairReplacementAfterSalvage,
 } from "./workspace-reclaim.js";
 import { encryptSecret } from "./secrets.js";
@@ -129,6 +130,7 @@ import {
   fenceRefusalResponse,
   fencedRunWhere,
   isFenceRefusalResponse,
+  type FenceRefusalResponse,
   type RunFence,
   withFencedRun,
 } from "./run-fence.js";
@@ -161,6 +163,19 @@ import { withoutUndefined } from "./without-undefined.js";
 import { versionPayload } from "./version.js";
 
 type AppEnvironment = { Variables: { principal: Principal } };
+
+const refusal = (reason: RefusalReason, message: string, detail?: RefusalDetail): Refusal => (
+  detail === undefined ? { reason, message } : { reason, message, detail }
+);
+
+const refusalJson = (context: Context, refused: Refusal): Response => {
+  const response = refusalResponse(refused);
+  return context.json(response.body, response.status);
+};
+
+const runFenceRefusal = (refused: FenceRefusalResponse): Refusal => (
+  refusal("conflict", refused.error, { reason: refused.reason })
+);
 
 export interface LiveAppOptions {
   ownership: { assertHeld(): void | Promise<void> };
@@ -669,7 +684,7 @@ const isTemplateInputError = (error: unknown): error is Error => (
   error instanceof Error
   && /(not found|has no|is archived|Missing template|Unknown template|must be agent|Invalid template branch)/iu.test(error.message)
 );
-const templateSchemaRefusal = (error: unknown): { error: string; code: string } | null => {
+const templateSchemaRefusal = (error: unknown): Refusal | null => {
   if (!(error instanceof z.ZodError)) return null;
   const issue = error.issues.find((candidate) => {
     const params = (candidate as unknown as { params?: Record<string, unknown> }).params;
@@ -678,7 +693,7 @@ const templateSchemaRefusal = (error: unknown): { error: string; code: string } 
   if (!issue) return null;
   const params = (issue as unknown as { params?: Record<string, unknown> }).params;
   return typeof params?.templateRefusalCode === "string"
-    ? { error: issue.message, code: params.templateRefusalCode }
+    ? refusal("invalid-request", issue.message, { code: params.templateRefusalCode })
     : null;
 };
 // `Fire now` merges over the template's own defaults, so an all-defaulted
@@ -808,7 +823,7 @@ const isPublic = (path: string, method: string): boolean =>
   || method === "POST" && /^\/hooks\/templates\/[^/]+$/.test(path);
 
 type CancellationSettlement =
-  | { error: string; code: 404 | 409 }
+  | Refusal
   | {
       runId: string; taskId: string | null; status: RunStatus; cancellationState: "acknowledged";
       requestId: string; releaseMergeLeaseTask: string | null;
@@ -841,10 +856,10 @@ const settleCancellation = async (
       session: { select: { id: true, waitingOnMessageId: true } },
     },
   });
-  if (!run) return { error: "Run not found", code: 404 };
-  if (run.cancelRequestId !== input.requestId) return { error: "Cancellation request does not match this Run", code: 409 };
+  if (!run) return refusal("not-found", "Run not found");
+  if (run.cancelRequestId !== input.requestId) return refusal("conflict", "Cancellation request does not match this Run");
   if (input.runnerId !== undefined && (run.runnerId !== input.runnerId || run.fencingToken !== input.fencingToken)) {
-    return { error: "Cancellation acknowledgement is not owned by this runner", code: 409 };
+    return refusal("conflict", "Cancellation acknowledgement is not owned by this runner");
   }
   if (run.status === RunStatus.CANCELLED) {
     // Reconciliation can settle an expired cancellation before the runner's
@@ -873,7 +888,7 @@ const settleCancellation = async (
         metadata: { runId: run.id, requestId: input.requestId, status: RunStatus.CANCELLED },
       } });
     } else if (!run.cancelAcknowledgedAt) {
-      return { error: "Cancellation cleanup has not been acknowledged by the runner", code: 409 };
+      return refusal("conflict", "Cancellation cleanup has not been acknowledged by the runner");
     }
     // The terminal writer that got here first already released the lease; a
     // later acknowledgement of the same cancellation has nothing left to free.
@@ -907,7 +922,7 @@ const settleCancellation = async (
       ...(input.baseSha === undefined ? {} : { baseSha: input.baseSha }),
     },
   });
-  if (settled.count !== 1) return { error: `Run is already ${run.status}`, code: 409 };
+  if (settled.count !== 1) return refusal("conflict", `Run is already ${run.status}`);
   await tx.session.updateMany({
     where: { runId: run.id },
     data: {
@@ -1259,7 +1274,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     // the target is what refuses it, and the caller recovers by reading GET
     // /onboarding rather than by editing anything. A committed-but-lost response
     // lands here too, which is why the code is stable and the rows are untouched.
-    if (!result.ok) return context.json({ error: "An installation already exists", code: result.code }, 409);
+    if (!result.ok) {
+      return refusalJson(context, refusal("conflict", "An installation already exists", { code: result.code }));
+    }
     return context.json(result.installation, 201);
   });
 
@@ -1401,21 +1418,21 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const body = await readJson(context.req.raw, agentPatch);
     const result = await db.$transaction(async (tx) => {
       const before = await lockAgentRow(tx, agentId);
-      if (!before) return { error: "Agent not found", code: 404 as const };
+      if (!before) return refusal("not-found", "Agent not found");
       const patch = withoutUndefined(body);
       const merged = { ...before, ...patch };
       if (before.name === "implementation-plan-executioner" && merged.name !== before.name) {
-        return { error: "implementation-plan-executioner is a canonical Agent name and cannot be changed", code: 400 as const };
+        return refusal("invalid-request", "implementation-plan-executioner is a canonical Agent name and cannot be changed");
       }
       const modelRefusal = runnerModelRefusal(merged);
-      if (modelRefusal) return { error: modelRefusal, code: 400 as const };
+      if (modelRefusal) return refusal("invalid-request", modelRefusal);
       const executionerRefusal = executionerRuntimeRefusal(merged);
-      if (executionerRefusal) return { error: executionerRefusal, code: 400 as const };
+      if (executionerRefusal) return refusal("invalid-request", executionerRefusal);
       const tierRefusal = codexServiceTierRefusal(merged);
-      if (tierRefusal) return { error: tierRefusal, code: 400 as const };
+      if (tierRefusal) return refusal("invalid-request", tierRefusal);
       if (body.environmentId) {
         const environment = await tx.environment.findFirst({ where: { id: body.environmentId, projectId: before.projectId } });
-        if (!environment) return { error: "Environment does not belong to this project", code: 400 as const };
+        if (!environment) return refusal("invalid-request", "Environment does not belong to this project");
       }
       return { agent: await tx.agent.update({
         where: { id: agentId },
@@ -1428,7 +1445,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         } as Prisma.AgentUncheckedUpdateInput,
       }) };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result.agent);
   });
   app.delete("/agents/:agentId", async (context) => {
@@ -1452,14 +1469,14 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const now = new Date();
     const result = await readCommitted(db, async (tx) => {
       const locked = await lockAgentRow(tx, agentId);
-      if (!locked) return { error: "Agent not found", code: 404 as const };
+      if (!locked) return refusal("not-found", "Agent not found");
       const agent = await tx.agent.findUniqueOrThrow({ where: { id: agentId } });
       if (agent.archivedAt) return { agent };
       const blocker = await agentArchiveBlocker(tx, agentId);
-      if (blocker) return { error: blocker, code: 409 as const };
+      if (blocker) return refusal("conflict", blocker);
       return { agent: await tx.agent.update({ where: { id: agentId }, data: { archivedAt: now } }) };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     // Unchanged sweep: rows archived before this protocol existed — or queued by
     // a writer that committed first — still get their explanatory activity.
     await noteArchivedQueuedRuns(db, { agentId });
@@ -1709,10 +1726,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     if (!grant) return context.json({ error: "Repo access not found" }, 404);
     const result = await db.$transaction(async (tx) => {
       if (!await lockAgentRepoGrantForRevocation(tx, { projectId: grant.projectId, agentId, repoId })) {
-        return { error: "Repo access not found", code: 404 as const };
+        return refusal("not-found", "Repo access not found");
       }
       const active = await tx.run.count({ where: { agentId, repoId, status: { in: ACTIVE_RUN_STATUSES } } });
-      if (active > 0) return { error: "Cannot revoke repo access while the agent has an active run on this Repo", code: 409 as const };
+      if (active > 0) return refusal("conflict", "Cannot revoke repo access while the agent has an active run on this Repo");
       const dependentSteps = await tx.task.count({ where: {
         projectId: grant.projectId,
         repoId,
@@ -1722,15 +1739,12 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         status: { in: [TaskStatus.BACKLOG, TaskStatus.TODO, TaskStatus.DOING, TaskStatus.REVIEW] },
       } });
       if (dependentSteps > 0) {
-        return {
-          error: "Cannot revoke repo access while a nonterminal chain step depends on this grant",
-          code: 409 as const,
-        };
+        return refusal("conflict", "Cannot revoke repo access while a nonterminal chain step depends on this grant");
       }
       await tx.agentRepoAccess.delete({ where: { agentId_repoId: { agentId, repoId } } });
       return { ok: true as const };
     });
-    return "error" in result ? context.json({ error: result.error }, result.code) : context.body(null, 204);
+    return "message" in result ? refusalJson(context, result) : context.body(null, 204);
   });
 
   app.get("/projects/:projectId/goals", async (context) => context.json(await db.goal.findMany({
@@ -1942,10 +1956,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       ), 201);
     } catch (error: unknown) {
       if (isTemplateInstantiationRefusal(error)) {
-        return context.json({ error: error.message, code: error.code }, 400);
+        return refusalJson(context, refusal("invalid-request", error.message, { code: error.code }));
       }
       const schemaRefusal = templateSchemaRefusal(error);
-      if (schemaRefusal) return context.json(schemaRefusal, 400);
+      if (schemaRefusal) return refusalJson(context, schemaRefusal);
       if (isTemplateInputError(error)) {
         return context.json({ error: error.message }, 400);
       }
@@ -2208,8 +2222,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       // Agent-row mutex through the task — and the inline run below — so a
       // concurrent archive either loses the race or is refused for this run.
       const currentAgent = agent ? await lockAgentRow(tx, agent.id) : null;
-      if (agent && !currentAgent) return { error: "Assignee does not belong to this project", code: 400 as const };
-      if (currentAgent?.archivedAt) return { error: `Assignee ${currentAgent.name} is archived`, code: 400 as const };
+      if (agent && !currentAgent) return refusal("invalid-request", "Assignee does not belong to this project");
+      if (currentAgent?.archivedAt) return refusal("invalid-request", `Assignee ${currentAgent.name} is archived`);
       // §D-P4, inside the transaction and before `tx.task.create` and the inline
       // `tx.run.create` below. This route cannot set `templateStepId` at all, so
       // in practice it refuses the sentinel Agent outright — which is the point:
@@ -2219,7 +2233,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         assigneeAgentName: currentAgent?.name ?? null,
         templateStep: null,
       });
-      if (bindingRefusal) return { error: bindingRefusal, code: 400 as const };
+      if (bindingRefusal) return refusal("invalid-request", bindingRefusal);
       const created = await tx.task.create({
         data: {
           ...withoutUndefined(body),
@@ -2265,7 +2279,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       }
       return { created };
     });
-    if ("error" in task) return context.json({ error: task.error }, task.code);
+    if ("message" in task) return refusalJson(context, task);
     return context.json(task.created, 201);
   });
   app.get("/tasks/:taskId", async (context) => {
@@ -2500,14 +2514,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.patch("/tasks/:taskId", async (context) => {
     const taskId = id.parse(context.req.param("taskId"));
     const result = await patchTask(db, taskId, await readJson(context.req.raw, taskPatch));
-    if ("error" in result) {
-      return context.json(
-        result.errorCode === undefined
-          ? { error: result.error }
-          : { error: result.error, code: result.errorCode },
-        result.code,
-      );
-    }
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result.task);
   });
   app.delete("/tasks/:taskId", async (context) => {
@@ -2526,10 +2533,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const now = new Date();
     const result = await db.$transaction(async (tx) => {
       const locked = await lockTaskMutationRows(tx, taskId);
-      if (!locked) return { error: "Task not found", code: 404 as const };
+      if (!locked) return refusal("not-found", "Task not found");
       // Retry joins the exclusion protocol: a guard set in which one writer
       // ignores archivedAt excludes nothing.
-      if (locked.archivedAt !== null) return { error: "Cannot retry an archived task", code: 409 as const };
+      if (locked.archivedAt !== null) return refusal("conflict", "Cannot retry an archived task");
       const task = await tx.task.findUnique({
         where: { id: taskId },
         include: {
@@ -2542,7 +2549,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           runs: { orderBy: { runNumber: "desc" }, take: 1 },
         },
       });
-      if (!task) return { error: "Task not found", code: 404 as const };
+      if (!task) return refusal("not-found", "Task not found");
       if (task.chainId && task.chainIndex !== null) {
         const chainRows = await tx.task.findMany({
           where: { projectId: task.projectId, chainId: task.chainId },
@@ -2557,15 +2564,12 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           templateStep: null,
         })), taskId);
         if (blocker) {
-          return {
-            error: `Cannot retry ${task.name}; predecessor ${blocker.name} is not done`,
-            code: 409 as const,
-          };
+          return refusal("conflict", `Cannot retry ${task.name}; predecessor ${blocker.name} is not done`);
         }
       }
       const integratorStepShape = task.templateStep;
       const last = task.runs[0];
-      if (!last) return { error: "Task has no run to retry", code: 409 as const };
+      if (!last) return refusal("conflict", "Task has no run to retry");
       // Checked across ALL of the task's runs with the shared active set, not
       // the latest run's status alone: the old latest-only enum check missed
       // PROVISIONING and WAITING_INBOX, so a retry during a clone or a
@@ -2573,28 +2577,28 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       // same task and chain branch.
       const activeRuns = await tx.run.count({ where: { taskId, status: { in: ACTIVE_RUN_STATUSES } } });
       if (activeRuns > 0) {
-        return { error: "Task already has an active run", code: 409 as const };
+        return refusal("conflict", "Task already has an active run");
       }
       const stoppedForRetry = await stopStateFor(tx, taskId);
-      if (stoppedForRetry) return { error: stopStateRefusal(stoppedForRetry), code: 409 as const };
+      if (stoppedForRetry) return refusal("conflict", stopStateRefusal(stoppedForRetry));
       // The same ceiling the Start gate uses, for the same reason: the budget an
       // operator configured now, plus what has been granted on top of it. The
       // old `last.maxRunsPerTask` could not tell a refund from a budget that had
       // since been lowered.
       if (last.runNumber >= runBudgetCeiling(task.maxSessionsPerTask, last.budgetGrants)) {
-        return { error: "Run budget exhausted", code: 409 as const };
+        return refusal("conflict", "Run budget exhausted");
       }
       if (!task.assigneeAgent) {
-        return { error: "Task assignee no longer exists; assign an agent before retrying", code: 409 as const };
+        return refusal("conflict", "Task assignee no longer exists; assign an agent before retrying");
       }
       // Retry builds its Run inline rather than through enqueueTaskRun, so it
       // takes the Agent-row mutex itself — Task row first, Agent row second.
       const lockedAgent = await lockAgentRow(tx, task.assigneeAgent.id);
       if (!lockedAgent || lockedAgent.archivedAt) {
-        return { error: `Assignee ${task.assigneeAgent.name} is archived; unarchive it to retry`, code: 409 as const };
+        return refusal("conflict", `Assignee ${task.assigneeAgent.name} is archived; unarchive it to retry`);
       }
       const currentBinding = integratorBindingRefusal(lockedAgent.name, integratorStepShape);
-      if (currentBinding) return { error: currentBinding, code: 400 as const };
+      if (currentBinding) return refusal("invalid-request", currentBinding);
       const derived = deriveRunConfig(lockedAgent, task.templateStep, task);
       const subagent = nativeImplementationSubagentRunConfig(derived.runner, task.templateStep);
       // A task with no repo cannot be a chain step with a branch, and this route
@@ -2630,7 +2634,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       await tx.taskActivity.create({ data: { taskId, actorType: "operator", body: `Run ${run.runNumber} queued by operator retry` } });
       return { run };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result.run, 201);
   });
   app.post("/tasks/:taskId/start", async (context) => {
@@ -2642,7 +2646,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     try {
       const result = await readCommitted(db, async (tx) => {
         if (!await lockTaskMutationRows(tx, taskId)) {
-          return { error: "Task not found", code: 404 as const };
+          return refusal("not-found", "Task not found");
         }
         const task = await tx.task.findUniqueOrThrow({
           where: { id: taskId },
@@ -2669,29 +2673,23 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
             templateStep: null,
           })), taskId);
           if (blocker) {
-            return {
-              error: `Cannot start ${task.name}; predecessor ${blocker.name} is not done`,
-              code: 409 as const,
-            };
+            return refusal("conflict", `Cannot start ${task.name}; predecessor ${blocker.name} is not done`);
           }
         }
         if (task.dispatchAfterTaskId !== null && task.dispatchAfter?.status !== TaskStatus.DONE) {
           const predecessorName = task.dispatchAfter?.name ?? task.dispatchAfterTaskId;
-          return {
-            error: `Cannot start ${task.name}; bound predecessor ${predecessorName} is not done`,
-            code: 409 as const,
-          };
+          return refusal("conflict", `Cannot start ${task.name}; bound predecessor ${predecessorName} is not done`);
         }
-        if (task.archivedAt !== null) return { error: "Cannot start an archived task", code: 409 as const };
-        if (task.status === TaskStatus.DONE) return { error: "Task is already done", code: 409 as const };
+        if (task.archivedAt !== null) return refusal("conflict", "Cannot start an archived task");
+        if (task.status === TaskStatus.DONE) return refusal("conflict", "Task is already done");
         if (task.assigneeType !== AssigneeType.AGENT) {
-          return { error: "Human steps cannot be started", code: 409 as const };
+          return refusal("conflict", "Human steps cannot be started");
         }
         if (isMergeReadinessStep(task.templateStep)) {
-          return { error: "Merge readiness is server-owned and cannot be started as a model run", code: 409 as const };
+          return refusal("conflict", "Merge readiness is server-owned and cannot be started as a model run");
         }
         if (await hasActiveRun(tx, taskId)) {
-          return { error: "Task already has an active run", code: 409 as const };
+          return refusal("conflict", "Task already has an active run");
         }
         // A count, not the latest run number: Run is one-to-many and a task at
         // its ceiling whose last run failed must not look startable.
@@ -2711,7 +2709,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         });
         const facts = { total: budget._count._all, active: false, budgetGrants: budget._max.budgetGrants };
         if (facts.total >= runBudgetCeiling(task.maxSessionsPerTask, facts.budgetGrants)) {
-          return { error: "Run budget exhausted", code: 409 as const };
+          return refusal("conflict", "Run budget exhausted");
         }
         // The specific messages above and below are a reason ladder in front of
         // the shared predicate, so the operator gets the sentence that names
@@ -2720,13 +2718,13 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         // re-deriving them by hand was how it came to accept gated REVIEW steps
         // and DOING steps and to answer 500 on a task with no repo.
         if (task.status !== TaskStatus.TODO && task.status !== TaskStatus.BACKLOG) {
-          return { error: "Only Todo and Backlog steps can be started", code: 409 as const };
+          return refusal("conflict", "Only Todo and Backlog steps can be started");
         }
         if (!task.repoId) {
-          return { error: "This task has no repository", code: 400 as const };
+          return refusal("invalid-request", "This task has no repository");
         }
         if (!task.assigneeAgentId) {
-          return { error: "This task has no assignee", code: 400 as const };
+          return refusal("invalid-request", "This task has no assignee");
         }
         const hasRepoGrant = await lockAgentRepoGrant(tx, {
           projectId: task.projectId,
@@ -2734,7 +2732,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           repoId: task.repoId,
         });
         if (!hasRepoGrant) {
-          return { error: "Assignee has no grant for this Repo", code: 400 as const };
+          return refusal("invalid-request", "Assignee has no grant for this Repo");
         }
         if (!taskStartability({ ...task, hasRepoGrant }, facts, task.maxSessionsPerTask).startable) {
           // The one remaining `startable` condition with no message of its own
@@ -2742,7 +2740,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           // error that names the agent — a better sentence than anything this
           // branch could write. Fall through to it; the catch maps it to 409.
           if (!task.assigneeAgent?.archivedAt) {
-            return { error: "This step cannot be started", code: 409 as const };
+            return refusal("conflict", "This step cannot be started");
           }
         }
         const run = await enqueueTaskRun(tx, taskId);
@@ -2759,10 +2757,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         } });
         return { run };
       });
-      if ("error" in result) return context.json({ error: result.error }, result.code);
+      if ("message" in result) return refusalJson(context, result);
       return context.json({ runId: result.run.id, runNumber: result.run.runNumber }, 201);
     } catch (error: unknown) {
-      if (isArchivedAssigneeError(error) || isArchivedTaskError(error) || isIntegratorStoppedError(error)) return context.json({ error: error.message }, 409);
       // Unreachable under the lock, because the loser sees the winner's run and
       // returns the 409 above. Mapped anyway: a 500 on a double-click is exactly
       // the failure the guard exists to prevent.
@@ -2776,13 +2773,13 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const taskId = id.parse(context.req.param("taskId"));
     const result = await readCommitted(db, async (tx) => {
       const locked = await lockTaskMutationRows(tx, taskId);
-      if (!locked) return { error: "Task not found", code: 404 as const };
+      if (!locked) return refusal("not-found", "Task not found");
       if (await hasActiveRun(tx, taskId)) {
-        return { error: "Cannot archive a task with an active run", code: 409 as const };
+        return refusal("conflict", "Cannot archive a task with an active run");
       }
       if (locked.status === TaskStatus.REVIEW) {
         const open = await tx.inboxMessage.count({ where: { gateTaskId: taskId, status: InboxStatus.OPEN } });
-        if (open > 0) return { error: "Decide the approval gate in the Inbox first", code: 409 as const };
+        if (open > 0) return refusal("conflict", "Decide the approval gate in the Inbox first");
       }
       if (locked.archivedAt !== null) {
         return { task: await tx.task.findUniqueOrThrow({ where: { id: taskId } }) };
@@ -2791,7 +2788,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       await tx.taskActivity.create({ data: { taskId, actorType: "operator", body: "Task archived" } });
       return { task };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result.task);
   });
   app.post("/tasks/:taskId/unarchive", async (context) => {
@@ -2808,19 +2805,19 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     // operator's ability to read their own history back onto the board.
     const result = await readCommitted(db, async (tx) => {
       const locked = await lockTaskMutationRows(tx, taskId);
-      if (!locked) return { error: "Task not found", code: 404 as const };
+      if (!locked) return refusal("not-found", "Task not found");
       if (locked.archivedAt === null) {
         return { task: await tx.task.findUniqueOrThrow({ where: { id: taskId } }) };
       }
       if (isLiveStatus(locked.status)) {
         const blocked = await reactivationBlocked(tx, locked);
-        if (blocked) return { error: blocked, code: 409 as const };
+        if (blocked) return refusal("conflict", blocked);
       }
       const task = await tx.task.update({ where: { id: taskId }, data: { archivedAt: null } });
       await tx.taskActivity.create({ data: { taskId, actorType: "operator", body: "Task unarchived" } });
       return { task };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result.task);
   });
   app.post("/projects/:projectId/tasks/archive-done", async (context) => {
@@ -2866,40 +2863,40 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/tasks/:taskId/schedule/pause", async (context) => {
     const taskId = id.parse(context.req.param("taskId"));
     const result = await db.$transaction(async (tx) => {
-      if (!await lockTaskMutationRows(tx, taskId)) return { error: "Task not found", code: 404 as const };
+      if (!await lockTaskMutationRows(tx, taskId)) return refusal("not-found", "Task not found");
       const task = await tx.task.findUniqueOrThrow({ where: { id: taskId }, select: { scheduleKind: true } });
-      if (task.scheduleKind !== ScheduleKind.CRON) return { error: "Only CRON tasks can be paused", code: 400 as const };
+      if (task.scheduleKind !== ScheduleKind.CRON) return refusal("invalid-request", "Only CRON tasks can be paused");
       // In-flight copies are left alone: pausing stops future occurrences, it does
       // not reach into work that already started.
       const paused = await tx.task.update({ where: { id: taskId }, data: { schedulePausedAt: new Date() } });
       await tx.taskActivity.create({ data: { taskId, actorType: "operator", body: "Schedule paused" } });
       return { task: paused };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result.task);
   });
   app.post("/tasks/:taskId/schedule/resume", async (context) => {
     const taskId = id.parse(context.req.param("taskId"));
     const result = await db.$transaction(async (tx) => {
-      if (!await lockTaskMutationRows(tx, taskId)) return { error: "Task not found", code: 404 as const };
+      if (!await lockTaskMutationRows(tx, taskId)) return refusal("not-found", "Task not found");
       const task = await tx.task.findUniqueOrThrow({
         where: { id: taskId },
         select: { scheduleKind: true, cron: true, timezone: true },
       });
-      if (task.scheduleKind !== ScheduleKind.CRON) return { error: "Only CRON tasks can be resumed", code: 400 as const };
+      if (task.scheduleKind !== ScheduleKind.CRON) return refusal("invalid-request", "Only CRON tasks can be resumed");
       let runAt: Date;
       try {
         if (!task.cron) throw new Error("CRON tasks require cron");
         // Recomputed from *now*, so a long pause produces no catch-up burst.
         runAt = computeNextOccurrence(task.cron, task.timezone, new Date());
       } catch (error: unknown) {
-        return { error: error instanceof Error ? error.message : "Invalid schedule", code: 400 as const };
+        return refusal("invalid-request", error instanceof Error ? error.message : "Invalid schedule");
       }
       const resumed = await tx.task.update({ where: { id: taskId }, data: { schedulePausedAt: null, runAt } });
       await tx.taskActivity.create({ data: { taskId, actorType: "operator", body: "Schedule resumed" } });
       return { task: resumed };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result.task);
   });
   app.get("/tasks/:taskId/recurring-fires", async (context) => {
@@ -2944,7 +2941,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const body = await readJson(context.req.raw, taskOutputInput);
     const result = await readCommitted(db, async (tx) => {
       const locked = await lockTaskMutationRows(tx, taskId);
-      if (!locked) return { error: "Task not found", code: 404 as const };
+      if (!locked) return refusal("not-found", "Task not found");
       const task = await tx.task.findUniqueOrThrow({
         where: { id: taskId },
         select: { templateStep: { select: {
@@ -2957,7 +2954,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       const immutableReview = isCanonicalSolFindingsStep(task.templateStep)
         || isCanonicalBlindFindingsStep(task.templateStep);
       if (immutableReview && existing) {
-        return { error: `${task.templateStep?.outputKind ?? body.kind} task output is immutable once persisted`, code: 409 as const };
+        return refusal("conflict", `${task.templateStep?.outputKind ?? body.kind} task output is immutable once persisted`);
       }
       const output = await tx.taskStepOutput.upsert({
         where: { taskId },
@@ -2966,7 +2963,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       });
       return { output };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result.output);
   });
   /**
@@ -2984,29 +2981,29 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const body = await readJson(context.req.raw, mergeTargetInput);
     const result = await readCommitted(db, async (tx) => {
       const locked = await lockTaskMutationRows(tx, taskId);
-      if (!locked) return { error: "Task not found", code: 404 as const };
+      if (!locked) return refusal("not-found", "Task not found");
       const task = await loadIntegratorTask(tx, taskId);
       if (!task || !taskIsIntegratorStep(task)) {
-        return { error: "Task is not a mechanical merge step", code: 409 as const };
+        return refusal("conflict", "Task is not a mechanical merge step");
       }
       const stopped = await stopStateFor(tx, taskId);
-      if (!stopped) return { error: "Task is not in a merge stop state", code: 409 as const };
+      if (!stopped) return refusal("conflict", "Task is not in a merge stop state");
       if (stopped.stop.condition !== "target-unresolvable") {
-        return { error: `Merge target correction applies to target-unresolvable only, not ${stopped.stop.condition}`, code: 409 as const };
+        return refusal("conflict", `Merge target correction applies to target-unresolvable only, not ${stopped.stop.condition}`);
       }
-      if (!task.chainId) return { error: "Task is not part of a chain", code: 409 as const };
+      if (!task.chainId) return refusal("conflict", "Task is not part of a chain");
       const observed = await observedChainPullRequests(tx, task.projectId, task.chainId);
       if (observed.length === 0) {
-        return {
-          error: "This chain delivered no pull request; abandon it, or deliver the pull request by re-running the delivering step, after which resolution succeeds with no correction",
-          code: 409 as const,
-        };
+        return refusal(
+          "conflict",
+          "This chain delivered no pull request; abandon it, or deliver the pull request by re-running the delivering step, after which resolution succeeds with no correction",
+        );
       }
       if (!observed.includes(body.prNumber)) {
-        return {
-          error: `Pull request #${body.prNumber} is not among this chain's own delivered pull requests (${observed.join(", ")})`,
-          code: 409 as const,
-        };
+        return refusal(
+          "conflict",
+          `Pull request #${body.prNumber} is not among this chain's own delivered pull requests (${observed.join(", ")})`,
+        );
       }
       const priorCorrection = await latestTargetCorrection(tx, taskId);
       const activity = await tx.taskActivity.create({ data: {
@@ -3028,14 +3025,13 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       try {
         cardId = await requestConfirmationCard(tx, task, stopped.stop.stopId, new Date());
       } catch (error: unknown) {
-        if (isMergeConfirmationError(error)) {
-          return { error: error.message, code: 409 as const };
-        }
+        const rejected = refusalFor(error);
+        if (rejected) return rejected;
         throw error;
       }
       return { correction: { id: activity.id, prNumber: body.prNumber, observed, confirmationCardId: cardId } };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result.correction, 201);
   });
 
@@ -3092,11 +3088,6 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       });
       return context.json(result, result.duplicate ? 200 : 201);
     } catch (error: unknown) {
-      if (isArchivedAssigneeError(error) || isArchivedTaskError(error) || isIntegratorStoppedError(error)
-        || isMergeConfirmationError(error)) return context.json({ error: error.message }, 409);
-      if (error instanceof Error && /(No matching|must be approve|must match|no executable)/i.test(error.message)) {
-        return context.json({ error: error.message }, 409);
-      }
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
         return context.json({ duplicate: true, resumed: false });
       }
@@ -3115,11 +3106,6 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       });
       return context.json(result, result.duplicate ? 200 : 201);
     } catch (error: unknown) {
-      if (isArchivedAssigneeError(error) || isArchivedTaskError(error) || isIntegratorStoppedError(error)
-        || isMergeConfirmationError(error)) return context.json({ error: error.message }, 409);
-      if (error instanceof Error && /(No matching|must be approve|no executable)/i.test(error.message)) {
-        return context.json({ error: error.message }, 409);
-      }
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
         return context.json({ duplicate: true, resumed: false });
       }
@@ -3180,7 +3166,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       id.parse(context.req.param("messageId")),
       body.requestId,
     );
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     return context.json(result);
   });
 
@@ -3376,7 +3362,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     await reconcileDatabaseRuns(db, now, releaseChainLease);
     await noteArchivedQueuedRunsOnClaim(now).catch((error: unknown) => console.error("Archived-run notice failed", error));
     const claimed = await claimRun(db, { body, claimantClass, now });
-    if (claimed && "error" in claimed) return context.json({ error: claimed.error }, 409);
+    if (claimed && "error" in claimed) {
+      if (typeof claimed.error !== "string") throw new TypeError("Run claim refusal has no message");
+      return refusalJson(context, refusal("conflict", claimed.error));
+    }
     return claimed ? context.json(claimed) : context.body(null, 204);
   });
 
@@ -3433,7 +3422,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     });
     return started === null
       ? context.json({ ok: true })
-      : context.json(fenceRefusalResponse(started), 409);
+      : refusalJson(context, runFenceRefusal(fenceRefusalResponse(started)));
   });
 
   app.post("/runner/runs/:runId/heartbeat", async (context) => {
@@ -3482,8 +3471,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     }
     const waiting = await db.run.findFirst({ where: { id: runId, status: RunStatus.WAITING_INBOX }, select: { id: true } });
     return waiting
-      ? context.json({ error: "Run suspended for Inbox", code: "WAITING_INBOX" }, 409)
-      : context.json(fenceRefusalResponse(await explainFenceRefusal(db, fence)), 409);
+      ? refusalJson(context, refusal("conflict", "Run suspended for Inbox", { code: "WAITING_INBOX" }))
+      : refusalJson(context, runFenceRefusal(fenceRefusalResponse(await explainFenceRefusal(db, fence))));
   });
 
   app.post("/runner/runs/:runId/cancel/acknowledge", async (context) => {
@@ -3500,7 +3489,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       ...(body.branch === undefined ? {} : { branch: body.branch }),
       ...(body.baseSha === undefined ? {} : { baseSha: body.baseSha }),
     }));
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     const { releaseMergeLeaseTask, ...settlement } = result;
     await releaseMergeLeaseSafely(releaseChainLease, releaseMergeLeaseTask);
     return context.json(settlement);
@@ -3538,7 +3527,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       && body.pushedBranch === salvageBranch
       && (run?.pushedBranch === null || run?.pushedBranch === body.pushedBranch);
     if (!live && !salvage) {
-      return context.json(fenceRefusalResponse(await explainFenceRefusal(db, fence)), 409);
+      return refusalJson(context, runFenceRefusal(fenceRefusalResponse(await explainFenceRefusal(db, fence))));
     }
     const updated = await db.$transaction(async (tx) => {
       const ack = await tx.run.updateMany({
@@ -3563,8 +3552,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return updated.count === 1 && updated.repair !== "already-started"
       ? context.json({ ok: true, replacementRepair: updated.repair })
       : updated.count === 1
-        ? context.json({ error: "Salvage is durable, but the replacement already started from its prior base" }, 409)
-      : context.json(fenceRefusalResponse(await explainFenceRefusal(db, fence)), 409);
+        ? refusalJson(context, refusal("conflict", "Salvage is durable, but the replacement already started from its prior base"))
+        : refusalJson(context, runFenceRefusal(fenceRefusalResponse(await explainFenceRefusal(db, fence))));
   });
 
   // Cleanup is still runner-owned after the live lease is gone. This endpoint
@@ -3637,8 +3626,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     if (isFenceRefusalResponse(result)) {
       const waiting = await db.run.findFirst({ where: { id: runId, status: RunStatus.WAITING_INBOX }, select: { id: true } });
       return waiting
-        ? context.json({ error: "Run suspended for Inbox", code: "WAITING_INBOX" }, 409)
-        : context.json(result, 409);
+        ? refusalJson(context, refusal("conflict", "Run suspended for Inbox", { code: "WAITING_INBOX" }))
+        : refusalJson(context, runFenceRefusal(result));
     }
     // Recompute on "a FINAL_OUTPUT arrived", not "this payload had usage": a batch
     // whose event was already stored still recomputes, which is what self-heals a
@@ -3702,7 +3691,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       });
     }));
     return isFenceRefusalResponse(result)
-      ? context.json(result, 409)
+      ? refusalJson(context, runFenceRefusal(result))
       : context.json(result, 201);
   };
   app.post("/runner/runs/:runId/activity", appendFencedActivity);
@@ -3871,11 +3860,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         ...(body.metadata ? { metadata: jsonValue(body.metadata) } : {}),
       }) };
     }));
-    if (isFenceRefusalResponse(result)) return context.json(result, 409);
+    if (isFenceRefusalResponse(result)) return refusalJson(context, runFenceRefusal(result));
     if ("requestError" in result) return context.json({ error: result.requestError }, result.status);
     const { persisted } = result;
-    if (isFenceRefusalResponse(persisted)) return context.json(persisted, 409);
-    if (!persisted.ok) return context.json({ error: persisted.reason }, 409);
+    if (isFenceRefusalResponse(persisted)) return refusalJson(context, runFenceRefusal(persisted));
+    if (!persisted.ok) return refusalJson(context, refusal("conflict", persisted.reason));
     return context.json({ ...persisted.output, predecessorOutputs: persisted.predecessorOutputs });
   });
 
@@ -3997,12 +3986,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       body,
       claimantClass: principal.kind === "merge-executor" ? "merge-executor" : "runner",
     });
-    if ("kind" in result) {
-      if (result.kind === "principal") return context.json({ error: result.error }, 403);
-      return result.kind === "waiting-inbox"
-        ? context.json({ error: "Run suspended for Inbox", code: "WAITING_INBOX" }, 409)
-        : context.json(fenceRefusalResponse(result.reason), 409);
-    }
+    if ("message" in result) return refusalJson(context, result);
     await releaseMergeLeaseSafely(releaseChainLease, result.releaseMergeLeaseTask);
     await options.ownership.assertHeld();
     // Nothing is deleted here, or anywhere else in this process. The runner
@@ -4107,14 +4091,14 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           } } } },
         },
       });
-      if (!run) return { error: "Run not found", code: 404 as const };
-      if (body.parkTask && !run.taskId) return { error: "Run has no Task to park", code: 409 as const };
+      if (!run) return refusal("not-found", "Run not found");
+      if (body.parkTask && !run.taskId) return refusal("conflict", "Run has no Task to park");
       const parkTarget = body.parkTask && run.taskId ? await lockTaskMutationRows(tx, run.taskId) : null;
-      if (body.parkTask && run.taskId && !parkTarget) return { error: "Task not found", code: 404 as const };
+      if (body.parkTask && run.taskId && !parkTarget) return refusal("not-found", "Task not found");
       if (parkTarget && parkTarget.archivedAt !== null) {
-        return { error: "Cannot park an archived task", code: 409 as const };
+        return refusal("conflict", "Cannot park an archived task");
       }
-      if (parkTarget?.status === TaskStatus.DONE) return { error: "Cannot park a completed task", code: 409 as const };
+      if (parkTarget?.status === TaskStatus.DONE) return refusal("conflict", "Cannot park a completed task");
       const parkTask = async () => {
         const task = parkTarget;
         if (!task) return;
@@ -4133,7 +4117,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       };
       if (run.cancelRequestId) {
         if (run.cancelRequestId !== body.requestId) {
-          return { error: `Run already has cancellation request ${run.cancelRequestId}`, code: 409 as const };
+          return refusal("conflict", `Run already has cancellation request ${run.cancelRequestId}`);
         }
         await parkTask();
         return {
@@ -4149,7 +4133,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         };
       }
       if (executionModeFor(run.task?.templateStep ?? null) === "mechanical") {
-        return { error: "Mechanical merge Runs cannot be cancelled after authorization", code: 409 as const };
+        return refusal("conflict", "Mechanical merge Runs cannot be cancelled after authorization");
       }
       if (!([RunStatus.QUEUED, ...activeRunStatuses] as RunStatus[]).includes(run.status)) {
         return {
@@ -4172,7 +4156,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           sessionTokenRevokedAt: now,
         },
       });
-      if (requested.count !== 1) return { error: "Run changed while cancellation was being requested", code: 409 as const };
+      if (requested.count !== 1) return refusal("conflict", "Run changed while cancellation was being requested");
       await parkTask();
       if (run.taskId) await tx.taskActivity.create({ data: {
         taskId: run.taskId,
@@ -4198,7 +4182,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         releaseMergeLeaseTask: null,
       };
     });
-    if ("error" in result) return context.json({ error: result.error }, result.code);
+    if ("message" in result) return refusalJson(context, result);
     const { releaseMergeLeaseTask, ...cancellation } = result;
     await releaseMergeLeaseSafely(releaseChainLease, releaseMergeLeaseTask);
     return context.json(cancellation);
@@ -4224,17 +4208,15 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     if (error instanceof SerializableTransactionExhaustedError) {
       return context.json({ error: "Transaction is busy; retry later" }, 503);
     }
-    if (isCompoundImplementationAssigneeError(error)) {
-      return context.json({ error: error.message, code: COMPOUND_IMPLEMENTATION_ASSIGNEE_ERROR_CODE }, 409);
-    }
-    if (isArchivedAssigneeError(error)) return context.json({ error: error.message }, 409);
+    const rejected = refusalFor(error);
+    if (rejected) return refusalJson(context, rejected);
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === "P2025") return context.json({ error: "Resource not found" }, 404);
-      if (error.code === "P2002") return context.json({ error: "Unique constraint violated" }, 409);
+      if (error.code === "P2025") return refusalJson(context, refusal("not-found", "Resource not found"));
+      if (error.code === "P2002") return refusalJson(context, refusal("conflict", "Unique constraint violated"));
     }
     console.error(error);
     return context.json({ error: "Internal server error" }, 500);
   });
-  app.notFound((context) => context.json({ error: "Not found" }, 404));
+  app.notFound((context) => refusalJson(context, refusal("not-found", "Not found")));
   return app;
 };

--- a/packages/api/src/inbox.ts
+++ b/packages/api/src/inbox.ts
@@ -17,6 +17,7 @@ import {
   type RunFence,
   withFencedRun,
 } from "./run-fence.js";
+import type { Refusal } from "./refusal.js";
 
 export const defaultInboxResumeWindowMs = 7 * 24 * 60 * 60 * 1_000;
 
@@ -33,7 +34,7 @@ export type SuspendQuestion = {
 export type SupersedeInboxMessageResult =
   | { closed: true; duplicate: false; requestId: string }
   | { closed: false; duplicate: true; requestId: string }
-  | { error: string; code: 404 | 409 };
+  | Refusal;
 
 export class InboxRunFenceRefusal extends Error {
   readonly refusal: FenceRefusalResponse;
@@ -61,15 +62,15 @@ export const supersedeTaskInboxMessage = async (
     where: { id: messageId },
     select: { status: true, from: true, taskId: true, gateTaskId: true, replyToMessageId: true },
   });
-  if (!initial) return { error: "Inbox message not found", code: 404 };
+  if (!initial) return { reason: "not-found", message: "Inbox message not found" };
   if (initial.taskId === null) {
-    return { error: "Only a task-linked Inbox message can be superseded", code: 409 };
+    return { reason: "conflict", message: "Only a task-linked Inbox message can be superseded" };
   }
   if (initial.from !== InboxSender.AGENT || initial.replyToMessageId !== null) {
-    return { error: "Only a top-level agent Inbox message can be superseded", code: 409 };
+    return { reason: "conflict", message: "Only a top-level agent Inbox message can be superseded" };
   }
   if (initial.gateTaskId !== null) {
-    return { error: "Only a non-gate Inbox message can be superseded", code: 409 };
+    return { reason: "conflict", message: "Only a non-gate Inbox message can be superseded" };
   }
   // A prior successful supersession is safe to acknowledge without touching
   // the Task row again. This keeps retries idempotent even if the operator
@@ -82,9 +83,9 @@ export const supersedeTaskInboxMessage = async (
   // archivedAt. Do not replace this with an unlocked task read: that would
   // allow an unarchive to commit between the check and the Inbox update.
   const task = await lockTaskMutationRows(tx, initial.taskId);
-  if (!task) return { error: "Inbox message task not found", code: 404 };
+  if (!task) return { reason: "not-found", message: "Inbox message task not found" };
   if (task.archivedAt === null) {
-    return { error: "Only an Inbox message for an archived task can be superseded", code: 409 };
+    return { reason: "conflict", message: "Only an Inbox message for an archived task can be superseded" };
   }
 
   // Re-read the mutable status after the Task lock. The conditional update
@@ -94,12 +95,12 @@ export const supersedeTaskInboxMessage = async (
     where: { id: messageId },
     select: { status: true },
   });
-  if (!message) return { error: "Inbox message not found", code: 404 };
+  if (!message) return { reason: "not-found", message: "Inbox message not found" };
   if (message.status === InboxStatus.CLOSED) {
     return { closed: false, duplicate: true, requestId };
   }
   if (message.status !== InboxStatus.OPEN) {
-    return { error: "Only an open Inbox message can be superseded", code: 409 };
+    return { reason: "conflict", message: "Only an open Inbox message can be superseded" };
   }
 
   const closed = await tx.inboxMessage.updateMany({
@@ -125,7 +126,7 @@ export const supersedeTaskInboxMessage = async (
 
   const current = await tx.inboxMessage.findUnique({ where: { id: messageId }, select: { status: true } });
   if (current?.status === InboxStatus.CLOSED) return { closed: false, duplicate: true, requestId };
-  return { error: "Inbox message changed before it could be superseded", code: 409 };
+  return { reason: "conflict", message: "Inbox message changed before it could be superseded" };
 }, { isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted });
 
 /** Creates the durable outbox item and releases the Run lease in one commit. */

--- a/packages/api/src/refusal.test.ts
+++ b/packages/api/src/refusal.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  ArchivedAssigneeError,
+  ArchivedTaskError,
+  CompoundImplementationAssigneeError,
+  IntegratorStoppedError,
+  MergeConfirmationError,
+  MergeEvidenceError,
+  PinnedBaseCommitError,
+} from "@agentos/db";
+
+import {
+  type Refusal,
+  type RefusalReason,
+  refusalFor,
+  refusalResponse,
+} from "./refusal.js";
+
+const refusalByReason = {
+  "invalid-request": { reason: "invalid-request", message: "invalid" },
+  forbidden: { reason: "forbidden", message: "forbidden" },
+  "not-found": { reason: "not-found", message: "missing" },
+  conflict: { reason: "conflict", message: "conflict" },
+  "compound-implementation-assignee": { reason: "compound-implementation-assignee", message: "compound" },
+  "archived-assignee": { reason: "archived-assignee", message: "archived assignee" },
+  "archived-task": { reason: "archived-task", message: "archived task" },
+  "integrator-stopped": { reason: "integrator-stopped", message: "integrator stopped" },
+  "pinned-base-commit": { reason: "pinned-base-commit", message: "pinned base" },
+  "merge-evidence": { reason: "merge-evidence", message: "merge evidence" },
+  "merge-confirmation": { reason: "merge-confirmation", message: "merge confirmation" },
+  "inbox-question-not-found": { reason: "inbox-question-not-found", message: "missing question" },
+  "approval-gate-decision-invalid": { reason: "approval-gate-decision-invalid", message: "invalid decision" },
+  "inbox-choice-mismatch": { reason: "inbox-choice-mismatch", message: "choice mismatch" },
+  "inbox-run-not-waiting": { reason: "inbox-run-not-waiting", message: "run not waiting" },
+  "approval-gate-rejection-target-missing": {
+    reason: "approval-gate-rejection-target-missing",
+    message: "missing rejection target",
+  },
+} as const satisfies Record<RefusalReason, Refusal>;
+
+test("every refusal reason has one exhaustive HTTP status", () => {
+  const statuses = Object.fromEntries(
+    Object.entries(refusalByReason).map(([reason, refusal]) => [reason, refusalResponse(refusal).status]),
+  );
+  assert.deepEqual(statuses, {
+    "invalid-request": 400,
+    forbidden: 403,
+    "not-found": 404,
+    conflict: 409,
+    "compound-implementation-assignee": 409,
+    "archived-assignee": 409,
+    "archived-task": 409,
+    "integrator-stopped": 409,
+    "pinned-base-commit": 409,
+    "merge-evidence": 409,
+    "merge-confirmation": 409,
+    "inbox-question-not-found": 409,
+    "approval-gate-decision-invalid": 409,
+    "inbox-choice-mismatch": 409,
+    "inbox-run-not-waiting": 409,
+    "approval-gate-rejection-target-missing": 409,
+  });
+});
+
+test("all seven refusal error families map through the same module", () => {
+  const errors = [
+    [new CompoundImplementationAssigneeError(), "compound-implementation-assignee"],
+    [new ArchivedAssigneeError("task-1", "Task 1", "agent-1"), "archived-assignee"],
+    [new ArchivedTaskError("task-1", "Task 1"), "archived-task"],
+    [new IntegratorStoppedError("task-1", "target-unresolvable"), "integrator-stopped"],
+    [new PinnedBaseCommitError("task-1", 4, "missing output"), "pinned-base-commit"],
+    [new MergeEvidenceError("Merge evidence is incomplete"), "merge-evidence"],
+    [new MergeConfirmationError("Merge confirmation is incomplete"), "merge-confirmation"],
+  ] as const;
+
+  for (const [error, reason] of errors) {
+    const refusal = refusalFor(error);
+    assert.equal(refusal?.reason, reason);
+    assert.equal(refusal && refusalResponse(refusal).status, 409);
+  }
+});
+
+test("the five error families formerly missed by app.onError never reach its 500 fallback", () => {
+  const responseFor = (error: Error) => {
+    const refusal = refusalFor(error);
+    assert.ok(refusal);
+    return refusalResponse(refusal);
+  };
+
+  assert.equal(responseFor(new ArchivedTaskError("task-1", "Task 1")).status, 409);
+  assert.equal(responseFor(new IntegratorStoppedError("task-1", "target-unresolvable")).status, 409);
+  assert.equal(responseFor(new MergeConfirmationError("Merge confirmation is incomplete")).status, 409);
+  assert.equal(responseFor(new PinnedBaseCommitError("task-1", 4, "missing output")).status, 409);
+  assert.equal(responseFor(new MergeEvidenceError("Merge evidence is incomplete")).status, 409);
+});
+
+test("the five Inbox decision messages formerly matched by regex have concrete reasons", () => {
+  const cases = {
+    "No matching Inbox question": "inbox-question-not-found",
+    "Approval gate decision must be approve or reject": "approval-gate-decision-invalid",
+    "Decision must match an Inbox choice id": "inbox-choice-mismatch",
+    "No matching waiting Inbox question": "inbox-run-not-waiting",
+    "Approval gate has no executable previous task to reject to": "approval-gate-rejection-target-missing",
+  } as const;
+  for (const [message, reason] of Object.entries(cases)) {
+    const refusal = refusalFor(new Error(message));
+    assert.equal(refusal?.reason, reason);
+    assert.equal(refusal && refusalResponse(refusal).status, 409);
+  }
+  assert.equal(refusalFor(new Error("unclassified")), null);
+});
+
+test("refusal detail is preserved beside the public error message", () => {
+  assert.deepEqual(refusalResponse({
+    reason: "conflict",
+    message: "Run suspended for Inbox",
+    detail: { code: "WAITING_INBOX" },
+  }), {
+    body: { error: "Run suspended for Inbox", code: "WAITING_INBOX" },
+    status: 409,
+  });
+});

--- a/packages/api/src/refusal.ts
+++ b/packages/api/src/refusal.ts
@@ -1,0 +1,115 @@
+import {
+  isArchivedAssigneeError,
+  isArchivedTaskError,
+  isCompoundImplementationAssigneeError,
+  isIntegratorStoppedError,
+  isMergeConfirmationError,
+  isMergeEvidenceError,
+  isPinnedBaseCommitError,
+} from "@agentos/db";
+
+export type RefusalReason =
+  | "invalid-request"
+  | "forbidden"
+  | "not-found"
+  | "conflict"
+  | "compound-implementation-assignee"
+  | "archived-assignee"
+  | "archived-task"
+  | "integrator-stopped"
+  | "pinned-base-commit"
+  | "merge-evidence"
+  | "merge-confirmation"
+  | "inbox-question-not-found"
+  | "approval-gate-decision-invalid"
+  | "inbox-choice-mismatch"
+  | "inbox-run-not-waiting"
+  | "approval-gate-rejection-target-missing";
+
+export type RefusalValue =
+  | string
+  | number
+  | boolean
+  | null
+  | RefusalValue[]
+  | { [key: string]: RefusalValue };
+
+export type RefusalDetail = Readonly<Record<string, RefusalValue> & { error?: never }>;
+
+export type Refusal = {
+  reason: RefusalReason;
+  message: string;
+  detail?: RefusalDetail;
+};
+
+export type RefusalResponse = {
+  body: Readonly<{ error: string } & Record<string, RefusalValue>>;
+  status: 400 | 403 | 404 | 409;
+};
+
+const inboxReasonByMessage = {
+  "No matching Inbox question": "inbox-question-not-found",
+  "Approval gate decision must be approve or reject": "approval-gate-decision-invalid",
+  "Decision must match an Inbox choice id": "inbox-choice-mismatch",
+  "No matching waiting Inbox question": "inbox-run-not-waiting",
+  "Approval gate has no executable previous task to reject to": "approval-gate-rejection-target-missing",
+} as const satisfies Readonly<Record<string, RefusalReason>>;
+
+export const refusalResponse = (refusal: Refusal): RefusalResponse => {
+  let status: RefusalResponse["status"];
+  switch (refusal.reason) {
+    case "invalid-request":
+      status = 400;
+      break;
+    case "forbidden":
+      status = 403;
+      break;
+    case "not-found":
+      status = 404;
+      break;
+    case "conflict":
+    case "compound-implementation-assignee":
+    case "archived-assignee":
+    case "archived-task":
+    case "integrator-stopped":
+    case "pinned-base-commit":
+    case "merge-evidence":
+    case "merge-confirmation":
+    case "inbox-question-not-found":
+    case "approval-gate-decision-invalid":
+    case "inbox-choice-mismatch":
+    case "inbox-run-not-waiting":
+    case "approval-gate-rejection-target-missing":
+      status = 409;
+      break;
+    default: {
+      const unhandled: never = refusal.reason;
+      return unhandled;
+    }
+  }
+  return {
+    body: refusal.detail === undefined
+      ? { error: refusal.message }
+      : { error: refusal.message, ...refusal.detail },
+    status,
+  };
+};
+
+export const refusalFor = (error: unknown): Refusal | null => {
+  if (isCompoundImplementationAssigneeError(error)) {
+    return {
+      reason: "compound-implementation-assignee",
+      message: error.message,
+      detail: { code: error.code },
+    };
+  }
+  if (isArchivedAssigneeError(error)) return { reason: "archived-assignee", message: error.message };
+  if (isArchivedTaskError(error)) return { reason: "archived-task", message: error.message };
+  if (isIntegratorStoppedError(error)) return { reason: "integrator-stopped", message: error.message };
+  if (isPinnedBaseCommitError(error)) return { reason: "pinned-base-commit", message: error.message };
+  if (isMergeEvidenceError(error)) return { reason: "merge-evidence", message: error.message };
+  if (isMergeConfirmationError(error)) return { reason: "merge-confirmation", message: error.message };
+  if (!(error instanceof Error)) return null;
+  const reason = inboxReasonByMessage[error.message as keyof typeof inboxReasonByMessage];
+  return reason === undefined ? null : { reason, message: error.message };
+};

--- a/packages/api/src/run-completion.dbtest.ts
+++ b/packages/api/src/run-completion.dbtest.ts
@@ -75,8 +75,8 @@ test("the merge-executor principal on an ordinary run is refused before anything
     claimantClass: "merge-executor",
   });
   assert.deepEqual(refused, {
-    kind: "principal",
-    error: "The merge-executor principal may only act on mechanical runs",
+    reason: "forbidden",
+    message: "The merge-executor principal may only act on mechanical runs",
   });
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: run.id } })).status, RunStatus.RUNNING);
 });
@@ -93,7 +93,11 @@ test("a suspended run refuses as waiting-inbox, not as a stale fence", async () 
     body: completion("fence-from-a-previous-generation"),
     claimantClass: "runner",
   });
-  assert.deepEqual(refused, { kind: "waiting-inbox" });
+  assert.deepEqual(refused, {
+    reason: "conflict",
+    message: "Run suspended for Inbox",
+    detail: { code: "WAITING_INBOX" },
+  });
 });
 
 test("a superseded fencing token refuses as a fence, carrying the reason", async () => {
@@ -103,7 +107,11 @@ test("a superseded fencing token refuses as a fence, carrying the reason", async
     body: completion("fence-from-a-previous-generation"),
     claimantClass: "runner",
   });
-  assert.deepEqual(refused, { kind: "fence", reason: "stale-fence" });
+  assert.deepEqual(refused, {
+    reason: "conflict",
+    message: "Stale fencing token",
+    detail: { reason: "stale-fence" },
+  });
 });
 
 test("an accepted completion returns what it did rather than a response", async () => {

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -70,7 +70,8 @@ import {
   openMergeTailStopNotice,
   stopBaseDriftRecoveryTail,
 } from "./merge-tail-actions.js";
-import { explainFenceRefusal, fencedRunWhere, type FenceRefusal, type RunFence } from "./run-fence.js";
+import { explainFenceRefusal, fenceRefusalResponse, fencedRunWhere, type RunFence } from "./run-fence.js";
+import type { Refusal } from "./refusal.js";
 import { lockTask, lockTaskMutationRows } from "./task-write.js";
 
 /** Full Assurance regression and the documentation node a repair must reopen. */
@@ -222,10 +223,7 @@ export type RunCompletion = {
 
 /** Why a completion wrote nothing. Three distinct answers the route used to
  *  distinguish with an inline `null` plus a follow-up query of its own. */
-export type CompleteRunRefusal =
-  | { kind: "principal"; error: string }
-  | { kind: "waiting-inbox" }
-  | { kind: "fence"; reason: FenceRefusal };
+export type CompleteRunRefusal = Refusal;
 
 export type CompleteRunInput = {
   runId: string;
@@ -268,7 +266,7 @@ export const completeRun = async (
       claimantClass,
       completing.runnerId ?? body.runnerId,
     );
-    if (refusal) return { kind: "principal", error: refusal };
+    if (refusal) return { reason: "forbidden", message: refusal };
   }
   const result = await db.$transaction(async (tx) => {
     // Run owns fencing, cancellation, and terminalization. Take that mutex
@@ -1098,9 +1096,19 @@ export const completeRun = async (
   // "stale fence" would be re-deriving a distinction this action already made.
   if (!result) {
     const waiting = await db.run.findFirst({ where: { id: runId, status: RunStatus.WAITING_INBOX }, select: { id: true } });
-    return waiting
-      ? { kind: "waiting-inbox" }
-      : { kind: "fence", reason: await explainFenceRefusal(db, fence) };
+    if (waiting) {
+      return {
+        reason: "conflict",
+        message: "Run suspended for Inbox",
+        detail: { code: "WAITING_INBOX" },
+      };
+    }
+    const fenceRefusal = fenceRefusalResponse(await explainFenceRefusal(db, fence));
+    return {
+      reason: "conflict",
+      message: fenceRefusal.error,
+      detail: { reason: fenceRefusal.reason },
+    };
   }
   return result;
 };

--- a/packages/api/src/task-patch.dbtest.ts
+++ b/packages/api/src/task-patch.dbtest.ts
@@ -47,8 +47,8 @@ test("a dispatched chain task refuses an approval-gate patch", async () => {
   const { task } = await seed({ chainId: `chain-${process.pid}` });
   const result = await patchTask(db, task.id, { approvalGate: true });
   assert.deepEqual(result, {
-    error: "Approval gates on dispatched chain tasks are controlled by the chain",
-    code: 409,
+    reason: "conflict",
+    message: "Approval gates on dispatched chain tasks are controlled by the chain",
   });
 });
 
@@ -56,15 +56,15 @@ test("an assignee from another project is refused with 400", async () => {
   const { task } = await seed();
   const other = await seed();
   const result = await patchTask(db, task.id, { assigneeAgentId: other.agent.id });
-  assert.deepEqual(result, { error: "Assignee does not belong to this project", code: 400 });
+  assert.deepEqual(result, { reason: "invalid-request", message: "Assignee does not belong to this project" });
 });
 
 test("an archived task refuses a status write from inside the transaction", async () => {
   const { task } = await seed({ archivedAt: new Date() });
   const result = await patchTask(db, task.id, { status: TaskStatus.DONE });
   assert.deepEqual(result, {
-    error: "Cannot change the status of an archived task; unarchive it first",
-    code: 409,
+    reason: "conflict",
+    message: "Cannot change the status of an archived task; unarchive it first",
   });
 });
 

--- a/packages/api/src/task-patch.ts
+++ b/packages/api/src/task-patch.ts
@@ -16,6 +16,7 @@ import {
 
 import type { TaskPatchInput } from "./app.js";
 import { blockingPredecessor } from "./chain.js";
+import { type Refusal, refusalFor } from "./refusal.js";
 import { validateSchedule } from "./scheduler.js";
 import {
   hasActiveRun,
@@ -26,23 +27,14 @@ import {
 } from "./task-write.js";
 import { withoutUndefined } from "./without-undefined.js";
 
-/**
- * Why a patch was refused, in the terms the HTTP route needs and nothing more.
- * `code` is the status; `errorCode` is the machine-readable code the compound
- * implementation refusal has always carried in its body beside the message.
- */
-export type TaskPatchRefusal = {
-  error: string;
-  code: 400 | 404 | 409;
-  errorCode?: string;
-};
+export type TaskPatchRefusal = Refusal;
 
 export type TaskPatchResult = { task: Task } | TaskPatchRefusal;
 
 /** What the status write plans under the lock: a refusal this action owns, a
  *  replay of an already-decided gate, or the write itself. */
 type StatusWritePlan =
-  | { error: string; code: 409 }
+  | Refusal
   | { replay: true }
   | { gate: GateWinner; previousStatus: TaskStatus };
 
@@ -53,10 +45,10 @@ type GateWinner = {
 
 /** A refusal from `writeTask` in this action's terms: the task is gone, or the
  *  assignee the request named may not be written onto it. */
-const taskWriteRefusal = (refusal: TaskWriteRefusal): { error: string; code: 404 | 400 } => (
+const taskWriteRefusal = (refusal: TaskWriteRefusal): Refusal => (
   refusal.kind === "absent"
-    ? { error: "Task not found", code: 404 }
-    : { error: refusal.reason, code: 400 }
+    ? { reason: "not-found", message: "Task not found" }
+    : { reason: "invalid-request", message: refusal.reason }
 );
 
 /**
@@ -75,7 +67,7 @@ export const patchTask = async (
 ): Promise<TaskPatchResult> => {
   const before = await db.task.findUniqueOrThrow({ where: { id: taskId } });
   if (before.chainId !== null && body.approvalGate !== undefined && body.approvalGate !== before.approvalGate) {
-    return { error: "Approval gates on dispatched chain tasks are controlled by the chain", code: 409 };
+    return { reason: "conflict", message: "Approval gates on dispatched chain tasks are controlled by the chain" };
   }
   // Held for the whole route: whichever of the three write paths below runs
   // re-reads this assignee under the Agent-row mutex before it commits.
@@ -104,23 +96,25 @@ export const patchTask = async (
       templateStep,
     )) {
       const error = new CompoundImplementationAssigneeError();
-      return { error: error.message, errorCode: error.code, code: 409 };
+      const refusal = refusalFor(error);
+      if (!refusal) throw error;
+      return refusal;
     }
   }
   if (body.assigneeAgentId) {
-    if (!assignee) return { error: "Assignee does not belong to this project", code: 400 };
-    if (assignee.archivedAt) return { error: `Assignee ${assignee.name} is archived`, code: 400 };
+    if (!assignee) return { reason: "invalid-request", message: "Assignee does not belong to this project" };
+    if (assignee.archivedAt) return { reason: "invalid-request", message: `Assignee ${assignee.name} is archived` };
   }
   if (body.repoId) {
     const repo = await db.repo.findFirst({ where: { id: body.repoId, projectId: before.projectId } });
-    if (!repo) return { error: "Repo does not belong to this project", code: 400 };
+    if (!repo) return { reason: "invalid-request", message: "Repo does not belong to this project" };
   }
   const effectiveRepoId = body.repoId === undefined ? before.repoId : body.repoId;
   if (effectiveAgentId && effectiveRepoId) {
     const access = await db.agentRepoAccess.findFirst({
       where: { agentId: effectiveAgentId, repoId: effectiveRepoId, projectId: before.projectId },
     });
-    if (!access) return { error: "Assignee has no grant for this Repo", code: 400 };
+    if (!access) return { reason: "invalid-request", message: "Assignee has no grant for this Repo" };
   }
   // §D-P4 on reassignment. `templateStepId` is not a patchable field, so the
   // step half of the pair cannot move under this check; the assignee half is
@@ -132,7 +126,7 @@ export const patchTask = async (
       : null,
     templateStepId: before.templateStepId,
   });
-  if (reassignmentRefusal) return { error: reassignmentRefusal, code: 400 };
+  if (reassignmentRefusal) return { reason: "invalid-request", message: reassignmentRefusal };
   const scheduleTouched = body.scheduleKind !== undefined || body.runAt !== undefined || body.cron !== undefined || body.timezone !== undefined;
   const atExecutorTouched = before.scheduleKind === ScheduleKind.AT
     && (body.assigneeType !== undefined || body.assigneeAgentId !== undefined || body.repoId !== undefined);
@@ -149,7 +143,7 @@ export const patchTask = async (
         repoId: effectiveRepoId,
       });
     } catch (error: unknown) {
-      return { error: error instanceof Error ? error.message : "Invalid schedule", code: 400 };
+      return { reason: "invalid-request", message: error instanceof Error ? error.message : "Invalid schedule" };
     }
   }
   const updateData = {
@@ -182,7 +176,11 @@ export const patchTask = async (
   if (body.status !== undefined) {
     const written = await db.$transaction(async (tx) => {
       const result = await writeTask<StatusWritePlan>(tx, taskId, async (locked) => {
-        const refuse = (error: string) => ({ update: null, activity: null, value: { error, code: 409 as const } });
+        const refuse = (message: string) => ({
+          update: null,
+          activity: null,
+          value: { reason: "conflict" as const, message },
+        });
         if (locked.archivedAt !== null) {
           return refuse("Cannot change the status of an archived task; unarchive it first");
         }
@@ -302,7 +300,7 @@ export const patchTask = async (
       });
       if (!result.ok) return taskWriteRefusal(result.refusal);
       const plan = result.value;
-      if ("error" in plan) return plan;
+      if ("message" in plan) return plan;
       // The replay branch wrote nothing, so what the caller gets back is the
       // row the gate was already decided on.
       if ("replay" in plan) return { task: await tx.task.findUniqueOrThrow({ where: { id: taskId } }) };
@@ -345,7 +343,7 @@ export const patchTask = async (
       }
       return { task: updated };
     }, { isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted });
-    if ("error" in written) return written;
+    if ("message" in written) return written;
     return { task: written.task };
   }
   if (body.opensPullRequest !== undefined) {


### PR DESCRIPTION
## Summary

- add a deep `Refusal` module that owns exhaustive `RefusalReason` to HTTP mapping and all seven database refusal error families
- collapse the retry and Inbox catch lists, remove both prose regexes, and route the anonymous refusal epilogues through one response helper
- unify `TaskPatchRefusal`, `CompleteRunRefusal`, `SupersedeInboxMessageResult`, and cancellation settlement on `Refusal` without changing their public response bodies

## Final interface for W2-2

`packages/api/src/refusal.ts` exports:

```ts
export type Refusal = {
  reason: RefusalReason;
  message: string;
  detail?: RefusalDetail;
};

export const refusalResponse = (
  refusal: Refusal,
): { body: Readonly<{ error: string } & Record<string, RefusalValue>>; status: 400 | 403 | 404 | 409 };

export const refusalFor = (error: unknown): Refusal | null;
```

`RefusalReason` contains the generic `invalid-request`, `forbidden`, `not-found`, and `conflict` reasons; seven named database error-family reasons; and five named Inbox decision reasons. `RefusalDetail` is JSON data that cannot override `error`. W2-2 can return `Refusal` directly and let the route call `refusalResponse`.

## Conservative Inbox mappings

- `No matching Inbox question` -> `inbox-question-not-found` -> 409
- `Approval gate decision must be approve or reject` -> `approval-gate-decision-invalid` -> 409
- `Decision must match an Inbox choice id` -> `inbox-choice-mismatch` -> 409
- `No matching waiting Inbox question` -> `inbox-run-not-waiting` -> 409
- `Approval gate has no executable previous task to reject to` -> `approval-gate-rejection-target-missing` -> 409

Design choice: all seven thrown refusal families and the five legacy Inbox cases remain 409 because they describe state or decision conflicts; request-shape, principal, and absence refusals retain 400, 403, and 404 respectively.

## Verification

- `npm run lint`
- 93 targeted non-Postgres tests across `refusal.test.ts`, `app.test.ts`, `inbox.test.ts`, and `inbox-superseded-close.test.ts`
- `grep -c 'must match\|No matching' packages/api/src/app.ts` -> `0`
