### PR TITLE
fix(chains): preserve quiescent v1 rollovers

### DIFF
--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -182,7 +182,7 @@ test("canonical sync restores step, merge-resolver role, and foundational prompt
   assert.equal(persistedAgent.rolePrompt, expectedRole.rolePrompt);
 });
 
-test("canonical sync rolls the adjudication-era graphs only after their old tasks finish", async () => {
+test("canonical sync rolls quiescent adjudication-era graphs only after active Runs settle", async () => {
   assert.equal((await seed()).code, 0);
   const direct = await directTemplate();
   const compound = await db.taskTemplate.findUniqueOrThrow({
@@ -265,14 +265,25 @@ test("canonical sync rolls the adjudication-era graphs only after their old task
     } }));
   }
 
+  const activeRuns = await Promise.all(oldTasks.map(async (task) => {
+    const agent = await db.agent.findUniqueOrThrow({ where: { id: task.assigneeAgentId! } });
+    return db.run.create({ data: {
+      projectId: task.projectId,
+      taskId: task.id,
+      agentId: agent.id,
+      runNumber: 1,
+      dedupeKey: `adjudication-active:${task.id}`,
+      runner: "CODEX",
+      model: agent.model,
+      promptHash: "adjudication-active",
+    } });
+  }));
   const refused = await sync();
   assert.notEqual(refused.code, 0, refused.output);
-  assert.match(refused.output, /still has 1 active or unparked unfinished tasks/u);
+  assert.match(refused.output, /still has 1 tasks with active Runs or no chain identity/u);
   assert.equal((await db.taskTemplate.findUniqueOrThrow({ where: { id: compound.id } })).name, INTEGRATOR_TEMPLATE_NAME);
 
-  for (const task of oldTasks) {
-    await db.task.update({ where: { id: task.id }, data: { status: TaskStatus.DONE } });
-  }
+  await db.run.deleteMany({ where: { id: { in: activeRuns.map(({ id }) => id) } } });
   const synced = await sync();
   assert.equal(synced.code, 0, synced.output);
   assert.match(synced.output, /"createdCanonicalTemplates":2/u);
@@ -282,7 +293,7 @@ test("canonical sync rolls the adjudication-era graphs only after their old task
       where: { id: oldTemplate.id },
       include: { steps: { orderBy: { stepIndex: "asc" } } },
     });
-    // The old row keeps its step ids, so the finished tasks keep their contract.
+    // The old row keeps its step ids, so the quiescent tasks keep their contract.
     assert.equal(preserved.name, legacyAdjudicationTemplateName(oldTemplate.name, oldTemplate.id));
     assert.equal(preserved.steps.some((step) => step.outputKind === "must-fix"), true);
 

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -204,17 +204,15 @@ const main = async (): Promise<void> => {
         where: { templateId: existing.id, archivedAt: null, status: { not: TaskStatus.DONE } },
         select: {
           chainId: true,
-          status: true,
           _count: { select: { runs: { where: { status: { in: [...TEMPLATE_ROLLOVER_ACTIVE_RUN_STATUSES] } } } } },
         },
       });
       const blockers = templateRolloverBlockerCount(rolloverTasks.map((task) => ({
         chainId: task.chainId,
-        status: task.status,
         activeRunCount: task._count.runs,
       })));
       if (blockers > 0) {
-        throw new Error(`${INTEGRATOR_TEMPLATE_NAME} ${existing.id} still has ${blockers} active or unparked unfinished tasks; canonical rollover requires its active chains to finish or park first`);
+        throw new Error(`${INTEGRATOR_TEMPLATE_NAME} ${existing.id} still has ${blockers} tasks with active Runs or no chain identity; canonical rollover requires active Runs to settle first`);
       }
       if (existing.webhookSecretId !== null || existing.webhookRepoId !== null
         || existing.webhookPayloadMapping !== null || existing.webhookPausedAt !== null
@@ -311,17 +309,15 @@ const main = async (): Promise<void> => {
       where: { templateId: historicalDirect.id, archivedAt: null, status: { not: TaskStatus.DONE } },
       select: {
         chainId: true,
-        status: true,
         _count: { select: { runs: { where: { status: { in: [...TEMPLATE_ROLLOVER_ACTIVE_RUN_STATUSES] } } } } },
       },
     });
     const blockers = templateRolloverBlockerCount(rolloverTasks.map((task) => ({
       chainId: task.chainId,
-      status: task.status,
       activeRunCount: task._count.runs,
     })));
     if (blockers > 0) {
-      throw new Error(`${DIRECT_TEMPLATE_NAME} ${historicalDirect.id} still has ${blockers} active or unparked unfinished tasks; canonical rollover requires its active chains to finish or park first`);
+      throw new Error(`${DIRECT_TEMPLATE_NAME} ${historicalDirect.id} still has ${blockers} tasks with active Runs or no chain identity; canonical rollover requires active Runs to settle first`);
     }
     if (historicalDirect.webhookSecretId !== null || historicalDirect.webhookRepoId !== null
       || historicalDirect.webhookPayloadMapping !== null || historicalDirect.webhookPausedAt !== null

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -176,17 +176,15 @@ const transitionCanonicalTemplateRows = async (
         where: { templateId: row.id, archivedAt: null, status: { not: TaskStatus.DONE } },
         select: {
           chainId: true,
-          status: true,
           _count: { select: { runs: { where: { status: { in: [...TEMPLATE_ROLLOVER_ACTIVE_RUN_STATUSES] } } } } },
         },
       });
       const blockers = templateRolloverBlockerCount(rolloverTasks.map((task) => ({
         chainId: task.chainId,
-        status: task.status,
         activeRunCount: task._count.runs,
       })));
       if (blockers > 0) {
-        throw new Error(`${templateName} ${row.id} still has ${blockers} active or unparked unfinished tasks; canonical rollover requires its active chains to finish or park first`);
+        throw new Error(`${templateName} ${row.id} still has ${blockers} tasks with active Runs or no chain identity; canonical rollover requires active Runs to settle first`);
       }
       if (row.webhookSecretId !== null || row.webhookRepoId !== null
         || row.webhookPayloadMapping !== null || row.webhookPausedAt !== null

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -87,21 +87,22 @@ const ADJUDICATION_STEPS = {
   "compound-engineer-workflow": { stepIndex: 8, layer: 7, baseFromStepIndex: 5 },
 } as const;
 
-test("sync rolls the v1 Regression contract forward and preserves its template row", async () => {
+test("sync rolls parked and not-yet-started v1 chains forward without changing them", async () => {
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   const templates = await prisma.taskTemplate.findMany({
     where: { projectId: project.id, name: { in: ["direct-engineer-workflow", "compound-engineer-workflow"] } },
     include: { steps: { orderBy: { stepIndex: "asc" } } },
   });
   const oldPrompt = "Acquire before fetch and emit the v1 Regression contract.";
-  const parkedTaskIds: string[] = [];
+  const legacyTaskIds: string[] = [];
   for (const template of templates) {
     await prisma.taskTemplateStep.updateMany({
       where: { taskTemplateId: template.id, outputKind: "regression-verification-v2" },
       data: { outputKind: "regression-verification", prompt: oldPrompt },
     });
     const regressionIndex = template.steps.find(({ outputKind }) => outputKind === "regression-verification-v2")!.stepIndex;
-    const chainId = `parked-v1-${template.id}`;
+    const parked = template.name === "compound-engineer-workflow";
+    const chainId = `${parked ? "parked" : "not-started"}-v1-${template.id}`;
     for (const step of template.steps) {
       const task = await prisma.task.create({ data: {
         projectId: project.id,
@@ -111,7 +112,9 @@ test("sync rolls the v1 Regression contract forward and preserves its template r
         description: "parked v1 rollover compatibility fixture",
         assigneeAgentId: step.assigneeAgentId,
         assigneeType: step.assigneeType,
-        status: step.stepIndex < regressionIndex
+        status: !parked
+          ? TaskStatus.TODO
+          : step.stepIndex < regressionIndex
           ? TaskStatus.DONE
           : step.stepIndex === regressionIndex
             ? TaskStatus.BACKLOG
@@ -120,13 +123,13 @@ test("sync rolls the v1 Regression contract forward and preserves its template r
         chainIndex: step.stepIndex,
         chainLayer: step.layer,
       } });
-      parkedTaskIds.push(task.id);
+      legacyTaskIds.push(task.id);
     }
   }
 
-  const parkedBefore = await snapshotInstantiatedTasks(parkedTaskIds);
+  const legacyBefore = await snapshotInstantiatedTasks(legacyTaskIds);
   const activeTarget = await prisma.task.findFirstOrThrow({
-    where: { id: { in: parkedTaskIds }, status: TaskStatus.BACKLOG },
+    where: { id: { in: legacyTaskIds }, status: TaskStatus.BACKLOG },
     include: { assigneeAgent: { select: { model: true } } },
   });
   const activeRun = await prisma.run.create({ data: {
@@ -142,13 +145,13 @@ test("sync rolls the v1 Regression contract forward and preserves its template r
 
   const refusedWhileActive = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
   assert.notEqual(refusedWhileActive.status, 0, refusedWhileActive.output);
-  assert.match(refusedWhileActive.output, /active or unparked unfinished tasks/u);
+  assert.match(refusedWhileActive.output, /tasks with active Runs or no chain identity/u);
   await prisma.run.delete({ where: { id: activeRun.id } });
 
   const synced = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
   assert.equal(synced.status, 0, synced.output);
   assert.match(synced.output, /"createdCanonicalTemplates":2/u);
-  assert.equal(await snapshotInstantiatedTasks(parkedTaskIds), parkedBefore);
+  assert.equal(await snapshotInstantiatedTasks(legacyTaskIds), legacyBefore);
 
   for (const template of templates) {
     const legacyName = `${template.name}-legacy-pre-narrow-regression-lease-${template.id}`;
@@ -185,7 +188,7 @@ test("sync rolls the v1 Regression contract forward and preserves its template r
   const second = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
   assert.equal(second.status, 0, second.output);
   assert.match(second.output, /"createdCanonicalTemplates":0/u);
-  await prisma.task.deleteMany({ where: { id: { in: parkedTaskIds } } });
+  await prisma.task.deleteMany({ where: { id: { in: legacyTaskIds } } });
 });
 
 test("sync rolls the exact adjudication-era graphs forward without touching instantiated evidence", async () => {

--- a/packages/db/src/canonical-template-transition.test.ts
+++ b/packages/db/src/canonical-template-transition.test.ts
@@ -1,22 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { TaskStatus } from "@prisma/client";
-
 import { templateRolloverBlockerCount } from "./canonical-template-transition.js";
 
-test("a parked legacy chain may roll over with its dormant successors intact", () => {
+test("parked and not-yet-started legacy chains may roll over intact", () => {
   assert.equal(templateRolloverBlockerCount([
-    { chainId: "chain-1", status: TaskStatus.BACKLOG, activeRunCount: 0 },
-    { chainId: "chain-1", status: TaskStatus.TODO, activeRunCount: 0 },
-    { chainId: "chain-1", status: TaskStatus.TODO, activeRunCount: 0 },
+    { chainId: "parked", activeRunCount: 0 },
+    { chainId: "parked", activeRunCount: 0 },
+    { chainId: "not-started", activeRunCount: 0 },
   ]), 0);
 });
 
-test("active Runs and unfinished work without a parking point block rollover", () => {
+test("active Runs and unfinished work without a chain identity block rollover", () => {
   assert.equal(templateRolloverBlockerCount([
-    { chainId: "parked-active", status: TaskStatus.BACKLOG, activeRunCount: 1 },
-    { chainId: "unparked", status: TaskStatus.TODO, activeRunCount: 0 },
-    { chainId: null, status: TaskStatus.REVIEW, activeRunCount: 0 },
-  ]), 3);
+    { chainId: "active", activeRunCount: 1 },
+    { chainId: "quiescent", activeRunCount: 0 },
+    { chainId: null, activeRunCount: 0 },
+  ]), 2);
 });

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -1,4 +1,4 @@
-import { AssigneeType, Prisma, RunStatus, TaskStatus } from "@prisma/client";
+import { AssigneeType, Prisma, RunStatus } from "@prisma/client";
 
 type LegacyStepTuple = readonly [
   string,
@@ -129,29 +129,17 @@ export const TEMPLATE_ROLLOVER_ACTIVE_RUN_STATUSES = [
 ] as const;
 
 /**
- * A parked chain may move under a legacy template name without changing any
- * task or step identity. The BACKLOG row is its explicit stop and later TODO
- * rows are dormant. Active Runs, standalone unfinished work, and chains with
- * no parking point remain blockers.
+ * A quiescent chain may move under a legacy template name without changing any
+ * task or step identity. Its tasks keep the retired graph and runtime contract;
+ * only new chains bind the replacement graph. Active Runs and unfinished work
+ * that has no chain identity remain blockers.
  */
 export const templateRolloverBlockerCount = (
   tasks: readonly {
     chainId: string | null;
-    status: TaskStatus;
     activeRunCount: number;
   }[],
-): number => {
-  const parkedChainIds = new Set(
-    tasks
-      .filter((task) => task.status === TaskStatus.BACKLOG && task.chainId !== null)
-      .map((task) => task.chainId!),
-  );
-  return tasks.filter((task) => (
-    task.activeRunCount > 0
-    || (task.status !== TaskStatus.BACKLOG
-      && (task.chainId === null || !parkedChainIds.has(task.chainId)))
-  )).length;
-};
+): number => tasks.filter((task) => task.activeRunCount > 0 || task.chainId === null).length;
 
 /** The adjudication-era rename, kept for the rows and fixtures already carrying it. */
 export const legacyAdjudicationTemplateName = (templateName: string, templateId: string): string =>


### PR DESCRIPTION
## Summary

- allow canonical template rollover for quiescent legacy chains without changing their tasks or steps
- continue refusing rollover while a legacy task has an active Run or lacks a chain identity
- cover parked and never-started v1 chains plus active-Run refusal in DB tests

## Targeted verification

- DB and API typecheck
- Biome on changed files
- canonical-template-transition.test.ts (2/2)
- canonical-prompt-sync.dbtest.ts (9/9)
- merge-integrator-seed.dbtest.ts (21/21)
- public snapshot scan