### PR TITLE
feat(merge-tail): bind gate proof to regression head

### DIFF
--- a/agents/templates/compound-engineer-workflow/10-regression-verification.md
+++ b/agents/templates/compound-engineer-workflow/10-regression-verification.md
@@ -20,9 +20,9 @@ If Git reports a conflict, record both pre-refresh head SHAs,
 abort the merge so the workspace is deliverable, and finish with the
 `refresh-conflict` output below; do not resolve a hunk yourself.
 
-After a successful refresh, read both review reports, the fixed implementation
-with its dispositions, and the documentation result from AgentOS step outputs.
-Review the full final diff as one unit, account for every finding id either
+After a successful refresh, read both review reports and all preceding Step
+outputs from AgentOS, including the fixed implementation and its dispositions.
+Review the full refreshed diff as one unit, account for every finding id either
 report raised, and rerun relevant regressions. If an adopted finding remains
 open, a rejection is unsupported, or the fix introduces a defect, do not run the
 full gate; emit the `review-fail` output below.
@@ -55,12 +55,16 @@ If dispatch exits 75 or 76 without a verdict, retry dispatch in place up to two
 more times. If all three attempts return a non-verdict exit, or dispatch returns
 any other non-verdict exit, report it through the activity log and fail the run
 loudly.
+Read the dispatch output itself and copy its complete `MERGE GATE: PASS <oid>`
+or `MERGE GATE: FAIL (...)` line unchanged into `gateProof`; do not infer that
+line from the exit code or synthesize it from the command arguments. For PASS,
+the printed oid must be the same 40-hex commit recorded as `headSha`.
 Persist exactly one JSON object as the AgentOS task output and do not write a
 report file:
 
-- PASS: `{"schemaVersion":2,"outcome":"pass","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"PASS"}`
+- PASS: `{"schemaVersion":2,"outcome":"pass","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"PASS","gateProof":"MERGE GATE: PASS <same 40 hex as headSha>"}`
 - semantic FAIL: `{"schemaVersion":2,"outcome":"review-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","summary":"<unresolved finding IDs or newly discovered defect>"}`
-- gate FAIL: `{"schemaVersion":2,"outcome":"gate-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"FAIL","summary":"<named failing stage>"}`
+- gate FAIL: `{"schemaVersion":2,"outcome":"gate-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"FAIL","gateProof":"MERGE GATE: FAIL (<named failing stage>)","summary":"<named failing stage>"}`
 - refresh conflict: `{"schemaVersion":2,"outcome":"refresh-conflict","headSha":"<chain head before refresh>","baseHeadSha":"<target head>","summary":"<conflicted paths>"}`
 - release authority re-signature required: `{"schemaVersion":2,"outcome":"authority-resign","headSha":"<40 hex>","baseHeadSha":"<40 hex>","summary":"<the RESIGN release-authority lines>"}`
 

--- a/agents/templates/direct-engineer-workflow/05-regression-verification.md
+++ b/agents/templates/direct-engineer-workflow/05-regression-verification.md
@@ -20,12 +20,12 @@ If Git reports a conflict, record both pre-refresh head SHAs,
 abort the merge so the workspace is deliverable, and finish with the
 `refresh-conflict` output below; do not resolve a hunk yourself.
 
-After a successful refresh, read both review reports and the fixed
-implementation with its dispositions from AgentOS step outputs. Review the full
-fix diff as one unit, account for every finding id either report raised, and
-rerun relevant regressions. If an adopted finding remains open, a rejection is
-unsupported, or the fix introduces a defect, do not run the full gate; emit the
-`review-fail` output below.
+After a successful refresh, read both review reports and all preceding Step
+outputs from AgentOS, including the fixed implementation and its dispositions.
+Review the full refreshed diff as one unit, account for every finding id either
+report raised, and rerun relevant regressions. If an adopted finding remains
+open, a rejection is unsupported, or the fix introduces a defect, do not run the
+full gate; emit the `review-fail` output below.
 
 Before the gate, run `npm run db:authority-check -w @agentos/db` once. Exit 0
 means the tracked `release-authority.json` still covers this tree. Exit 1 means
@@ -55,12 +55,16 @@ If dispatch exits 75 or 76 without a verdict, retry dispatch in place up to two
 more times. If all three attempts return a non-verdict exit, or dispatch returns
 any other non-verdict exit, report it through the activity log and fail the run
 loudly.
+Read the dispatch output itself and copy its complete `MERGE GATE: PASS <oid>`
+or `MERGE GATE: FAIL (...)` line unchanged into `gateProof`; do not infer that
+line from the exit code or synthesize it from the command arguments. For PASS,
+the printed oid must be the same 40-hex commit recorded as `headSha`.
 Persist exactly one JSON object as the AgentOS task output and do not write a
 report file:
 
-- PASS: `{"schemaVersion":2,"outcome":"pass","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"PASS"}`
+- PASS: `{"schemaVersion":2,"outcome":"pass","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"PASS","gateProof":"MERGE GATE: PASS <same 40 hex as headSha>"}`
 - semantic FAIL: `{"schemaVersion":2,"outcome":"review-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","summary":"<unresolved finding IDs or newly discovered defect>"}`
-- gate FAIL: `{"schemaVersion":2,"outcome":"gate-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"FAIL","summary":"<named failing stage>"}`
+- gate FAIL: `{"schemaVersion":2,"outcome":"gate-fail","headSha":"<40 hex>","baseHeadSha":"<40 hex>","gateVerdict":"FAIL","gateProof":"MERGE GATE: FAIL (<named failing stage>)","summary":"<named failing stage>"}`
 - refresh conflict: `{"schemaVersion":2,"outcome":"refresh-conflict","headSha":"<chain head before refresh>","baseHeadSha":"<target head>","summary":"<conflicted paths>"}`
 - release authority re-signature required: `{"schemaVersion":2,"outcome":"authority-resign","headSha":"<40 hex>","baseHeadSha":"<40 hex>","summary":"<the RESIGN release-authority lines>"}`
 

--- a/packages/api/src/canonical-task-output.test.ts
+++ b/packages/api/src/canonical-task-output.test.ts
@@ -47,10 +47,18 @@ test("Regression v2 is canonical while the rolled v1 contract remains readable",
     5,
     "regression-verification",
   );
-  const output = (kind: string, schemaVersion: number) => ({
+  const output = (kind: string, schemaVersion: number, bodyOverrides: Record<string, unknown> = {}) => ({
     runId: "run-1",
     kind,
-    body: JSON.stringify({ schemaVersion, outcome: "pass", headSha, baseHeadSha, gateVerdict: "PASS" }),
+    body: JSON.stringify({
+      schemaVersion,
+      outcome: "pass",
+      headSha,
+      baseHeadSha,
+      gateVerdict: "PASS",
+      ...(schemaVersion === 2 ? { gateProof: `MERGE GATE: PASS ${headSha}` } : {}),
+      ...bodyOverrides,
+    }),
     commitSha: headSha,
     metadata: null,
   });
@@ -60,6 +68,18 @@ test("Regression v2 is canonical while the rolled v1 contract remains readable",
   assert.match(
     canonicalOutputRefusal(current, output("regression-verification-v2", 1), "run-1", headSha) ?? "",
     /schemaVersion 2/u,
+  );
+  assert.match(
+    canonicalOutputRefusal(current, output("regression-verification-v2", 2, {
+      gateProof: `MERGE GATE: PASS ${baseHeadSha}`,
+    }), "run-1", headSha) ?? "",
+    /gate proof oid must match headSha/u,
+  );
+  assert.match(
+    canonicalOutputRefusal(current, output("regression-verification-v2", 2, {
+      gateProof: undefined,
+    }), "run-1", headSha) ?? "",
+    /gateProof/u,
   );
   assert.equal(isCanonicalAgentStep(legacy), true);
   assert.equal(requiredOutputKind(legacy), "regression-verification");

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -167,6 +167,8 @@ const metadataPhase = (metadata: Prisma.JsonValue | Prisma.InputJsonValue | unde
 
 const commitSha = z.string().regex(/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u);
 const nonEmptyString = z.string().trim().min(1);
+const passGateProof = z.string().regex(/^MERGE GATE: PASS [0-9a-f]{40}$/u);
+const failGateProof = z.string().regex(/^MERGE GATE: FAIL \(.+\)$/u);
 const stringList = z.array(nonEmptyString);
 const canonicalEnvelope = z.object({ schemaVersion: z.literal(1), headSha: commitSha });
 const reviewFinding = z.object({
@@ -459,6 +461,7 @@ const canonicalOutputSchemas: Record<string, z.ZodType> = {
       outcome: z.literal("pass"),
       baseHeadSha: commitSha,
       gateVerdict: z.literal("PASS"),
+      gateProof: passGateProof,
     }),
     canonicalEnvelope.extend({
       schemaVersion: z.literal(REGRESSION_VERIFICATION_SCHEMA_VERSION),
@@ -471,6 +474,7 @@ const canonicalOutputSchemas: Record<string, z.ZodType> = {
       outcome: z.literal("gate-fail"),
       baseHeadSha: commitSha,
       gateVerdict: z.literal("FAIL"),
+      gateProof: failGateProof,
       summary: nonEmptyString,
     }),
     canonicalEnvelope.extend({
@@ -485,7 +489,15 @@ const canonicalOutputSchemas: Record<string, z.ZodType> = {
       baseHeadSha: commitSha,
       summary: nonEmptyString,
     }),
-  ]),
+  ]).superRefine((verdict, context) => {
+    if (verdict.outcome === "pass" && verdict.gateProof !== `MERGE GATE: PASS ${verdict.headSha}`) {
+      context.addIssue({
+        code: "custom",
+        path: ["gateProof"],
+        message: "gate proof oid must match headSha",
+      });
+    }
+  }),
   documentation: canonicalEnvelope.extend({
     summary: nonEmptyString,
     changes: z.array(z.object({ path: nonEmptyString, action: z.enum(["ADDED", "UPDATED", "DELETED"]) })),

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -233,7 +233,11 @@ test("the canonical twelve-step layered template sources split review and preser
   assert.ok(compoundRegression.indexOf("semantic verification passes") < compoundRegression.indexOf("merge-lease.sh acquire"));
   assert.match(compoundRegression, /never call `scripts\/merge-lease\.sh release` or\s+`scripts\/merge-lease\.sh steal`/u);
   assert.match(compoundRegression, /fetch `origin\/<run\.pullRequestBase>` again/u);
-  assert.match(compoundRegression, /documentation result/u);
+  assert.match(compoundRegression, /all preceding Step\s+outputs/u);
+  assert.match(compoundRegression, /"gateProof":"MERGE GATE: PASS <same 40 hex as headSha>"/u);
+  const directRegression = (await loadTemplateStepSources(DIRECT_TEMPLATE_NAME))
+    .find((step) => step.stepIndex === 5)!.prompt;
+  assert.equal(compoundRegression, directRegression);
   assert.equal(templateSteps.every((step) => step.prompt.length > 0), true);
   assert.equal(templateSteps.every((step) => step.spawnPolicy === null), true);
   assert.match(templateSteps[1]!.prompt, /load-bearing decisions in `decisions\.md`/u);

--- a/packages/db/src/merge-tail.test.ts
+++ b/packages/db/src/merge-tail.test.ts
@@ -55,12 +55,55 @@ test("regression verdicts are exact-head, versioned, and fail closed", () => {
 });
 
 test("the narrowed Regression contract requires v2 while legacy output remains readable", () => {
-  const v2 = JSON.stringify({ schemaVersion: 2, outcome: "pass", headSha: A, baseHeadSha: B, gateVerdict: "PASS" });
+  const v2 = JSON.stringify({
+    schemaVersion: 2,
+    outcome: "pass",
+    headSha: A,
+    baseHeadSha: B,
+    gateVerdict: "PASS",
+    gateProof: `MERGE GATE: PASS ${A}`,
+  });
   const v1 = JSON.stringify({ schemaVersion: 1, outcome: "pass", headSha: A, baseHeadSha: B, gateVerdict: "PASS" });
   assert.equal(parseRegressionVerdict(v2, "regression-verification-v2").status, "ok");
+  assert.equal(parseRegressionVerdict(JSON.stringify({
+    schemaVersion: 2,
+    outcome: "pass",
+    headSha: A,
+    baseHeadSha: B,
+    gateVerdict: "PASS",
+    gateProof: `MERGE GATE: PASS ${B}`,
+  }), "regression-verification-v2").status, "invalid");
+  assert.equal(parseRegressionVerdict(JSON.stringify({
+    schemaVersion: 2,
+    outcome: "pass",
+    headSha: A,
+    baseHeadSha: B,
+    gateVerdict: "PASS",
+  }), "regression-verification-v2").status, "invalid");
   assert.equal(parseRegressionVerdict(v1, "regression-verification").status, "ok");
   assert.equal(parseRegressionVerdict(v1, "regression-verification-v2").status, "invalid");
   assert.equal(parseRegressionVerdict(v2, "regression-verification").status, "invalid");
+});
+
+test("Regression v2 gate failures carry the complete Merge gate verdict", () => {
+  const verdict = {
+    schemaVersion: 2,
+    outcome: "gate-fail",
+    headSha: A,
+    baseHeadSha: B,
+    gateVerdict: "FAIL",
+    gateProof: "MERGE GATE: FAIL (unit tests)",
+    summary: "unit tests",
+  };
+  assert.equal(parseRegressionVerdict(JSON.stringify(verdict), "regression-verification-v2").status, "ok");
+  assert.equal(parseRegressionVerdict(JSON.stringify({
+    schemaVersion: 2,
+    outcome: "gate-fail",
+    headSha: A,
+    baseHeadSha: B,
+    gateVerdict: "FAIL",
+    summary: "unit tests",
+  }), "regression-verification-v2").status, "invalid");
 });
 
 test("both canonical readiness steps are mechanical server-owned shapes", () => {

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -121,13 +121,17 @@ export const mergeRecoveryPhase = (status: MergeRecoveryStatus): MergeRecoveryPh
 );
 
 const SHA = /^[0-9a-f]{40}$/u;
+const PASS_GATE_PROOF = /^MERGE GATE: PASS ([0-9a-f]{40})$/u;
+const FAIL_GATE_PROOF = /^MERGE GATE: FAIL \(.+\)$/u;
 
 type RegressionVerdictSchemaVersion = typeof MERGE_TAIL_SCHEMA_VERSION | typeof REGRESSION_VERIFICATION_SCHEMA_VERSION;
 
 export type RegressionVerdict =
-  | { schemaVersion: RegressionVerdictSchemaVersion; outcome: "pass"; headSha: string; baseHeadSha: string; gateVerdict: "PASS" }
+  | { schemaVersion: typeof MERGE_TAIL_SCHEMA_VERSION; outcome: "pass"; headSha: string; baseHeadSha: string; gateVerdict: "PASS" }
+  | { schemaVersion: typeof REGRESSION_VERIFICATION_SCHEMA_VERSION; outcome: "pass"; headSha: string; baseHeadSha: string; gateVerdict: "PASS"; gateProof: string }
   | { schemaVersion: RegressionVerdictSchemaVersion; outcome: "review-fail"; headSha: string; baseHeadSha: string; summary: string }
-  | { schemaVersion: RegressionVerdictSchemaVersion; outcome: "gate-fail"; headSha: string; baseHeadSha: string; gateVerdict: "FAIL"; summary: string }
+  | { schemaVersion: typeof MERGE_TAIL_SCHEMA_VERSION; outcome: "gate-fail"; headSha: string; baseHeadSha: string; gateVerdict: "FAIL"; summary: string }
+  | { schemaVersion: typeof REGRESSION_VERIFICATION_SCHEMA_VERSION; outcome: "gate-fail"; headSha: string; baseHeadSha: string; gateVerdict: "FAIL"; gateProof: string; summary: string }
   | { schemaVersion: RegressionVerdictSchemaVersion; outcome: "refresh-conflict"; headSha: string; baseHeadSha: string; summary: string }
   /**
    * The tree moved attested release-path files without re-signing
@@ -202,12 +206,23 @@ export const parseRegressionVerdict = (
   if (typeof value.headSha !== "string" || !SHA.test(value.headSha)) return { status: "invalid", reason: "invalid regression headSha" };
   if (typeof value.baseHeadSha !== "string" || !SHA.test(value.baseHeadSha)) return { status: "invalid", reason: "invalid regression baseHeadSha" };
   if (value.outcome === "pass" && value.gateVerdict === "PASS") {
+    if (value.schemaVersion === REGRESSION_VERIFICATION_SCHEMA_VERSION) {
+      const proof = typeof value.gateProof === "string" ? PASS_GATE_PROOF.exec(value.gateProof) : null;
+      if (!proof) return { status: "invalid", reason: "invalid regression gateProof for PASS" };
+      if (proof[1] !== value.headSha) {
+        return { status: "invalid", reason: "regression gateProof oid does not match headSha" };
+      }
+    }
     return { status: "ok", verdict: value as RegressionVerdict };
   }
   if (value.outcome === "review-fail" && typeof value.summary === "string" && value.summary.trim().length > 0) {
     return { status: "ok", verdict: value as RegressionVerdict };
   }
   if (value.outcome === "gate-fail" && value.gateVerdict === "FAIL" && typeof value.summary === "string" && value.summary.length > 0) {
+    if (value.schemaVersion === REGRESSION_VERIFICATION_SCHEMA_VERSION
+      && (typeof value.gateProof !== "string" || !FAIL_GATE_PROOF.test(value.gateProof))) {
+      return { status: "invalid", reason: "invalid regression gateProof for FAIL" };
+    }
     return { status: "ok", verdict: value as RegressionVerdict };
   }
   if (value.outcome === "refresh-conflict" && typeof value.summary === "string" && value.summary.length > 0) {


### PR DESCRIPTION
## Summary

- require v2 Regression PASS and gate-fail outputs to carry the complete Merge gate verdict line
- reject PASS proofs whose printed oid differs from headSha
- preserve the frozen v1 output contract unchanged
- keep Direct and Full Assurance Regression prompt bodies byte-identical

Design: gate-fail validates the complete canonical FAIL line but does not compare an oid because that line contains no oid; both prompts use shared all-preceding-Step wording so the Direct chain does not name a documentation step it lacks.

## Verification

- targeted merge-tail tests: 18/18 pass
- targeted canonical-task-output tests: 7/7 pass
- npm run lint
- npm run test:snapshot-scan
- npm run typecheck -w @agentos/db
- npm run typecheck -w @agentos/api
- no migration added