### PR TITLE
refactor(api): deepen merge lease lifecycle

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -91,8 +91,7 @@ import { LOOPBACK_BROWSER_ORIGINS, originMayReachHandlers } from "./local-origin
 import {
   mergeTailLeaseChainId,
   releaseMergeLease,
-  releaseMergeLeaseSafely,
-  type MergeLeaseReleaser,
+  type ReleaseMergeLease,
 } from "./merge-lease.js";
 import { createRunnerRegistry } from "./runners.js";
 import {
@@ -165,7 +164,7 @@ type AppEnvironment = { Variables: { principal: Principal } };
 export interface LiveAppOptions {
   ownership: { assertHeld(): void | Promise<void> };
   onboardingRepositoryPreflight?: typeof preflightOnboardingRepository;
-  releaseMergeLease?: MergeLeaseReleaser;
+  releaseMergeLease?: ReleaseMergeLease;
 }
 
 
@@ -3502,7 +3501,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     }));
     if ("error" in result) return context.json({ error: result.error }, result.code);
     const { releaseMergeLeaseTask, ...settlement } = result;
-    await releaseMergeLeaseSafely(releaseChainLease, releaseMergeLeaseTask);
+    await releaseChainLease(releaseMergeLeaseTask);
     return context.json(settlement);
   });
 
@@ -4003,7 +4002,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         ? context.json({ error: "Run suspended for Inbox", code: "WAITING_INBOX" }, 409)
         : context.json(fenceRefusalResponse(result.reason), 409);
     }
-    await releaseMergeLeaseSafely(releaseChainLease, result.releaseMergeLeaseTask);
+    await releaseChainLease(result.releaseMergeLeaseTask);
     await options.ownership.assertHeld();
     // Nothing is deleted here, or anywhere else in this process. The runner
     // removed its own workspace before it called /complete and reported the
@@ -4200,7 +4199,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     });
     if ("error" in result) return context.json({ error: result.error }, result.code);
     const { releaseMergeLeaseTask, ...cancellation } = result;
-    await releaseMergeLeaseSafely(releaseChainLease, releaseMergeLeaseTask);
+    await releaseChainLease(releaseMergeLeaseTask);
     return context.json(cancellation);
   });
 

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -22,6 +22,13 @@ import {
 import { handleRegressionCompletion } from "./merge-tail-actions.js";
 import { baseDriftRecoveryTick } from "./merge-base-drift-worker.js";
 import { seedIntegratorChain } from "./merge-integrator-fixture.js";
+import {
+  withMergeLease,
+  type MergeLeaseAcquirer,
+  type MergeLeaseReleaser,
+  type ReleaseMergeLease,
+  type WithMergeLease,
+} from "./merge-lease.js";
 import { readinessTick } from "./merge-readiness-worker.js";
 import { reconcileDatabaseRuns } from "./reconcile.js";
 import type { GitHubReader, PullRequestSnapshot } from "./github-read.js";
@@ -34,6 +41,13 @@ const BASE_2 = "c".repeat(40);
 const BASE_3 = "d".repeat(40);
 const BASE_4 = "e".repeat(40);
 const OPERATOR = "base-drift-recovery-operator";
+const acquireChainLease: MergeLeaseAcquirer = async () => ({ outcome: "acquired" });
+const releaseLeaseAdapter: MergeLeaseReleaser = async () => ({ outcome: "not-held" });
+const releaseChainLease: ReleaseMergeLease = async () => {};
+const runWithMergeLease: WithMergeLease = (chainId, fn) => withMergeLease(chainId, fn, {
+  acquire: acquireChainLease,
+  release: releaseLeaseAdapter,
+});
 
 let db: PrismaClient;
 before(() => { db = setupTestDb(); });
@@ -171,7 +185,7 @@ const finishRecoveryPass = async (
   baseSha: string,
 ) => {
   await recordRecoveryPass(seeded, baseSha);
-  const tick = await readinessTick(db, reader(snapshot(baseSha)));
+  const tick = await readinessTick(db, reader(snapshot(baseSha)), new Date(), 5, releaseChainLease, runWithMergeLease);
   assert.equal(tick.authorized, 1);
   return db.taskActivity.findFirstOrThrow({
     where: { taskId: seeded.readinessTask!.id, metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.authorization } },
@@ -256,7 +270,7 @@ test("recovery holds the full chain mutex before mutation and a concurrent chain
   const writerDb = new PrismaClient({ datasources: { db: { url: process.env.TEST_DATABASE_URL! } } });
   const priorToken = process.env.OPERATOR_TOKEN;
   try {
-    const recovery = readinessTick(recoveryDb, reader(snapshot(BASE_2)));
+    const recovery = readinessTick(recoveryDb, reader(snapshot(BASE_2)), new Date(), 5, releaseChainLease, runWithMergeLease);
     await recoveryHasChain;
     process.env.OPERATOR_TOKEN = OPERATOR;
     const writer = createApp(writerDb).request(`/tasks/${seeded.integratorTask!.id}`, {
@@ -285,7 +299,7 @@ test("recovery freshness requeue preserves the run binding through fresh authori
 
   const firstRecoveryRun = await recordRecoveryPass(seeded, BASE_2);
 
-  assert.equal((await readinessTick(db, reader(snapshot(BASE_3)))).requeued, 1);
+  assert.equal((await readinessTick(db, reader(snapshot(BASE_3)), new Date(), 5, releaseChainLease, runWithMergeLease)).requeued, 1);
   const secondRecoveryRun = await db.run.findFirstOrThrow({
     where: { taskId: seeded.gateTask.id },
     orderBy: { runNumber: "desc" },
@@ -660,7 +674,7 @@ test("a recovery-cycle readiness failure restores the integrator stop guard", as
   });
   await db.task.update({ where: { id: seeded.gateTask.id }, data: { status: TaskStatus.DONE } });
 
-  const readiness = await readinessTick(db, reader(snapshot(BASE_2), [], false));
+  const readiness = await readinessTick(db, reader(snapshot(BASE_2), [], false), new Date(), 5, releaseChainLease, runWithMergeLease);
   assert.equal(readiness.stopped, 1);
   assert.equal(await db.taskActivity.count({ where: {
     taskId: seeded.integratorTask!.id,
@@ -693,7 +707,7 @@ test("a recovery-cycle independent-review rejection stops once without a review-
   } });
   const readiness = await readinessTick(db, reader(snapshot(BASE_2), [{
     filename: "packages/api/src/app.ts", previousFilename: null, patch: "@@ -1 +1 @@\n-old\n+new",
-  }]));
+  }]), new Date(), 5, releaseChainLease, runWithMergeLease);
   assert.equal(readiness.reviewing, 1);
   const reviewTask = await db.task.findFirstOrThrow({ where: { name: "Autonomous merge tail: independent review" } });
   const reviewRun = await db.run.findFirstOrThrow({ where: { taskId: reviewTask.id } });

--- a/packages/api/src/merge-lease-cancel-release.dbtest.ts
+++ b/packages/api/src/merge-lease-cancel-release.dbtest.ts
@@ -20,7 +20,7 @@ import { after, before, beforeEach, test } from "node:test";
 
 import { DIRECT_TEMPLATE_NAME, MERGE_TAIL_KIND, PrismaClient, RunStatus, TaskStatus } from "@agentos/db";
 
-import type { MergeLeaseReleaser } from "./merge-lease.js";
+import type { ReleaseMergeLease } from "./merge-lease.js";
 import { reconcileDatabaseRuns } from "./reconcile.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
@@ -48,8 +48,7 @@ const call = async (method: string, path: string, token: string, body?: unknown)
   try {
     const response = await createApp(db, {
       releaseMergeLease: async (chainId) => {
-      releasedChainLeases.push(chainId);
-      return { outcome: "released", ref: "refs/merge-lease/holder", sha: "lease-fixture" };
+      if (chainId) releasedChainLeases.push(chainId);
     },
     }).request(path, {
       method,
@@ -64,9 +63,9 @@ const call = async (method: string, path: string, token: string, body?: unknown)
   }
 };
 
-const collectRelease: MergeLeaseReleaser = async (chainId) => {
+const collectRelease: ReleaseMergeLease = async (chainId) => {
+  if (!chainId) return;
   releasedChainLeases.push(chainId);
-  return { outcome: "released", ref: "refs/merge-lease/holder", sha: "lease-fixture" };
 };
 
 let sequence = 0;

--- a/packages/api/src/merge-lease.test.ts
+++ b/packages/api/src/merge-lease.test.ts
@@ -2,71 +2,128 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  releaseMergeLeaseSafely,
-  reportMergeLeaseAnomaly,
+  withMergeLease,
+  type MergeLeaseAcquirer,
   type MergeLeaseRelease,
   type MergeLeaseReleaser,
 } from "./merge-lease.js";
 
-const errorsFrom = (t: test.TestContext, body: () => void): string[] => {
-  const said: string[] = [];
-  t.mock.method(console, "error", (...args: unknown[]) => { said.push(args.map(String).join(" ")); });
-  body();
-  return said;
+const acquired: MergeLeaseAcquirer = async () => ({ outcome: "acquired" });
+const released: MergeLeaseRelease = {
+  outcome: "released",
+  ref: "refs/merge-lease/holder",
+  sha: "abc",
 };
 
-const releaserSaying = (release: MergeLeaseRelease): MergeLeaseReleaser => async () => release;
-
-test("a release that freed the lease is not reported as an anomaly", (t) => {
-  const said = errorsFrom(t, () => {
-    reportMergeLeaseAnomaly("chain-1", { outcome: "released", ref: "refs/merge-lease/holder", sha: "abc" });
-    reportMergeLeaseAnomaly("chain-1", { outcome: "not-held" });
+test("a completed callback releases the merge Lease", async () => {
+  const acquiredFor: string[] = [];
+  const releasedFor: string[] = [];
+  const result = await withMergeLease("chain-1", async () => ({
+    disposition: "release",
+    value: 42,
+  }), {
+    acquire: async (chainId) => {
+      acquiredFor.push(chainId);
+      return { outcome: "acquired" };
+    },
+    release: async (chainId) => {
+      releasedFor.push(chainId);
+      return released;
+    },
   });
-  assert.deepEqual(said, []);
+
+  assert.deepEqual(result, { outcome: "ran", value: 42 });
+  assert.deepEqual(acquiredFor, ["chain-1"]);
+  assert.deepEqual(releasedFor, ["chain-1"]);
 });
 
-// The defect: the script exits 0, the lease is still standing for somebody
-// else's task, and the merge tail used to carry on as though it had freed it.
-test("a skipped release is reported as an anomaly naming the task the lease is held for", async (t) => {
-  const release = await releaseMergeLeaseSafely(
-    releaserSaying({ outcome: "skipped", heldFor: "chain-42" }),
-    "chain-43",
+test("retain hands the merge Lease to the downstream consumer", async () => {
+  let releaseCalled = false;
+  const result = await withMergeLease("chain-2", async () => ({
+    disposition: "retain",
+    value: "authorized",
+  }), {
+    acquire: acquired,
+    release: async () => {
+      releaseCalled = true;
+      return released;
+    },
+  });
+
+  assert.deepEqual(result, { outcome: "ran", value: "authorized" });
+  assert.equal(releaseCalled, false);
+});
+
+test("a callback exception still releases the merge Lease", async () => {
+  const releasedFor: string[] = [];
+  await assert.rejects(
+    withMergeLease("chain-3", async () => {
+      throw new Error("authorization failed");
+    }, {
+      acquire: acquired,
+      release: async (chainId) => {
+        releasedFor.push(chainId);
+        return released;
+      },
+    }),
+    /authorization failed/u,
   );
-  assert.deepEqual(release, { outcome: "skipped", heldFor: "chain-42" });
-  const said = errorsFrom(t, () => { reportMergeLeaseAnomaly("chain-43", release); });
+  assert.deepEqual(releasedFor, ["chain-3"]);
+});
+
+test("a contended merge Lease does not run the callback", async () => {
+  let callbackCalled = false;
+  let releaseCalled = false;
+  const result = await withMergeLease("chain-4", async () => {
+    callbackCalled = true;
+    return { disposition: "release", value: null };
+  }, {
+    acquire: async () => ({ outcome: "contended" }),
+    release: async () => {
+      releaseCalled = true;
+      return released;
+    },
+  });
+
+  assert.deepEqual(result, { outcome: "contended" });
+  assert.equal(callbackCalled, false);
+  assert.equal(releaseCalled, false);
+});
+
+test("the module reports a release anomaly itself", async (t) => {
+  const said: string[] = [];
+  t.mock.method(console, "error", (...args: unknown[]) => { said.push(args.map(String).join(" ")); });
+
+  await withMergeLease("chain-5", async () => ({ disposition: "release", value: null }), {
+    acquire: acquired,
+    release: async () => ({ outcome: "skipped", heldFor: "chain-42" }),
+  });
+
   assert.equal(said.length, 1);
-  assert.match(said[0]!, /chain-43/u);
+  assert.match(said[0]!, /chain-5/u);
   assert.match(said[0]!, /chain-42/u);
 });
 
-test("a refused release is reported as an anomaly naming the holder", (t) => {
-  const said = errorsFrom(t, () => {
-    reportMergeLeaseAnomaly("chain-43", { outcome: "refused", heldBy: "other@host" });
-  });
-  assert.equal(said.length, 1);
-  assert.match(said[0]!, /other@host/u);
-});
-
-test("a release that never reached the script becomes unreachable rather than silence", async (t) => {
+test("a rejected release adapter is reported as unreachable", async (t) => {
   const said: string[] = [];
   t.mock.method(console, "error", (...args: unknown[]) => { said.push(args.map(String).join(" ")); });
-  const release = await releaseMergeLeaseSafely(
-    () => Promise.reject(new Error("spawn bash ENOENT")),
-    "chain-44",
-  );
-  assert.deepEqual(release, { outcome: "unreachable", detail: "spawn bash ENOENT" });
-  reportMergeLeaseAnomaly("chain-44", release);
-  // The catch still logs, as it always did; what is new is that the caller is
-  // told, rather than the log being the only record.
-  assert.equal(said.length, 2);
-  assert.match(said[1]!, /spawn bash ENOENT/u);
+  const releaser: MergeLeaseReleaser = async () => { throw new Error("spawn bash ENOENT"); };
+
+  await withMergeLease("chain-6", async () => ({ disposition: "release", value: null }), {
+    acquire: acquired,
+    release: releaser,
+  });
+
+  assert.equal(said.length, 1);
+  assert.match(said[0]!, /chain-6/u);
+  assert.match(said[0]!, /spawn bash ENOENT/u);
 });
 
-test("no chain is no release and no anomaly", async (t) => {
-  const release = await releaseMergeLeaseSafely(
-    () => { throw new Error("the releaser must not be called"); },
-    null,
-  );
-  assert.equal(release, null);
-  assert.deepEqual(errorsFrom(t, () => { reportMergeLeaseAnomaly(null, release); }), []);
+test("a Task without a Chain runs without either Lease adapter", async () => {
+  const result = await withMergeLease(null, async () => ({ disposition: "release", value: "unleased" }), {
+    acquire: async () => { throw new Error("the acquirer must not be called"); },
+    release: async () => { throw new Error("the releaser must not be called"); },
+  });
+
+  assert.deepEqual(result, { outcome: "ran", value: "unleased" });
 });

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -53,7 +53,7 @@ const readOutcome = (output: string): MergeLeaseRelease | null => {
   }
 };
 
-export const releaseMergeLease: MergeLeaseReleaser = async (chainId) => {
+const releaseMergeLeaseAdapter: MergeLeaseReleaser = async (chainId) => {
   try {
     const { stdout, stderr } = await execFileAsync("bash", [mergeLeaseScript, "release", "--task", chainId], {
       timeout: 90_000,
@@ -75,29 +75,35 @@ export const releaseMergeLease: MergeLeaseReleaser = async (chainId) => {
   }
 };
 
-export const releaseMergeLeaseSafely = async (
+const releaseMergeLeaseWith = async (
   releaser: MergeLeaseReleaser,
   chainId: string | null,
-): Promise<MergeLeaseRelease | null> => {
-  if (!chainId) return null;
+): Promise<void> => {
+  if (!chainId) return;
+  let release: MergeLeaseRelease;
   try {
-    return await releaser(chainId);
+    release = await releaser(chainId);
   } catch (error: unknown) {
-    console.error(`Merge lease release failed for chain ${chainId}`, error);
-    return { outcome: "unreachable", detail: error instanceof Error ? error.message : String(error) };
+    release = { outcome: "unreachable", detail: error instanceof Error ? error.message : String(error) };
   }
+  reportMergeLeaseAnomaly(chainId, release);
+};
+
+export type ReleaseMergeLease = (chainId: string | null) => Promise<void>;
+
+export const releaseMergeLease: ReleaseMergeLease = async (chainId) => {
+  await releaseMergeLeaseWith(releaseMergeLeaseAdapter, chainId);
 };
 
 /**
  * Say out loud that a release did not free the lock it was asked to free.
  * `released` and `not-held` are the ordinary answers. The other three are
- * anomalies on the lock that serialises the merge window on main -- the lease is
+ * anomalies on the Lease that serialises the merge window on main -- the Lease is
  * still standing, or nobody knows whether it is -- and they arrive on a path
- * that otherwise reports nothing at all. This reports and returns: what the
- * merge tail should do about a stuck lease is not decided here.
+ * that otherwise reports nothing at all. The caller has no reporting
+ * obligation: every release adapter result is consumed inside this module.
  */
-export const reportMergeLeaseAnomaly = (chainId: string | null, release: MergeLeaseRelease | null): void => {
-  if (!chainId || !release) return;
+const reportMergeLeaseAnomaly = (chainId: string, release: MergeLeaseRelease): void => {
   switch (release.outcome) {
     case "released":
     case "not-held":
@@ -186,7 +192,7 @@ const CONTENDED_EXIT = 75;
  * string matches the one the chain's own regression run writes, so an operator
  * reading `merge-lease.sh status` sees the same lease either way.
  */
-export const acquireMergeLease: MergeLeaseAcquirer = async (chainId) => {
+const acquireMergeLease: MergeLeaseAcquirer = async (chainId) => {
   try {
     const { stdout, stderr } = await execFileAsync("bash", [
       mergeLeaseScript,
@@ -207,5 +213,55 @@ export const acquireMergeLease: MergeLeaseAcquirer = async (chainId) => {
     const detail = `${failure.stdout ?? ""}${failure.stderr ?? ""}`.trim();
     console.error(`Merge lease acquire failed for chain ${chainId}${detail ? `: ${detail}` : ""}`);
     return { outcome: "unreachable", detail: detail || String(error) };
+  }
+};
+
+export type LeaseDisposition = "release" | "retain";
+
+export type MergeLeaseDependencies = {
+  acquire: MergeLeaseAcquirer;
+  release: MergeLeaseReleaser;
+};
+
+export type WithMergeLease = <T>(
+  chainId: string | null,
+  fn: () => Promise<{ disposition: LeaseDisposition; value: T }>,
+) => Promise<{ outcome: "contended" } | { outcome: "ran"; value: T }>;
+
+/**
+ * Run one authorization attempt under the Chain's merge Lease. A successful
+ * authorization explicitly hands the Lease to mechanical merge with `retain`;
+ * every other completed or exceptional callback path gives it back here.
+ * A Task without a Chain has no Lease to acquire or release, but still runs the
+ * callback through the same interface.
+ */
+export const withMergeLease = async <T>(
+  chainId: string | null,
+  fn: () => Promise<{ disposition: LeaseDisposition; value: T }>,
+  dependencies: MergeLeaseDependencies = {
+    acquire: acquireMergeLease,
+    release: releaseMergeLeaseAdapter,
+  },
+): Promise<{ outcome: "contended" } | { outcome: "ran"; value: T }> => {
+  if (chainId === null) {
+    const result = await fn();
+    return { outcome: "ran", value: result.value };
+  }
+
+  const acquisition = await dependencies.acquire(chainId);
+  if (acquisition.outcome === "contended") return { outcome: "contended" };
+  if (acquisition.outcome === "unreachable") {
+    throw new Error(`merge lease acquire is unreachable: ${acquisition.detail}`);
+  }
+
+  let disposition: LeaseDisposition = "release";
+  try {
+    const result = await fn();
+    disposition = result.disposition;
+    return { outcome: "ran", value: result.value };
+  } finally {
+    if (disposition === "release") {
+      await releaseMergeLeaseWith(dependencies.release, chainId);
+    }
   }
 };

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -47,12 +47,10 @@ import {
   type ReadinessInput,
 } from "./readiness-decision.js";
 import {
-  acquireMergeLease,
   releaseMergeLease,
-  releaseMergeLeaseSafely,
-  reportMergeLeaseAnomaly,
-  type MergeLeaseAcquirer,
-  type MergeLeaseReleaser,
+  withMergeLease,
+  type ReleaseMergeLease,
+  type WithMergeLease,
 } from "./merge-lease.js";
 
 export const readinessPollIntervalMs = (): number => {
@@ -156,7 +154,7 @@ const stopReadiness = async (
     recovery: RecoveryContext | null;
     claimReason: string;
   },
-  releaseChainLease: MergeLeaseReleaser,
+  releaseChainLease: ReleaseMergeLease,
 ): Promise<boolean> => {
   const recoveryBody = input.recovery
     ? `Automatic base-drift recovery ${input.recovery.attempt} stopped at readiness: ${input.reason}`
@@ -217,10 +215,7 @@ const stopReadiness = async (
     return { applied: true as const, chainId: readiness?.chainId ?? null };
   });
   if (!transition.applied) return false;
-  reportMergeLeaseAnomaly(
-    transition.chainId,
-    await releaseMergeLeaseSafely(releaseChainLease, transition.chainId),
-  );
+  await releaseChainLease(transition.chainId);
   return true;
 };
 
@@ -342,19 +337,14 @@ export type ReadinessTickResult = { claimed: number; authorized: number; reviewi
  * neither produces nor consumes the exact-head gate proof -- it reads a diff on
  * GitHub -- so holding the lease across it charges an agent session, and
  * however many runner losses and retries that session takes, to every other
- * delivery line's queue. `not-held` and `skipped` are ordinary answers here:
- * this path has to leave the lock free, not prove it was the one holding it.
- * Only "nobody knows" is worth saying out loud.
+ * delivery line's queue. The merge Lease module owns reporting when the
+ * adapter cannot carry out that handback.
  */
 const releaseForReview = async (
-  releaseChainLease: MergeLeaseReleaser,
+  releaseChainLease: ReleaseMergeLease,
   chainId: string | null,
 ): Promise<void> => {
-  const release = await releaseMergeLeaseSafely(releaseChainLease, chainId);
-  if (release?.outcome !== "unreachable") return;
-  console.error(
-    `Merge lease anomaly: the release for chain ${chainId ?? "unknown"} before its independent review could not be carried out: ${release.detail}. The merge window on main may stay locked for the length of that review.`,
-  );
+  await releaseChainLease(chainId);
 };
 
 const requeueRegression = async (
@@ -640,8 +630,8 @@ const applyReadinessDecision = async (
   read: ClaimedReadiness,
   decision: ReadinessDecision,
   result: ReadinessTickResult,
-  releaseChainLease: MergeLeaseReleaser,
-  acquireChainLease: MergeLeaseAcquirer,
+  releaseChainLease: ReleaseMergeLease,
+  runWithMergeLease: WithMergeLease,
 ): Promise<void> => {
   const { readiness, regression, recovery } = read;
   let claimReason = read.claimReason;
@@ -669,7 +659,10 @@ const applyReadinessDecision = async (
       recovery,
       claimReason,
     });
-    if (requeued) result.requeued += 1;
+    if (requeued) {
+      result.requeued += 1;
+      await releaseChainLease(readiness.chainId);
+    }
     return requeued;
   };
 
@@ -738,121 +731,130 @@ const applyReadinessDecision = async (
       break;
   }
 
-  // Renew immediately before the only network call outside the GitHub read
-  // budget. The original claim covered the reads; this one covers the acquire
-  // and authorization transaction.
-  const renewedClaim = await renewReadinessClaim(db, readiness.id, claimReason);
-  if (!renewedClaim) return;
-  claimReason = renewedClaim;
-  read.claimReason = renewedClaim;
-
   // From the base this authorization pins to the merge that consumes it,
-  // `main` must not move. Earlier reads and Blind review can be repeated.
-  if (readiness.chainId) {
-    const acquisition = await acquireChainLease(readiness.chainId);
-    if (acquisition.outcome === "contended") return;
-    if (acquisition.outcome === "unreachable") {
-      await stop(`merge lease acquire is unreachable: ${acquisition.detail}`);
-      return;
-    }
-  }
-  const authorization = await db.$transaction(async (tx) => {
-    await lockTaskMutationRows(tx, readiness.id);
-    const held = await tx.task.updateMany({
-      where: { id: readiness.id, status: TaskStatus.DOING, failureReason: claimReason },
-      data: { status: TaskStatus.DONE, failureReason: null },
-    });
-    if (held.count !== 1) {
-      const current = await tx.task.findUnique({
+  // `main` must not move. The callback makes the sole lawful handoff explicit:
+  // only an authorized mechanical merge retains the Lease.
+  const leased = await runWithMergeLease(readiness.chainId, async () => {
+    // The acquire is the only network call outside the GitHub read budget. A
+    // stale worker that lost its claim while taking the Lease must classify the
+    // new owner before choosing release or retain.
+    const renewedClaim = await renewReadinessClaim(db, readiness.id, claimReason);
+    if (!renewedClaim) {
+      const current = await db.task.findUnique({
         where: { id: readiness.id },
         select: { status: true, failureReason: true },
       });
       const activeSuccessor = current?.status === TaskStatus.DONE
         || (current?.status === TaskStatus.DOING
           && current.failureReason?.startsWith(READINESS_CLAIM_PREFIX));
-      return activeSuccessor ? "claim-lost-active" as const : "claim-lost-inactive" as const;
+      return {
+        disposition: activeSuccessor ? "retain" as const : "release" as const,
+        value: activeSuccessor ? "claim-lost-active" as const : "claim-lost-inactive" as const,
+      };
     }
-    const binding = `mechanical:${readiness.id}:${randomUUID()}`;
-    const payload = {
-      ...decision.evidence,
-      mergeMethod: AUTHORIZED_MERGE_METHOD,
-      issuedAt: decision.issuedAt,
-      decision: {
-        channel: "mechanical" as const,
-        inboxDecisionId: binding,
-        inboxMessageId: binding,
-      },
-    };
-    const activity = await tx.taskActivity.create({ data: {
-      taskId: readiness.id,
-      actorType: "control-plane",
-      body: `Mechanical merge authorized for PR #${decision.prNumber} at ${decision.evidence.headSha}`,
-      metadata: {
-        ...authorizationMetadata(payload),
-        recoverySourceStopId: recovery?.sourceStopId ?? null,
-      } as Prisma.InputJsonObject,
-    } });
-    await tx.taskStepOutput.upsert({
-      where: { taskId: readiness.id },
-      create: {
+    claimReason = renewedClaim;
+    read.claimReason = renewedClaim;
+
+    const authorization = await db.$transaction(async (tx) => {
+      await lockTaskMutationRows(tx, readiness.id);
+      const held = await tx.task.updateMany({
+        where: { id: readiness.id, status: TaskStatus.DOING, failureReason: claimReason },
+        data: { status: TaskStatus.DONE, failureReason: null },
+      });
+      if (held.count !== 1) {
+        const current = await tx.task.findUnique({
+          where: { id: readiness.id },
+          select: { status: true, failureReason: true },
+        });
+        const activeSuccessor = current?.status === TaskStatus.DONE
+          || (current?.status === TaskStatus.DOING
+            && current.failureReason?.startsWith(READINESS_CLAIM_PREFIX));
+        return activeSuccessor ? "claim-lost-active" as const : "claim-lost-inactive" as const;
+      }
+      const binding = `mechanical:${readiness.id}:${randomUUID()}`;
+      const payload = {
+        ...decision.evidence,
+        mergeMethod: AUTHORIZED_MERGE_METHOD,
+        issuedAt: decision.issuedAt,
+        decision: {
+          channel: "mechanical" as const,
+          inboxDecisionId: binding,
+          inboxMessageId: binding,
+        },
+      };
+      const activity = await tx.taskActivity.create({ data: {
         taskId: readiness.id,
-        kind: "merge-authorization",
-        body: JSON.stringify({
-          authorizationActivityId: activity.id,
+        actorType: "control-plane",
+        body: `Mechanical merge authorized for PR #${decision.prNumber} at ${decision.evidence.headSha}`,
+        metadata: {
+          ...authorizationMetadata(payload),
+          recoverySourceStopId: recovery?.sourceStopId ?? null,
+        } as Prisma.InputJsonObject,
+      } });
+      await tx.taskStepOutput.upsert({
+        where: { taskId: readiness.id },
+        create: {
+          taskId: readiness.id,
+          kind: "merge-authorization",
+          body: JSON.stringify({
+            authorizationActivityId: activity.id,
+            headSha: decision.evidence.headSha,
+          }),
+          commitSha: decision.evidence.headSha,
+        },
+        update: {
+          kind: "merge-authorization",
+          body: JSON.stringify({
+            authorizationActivityId: activity.id,
+            headSha: decision.evidence.headSha,
+          }),
+          commitSha: decision.evidence.headSha,
+        },
+      });
+      await tx.task.update({ where: { id: regression.id }, data: { failureReason: null } });
+      await writeMarker(tx, readiness.id, "readiness", {
+        actorType: "control-plane",
+        body: `Merge readiness authorized exact head ${decision.evidence.headSha}; merge execution queued`,
+        metadata: {
+          state: "authorized",
           headSha: decision.evidence.headSha,
-        }),
-        commitSha: decision.evidence.headSha,
-      },
-      update: {
-        kind: "merge-authorization",
-        body: JSON.stringify({
           authorizationActivityId: activity.id,
-          headSha: decision.evidence.headSha,
-        }),
-        commitSha: decision.evidence.headSha,
-      },
+          recoverySourceStopId: recovery?.sourceStopId ?? null,
+        },
+      });
+      if (recovery) {
+        await activateRecoveryIntegratorSuccessor(tx, {
+          readinessTaskId: readiness.id,
+          integratorTaskId: recovery.integratorTaskId,
+          sourceStopId: recovery.sourceStopId,
+          recoveryRunId: recovery.recoveryRunId,
+          authorizationActivityId: activity.id,
+        }, read.input.now);
+      } else {
+        await activateChainSuccessor(tx, readiness, {}, read.input.now);
+      }
+      return "authorized" as const;
     });
-    await tx.task.update({ where: { id: regression.id }, data: { failureReason: null } });
-    await writeMarker(tx, readiness.id, "readiness", {
-      actorType: "control-plane",
-      body: `Merge readiness authorized exact head ${decision.evidence.headSha}; merge execution queued`,
-      metadata: {
-        state: "authorized",
-        headSha: decision.evidence.headSha,
-        authorizationActivityId: activity.id,
-        recoverySourceStopId: recovery?.sourceStopId ?? null,
-      },
-    });
-    if (recovery) {
-      await activateRecoveryIntegratorSuccessor(tx, {
-        readinessTaskId: readiness.id,
-        integratorTaskId: recovery.integratorTaskId,
-        sourceStopId: recovery.sourceStopId,
-        recoveryRunId: recovery.recoveryRunId,
-        authorizationActivityId: activity.id,
-      }, read.input.now);
-    } else {
-      await activateChainSuccessor(tx, readiness, {}, read.input.now);
-    }
-    return "authorized" as const;
+    return {
+      disposition: authorization === "authorized" || authorization === "claim-lost-active"
+        ? "retain" as const
+        : "release" as const,
+      value: authorization,
+    };
   });
-  if (authorization === "authorized") {
+  if (leased.outcome === "contended") return;
+  if (leased.value === "authorized") {
     result.authorized += 1;
-  } else if (authorization === "claim-lost-inactive") {
-    reportMergeLeaseAnomaly(
-      readiness.chainId,
-      await releaseMergeLeaseSafely(releaseChainLease, readiness.chainId),
-    );
   }
 };
 
 export const readinessTick = async (
   db: PrismaClient,
-  reader: GitHubReader | null = createGitHubReader(),
-  now = new Date(),
-  limit = 5,
-  releaseChainLease: MergeLeaseReleaser = async () => ({ outcome: "not-held" }),
-  acquireChainLease: MergeLeaseAcquirer = async () => ({ outcome: "acquired" }),
+  reader: GitHubReader | null,
+  now: Date,
+  limit: number,
+  releaseChainLease: ReleaseMergeLease,
+  runWithMergeLease: WithMergeLease,
 ): Promise<ReadinessTickResult> => {
   const result: ReadinessTickResult = { claimed: 0, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 };
   const pageSize = Math.max(limit * 20, 100);
@@ -871,7 +873,7 @@ export const readinessTick = async (
         decision,
         result,
         releaseChainLease,
-        acquireChainLease,
+        runWithMergeLease,
       );
     } catch (error: unknown) {
       const reason = `readiness evaluation failed: ${error instanceof Error ? error.message : String(error)}`;
@@ -896,7 +898,7 @@ export const startReadinessWorker = (
   const timer = setInterval(() => {
     if (inFlight) return;
     inFlight = true;
-    void readinessTick(db, reader, new Date(), 5, releaseMergeLease, acquireMergeLease)
+    void readinessTick(db, reader, new Date(), 5, releaseMergeLease, withMergeLease)
       .catch((error: unknown) => console.error("Merge readiness tick failed", error))
       .finally(() => {
         inFlight = false;

--- a/packages/api/src/merge-stop-state.dbtest.ts
+++ b/packages/api/src/merge-stop-state.dbtest.ts
@@ -65,8 +65,7 @@ const call = async (method: string, path: string, body?: unknown, token = OPERAT
   try {
     const response = await createApp(db, {
       releaseMergeLease: async (chainId) => {
-      releasedChainLeases.push(chainId);
-      return { outcome: "released", ref: "refs/merge-lease/holder", sha: "lease-fixture" };
+      if (chainId) releasedChainLeases.push(chainId);
     },
     }).request(path, {
       method,

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -10,7 +10,13 @@ import {
 } from "@agentos/db";
 
 import type { GitHubReader, PullRequestSnapshot } from "./github-read.js";
-import type { MergeLeaseAcquirer, MergeLeaseReleaser } from "./merge-lease.js";
+import {
+  withMergeLease,
+  type MergeLeaseAcquirer,
+  type MergeLeaseReleaser,
+  type ReleaseMergeLease,
+  type WithMergeLease,
+} from "./merge-lease.js";
 import { READINESS_CLAIM_LEASE_MS, readinessTick } from "./merge-readiness-worker.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
@@ -18,10 +24,19 @@ import { resetTestDb, setupTestDb } from "./testdb.js";
 let db: PrismaClient;
 before(() => { db = setupTestDb(); });
 const releasedChainLeases: string[] = [];
-const releaseChainLease: MergeLeaseReleaser = async (chainId) => {
+const releaseLeaseAdapter: MergeLeaseReleaser = async (chainId) => {
   releasedChainLeases.push(chainId);
   return { outcome: "released", ref: "refs/merge-lease/holder", sha: "lease-fixture" };
 };
+const releaseChainLease: ReleaseMergeLease = async (chainId) => {
+  if (chainId) releasedChainLeases.push(chainId);
+};
+const acquireChainLease: MergeLeaseAcquirer = async () => ({ outcome: "acquired" });
+const leaseRunner = (acquire: MergeLeaseAcquirer): WithMergeLease => (
+  chainId,
+  fn,
+) => withMergeLease(chainId, fn, { acquire, release: releaseLeaseAdapter });
+const runWithMergeLease = leaseRunner(acquireChainLease);
 beforeEach(async () => {
   releasedChainLeases.length = 0;
   await resetTestDb(db);
@@ -161,7 +176,7 @@ test("clean exact-head readiness authorizes and queues mechanical merge", async 
     where: { id: seeded.regression.id },
     data: { failureReason: "readiness evaluation failed: GitHub read failed: fetch failed" },
   });
-  assert.deepEqual(await readinessTick(db, reader()), { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 });
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.DONE);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } })).failureReason, null);
   const output = await db.taskStepOutput.findUniqueOrThrow({ where: { taskId: seeded.readiness.id } });
@@ -172,7 +187,7 @@ test("clean exact-head readiness authorizes and queues mechanical merge", async 
 test("a defense-list diff opens one blind review and blocks authorization until exact-head approval", async () => {
   const seeded = await seedReadiness();
   const guarded = reader([{ filename: "scripts/merge-gate.sh", previousFilename: null, patch: "@@ -1 +1 @@\n-old\n+new" }]);
-  assert.deepEqual(await readinessTick(db, guarded), { claimed: 1, authorized: 0, reviewing: 1, requeued: 0, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, guarded, new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 0, reviewing: 1, requeued: 0, stopped: 0 });
   assert.equal(await db.taskStepOutput.count({ where: { taskId: seeded.readiness.id } }), 0);
   const review = await db.task.findFirstOrThrow({ where: { projectId: seeded.project.id, name: "Autonomous merge tail: independent review" } });
   const reviewRun = await db.run.findFirstOrThrow({ where: { taskId: review.id } });
@@ -184,7 +199,7 @@ test("a defense-list diff opens one blind review and blocks authorization until 
     metadata: { kind: "mergeTail.reviewObligation", schemaVersion: 1, state: "approved", reviewTaskId: review.id, headSha: HEAD, baseSha: BASE },
   } });
   await db.task.update({ where: { id: seeded.readiness.id }, data: { status: TaskStatus.TODO, failureReason: null } });
-  assert.deepEqual(await readinessTick(db, guarded), { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, guarded, new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 });
 });
 
 test("a conflict resolution that edits existing test lines opens the same review obligation", async () => {
@@ -205,7 +220,7 @@ test("a conflict resolution that edits existing test lines opens the same review
       ? []
       : [{ filename: "packages/api/src/example.test.ts", previousFilename: null, patch: "@@ -1 +1 @@\n-old\n+new" }] }),
   };
-  assert.deepEqual(await readinessTick(db, testEditReader), { claimed: 1, authorized: 0, reviewing: 1, requeued: 0, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, testEditReader, new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 0, reviewing: 1, requeued: 0, stopped: 0 });
   const obligation = await db.taskActivity.findFirstOrThrow({ where: { taskId: seeded.readiness.id, body: { startsWith: "Independent review obligation opened" } } });
   assert.match(JSON.stringify(obligation.metadata), /existing-test-lines-modified/u);
 });
@@ -213,7 +228,7 @@ test("a conflict resolution that edits existing test lines opens the same review
 test("base drift invalidates a head-bound PASS and returns the chain to regression", async () => {
   const seeded = await seedReadiness();
   const driftedBase = "d".repeat(40);
-  assert.deepEqual(await readinessTick(db, reader([], snapshot({ baseSha: driftedBase })), new Date(), 5, releaseChainLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 1, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, reader([], snapshot({ baseSha: driftedBase })), new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 1, stopped: 0 });
   const [readiness, regression] = await Promise.all([
     db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } }),
     db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } }),
@@ -228,7 +243,7 @@ test("base drift invalidates a head-bound PASS and returns the chain to regressi
   assert.equal(compensated.runNumber, 2);
   assert.equal(compensated.maxRunsPerTask, 6);
   assert.equal(compensated.budgetGrants, 1);
-  assert.deepEqual(releasedChainLeases, [], "base drift requeue keeps the chain lease");
+  assert.deepEqual(releasedChainLeases, [seeded.readiness.chainId], "base drift requeue releases before the next v2 Regression run");
 });
 
 test("ordinary base requeue reuses an approved exact-head review", async () => {
@@ -243,7 +258,7 @@ test("ordinary base requeue reuses an approved exact-head review", async () => {
       reviewTaskId: "prior-review", headSha: HEAD, baseSha: BASE,
     },
   } });
-  assert.equal((await readinessTick(db, reader([], snapshot({ baseSha: driftedBase })))).requeued, 1);
+  assert.equal((await readinessTick(db, reader([], snapshot({ baseSha: driftedBase })), new Date(), 5, releaseChainLease, runWithMergeLease)).requeued, 1);
   const freshRun = await db.run.findFirstOrThrow({
     where: { taskId: seeded.regression.id }, orderBy: { runNumber: "desc" },
   });
@@ -260,7 +275,7 @@ test("ordinary base requeue reuses an approved exact-head review", async () => {
     [{ filename: "scripts/merge-gate.sh", previousFilename: null, patch: "@@ -1 +1 @@\n-old\n+new" }],
     snapshot({ baseSha: driftedBase }),
   );
-  assert.deepEqual(await readinessTick(db, guarded), {
+  assert.deepEqual(await readinessTick(db, guarded, new Date(), 5, releaseChainLease, runWithMergeLease), {
     claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0,
   });
   assert.equal(await db.task.count({ where: { name: "Autonomous merge tail: independent review" } }), 0);
@@ -269,12 +284,12 @@ test("ordinary base requeue reuses an approved exact-head review", async () => {
 test("future and wrong-index readiness steps are never claimed", async () => {
   const future = await seedReadiness();
   await db.task.update({ where: { id: future.regression.id }, data: { status: TaskStatus.TODO } });
-  assert.deepEqual(await readinessTick(db, reader()), { claimed: 0, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 0, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 });
   assert.equal(await db.inboxMessage.count(), 0);
 
   await db.task.update({ where: { id: future.regression.id }, data: { status: TaskStatus.DONE } });
   await db.taskTemplateStep.update({ where: { id: future.readiness.templateStepId! }, data: { stepIndex: 9 } });
-  assert.deepEqual(await readinessTick(db, reader()), { claimed: 0, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 0, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 });
 });
 
 test("an expired orphaned DOING readiness claim is reclaimed after restart", async () => {
@@ -283,7 +298,7 @@ test("an expired orphaned DOING readiness claim is reclaimed after restart", asy
     status: TaskStatus.DOING,
     failureReason: "merge-readiness-claim:dead-worker|2000-01-01T00:00:00.000Z",
   } });
-  assert.deepEqual(await readinessTick(db, reader()), { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 });
 });
 
 test("an incomplete compare response and a behind head fail closed", async () => {
@@ -295,7 +310,7 @@ test("an incomplete compare response and a behind head fail closed", async () =>
     readPullRequest: async () => snapshot(),
     compareCommits: async () => ({ status: "ahead", behindBy: 0, filesComplete: false, files: maxFiles }),
   };
-  assert.deepEqual(await readinessTick(db, incompleteReader, new Date(), 5, releaseChainLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 1 });
+  assert.deepEqual(await readinessTick(db, incompleteReader, new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 1 });
   assert.match((await db.task.findUniqueOrThrow({ where: { id: incomplete.readiness.id } })).failureReason ?? "", /completeness/u);
   assert.deepEqual(releasedChainLeases, [incomplete.readiness.chainId]);
 
@@ -306,9 +321,9 @@ test("an incomplete compare response and a behind head fail closed", async () =>
     readPullRequest: async () => snapshot(),
     compareCommits: async () => ({ status: "behind", behindBy: 1, filesComplete: true, files: [] }),
   };
-  assert.deepEqual(await readinessTick(db, behindReader), { claimed: 1, authorized: 0, reviewing: 0, requeued: 1, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, behindReader, new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 1, stopped: 0 });
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: behind.regression.id } })).status, TaskStatus.TODO);
-  assert.deepEqual(releasedChainLeases, []);
+  assert.deepEqual(releasedChainLeases, [behind.readiness.chainId]);
 });
 
 test("an absent runner-created PR identity stops loudly before authorization", async () => {
@@ -316,7 +331,7 @@ test("an absent runner-created PR identity stops loudly before authorization", a
   await db.run.updateMany({ where: { taskId: seeded.regression.id }, data: {
     pullRequestNumber: null, pullRequestUrl: null,
   } });
-  assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 1 });
+  assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 1 });
   assert.match((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).failureReason ?? "", /pull-request target/u);
   assert.deepEqual(releasedChainLeases, [seeded.readiness.chainId]);
 });
@@ -342,7 +357,7 @@ test("manual start cannot turn server-owned readiness into a model run", async (
 test("the merge lease is handed back for the length of an independent review", async () => {
   const seeded = await seedReadiness();
   const guarded = reader([{ filename: "scripts/merge-gate.sh", previousFilename: null, patch: "@@ -1 +1 @@\n-old\n+new" }]);
-  assert.deepEqual(await readinessTick(db, guarded, new Date(), 5, releaseChainLease), { claimed: 1, authorized: 0, reviewing: 1, requeued: 0, stopped: 0 });
+  assert.deepEqual(await readinessTick(db, guarded, new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 0, reviewing: 1, requeued: 0, stopped: 0 });
   assert.deepEqual(releasedChainLeases, [seeded.readiness.chainId]);
 });
 
@@ -355,7 +370,7 @@ test("a contended lease leaves readiness for a later tick instead of authorizing
   };
   const started = new Date();
   assert.deepEqual(
-    await readinessTick(db, reader(), started, 5, releaseChainLease, contended),
+    await readinessTick(db, reader(), started, 5, releaseChainLease, leaseRunner(contended)),
     { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 },
   );
   assert.deepEqual(asked, [seeded.readiness.chainId]);
@@ -374,7 +389,7 @@ test("a contended lease leaves readiness for a later tick instead of authorizing
       new Date(started.getTime() + (READINESS_CLAIM_LEASE_MS * 2)),
       5,
       releaseChainLease,
-      acquired,
+      leaseRunner(acquired),
     ),
     { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 },
   );
@@ -396,7 +411,7 @@ test("a stale worker cannot stop readiness after a newer worker owns the claim",
     },
     compareCommits: async () => ({ status: "ahead", behindBy: 0, filesComplete: true, files: [] }),
   };
-  const tick = readinessTick(db, delayed, new Date(), 5, releaseChainLease);
+  const tick = readinessTick(db, delayed, new Date(), 5, releaseChainLease, runWithMergeLease);
   await readStarted;
   await db.task.update({
     where: { id: seeded.readiness.id },
@@ -429,7 +444,7 @@ test("a stale worker cannot requeue regression after a newer worker owns the cla
     },
     compareCommits: async () => ({ status: "ahead", behindBy: 0, filesComplete: true, files: [] }),
   };
-  const tick = readinessTick(db, delayed);
+  const tick = readinessTick(db, delayed, new Date(), 5, releaseChainLease, runWithMergeLease);
   await readStarted;
   await db.task.update({
     where: { id: seeded.readiness.id },
@@ -446,7 +461,7 @@ test("an unreachable merge lease acquire stops with a durable reason", async () 
   const seeded = await seedReadiness();
   const unreachable: MergeLeaseAcquirer = async () => ({ outcome: "unreachable", detail: "spawn bash ENOENT" });
   assert.deepEqual(
-    await readinessTick(db, reader(), new Date(), 5, releaseChainLease, unreachable),
+    await readinessTick(db, reader(), new Date(), 5, releaseChainLease, leaseRunner(unreachable)),
     { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 1 },
   );
   const readiness = await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } });
@@ -465,7 +480,7 @@ test("a worker that acquired then lost its claim releases unless a successor own
     return { outcome: "acquired" };
   };
   assert.deepEqual(
-    await readinessTick(db, reader(), new Date(), 5, releaseChainLease, loseToOperator),
+    await readinessTick(db, reader(), new Date(), 5, releaseChainLease, leaseRunner(loseToOperator)),
     { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 },
   );
   assert.deepEqual(releasedChainLeases, [abandoned.readiness.chainId]);
@@ -481,7 +496,7 @@ test("a worker that acquired then lost its claim releases unless a successor own
     return { outcome: "acquired" };
   };
   assert.deepEqual(
-    await readinessTick(db, reader(), new Date(), 5, releaseChainLease, loseToWorker),
+    await readinessTick(db, reader(), new Date(), 5, releaseChainLease, leaseRunner(loseToWorker)),
     { claimed: 1, authorized: 0, reviewing: 0, requeued: 0, stopped: 0 },
   );
   assert.deepEqual(releasedChainLeases, []);
@@ -508,7 +523,7 @@ test("eligible readiness is not hidden behind the first hundred ineligible candi
   })) });
 
   assert.deepEqual(
-    await readinessTick(db, reader(), new Date(), 1),
+    await readinessTick(db, reader(), new Date(), 1, releaseChainLease, runWithMergeLease),
     { claimed: 1, authorized: 1, reviewing: 0, requeued: 0, stopped: 0 },
   );
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.DONE);

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -12,7 +12,7 @@ import {
 } from "@agentos/db";
 
 import { makeDedupeKey } from "./execution.js";
-import { mergeTailLeaseChainId, releaseMergeLease, releaseMergeLeaseSafely, type MergeLeaseReleaser } from "./merge-lease.js";
+import { mergeTailLeaseChainId, releaseMergeLease, type ReleaseMergeLease } from "./merge-lease.js";
 import { openReclaimIntentCount } from "./workspace-reclaim.js";
 
 const activeStatuses = [RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING] as const;
@@ -80,7 +80,7 @@ export const createArchivedRunNoticeScheduler = (
 export const reconcileDatabaseRuns = async (
   db: PrismaClient,
   now = new Date(),
-  releaseChainLease: MergeLeaseReleaser = releaseMergeLease,
+  releaseChainLease: ReleaseMergeLease = releaseMergeLease,
 ): Promise<number> => {
   const [candidates, expiredInboxRuns] = await Promise.all([
     db.run.findMany({
@@ -376,7 +376,7 @@ export const reconcileDatabaseRuns = async (
     }
     return [...stranded];
   });
-  for (const chainId of strandedChainLeases) await releaseMergeLeaseSafely(releaseChainLease, chainId);
+  for (const chainId of strandedChainLeases) await releaseChainLease(chainId);
   return orphans.length + expiredInboxRuns.length;
 };
 

--- a/packages/api/src/run-output.dbtest.ts
+++ b/packages/api/src/run-output.dbtest.ts
@@ -67,8 +67,7 @@ const call = async (
 ): Promise<{ status: number; body: any }> => withTokens(async () => {
   const response = await createApp(db, {
     releaseMergeLease: async (chainId) => {
-      releasedChainLeases.push(chainId);
-      return { outcome: "released", ref: "refs/merge-lease/holder", sha: "lease-fixture" };
+      if (chainId) releasedChainLeases.push(chainId);
     },
   }).request(path, {
     method,

--- a/packages/api/src/test-app.ts
+++ b/packages/api/src/test-app.ts
@@ -5,7 +5,7 @@ import type { PrismaClient } from "@agentos/db";
 
 import { createApp as createLiveApp } from "./app.js";
 import { defaultControlPlaneStateDir } from "./control-plane-state.js";
-import type { MergeLeaseReleaser } from "./merge-lease.js";
+import type { ReleaseMergeLease } from "./merge-lease.js";
 import type { preflightOnboardingRepository } from "./onboarding-preflight.js";
 import { defaultWorkspaceRoot } from "./workspace-root.js";
 
@@ -76,7 +76,7 @@ const assertRootIsDisposable = (root: string): string => {
 export const createApp = (db: PrismaClient, options: {
   workspaceRoot?: string;
   onboardingRepositoryPreflight?: typeof preflightOnboardingRepository;
-  releaseMergeLease?: MergeLeaseReleaser;
+  releaseMergeLease?: ReleaseMergeLease;
 } = {}) => {
   const configured = options.workspaceRoot ?? process.env.RUNNER_WORKSPACE_ROOT;
   if (!configured) {
@@ -91,7 +91,7 @@ export const createApp = (db: PrismaClient, options: {
   return createLiveApp(db, {
     ownership: { assertHeld: () => { assertRootIsDisposable(root); } },
     onboardingRepositoryPreflight: options.onboardingRepositoryPreflight ?? (async () => {}),
-    releaseMergeLease: options.releaseMergeLease ?? (async () => ({ outcome: "not-held" })),
+    releaseMergeLease: options.releaseMergeLease ?? (async () => {}),
   });
 };
 


### PR DESCRIPTION
## Summary

- encode merge Lease handoff as an explicit `release`/`retain` disposition
- make readiness Lease seams mandatory and cover claim loss, contention, and Chain-less execution
- release before base-drift regression requeue under the v2 protocol and centralize release anomaly reporting

Design choice: the high-level release seam remains public because retained authorization transfers ownership across requests to the mechanical merge consumer.

## Verification

- `npm run lint`
- `npm run typecheck -w @agentos/api`
- `npm test -w @agentos/api -- src/merge-lease.test.ts` (7 passed)
- targeted dbtests: merge-tail-readiness, merge-base-drift-recovery, merge-lease-cancel-release, merge-stop-state, run-output (81 passed)