### PR TITLE
refactor(runs): centralize run creation

### DIFF
--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -662,21 +662,29 @@ test("only environment failures are external, so agent failures still spend budg
   assert.equal(externalFailure({ succeeded: false, failureClass: "TASK_FAILED" }), false);
 });
 
-test("an archived assignee's automatic retry is queued, audited, and does not spend an external-failure attempt", async () => {
+test("completion refunds an external failure but refuses an automatic retry for an archived Agent", async () => {
   const previousRoot = process.env.RUNNER_WORKSPACE_ROOT;
   process.env.RUNNER_WORKSPACE_ROOT = `/tmp/agentos-missing-${Date.now()}`;
   try {
     await withTokens(async () => {
     let closed: Record<string, unknown> | undefined;
     let retry: Record<string, unknown> | undefined;
+    const taskWrites: Record<string, unknown>[] = [];
+    const inbox: Record<string, unknown>[] = [];
+    const archivedAt = new Date("2026-08-16T06:00:00.000Z");
     const run = {
       id: "run-3", projectId: "project-1", taskId: "task-1", goalId: null, agentId: "agent-1", repoId: "repo-1",
       runNumber: 3, maxRunsPerTask: 3, runner: "CLAUDE", model: "claude", targetBranch: "main", branch: "feat/x",
+      codexServiceTier: "DEFAULT", subagentModel: null, subagentMaxConcurrent: null, budgetGrants: 0,
       baseSha: null, promptHash: "hash", maxDurationMin: 120, stallTimeoutMin: 10,
       task: {
-        id: "task-1", projectId: "project-1", repoId: "repo-1", chainId: null, chainIndex: null,
+        id: "task-1", projectId: "project-1", name: "Archived retry", description: "retry",
+        assigneeType: "AGENT", assigneeAgentId: "agent-1",
+        assigneeAgent: { id: "agent-1", name: "Archived Retry Agent", archivedAt },
+        repoId: "repo-1", chainId: null, chainIndex: null,
         templateId: null, templateStep: null, repo: null, targetBranch: "main", opensPullRequest: true,
-        status: "DOING", archivedAt: null,
+        maxDurationMin: 120, stallTimeoutMin: 10, maxSessionsPerTask: 3,
+        status: "DOING", archivedAt: null, templateStepId: null,
       }, session: { id: "session-1" },
     };
     const tx = {
@@ -686,15 +694,19 @@ test("an archived assignee's automatic retry is queued, audited, and does not sp
         updateMany: async ({ data }: { data: Record<string, unknown> }) => { closed = data; return { count: 1 }; },
         create: async ({ data }: { data: Record<string, unknown> }) => { retry = data; return { id: "run-4", ...data }; },
       },
+      agent: { findUnique: async () => run.task.assigneeAgent },
       session: { update: async () => ({}) },
       task: {
-        updateMany: async () => ({ count: 1 }),
-        findUnique: async () => run.task,
+        updateMany: async ({ data }: { data: Record<string, unknown> }) => { taskWrites.push(data); return { count: 1 }; },
+        findUnique: async () => ({
+          ...run.task,
+          runs: [{ ...run, task: undefined, session: undefined, maxRunsPerTask: 4, budgetGrants: 1 }],
+        }),
         findUniqueOrThrow: async () => run.task,
       },
       taskActivity: { create: async () => ({}) },
       runnerBackendState: { upsert: async () => ({ consecutiveAuthFailures: 0 }), update: async () => ({}) },
-      inboxMessage: { create: async () => ({}) },
+      inboxMessage: { create: async ({ data }: { data: Record<string, unknown> }) => { inbox.push(data); return {}; } },
     };
     const database = {
       $transaction: async (operation: (value: unknown) => Promise<unknown>) => operation(tx),
@@ -714,23 +726,16 @@ test("an archived assignee's automatic retry is queued, audited, and does not sp
     });
     assert.equal(response.status, 200);
     assert.equal(closed?.maxRunsPerTask, 4);
-    // Run 3 of 3 would have been the last attempt; the refunded ceiling requeues it.
-    assert.equal(retry?.runNumber, 4);
-    assert.equal(retry?.maxRunsPerTask, 4);
-    const notices: Record<string, unknown>[] = [];
-    const auditDb = {
-      run: {
-        findMany: async () => [{
-          id: "run-4", taskId: "task-1", runNumber: retry?.runNumber,
-          agent: { name: "Archived Retry Agent", archivedAt: new Date("2026-08-16T06:00:00.000Z") },
-        }],
-      },
-      taskActivity: {
-        createMany: async ({ data }: { data: Record<string, unknown>[] }) => { notices.push(...data); return { count: data.length }; },
-      },
-    } as unknown as PrismaClient;
-    assert.equal(await noteArchivedQueuedRuns(auditDb), 1);
-    assert.match(String(notices[0]?.body), /Archived Retry Agent.*run 4/);
+    assert.equal(retry, undefined);
+    assert.match(String(taskWrites.at(-1)?.failureReason), /Automatic retry refused.*Archived Retry Agent/);
+    assert.match(String(inbox.at(-1)?.body), /Automatic retry refused.*Archived Retry Agent/);
+    assert.deepEqual(await response.json(), {
+      taskId: "task-1",
+      succeeded: false,
+      retryCreated: false,
+      failureClass: "TRANSIENT_PROVIDER",
+      releaseMergeLeaseTask: null,
+    });
     });
   } finally {
     if (previousRoot === undefined) delete process.env.RUNNER_WORKSPACE_ROOT;
@@ -788,9 +793,17 @@ const retryRequest = async (
     archivedAt?: Date | null;
     name?: string;
   } | null,
-  templateStep: { runner: RunnerKind | null } | null = null,
+  templateStep: {
+    runner: RunnerKind | null;
+    stepIndex?: number;
+    outputKind?: string;
+    taskTemplate?: { name: string };
+  } | null = null,
 ) => {
   let created: Record<string, unknown> | undefined;
+  const currentTemplateStep = templateStep
+    ? { stepIndex: 1, outputKind: "result", taskTemplate: { name: "direct-engineer-workflow" }, ...templateStep }
+    : null;
   const last = {
     id: "run-1",
     projectId: "project-1",
@@ -821,12 +834,25 @@ const retryRequest = async (
         findUniqueOrThrow: async () => ({ id: "task-1", status: "TODO", archivedAt: null }),
         findUnique: async () => ({
           id: "task-1",
+          projectId: "project-1",
           name: "Retry me",
           description: "Use current config",
+          assigneeType: "AGENT",
+          assigneeAgentId: assigneeAgent?.id ?? null,
           repoId: "repo-current",
+          repo: null,
+          templateId: null,
+          templateStepId: currentTemplateStep ? "step-1" : null,
           maxSessionsPerTask: 4,
+          maxDurationMin: 120,
+          stallTimeoutMin: 10,
+          opensPullRequest: true,
+          chainId: null,
+          chainIndex: null,
+          targetBranch: "main",
+          archivedAt: null,
           assigneeAgent,
-          templateStep,
+          templateStep: currentTemplateStep,
           runs: [last],
         }),
         update: async () => ({}),
@@ -916,6 +942,30 @@ test("operator retry honors a template-step runner override", async () => {
     }, { runner: RunnerKind.CODEX });
     assert.equal(response.status, 201);
     assert.equal(created?.runner, RunnerKind.CODEX);
+  });
+});
+
+test("operator retry refuses a compound implementation Step assigned to a non-executioner Agent", async () => {
+  await withTokens(async () => {
+    const { response, created } = await retryRequest({
+      id: "agent-1",
+      model: "gpt-5.6-sol:high",
+      runnerPreference: RunnerPreference.CODEX,
+      foundationalPrompt: "foundation",
+      rolePrompt: "role",
+      name: "senior-dev",
+    }, {
+      runner: RunnerKind.CODEX,
+      stepIndex: 5,
+      outputKind: "implementation",
+      taskTemplate: { name: "compound-engineer-workflow" },
+    });
+    assert.equal(response.status, 409);
+    assert.deepEqual(await response.json(), {
+      error: "Compound implementation step must remain assigned to the active in-project Agent implementation-plan-executioner",
+      code: "COMPOUND_IMPLEMENTATION_ASSIGNEE_INVALID",
+    });
+    assert.equal(created, undefined);
   });
 });
 

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -20,7 +20,7 @@ import { LOOPBACK_BROWSER_ORIGINS } from "./local-origin.js";
 import { completionSucceeded, externalFailure } from "./execution.js";
 import { isStarterMountPath, isValidBranchName, onboardingInput, parseRepoRemote, slugify } from "./onboarding.js";
 import { RepositoryPreflightError } from "./onboarding-preflight.js";
-import { noteArchivedQueuedRuns, reconcileDatabaseRuns } from "./reconcile.js";
+import { reconcileDatabaseRuns } from "./reconcile.js";
 import { activeRunStatuses } from "./run-fence.js";
 
 const withTokens = async (callback: () => Promise<void>): Promise<void> => {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -8,17 +8,16 @@ import {
   catalogRunnerForModel,
   CleanupStatus,
   CodexServiceTier,
-  deriveRunConfig,
   FailureClass,
   GoalStatus,
   enqueueTaskRun,
+  openRun,
   InboxStatus,
   lockAgentRepoGrant,
   lockAgentRepoGrantForRevocation,
   lockAgentRow,
   lockChainRows,
   lockRunRow,
-  nativeImplementationSubagentRunConfig,
   NetworkingMode,
   Prisma,
   type PrismaClient,
@@ -29,7 +28,6 @@ import {
   RunnerKind,
   RunnerPreference,
   recomputeSessionUsage,
-  resolveRunBranches,
   runnerFor,
   sessionUsageCost,
   sumUsageCosts,
@@ -43,7 +41,6 @@ import {
   isMergeExecutorRunnerId,
   mechanicalPrincipalRefusal,
   executionModeFor,
-  integratorBindingRefusal,
   integratorBindingRefusalFor,
   projectMergeOutcome,
   runOwnsMergeOutcome,
@@ -56,7 +53,6 @@ import {
   resolveChainTarget,
   selectAuthorization,
   stopStateFor,
-  stopStateRefusal,
   taskIsIntegratorStep,
   type CandidateActivity,
   type CardRow,
@@ -107,7 +103,6 @@ import {
 } from "./chain.js";
 import {
   jsonValue,
-  makeDedupeKey,
   normalizeSessionEventValue,
   runBudgetCeiling,
 } from "./execution.js";
@@ -175,6 +170,13 @@ const refusalJson = (context: Context, refused: Refusal): Response => {
 const runFenceRefusal = (refused: FenceRefusalResponse): Refusal => (
   refusal("conflict", refused.error, { reason: refused.reason })
 );
+
+class TaskCreateOpenRunRefusal extends Error {
+  constructor(readonly refusal: Refusal) {
+    super(refusal.message);
+    this.name = "TaskCreateOpenRunRefusal";
+  }
+}
 
 export interface LiveAppOptions {
   ownership: { assertHeld(): void | Promise<void> };
@@ -2216,70 +2218,55 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     } catch (error: unknown) {
       return context.json({ error: error instanceof Error ? error.message : "Invalid schedule" }, 400);
     }
-    const task = await db.$transaction(async (tx) => {
-      // The check above answered from an unlocked read. This one holds the
-      // Agent-row mutex through the task — and the inline run below — so a
-      // concurrent archive either loses the race or is refused for this run.
-      const currentAgent = agent ? await lockAgentRow(tx, agent.id) : null;
-      if (agent && !currentAgent) return refusal("invalid-request", "Assignee does not belong to this project");
-      if (currentAgent?.archivedAt) return refusal("invalid-request", `Assignee ${currentAgent.name} is archived`);
-      // §D-P4, inside the transaction and before `tx.task.create` and the inline
-      // `tx.run.create` below. This route cannot set `templateStepId` at all, so
-      // in practice it refuses the sentinel Agent outright — which is the point:
-      // an ordinary task assigned to the sentinel would claim as `agent` and
-      // spawn a model CLI with `mechanical/merge-executor-v1` as its model.
-      const bindingRefusal = await integratorBindingRefusalFor(tx, {
-        assigneeAgentName: currentAgent?.name ?? null,
-        templateStep: null,
-      });
-      if (bindingRefusal) return refusal("invalid-request", bindingRefusal);
-      const created = await tx.task.create({
-        data: {
-          ...withoutUndefined(body),
-          ...schedule,
-          projectId,
-          chainLayer: body.chainId === undefined ? null : body.chainIndex,
-        } as Prisma.TaskUncheckedCreateInput,
-      });
-      await tx.taskActivity.create({ data: { taskId: created.id, actorType: "operator", body: "Task created" } });
-      // API-created chains arrive one task at a time. Only index 0 may receive
-      // an eager run; later indexed steps stay parked until
-      // activateChainSuccessor observes their predecessor's durable success.
-      // Without this guard every POST snapshots the fallback base before step
-      // 0 can publish, and all runners race the same new shared head.
-      const mayQueueInline = created.chainIndex == null || created.chainIndex === 0;
-      if (currentAgent && repo && body.assigneeType === AssigneeType.AGENT && schedule.scheduleKind === ScheduleKind.NOW && mayQueueInline) {
-        const derived = deriveRunConfig(currentAgent, null, created);
-        // This run is built inline rather than through enqueueTaskRun, so it is
-        // one of the paths a chain fix can miss. Missing it puts step ① on a
-        // per-task branch while ②–⑨ share the chain branch — i.e. step ①'s work
-        // silently absent from the tree every later step reviews.
-        const branches = await resolveRunBranches(tx, { ...created, repo }, null);
-        await tx.run.create({
-          data: {
-            projectId,
-            taskId: created.id,
-            agentId: currentAgent.id,
-            repoId: repo.id,
-            runNumber: 1,
-            dedupeKey: makeDedupeKey(created.id, 1),
-            runner: derived.runner,
-            model: derived.model,
-            codexServiceTier: derived.codexServiceTier,
-            targetBranch: branches.targetBranch,
-            branch: branches.branch,
-            opensPullRequest: created.opensPullRequest,
-            promptHash: derived.promptHash,
-            maxDurationMin: body.maxDurationMin,
-            stallTimeoutMin: body.stallTimeoutMin,
-            maxRunsPerTask: body.maxSessionsPerTask,
-          },
+    try {
+      const task = await db.$transaction(async (tx) => {
+        // The check above answered from an unlocked read. This one holds the
+        // Agent-row mutex through the task and `openRun`, so a
+        // concurrent archive either loses the race or is refused for this run.
+        const currentAgent = agent ? await lockAgentRow(tx, agent.id) : null;
+        if (agent && !currentAgent) return refusal("invalid-request", "Assignee does not belong to this project");
+        if (currentAgent?.archivedAt) return refusal("invalid-request", `Assignee ${currentAgent.name} is archived`);
+        // §D-P4, inside the transaction and before `tx.task.create`. This route
+        // cannot set `templateStepId` at all, so in practice it refuses the
+        // sentinel Agent outright — which is the point: an ordinary task
+        // assigned to the sentinel would claim as `agent` and spawn a model CLI
+        // with `mechanical/merge-executor-v1` as its model.
+        const bindingRefusal = await integratorBindingRefusalFor(tx, {
+          assigneeAgentName: currentAgent?.name ?? null,
+          templateStep: null,
         });
-      }
-      return { created };
-    });
-    if ("message" in task) return refusalJson(context, task);
-    return context.json(task.created, 201);
+        if (bindingRefusal) return refusal("invalid-request", bindingRefusal);
+        const created = await tx.task.create({
+          data: {
+            ...withoutUndefined(body),
+            ...schedule,
+            projectId,
+            chainLayer: body.chainId === undefined ? null : body.chainIndex,
+          } as Prisma.TaskUncheckedCreateInput,
+        });
+        await tx.taskActivity.create({ data: { taskId: created.id, actorType: "operator", body: "Task created" } });
+        // API-created chains arrive one task at a time. Only index 0 may receive
+        // an eager run; later indexed steps stay parked until
+        // activateChainSuccessor observes their predecessor's durable success.
+        // Without this guard every POST snapshots the fallback base before step
+        // 0 can publish, and all runners race the same new shared head.
+        const mayQueueInline = created.chainIndex == null || created.chainIndex === 0;
+        if (currentAgent && repo && body.assigneeType === AssigneeType.AGENT && schedule.scheduleKind === ScheduleKind.NOW && mayQueueInline) {
+          // Bypassing `openRun` here once put step 1 on a per-Task branch while
+          // every later Step shared the Chain branch, silently dropping step 1.
+          const opened = await openRun(tx, created.id, { kind: "task-created", readyAt: new Date() });
+          // A refusal must roll back the Task born earlier in this transaction;
+          // returning it would commit a Task whose requested eager Run is absent.
+          if (!opened.ok) throw new TaskCreateOpenRunRefusal(opened.refusal);
+        }
+        return { created };
+      });
+      if ("message" in task) return refusalJson(context, task);
+      return context.json(task.created, 201);
+    } catch (error: unknown) {
+      if (error instanceof TaskCreateOpenRunRefusal) return refusalJson(context, error.refusal);
+      throw error;
+    }
   });
   app.get("/tasks/:taskId", async (context) => {
     const task = await db.task.findUnique({
@@ -2533,9 +2520,6 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const result = await db.$transaction(async (tx) => {
       const locked = await lockTaskMutationRows(tx, taskId);
       if (!locked) return refusal("not-found", "Task not found");
-      // Retry joins the exclusion protocol: a guard set in which one writer
-      // ignores archivedAt excludes nothing.
-      if (locked.archivedAt !== null) return refusal("conflict", "Cannot retry an archived task");
       const task = await tx.task.findUnique({
         where: { id: taskId },
         include: {
@@ -2566,7 +2550,6 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           return refusal("conflict", `Cannot retry ${task.name}; predecessor ${blocker.name} is not done`);
         }
       }
-      const integratorStepShape = task.templateStep;
       const last = task.runs[0];
       if (!last) return refusal("conflict", "Task has no run to retry");
       // Checked across ALL of the task's runs with the shared active set, not
@@ -2578,57 +2561,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       if (activeRuns > 0) {
         return refusal("conflict", "Task already has an active run");
       }
-      const stoppedForRetry = await stopStateFor(tx, taskId);
-      if (stoppedForRetry) return refusal("conflict", stopStateRefusal(stoppedForRetry));
-      // The same ceiling the Start gate uses, for the same reason: the budget an
-      // operator configured now, plus what has been granted on top of it. The
-      // old `last.maxRunsPerTask` could not tell a refund from a budget that had
-      // since been lowered.
-      if (last.runNumber >= runBudgetCeiling(task.maxSessionsPerTask, last.budgetGrants)) {
-        return refusal("conflict", "Run budget exhausted");
-      }
-      if (!task.assigneeAgent) {
-        return refusal("conflict", "Task assignee no longer exists; assign an agent before retrying");
-      }
-      // Retry builds its Run inline rather than through enqueueTaskRun, so it
-      // takes the Agent-row mutex itself — Task row first, Agent row second.
-      const lockedAgent = await lockAgentRow(tx, task.assigneeAgent.id);
-      if (!lockedAgent || lockedAgent.archivedAt) {
-        return refusal("conflict", `Assignee ${task.assigneeAgent.name} is archived; unarchive it to retry`);
-      }
-      const currentBinding = integratorBindingRefusal(lockedAgent.name, integratorStepShape);
-      if (currentBinding) return refusal("invalid-request", currentBinding);
-      const derived = deriveRunConfig(lockedAgent, task.templateStep, task);
-      const subagent = nativeImplementationSubagentRunConfig(derived.runner, task.templateStep);
-      // A task with no repo cannot be a chain step with a branch, and this route
-      // already tolerates a null repoId — so it keeps inheriting run-1's fields.
-      const branches = task.repo
-        ? await resolveRunBranches(tx, { ...task, repo: task.repo }, last)
-        : null;
-      const run = await tx.run.create({
-        data: {
-          projectId: last.projectId,
-          taskId,
-          goalId: last.goalId,
-          agentId: lockedAgent.id,
-          repoId: task.repoId,
-          runNumber: last.runNumber + 1,
-          dedupeKey: makeDedupeKey(taskId, last.runNumber + 1),
-          runner: derived.runner,
-          model: derived.model,
-          codexServiceTier: derived.codexServiceTier,
-          ...subagent,
-          targetBranch: branches ? branches.targetBranch : last.targetBranch,
-          branch: branches ? branches.branch : last.branch,
-          opensPullRequest: task.opensPullRequest,
-          promptHash: derived.promptHash,
-          maxDurationMin: last.maxDurationMin,
-          stallTimeoutMin: last.stallTimeoutMin,
-          maxRunsPerTask: runBudgetCeiling(task.maxSessionsPerTask, last.budgetGrants),
-          budgetGrants: last.budgetGrants,
-          readyAt: now,
-        },
-      });
+      const opened = await openRun(tx, taskId, { kind: "retry", readyAt: now });
+      if (!opened.ok) return opened.refusal;
+      const run = opened.run;
       await tx.task.update({ where: { id: taskId }, data: { status: TaskStatus.TODO, failureReason: null } });
       await tx.taskActivity.create({ data: { taskId, actorType: "operator", body: `Run ${run.runNumber} queued by operator retry` } });
       return { run };

--- a/packages/api/src/execution.ts
+++ b/packages/api/src/execution.ts
@@ -78,8 +78,7 @@ export const externalFailure = (evidence: {
  * same refund one route away, would have let it run. A ceiling only half the
  * system honours is not a ceiling.
  */
-export const runBudgetCeiling = (maxSessionsPerTask: number, budgetGrants: number | null | undefined): number =>
-  maxSessionsPerTask + Math.max(0, budgetGrants ?? 0);
+export { runBudgetCeiling } from "@agentos/db";
 
 export const retryDelayMs = (runNumber: number, failureClass: FailureClass): number => {
   const base = failureClass === FailureClass.RATE_LIMITED ? 60_000 : 30_000;

--- a/packages/api/src/reconcile.test.ts
+++ b/packages/api/src/reconcile.test.ts
@@ -164,11 +164,13 @@ test("startup reconciliation does not fail when archived notice persistence fail
   }
 });
 
-test("lease-loss requeue for an archived agent becomes visible through the sweep", async () => {
+test("lease-loss retry refuses an archived Agent and parks the Task visibly", async () => {
   const now = new Date("2026-08-16T06:00:00.000Z");
   let queued: Record<string, unknown> | undefined;
   let lostUpdate: Record<string, unknown> | undefined;
   const activities: Record<string, unknown>[] = [];
+  const taskUpdates: Record<string, unknown>[] = [];
+  const inbox: Record<string, unknown>[] = [];
   const candidate = {
     id: "lost-1", heartbeatAt: new Date(now.getTime() - 20 * 60_000),
     leaseExpiresAt: new Date(now.getTime() - 10 * 60_000), projectId: "project-1",
@@ -184,21 +186,31 @@ test("lease-loss requeue for an archived agent becomes visible through the sweep
     },
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
       $queryRaw: async () => [{ id: "task-1", archivedAt: null }],
+      agent: { findUnique: async () => ({ id: "agent-1", name: "Archived", archivedAt: now }) },
       run: {
         findFirst: async () => ({ cancelRequestId: null, cancelReason: null, cancelRequestedAt: null }),
         updateMany: async ({ data }: { data: Record<string, unknown> }) => { lostUpdate = data; return { count: 1 }; },
         create: async ({ data }: { data: Record<string, unknown> }) => { queued = data; return { id: "retry-2", ...data }; },
       },
       session: { updateMany: async () => ({ count: 1 }) },
-      // The requeue loads the task to decide whether to recompute a chain
-      // step's branches; a null row keeps the lost run's fields verbatim.
       task: {
-        update: async () => ({}),
-        findUnique: async () => null,
+        update: async ({ data }: { data: Record<string, unknown> }) => { taskUpdates.push(data); return {}; },
+        findUnique: async () => ({
+          id: "task-1", projectId: "project-1", name: "Lost task", description: "retry",
+          assigneeType: "AGENT", assigneeAgentId: "agent-1",
+          assigneeAgent: { id: "agent-1", name: "Archived", archivedAt: now },
+          repoId: null, repo: null, templateId: null, templateStepId: null, templateStep: null,
+          chainId: null, chainIndex: null, targetBranch: "main", opensPullRequest: true,
+          maxDurationMin: 120, stallTimeoutMin: 10, maxSessionsPerTask: 3, archivedAt: null,
+          runs: [{ ...candidate, maxRunsPerTask: 4, budgetGrants: 1 }],
+        }),
         findUniqueOrThrow: async () => ({ id: "task-1", archivedAt: null }),
       },
-      taskActivity: { create: async () => ({}) },
-      inboxMessage: { create: async () => ({}) },
+      taskActivity: {
+        findMany: async () => [],
+        create: async ({ data }: { data: Record<string, unknown> }) => { activities.push(data); return {}; },
+      },
+      inboxMessage: { create: async ({ data }: { data: Record<string, unknown> }) => { inbox.push(data); return {}; } },
     }),
     taskActivity: {
       createMany: async ({ data }: { data: Record<string, unknown>[] }) => { activities.push(...data); return { count: data.length }; },
@@ -207,6 +219,9 @@ test("lease-loss requeue for an archived agent becomes visible through the sweep
   assert.equal(await reconcileDatabaseRuns(database, now), 1);
   assert.equal(lostUpdate?.failureClass, "CANCELLED_OR_TIMED_OUT");
   assert.match(String(lostUpdate?.failureReason), /heartbeat starved.*lease expired/i);
-  assert.equal(await noteArchivedQueuedRuns(database), 1);
-  assert.match(String(activities[0]?.body), /Archived.*run 2/);
+  assert.equal(queued, undefined);
+  assert.equal(taskUpdates.at(-1)?.status, TaskStatus.REVIEW);
+  assert.match(String(taskUpdates.at(-1)?.failureReason), /retry refused.*Archived/i);
+  assert.match(String(activities.at(-1)?.body), /automatic retry refused.*Archived/i);
+  assert.match(String(inbox.at(-1)?.body), /Automatic retry refused.*Archived/i);
 });

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -3,15 +3,14 @@ import {
   FailureClass,
   InboxStatus,
   lockTaskRow,
-  resolveRequeueBase,
-  resolveRunBranches,
+  openRun,
+  runBudgetCeiling,
   RunStatus,
   SessionExecutionStatus,
   TaskStatus,
   type PrismaClient,
 } from "@agentos/db";
 
-import { makeDedupeKey } from "./execution.js";
 import { mergeTailLeaseChainId, releaseMergeLease, type ReleaseMergeLease } from "./merge-lease.js";
 import { openReclaimIntentCount } from "./workspace-reclaim.js";
 
@@ -222,7 +221,9 @@ export const reconcileDatabaseRuns = async (
         continue;
       }
       // Losing a lease is an external failure: it buys an attempt, never spends one.
-      const budgetCeiling = run.maxRunsPerTask + 1;
+      // A lost lease refunds the already-authorized Run; it does not recompute
+      // from a task budget that may have changed while the Run was in flight.
+      const budgetCeiling = runBudgetCeiling(run.maxRunsPerTask, 1);
       // The same grant, recorded apart from the ceiling it produced, so the
       // gates an operator reaches can still tell it from the configured budget
       // after that budget changes. See `runBudgetCeiling`.
@@ -258,63 +259,37 @@ export const reconcileDatabaseRuns = async (
       });
       if (!run.taskId) continue;
       if (run.runNumber < budgetCeiling) {
-        // Chain steps recompute; everything else keeps the lost run's own base,
-        // because the resolver's non-chain answer reads the *task's* current
-        // targetBranch and the lost run's may predate an operator edit. That
-        // snapshot still has to answer to publication evidence, though:
-        // copying it verbatim requeued a pre-fix run onto the very ref no
-        // remote had (issue #118), and dropped a salvage the lost run pushed.
-        const task = await tx.task.findUnique({
-          where: { id: run.taskId },
-          select: {
-            id: true, projectId: true, repoId: true, chainId: true, chainIndex: true, templateId: true,
-            targetBranch: true, opensPullRequest: true,
-            templateStep: { select: { baseFromStepIndex: true } },
-            repo: { select: { defaultBranch: true } },
-          },
+        const opened = await openRun(tx, run.taskId, {
+          kind: "retry-after-lease-loss",
+          sourceRunId: run.id,
+          sourceMaxRunsPerTask: run.maxRunsPerTask,
+          sourceBudgetGrants: run.budgetGrants,
+          readyAt: now,
         });
-        // Ordinary chain steps recompute without inheriting the lost run.
-        // Pinned template steps pass only the workspace branch identity; the
-        // resolver re-reads their immutable source range and never trusts the
-        // lost run's targetBranch as a commit.
-        const branches = task?.templateStep?.baseFromStepIndex != null && task.repo
-          ? await resolveRunBranches(tx, { ...task, repo: task.repo }, { branch: run.branch })
-          : task?.chainId && task.chainIndex !== null && !task.templateId && task.repo
-          ? await resolveRunBranches(tx, { ...task, repo: task.repo }, null)
-          : {
-            branch: run.branch,
-            targetBranch: task?.repo
-              ? await resolveRequeueBase(tx, { ...task, repo: task.repo }, run)
-              : run.targetBranch,
-          };
-        await tx.run.create({
-          data: {
-            projectId: run.projectId,
-            taskId: run.taskId,
-            goalId: run.goalId,
-            agentId: run.agentId,
-            repoId: run.repoId,
-            runNumber: run.runNumber + 1,
-            dedupeKey: makeDedupeKey(run.taskId, run.runNumber + 1),
-            runner: run.runner,
-            model: run.model,
-            codexServiceTier: run.codexServiceTier,
-            subagentModel: run.subagentModel,
-            subagentMaxConcurrent: run.subagentMaxConcurrent,
-            targetBranch: branches.targetBranch,
-            branch: branches.branch,
-            opensPullRequest: task?.opensPullRequest ?? true,
-            promptHash: run.promptHash,
-            maxDurationMin: run.maxDurationMin,
-            stallTimeoutMin: run.stallTimeoutMin,
-            maxRunsPerTask: budgetCeiling,
-            budgetGrants,
-          },
-        });
-        await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DOING, failureReason: null } });
-        await tx.taskActivity.create({
-          data: { taskId: run.taskId, actorType: "control-plane", body: `Run ${run.runNumber} lost; retry ${run.runNumber + 1} queued` },
-        });
+        if (opened.ok) {
+          await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DOING, failureReason: null } });
+          await tx.taskActivity.create({
+            data: { taskId: run.taskId, actorType: "control-plane", body: `Run ${run.runNumber} lost; retry ${opened.run.runNumber} queued` },
+          });
+        } else {
+          const lostChainId = await mergeTailLeaseChainId(tx, run.taskId);
+          if (lostChainId) stranded.add(lostChainId);
+          await tx.task.update({
+            where: { id: run.taskId },
+            data: { status: TaskStatus.REVIEW, failureReason: `Lease-loss retry refused: ${opened.refusal.message}` },
+          });
+          await tx.taskActivity.create({
+            data: { taskId: run.taskId, actorType: "control-plane", body: `Run ${run.runNumber} lost; automatic retry refused: ${opened.refusal.message}` },
+          });
+          await tx.inboxMessage.create({
+            data: {
+              from: "AGENT",
+              taskId: run.taskId,
+              kind: "TEXT",
+              body: `Automatic retry refused after lease loss: ${opened.refusal.message}`,
+            },
+          });
+        }
       } else {
         // Budget exhausted: no retry follows, so this lost run is the chain's
         // last word and its lease has no successor to hand itself to.

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -26,6 +26,7 @@ import {
   MAX_BLOCKING_REVIEW_ROUNDS,
   MERGE_TAIL_KIND,
   mechanicalPrincipalRefusal,
+  openRun,
   openReviewObligation,
   parseIndependentReviewDecision,
   parseMergeResult,
@@ -35,8 +36,7 @@ import {
   readMarkerHistory,
   readMarkers,
   recordIntegratorStop,
-  resolveRequeueBase,
-  resolveRunBranches,
+  runBudgetCeiling,
   RunStatus,
   SessionExecutionStatus,
   TaskStatus,
@@ -57,7 +57,6 @@ import {
   externalFailure,
   failureIsRetryable,
   jsonValue,
-  makeDedupeKey,
   retryDelayMs,
 } from "./execution.js";
 import { FAILURE_REASON_LIMIT, truncateFailureReason } from "./failure-reason.js";
@@ -374,7 +373,7 @@ export const completeRun = async (
     // not get to raise the ceiling on this step either.
     const mechanical = isIntegratorStep(run.task?.templateStep ?? null);
     const refunded = external && !mechanical ? 1 : 0;
-    const budgetCeiling = run.maxRunsPerTask + refunded;
+    const budgetCeiling = runBudgetCeiling(run.maxRunsPerTask, refunded);
     // One marker read for both completion outcomes; this handler used to
     // declare `tailRows` twice and scan twice. The success path consults it
     // only for a standalone auxiliary task — an automatic repair or an
@@ -538,69 +537,18 @@ export const completeRun = async (
       },
     });
     let retryCreated = false;
+    let retryRefusal: Refusal | null = null;
     if (!succeeded && retryable && run.task && run.runNumber < budgetCeiling) {
-      const currentTask = await tx.task.findUniqueOrThrow({
-        where: { id: run.task.id },
-        include: { templateStep: true, repo: { select: { defaultBranch: true } } },
+      const opened = await openRun(tx, run.task.id, {
+        kind: "retry-after-completion",
+        sourceRunId: run.id,
+        sourceMaxRunsPerTask: run.maxRunsPerTask,
+        sourceBudgetGrants: run.budgetGrants,
+        budgetGrant: refunded,
+        readyAt: retryAt ?? now,
       });
-      // The fifth run-creating path. Indexed chains already resolve their
-      // branch here; template chains must do the same or a retry is created
-      // with `branch: null` and workspace.ts silently moves it to a per-run
-      // branch. Pass the failed template run as the prior so publication
-      // evidence — including WIP salvage written by this completion — still
-      // decides the retry's base; the resolved logical chain head wins over
-      // that run's workspace branch. Non-template
-      // chains retain their existing no-prior resolution, and non-chain
-      // retries retain the historical `branch: null` behavior.
-      //
-      // All of this runs *after* the updateMany that writes the completing
-      // run's `branch`/`pushedBranch`, so the run's own push — a chain step's
-      // publication, or a failed run's salvage — is evidence in this
-      // transaction. `body.branch ?? run.branch` is that same effective value,
-      // because `run` was read before the update.
-      const resolveChain = currentTask.repo && currentTask.chainId
-        && (currentTask.templateId || currentTask.chainIndex !== null);
-      const branches = resolveChain && currentTask.repo
-        ? await resolveRunBranches(
-          tx,
-          { ...currentTask, repo: currentTask.repo },
-          currentTask.templateId ? { branch: body.branch ?? run.branch } : null,
-        )
-        : {
-          branch: null,
-          targetBranch: currentTask.repo
-            ? await resolveRequeueBase(tx, { ...currentTask, repo: currentTask.repo }, {
-              branch: body.branch ?? run.branch,
-              targetBranch: run.targetBranch,
-            })
-            : run.targetBranch,
-        };
-      await tx.run.create({
-        data: {
-          projectId: run.projectId,
-          taskId: run.taskId,
-          goalId: run.goalId,
-          agentId: run.agentId,
-          repoId: run.repoId,
-          runNumber: run.runNumber + 1,
-          dedupeKey: makeDedupeKey(run.task.id, run.runNumber + 1),
-          runner: run.runner,
-          model: run.model,
-          codexServiceTier: run.codexServiceTier,
-          subagentModel: run.subagentModel,
-          subagentMaxConcurrent: run.subagentMaxConcurrent,
-          targetBranch: branches.targetBranch,
-          branch: branches.branch,
-          opensPullRequest: currentTask.opensPullRequest,
-          promptHash: run.promptHash,
-          maxDurationMin: run.maxDurationMin,
-          stallTimeoutMin: run.stallTimeoutMin,
-          maxRunsPerTask: budgetCeiling,
-          budgetGrants,
-          readyAt: retryAt ?? now,
-        },
-      });
-      retryCreated = true;
+      if (opened.ok) retryCreated = true;
+      else retryRefusal = opened.refusal;
     }
     if (!succeeded && !retryCreated && (mechanical
       || isRegressionVerificationOutputKind(run.task?.templateStep?.outputKind)
@@ -608,7 +556,7 @@ export const completeRun = async (
       releaseMergeLeaseTask = tailLeaseChainId;
     }
     if (run.taskId) {
-      const budgetExhausted = !succeeded && retryable && !retryCreated;
+      const budgetExhausted = !succeeded && retryable && !retryCreated && !retryRefusal;
       let canonicalOutputFailure: string | null = null;
       if (!succeeded && !retryCreated && run.task) {
         // The same markers the success path above read, from the same scan.
@@ -1028,7 +976,9 @@ export const completeRun = async (
             // message below.
             failureReason: succeeded ? null : missingOutputReason ?? (budgetExhausted
               ? `Maximum ${budgetCeiling} runs reached`
-              : body.failureReason ?? "Execution failed"),
+              : retryRefusal
+                ? `Automatic retry refused: ${retryRefusal.message}`
+                : body.failureReason ?? "Execution failed"),
           },
         });
       }
@@ -1041,6 +991,7 @@ export const completeRun = async (
             : succeeded && (run.task?.templateId || run.task?.chainId || mergeTailAuxiliary) ? `Run ${run.runNumber} succeeded; chain advanced or awaiting approval`
             : succeeded ? `Run ${run.runNumber} succeeded; task moved to review`
             : retryCreated ? `Run ${run.runNumber} failed; retry queued`
+              : retryRefusal ? `Run ${run.runNumber} failed; automatic retry refused: ${retryRefusal.message}`
               : `Run ${run.runNumber} failed; task moved to review`,
           metadata: jsonValue({ exitCode: body.exitCode, terminalEventSeen: body.terminalEventSeen, failureClass, pushStatus: body.pushStatus, pullRequestUrl: body.pullRequestUrl }),
         },
@@ -1053,6 +1004,17 @@ export const completeRun = async (
             taskId: run.taskId,
             kind: "TEXT",
             body: `Run budget exhausted after ${budgetCeiling} attempts; operator action required.`,
+          },
+        });
+      }
+      if (retryRefusal) {
+        await tx.inboxMessage.create({
+          data: {
+            from: "AGENT",
+            sessionId: run.session.id,
+            taskId: run.taskId,
+            kind: "TEXT",
+            body: `Automatic retry refused: ${retryRefusal.message}`,
           },
         });
       }

--- a/packages/api/src/workflow.test.ts
+++ b/packages/api/src/workflow.test.ts
@@ -133,6 +133,7 @@ test("task creation keeps its runner, model, and promptHash output while derivat
   process.env.OPERATOR_TOKEN = "operator-workflow-test";
   try {
     let runData: Record<string, unknown> | undefined;
+    let createdTask: Record<string, unknown> | undefined;
     const agent = runAgent({
       model: "OpenAI-CoDeX/GPT",
       runnerPreference: RunnerPreference.INHERIT,
@@ -146,7 +147,19 @@ test("task creation keeps its runner, model, and promptHash output while derivat
       $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
         $queryRaw: async () => [{ id: agent.id, archivedAt: null }],
         agent: { findUnique: async () => agent },
-        task: { create: async ({ data }: { data: Record<string, unknown> }) => ({ id: "task-1", ...data }) },
+        task: {
+          create: async ({ data }: { data: Record<string, unknown> }) => {
+            createdTask = { id: "task-1", ...data };
+            return createdTask;
+          },
+          findUnique: async () => createdTask ? {
+            ...createdTask,
+            assigneeAgent: agent,
+            repo: { id: "repo-1", defaultBranch: "main" },
+            templateStep: null,
+            runs: [],
+          } : null,
+        },
         taskActivity: { create: async () => ({ id: "activity-1" }) },
         run: { create: async ({ data }: { data: Record<string, unknown> }) => { runData = data; return { id: "run-1", ...data }; } },
       }),
@@ -197,22 +210,27 @@ test("layer activation refuses a missing chain row instead of following a linked
 
 test("a later chain step runs on the chain's shared branch so the chain lands in one PR", async () => {
   const queued: Record<string, unknown>[] = [];
+  const task = {
+    id: "task-2", projectId: "project-1", name: "Plan", description: "plan", assigneeType: AssigneeType.AGENT,
+    assigneeAgentId: "agent-1", repoId: "repo-1", templateId: "template-1", templateStepId: "step-2",
+    chainId: "chain-1", chainIndex: 2, targetBranch: "feat/lines", opensPullRequest: true, maxDurationMin: 120,
+    stallTimeoutMin: 10, maxSessionsPerTask: 5, archivedAt: null, runs: [],
+    assigneeAgent: runAgent(),
+    repo: { id: "repo-1", defaultBranch: "main" },
+    templateStep: { stepIndex: 2, outputKind: "plan", baseFromStepIndex: null, runner: null, taskTemplate: { name: "template" } },
+  };
   const tx = {
     $queryRaw: async () => [{ id: "agent-1", archivedAt: null }],
     agent: { findUnique: async () => runAgent() },
     task: {
-      findUniqueOrThrow: async () => ({
-        id: "task-2", projectId: "project-1", name: "Plan", description: "plan", assigneeType: AssigneeType.AGENT,
-        assigneeAgentId: "agent-1", templateId: "template-1", targetBranch: "feat/lines", maxDurationMin: 120,
-        stallTimeoutMin: 10, maxSessionsPerTask: 5, runs: [],
-        assigneeAgent: runAgent(),
-        repo: { id: "repo-1", defaultBranch: "main" }, templateStep: { runner: null },
-      }),
-      // §D-P7's stop-state guard reads the task with its template step before
-      // queueing. This one is not a chain's step-12 task, so it is a no-op.
-      findUnique: async () => ({ id: "task-2", templateStep: { runner: null } }),
+      findUniqueOrThrow: async () => task,
+      findUnique: async () => task,
+      findFirst: async () => null,
     },
-    run: { create: async ({ data }: { data: Record<string, unknown> }) => { queued.push(data); return { id: "run-1", ...data }; } },
+    run: {
+      findFirst: async () => null,
+      create: async ({ data }: { data: Record<string, unknown> }) => { queued.push(data); return { id: "run-1", ...data }; },
+    },
   } as any;
   await enqueueTaskRun(tx, "task-2");
   assert.equal(queued[0]!.branch, "feat/lines");
@@ -274,7 +292,6 @@ const rejectionTx = (options: { redoArchivedAt?: Date | null; agentArchivedAt?: 
     assigneeAgent: runAgent(),
     repo: { id: "repo-1", defaultBranch: "main" }, templateStep: { runner: null }, runs: [{ runNumber: 1, branch: "feature/x" }],
   };
-  let lookup = 0;
   const tx = {
     // The Task-row mutex the reject path takes before queueing the redo, then
     // the Agent-row mutex enqueueTaskRun takes before creating the run.
@@ -299,7 +316,7 @@ const rejectionTx = (options: { redoArchivedAt?: Date | null; agentArchivedAt?: 
     inboxDecision: { create: async () => ({}) },
     task: {
       update: async () => ({}),
-      findUniqueOrThrow: async () => { lookup += 1; return executable; },
+      findUniqueOrThrow: async () => executable,
       findUnique: async () => executable,
     },
     taskActivity: { create: async () => ({}) },
@@ -313,14 +330,13 @@ const rejectionTx = (options: { redoArchivedAt?: Date | null; agentArchivedAt?: 
       create: async ({ data }: { data: Record<string, unknown> }) => { queued.push(data); return { id: "run-2", ...data }; },
     },
   } as any;
-  return { tx, queued, locks, lookups: () => lookup };
+  return { tx, queued, locks };
 };
 
 test("rejecting a gate transactionally returns the producing step to the queue", async () => {
-  const { tx, queued, locks, lookups } = rejectionTx();
+  const { tx, queued, locks } = rejectionTx();
   const result = await applyInboxDecisionTx(tx, { inboxMessageId: "gate-1", externalEventId: "feishu:evt-1", decision: "reject" });
   assert.equal(result.gateAction, "rejected");
-  assert.equal(lookups(), 1);
   // Task row first, Agent row second: the one global lock order.
   assert.deepEqual(locks, ["task-1", "agent-1"]);
   assert.equal(queued[0]!.runNumber, 2);
@@ -424,9 +440,10 @@ test("enqueueTaskRun rejects archived agents with a name-recognisable typed erro
     $queryRaw: async () => [{ id: "agent-1", archivedAt: new Date() }],
     agent: { findUnique: async () => runAgent({ name: "Ada", archivedAt: new Date() }) },
     task: {
-      findUniqueOrThrow: async () => ({
-        id: "task-archived", projectId: "project-1", name: "Archived work", description: "work",
-        assigneeType: AssigneeType.AGENT, templateId: null, targetBranch: "main",
+      findUnique: async () => ({
+        id: "task-archived", projectId: "project-1", name: "Archived work", description: "work", archivedAt: null,
+        assigneeType: AssigneeType.AGENT, assigneeAgentId: "agent-1", repoId: "repo-1", templateId: null,
+        templateStepId: null, chainId: null, chainIndex: null, targetBranch: "main", opensPullRequest: true,
         maxDurationMin: 120, stallTimeoutMin: 10, maxSessionsPerTask: 3, runs: [],
         assigneeAgent: {
           id: "agent-1", name: "Ada", archivedAt: new Date(), model: "claude",
@@ -435,7 +452,6 @@ test("enqueueTaskRun rejects archived agents with a name-recognisable typed erro
         repo: { id: "repo-1", defaultBranch: "main" },
         templateStep: null,
       }),
-      findUnique: async () => ({ id: "task-archived", templateStep: null }),
     },
     run: { create: async () => { throw new Error("must not create run"); } },
   } as any;
@@ -458,15 +474,21 @@ test("enqueueTaskRun preserves the precise archived-assignee refusal for a compo
     $queryRaw: async () => [{ id: executioner.id }],
     agent: { findUnique: async () => executioner },
     task: {
-      findUniqueOrThrow: async () => ({
+      findUnique: async () => ({
         id: "compound-implementation",
         projectId: "project-1",
         name: "Implementation",
         description: "implement",
+        archivedAt: null,
         assigneeType: AssigneeType.AGENT,
+        assigneeAgentId: executioner.id,
+        repoId: "repo-1",
         templateId: "compound-template",
         templateStepId: "implementation-step",
+        chainId: "chain-1",
+        chainIndex: 5,
         targetBranch: "main",
+        opensPullRequest: true,
         maxDurationMin: 120,
         stallTimeoutMin: 10,
         maxSessionsPerTask: 3,
@@ -476,10 +498,10 @@ test("enqueueTaskRun preserves the precise archived-assignee refusal for a compo
         templateStep: {
           stepIndex: 5,
           outputKind: "implementation",
+          baseFromStepIndex: null,
           taskTemplate: { name: "compound-engineer-workflow" },
         },
       }),
-      findUnique: async () => ({ id: "compound-implementation", templateStep: null }),
     },
     run: { create: async () => { throw new Error("must not create run"); } },
   } as any;

--- a/packages/db/src/merge-integrator-db.ts
+++ b/packages/db/src/merge-integrator-db.ts
@@ -14,7 +14,6 @@ import {
   InboxSender,
   InboxStatus,
   Prisma,
-  RunnerKind,
   TaskStatus,
 } from "@prisma/client";
 
@@ -386,75 +385,6 @@ export const findEvidenceRequestByNonce = async (
     if (request?.nonce === nonce) return request;
   }
   return null;
-};
-
-// ---------------------------------------------------------------------------
-// §D-P5 — the budget-exempt run an answer creates
-// ---------------------------------------------------------------------------
-
-/**
- * The only writer of a `maxRunsPerTask` above the task's original ceiling.
- * `runner.ts` refuses at claim when `runNumber > maxRunsPerTask`, so a renewed
- * authorization has to raise the ceiling on the row it creates — and completion
- * is separately prevented (Step 4) from raising it on any other path, which is
- * what makes "only a human answer may exceed the ceiling" true rather than
- * merely claimed.
- */
-export const createAuthorizedIntegratorRun = async (
-  tx: Tx,
-  integratorTaskId: string,
-  now = new Date(),
-): Promise<{ id: string; runNumber: number } | null> => {
-  const task = await tx.task.findUniqueOrThrow({
-    where: { id: integratorTaskId },
-    include: {
-      assigneeAgent: true,
-      repo: true,
-      templateStep: { include: { taskTemplate: { select: { name: true } } } },
-      runs: { orderBy: { runNumber: "desc" }, take: 1 },
-    },
-  });
-  if (!isIntegratorStep(task.templateStep)) throw new Error("Not an integrator step");
-  if (!task.assigneeAgent || !task.repo) throw new Error("Integrator step has no assignee or repo");
-  const prior = task.runs[0];
-  const runNumber = (prior?.runNumber ?? 0) + 1;
-  const ceiling = Math.max(prior?.maxRunsPerTask ?? task.maxSessionsPerTask, runNumber);
-  // The same authorization expressed as a grant rather than an absolute
-  // ceiling, so the operator-facing budget gates can tell it apart from the
-  // task's configured budget — including after that budget is edited. This is a
-  // human re-authorization, so it must survive exactly as a refund does.
-  const budgetGrants = Math.max(prior?.budgetGrants ?? 0, ceiling - task.maxSessionsPerTask);
-  const run = await tx.run.create({ data: {
-    projectId: task.projectId,
-    taskId: task.id,
-    agentId: task.assigneeAgent.id,
-    repoId: task.repo.id,
-    runNumber,
-    dedupeKey: `task:${task.id}:run:${runNumber}`,
-    // Inert. The sentinel Agent's runner is never used to spawn anything: the
-    // merge executor claims by runnerId allowlist and the ordinary runner
-    // refuses a mechanical claim outright (§D-P1 rules 3-4). The column is
-    // non-nullable, so it carries the prior row's value or a fixed default.
-    runner: prior?.runner ?? RunnerKind.CLAUDE,
-    model: task.assigneeAgent.model,
-    targetBranch: prior?.targetBranch ?? task.targetBranch,
-    branch: prior?.branch ?? null,
-    // Step 10 publishes nothing. The row-level flag is the second half of the
-    // §6.1 non-publication guarantee; the first is that the executor process
-    // contains no delivery code at all.
-    opensPullRequest: false,
-    promptHash: prior?.promptHash ?? "mechanical",
-    maxDurationMin: task.maxDurationMin,
-    stallTimeoutMin: task.stallTimeoutMin,
-    maxRunsPerTask: ceiling,
-    budgetGrants,
-    readyAt: now,
-  } });
-  await tx.task.updateMany({
-    where: { id: task.id, status: { in: [TaskStatus.REVIEW, TaskStatus.TODO, TaskStatus.DOING] } },
-    data: { status: TaskStatus.TODO, failureReason: null },
-  });
-  return { id: run.id, runNumber: run.runNumber };
 };
 
 /** Marks every still-OPEN question on the integrator task closed. Used when a disposition is terminal. */

--- a/packages/db/src/open-run.test.ts
+++ b/packages/db/src/open-run.test.ts
@@ -150,7 +150,7 @@ const integratorStep = {
   taskTemplate: { name: "compound-engineer-workflow" },
 };
 
-test("every OpenRunIntent applies the shared Run-birth invariants", async () => {
+test("every OpenRunIntent applies shared Run-birth invariants unless its branch names the exception", async () => {
   const repo = { id: "repo-1", defaultBranch: "main" };
   const stopRows = [{
     id: "stop-1",
@@ -216,6 +216,7 @@ test("every OpenRunIntent applies the shared Run-birth invariants", async () => 
 
   for (const intent of intents()) {
     for (const invariant of cases) {
+      if (intent.kind === "integrator-authorized" && invariant.name === "integrator stop state") continue;
       const { tx, creates } = fakeTx(invariant.task, invariant.options);
       const opened = await openRun(tx, invariant.task.id, intent);
       assert.equal(opened.ok, false, `${intent.kind} must refuse ${invariant.name}`);
@@ -223,6 +224,38 @@ test("every OpenRunIntent applies the shared Run-birth invariants", async () => 
       assert.equal(creates.length, 0, `${intent.kind} must not create after ${invariant.name}`);
     }
   }
+});
+
+test("integrator-authorized is the named human reauthorization exit from an unresolved stop", async () => {
+  const repo = { id: "repo-1", defaultBranch: "main" };
+  const integrator = agent({ name: "merge-integrator" });
+  const task = taskRow({
+    assigneeAgent: integrator,
+    repoId: repo.id,
+    repo,
+    templateStepId: integratorStep.id,
+    templateStep: integratorStep,
+    maxSessionsPerTask: 3,
+    runs: [priorRun({ runNumber: 3, maxRunsPerTask: 3, budgetGrants: 0 })],
+  });
+  const stopRows = [{
+    id: "stop-1",
+    createdAt: now,
+    metadata: {
+      kind: "mergeIntegrator.result",
+      schemaVersion: 1,
+      outcome: "stopped",
+      condition: "head-drift",
+      evidence: "head moved",
+      sourceRunId: "run-3",
+    },
+  }];
+  const { tx, creates } = fakeTx(task, { lockedAgent: integrator, stopRows });
+  const opened = await openRun(tx, task.id, { kind: "integrator-authorized", readyAt: now });
+  assert.equal(opened.ok, true);
+  assert.equal(creates.length, 1);
+  assert.equal(creates[0]?.runNumber, 4);
+  assert.equal(creates[0]?.maxRunsPerTask, 4);
 });
 
 test("openRun names every intent-specific refusal exit", async () => {

--- a/packages/db/src/open-run.test.ts
+++ b/packages/db/src/open-run.test.ts
@@ -1,0 +1,358 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AssigneeType,
+  CodexServiceTier,
+  RunnerKind,
+  RunnerPreference,
+} from "@prisma/client";
+
+import {
+  type OpenRunIntent,
+  openRun,
+  runBudgetCeiling,
+} from "./workflow.js";
+
+const now = new Date("2026-08-26T12:00:00.000Z");
+
+const agent = (overrides: Record<string, unknown> = {}) => ({
+  id: "agent-1",
+  projectId: "project-1",
+  environmentId: null,
+  name: "senior-dev",
+  title: "Senior Developer",
+  model: "claude-sonnet",
+  codexServiceTier: CodexServiceTier.DEFAULT,
+  runnerPreference: RunnerPreference.CLAUDE,
+  foundationalPrompt: "foundation",
+  rolePrompt: "role",
+  inboxAccess: false,
+  disabledTools: [],
+  archivedAt: null,
+  createdAt: now,
+  updatedAt: now,
+  ...overrides,
+});
+
+const priorRun = (overrides: Record<string, unknown> = {}) => ({
+  id: "run-3",
+  projectId: "project-1",
+  taskId: "task-1",
+  goalId: "goal-1",
+  agentId: "agent-1",
+  repoId: null,
+  runNumber: 3,
+  runner: RunnerKind.CLAUDE,
+  model: "snapshot-model",
+  codexServiceTier: CodexServiceTier.DEFAULT,
+  subagentModel: null,
+  subagentMaxConcurrent: null,
+  targetBranch: "main",
+  branch: "agentos/task-1/run-3",
+  promptHash: "snapshot-hash",
+  maxDurationMin: 90,
+  stallTimeoutMin: 12,
+  maxRunsPerTask: 5,
+  budgetGrants: 1,
+  ...overrides,
+});
+
+const taskRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "task-1",
+  projectId: "project-1",
+  name: "Implement seam",
+  description: "Create the Run once",
+  assigneeType: AssigneeType.AGENT,
+  assigneeAgentId: "agent-1",
+  assigneeAgent: agent(),
+  repoId: null,
+  repo: null,
+  templateId: null,
+  templateStepId: null,
+  templateStep: null,
+  chainId: null,
+  chainIndex: null,
+  targetBranch: "main",
+  opensPullRequest: true,
+  maxDurationMin: 120,
+  stallTimeoutMin: 10,
+  maxSessionsPerTask: 5,
+  archivedAt: null,
+  runs: [],
+  ...overrides,
+});
+
+const intents = (): OpenRunIntent[] => [
+  { kind: "enqueue", readyAt: now },
+  { kind: "task-created", readyAt: now },
+  { kind: "retry", readyAt: now },
+  { kind: "integrator-authorized", readyAt: now },
+  {
+    kind: "retry-after-completion",
+    readyAt: now,
+    sourceRunId: "run-3",
+    sourceMaxRunsPerTask: 5,
+    sourceBudgetGrants: 1,
+    budgetGrant: 1,
+  },
+  {
+    kind: "retry-after-lease-loss",
+    readyAt: now,
+    sourceRunId: "run-3",
+    sourceMaxRunsPerTask: 5,
+    sourceBudgetGrants: 1,
+  },
+];
+
+const fakeTx = (
+  task: ReturnType<typeof taskRow> | null,
+  options: {
+    lockedAgent?: ReturnType<typeof agent> | null;
+    stopRows?: Array<Record<string, unknown>>;
+  } = {},
+) => {
+  const creates: Array<Record<string, unknown>> = [];
+  let agentLocks = 0;
+  const tx = {
+    $queryRaw: async () => {
+      agentLocks += 1;
+      return options.lockedAgent === null ? [] : [{ id: task?.assigneeAgentId ?? "agent-1" }];
+    },
+    agent: {
+      findUnique: async () => options.lockedAgent === undefined ? task?.assigneeAgent ?? null : options.lockedAgent,
+    },
+    task: {
+      findUnique: async () => task,
+      findFirst: async () => null,
+    },
+    taskActivity: {
+      findMany: async () => options.stopRows ?? [],
+      create: async () => ({ id: "activity-1" }),
+    },
+    taskTemplateStep: { findUnique: async () => null },
+    run: {
+      findFirst: async () => null,
+      create: async ({ data }: { data: Record<string, unknown> }) => {
+        creates.push(data);
+        return { id: "opened-run", ...data };
+      },
+    },
+  };
+  return { tx: tx as never, creates, agentLocks: () => agentLocks };
+};
+
+const integratorStep = {
+  id: "integrator-step",
+  stepIndex: 12,
+  outputKind: "merge-result",
+  baseFromStepIndex: null,
+  taskTemplate: { name: "compound-engineer-workflow" },
+};
+
+test("every OpenRunIntent applies the shared Run-birth invariants", async () => {
+  const repo = { id: "repo-1", defaultBranch: "main" };
+  const stopRows = [{
+    id: "stop-1",
+    createdAt: now,
+    metadata: {
+      kind: "mergeIntegrator.result",
+      schemaVersion: 1,
+      outcome: "stopped",
+      condition: "head-drift",
+      evidence: "head moved",
+      sourceRunId: "run-3",
+    },
+  }];
+  const cases = [
+    {
+      name: "archived Task",
+      task: taskRow({ archivedAt: now, repoId: repo.id, repo }),
+      options: {},
+      reason: "archived-task",
+    },
+    {
+      name: "integrator stop state",
+      task: taskRow({
+        assigneeAgent: agent({ name: "merge-integrator" }),
+        repoId: repo.id,
+        repo,
+        templateStepId: integratorStep.id,
+        templateStep: integratorStep,
+      }),
+      options: { stopRows },
+      reason: "integrator-stopped",
+    },
+    {
+      name: "archived Agent under the shared row mutex",
+      task: taskRow({ repoId: repo.id, repo }),
+      options: { lockedAgent: agent({ archivedAt: now }) },
+      reason: "archived-assignee",
+    },
+    {
+      name: "compound implementation assignee",
+      task: taskRow({
+        repoId: repo.id,
+        repo,
+        templateStepId: "implementation-step",
+        templateStep: {
+          id: "implementation-step",
+          stepIndex: 5,
+          outputKind: "implementation",
+          baseFromStepIndex: null,
+          taskTemplate: { name: "compound-engineer-workflow" },
+        },
+      }),
+      options: {},
+      reason: "compound-implementation-assignee",
+    },
+    {
+      name: "integrator binding",
+      task: taskRow({ repoId: repo.id, repo, assigneeAgent: agent({ name: "merge-integrator" }) }),
+      options: { lockedAgent: agent({ name: "merge-integrator" }) },
+      reason: "invalid-request",
+    },
+  ] as const;
+
+  for (const intent of intents()) {
+    for (const invariant of cases) {
+      const { tx, creates } = fakeTx(invariant.task, invariant.options);
+      const opened = await openRun(tx, invariant.task.id, intent);
+      assert.equal(opened.ok, false, `${intent.kind} must refuse ${invariant.name}`);
+      if (!opened.ok) assert.equal(opened.refusal.reason, invariant.reason, `${intent.kind}: ${invariant.name}`);
+      assert.equal(creates.length, 0, `${intent.kind} must not create after ${invariant.name}`);
+    }
+  }
+});
+
+test("openRun names every intent-specific refusal exit", async () => {
+  const missing = await openRun(fakeTx(null).tx, "missing", { kind: "enqueue", readyAt: now });
+  assert.deepEqual(missing, { ok: false, refusal: { reason: "not-found", message: "Task not found" } });
+
+  const noAgentTask = taskRow({ assigneeType: AssigneeType.HUMAN, assigneeAgent: null, assigneeAgentId: null });
+  const noAgent = await openRun(fakeTx(noAgentTask).tx, noAgentTask.id, { kind: "retry", readyAt: now });
+  assert.equal(noAgent.ok ? null : noAgent.refusal.reason, "invalid-request");
+
+  const noRepo = taskRow();
+  const repoRequired = await openRun(fakeTx(noRepo).tx, noRepo.id, { kind: "enqueue", readyAt: now });
+  assert.equal(repoRequired.ok ? null : repoRequired.refusal.reason, "invalid-request");
+
+  const noPrior = await openRun(fakeTx(taskRow()).tx, "task-1", { kind: "retry", readyAt: now });
+  assert.equal(noPrior.ok ? null : noPrior.refusal.reason, "conflict");
+
+  const repo = { id: "repo-1", defaultBranch: "main" };
+  const alreadyOpenedTask = taskRow({ repoId: repo.id, repo, runs: [priorRun()] });
+  const duplicateFirst = await openRun(fakeTx(alreadyOpenedTask).tx, alreadyOpenedTask.id, { kind: "task-created", readyAt: now });
+  assert.equal(duplicateFirst.ok ? null : duplicateFirst.refusal.reason, "conflict");
+
+  const staleSourceTask = taskRow({ runs: [priorRun({ id: "newer-run" })] });
+  const staleSource = await openRun(fakeTx(staleSourceTask).tx, staleSourceTask.id, {
+    kind: "retry-after-completion",
+    readyAt: now,
+    sourceRunId: "run-3",
+    sourceMaxRunsPerTask: 5,
+    sourceBudgetGrants: 1,
+    budgetGrant: 0,
+  });
+  assert.equal(staleSource.ok ? null : staleSource.refusal.reason, "conflict");
+
+  const ordinaryPriorTask = taskRow({ repoId: "repo-1", repo: { id: "repo-1", defaultBranch: "main" }, runs: [priorRun()] });
+  const notIntegrator = await openRun(fakeTx(ordinaryPriorTask).tx, ordinaryPriorTask.id, {
+    kind: "integrator-authorized",
+    readyAt: now,
+  });
+  assert.equal(notIntegrator.ok ? null : notIntegrator.refusal.reason, "invalid-request");
+
+  const exhaustedTask = taskRow({ maxSessionsPerTask: 2, runs: [priorRun({ runNumber: 3, budgetGrants: 1 })] });
+  const exhausted = await openRun(fakeTx(exhaustedTask).tx, exhaustedTask.id, { kind: "retry", readyAt: now });
+  assert.deepEqual(exhausted, { ok: false, refusal: { reason: "conflict", message: "Run budget exhausted" } });
+});
+
+test("each OpenRunIntent creates through one seam with its named budget rule", async () => {
+  const repo = { id: "repo-1", defaultBranch: "main" };
+  const cases: Array<{
+    intent: OpenRunIntent;
+    task: ReturnType<typeof taskRow>;
+    expected: { runNumber: number; maxRunsPerTask: number; budgetGrants: number };
+  }> = [
+    {
+      intent: { kind: "task-created", readyAt: now },
+      task: taskRow({ repoId: repo.id, repo }),
+      expected: { runNumber: 1, maxRunsPerTask: 5, budgetGrants: 0 },
+    },
+    {
+      intent: { kind: "enqueue", readyAt: now },
+      task: taskRow({ repoId: repo.id, repo, runs: [priorRun({ budgetGrants: 2 })] }),
+      expected: { runNumber: 4, maxRunsPerTask: 7, budgetGrants: 2 },
+    },
+    {
+      intent: { kind: "retry", readyAt: now },
+      task: taskRow({ maxSessionsPerTask: 5, runs: [priorRun({ runNumber: 2, budgetGrants: 2 })] }),
+      expected: { runNumber: 3, maxRunsPerTask: 7, budgetGrants: 2 },
+    },
+    {
+      intent: { kind: "integrator-authorized", readyAt: now },
+      task: taskRow({
+        assigneeAgent: agent({ name: "merge-integrator" }),
+        repoId: repo.id,
+        repo,
+        templateStepId: integratorStep.id,
+        templateStep: integratorStep,
+        maxSessionsPerTask: 3,
+        // A historical absolute ceiling of 10 came from an old Task budget.
+        // Authorization grants only the next Run against the current budget;
+        // it must not carry that opaque old sum forward.
+        runs: [priorRun({ runNumber: 3, maxRunsPerTask: 10, budgetGrants: 0 })],
+      }),
+      expected: { runNumber: 4, maxRunsPerTask: 4, budgetGrants: 1 },
+    },
+    {
+      intent: {
+        kind: "retry-after-completion",
+        readyAt: now,
+        sourceRunId: "run-3",
+        sourceMaxRunsPerTask: 5,
+        sourceBudgetGrants: 1,
+        budgetGrant: 1,
+      },
+      task: taskRow({ runs: [priorRun()] }),
+      expected: { runNumber: 4, maxRunsPerTask: 6, budgetGrants: 2 },
+    },
+    {
+      intent: {
+        kind: "retry-after-lease-loss",
+        readyAt: now,
+        sourceRunId: "run-3",
+        sourceMaxRunsPerTask: 5,
+        sourceBudgetGrants: 1,
+      },
+      task: taskRow({ runs: [priorRun()] }),
+      expected: { runNumber: 4, maxRunsPerTask: 6, budgetGrants: 2 },
+    },
+  ];
+
+  for (const item of cases) {
+    const locked = item.task.assigneeAgent as ReturnType<typeof agent>;
+    const { tx, creates, agentLocks } = fakeTx(item.task, { lockedAgent: locked });
+    const opened = await openRun(tx, item.task.id, item.intent);
+    assert.equal(opened.ok, true, item.intent.kind);
+    assert.equal(agentLocks(), 1, `${item.intent.kind} must take the Agent-row mutex`);
+    assert.equal(creates.length, 1, `${item.intent.kind} must create exactly once`);
+    assert.deepEqual(
+      {
+        runNumber: creates[0]?.runNumber,
+        maxRunsPerTask: creates[0]?.maxRunsPerTask,
+        budgetGrants: creates[0]?.budgetGrants,
+      },
+      item.expected,
+      item.intent.kind,
+    );
+  }
+});
+
+test("runBudgetCeiling is the only ceiling algorithm and clamps negative grants", () => {
+  assert.equal(runBudgetCeiling(5, undefined), 5);
+  assert.equal(runBudgetCeiling(5, null), 5);
+  assert.equal(runBudgetCeiling(5, -2), 5);
+  assert.equal(runBudgetCeiling(5, 3), 8);
+});

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -768,7 +768,12 @@ export const openRun = async (
   // refusal by construction rather than by remembering to ask.
   const stopped = await stopStateFor(tx, task.id);
   const stopBypass = intent.kind === "enqueue" ? intent.stopBypass ?? null : null;
-  if (stopped && (stopBypass?.integratorTaskId !== task.id || stopBypass.sourceStopId !== stopped.stop.stopId)) {
+  // A recovered confirmation approval is itself the human-authorized exit
+  // from this unresolved stop. Its named intent is the only path that may open
+  // the renewed mechanical Run while the original stop remains in history.
+  const humanReauthorization = intent.kind === "integrator-authorized";
+  if (stopped && !humanReauthorization
+    && (stopBypass?.integratorTaskId !== task.id || stopBypass.sourceStopId !== stopped.stop.stopId)) {
     return openRunRefusal(
       "integrator-stopped",
       `Merge integrator stopped on ${stopped.stop.condition}; answer the stop question before starting another run`,

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -10,6 +10,7 @@ import {
   MergeRecoveryStatus,
   Prisma,
   RunStatus,
+  type Run,
   RunnerKind,
   RunnerPreference,
   SessionExecutionStatus,
@@ -32,10 +33,10 @@ import {
 } from "./merge-integrator.js";
 import {
   applyStopAnswer,
-  createAuthorizedIntegratorRun,
-  assertIntegratorBinding,
   findEvidenceRequestByNonce,
   gateFeedsIntegratorStep,
+  IntegratorBindingError,
+  integratorBindingRefusalFor,
   isIntegratorBindingError,
   parseStopQuestionKey,
   recoverRefreshRequestedConfirmationCard,
@@ -47,6 +48,11 @@ import { AUTHORITY_RESIGN_OPEN_PREFIX, INDEPENDENT_REVIEW_OPEN_PREFIX, isMergeRe
 import { stepRole } from "./step-role.js";
 
 type Tx = Prisma.TransactionClient;
+
+export const runBudgetCeiling = (
+  maxSessionsPerTask: number,
+  budgetGrants: number | null | undefined,
+): number => maxSessionsPerTask + Math.max(0, budgetGrants ?? 0);
 
 const promptHash = (parts: string[]): string => createHash("sha256").update(parts.join("\n")).digest("hex");
 
@@ -424,8 +430,8 @@ export const lockAgentRepoGrantForRevocation = async (
 };
 
 /** The shape `resolveRunBranches` needs. Structural rather than a Prisma payload
- *  type, so the five call sites can pass rows from five differently-shaped
- *  queries — the same reason `packages/api/src/chain.ts` keeps `ChainRow` plain. */
+ *  type so `openRun` can pass each intent's branch facts without coupling the
+ *  resolver to its full Task query. */
 export type RunBranchTask = {
   id: string;
   projectId: string;
@@ -549,11 +555,10 @@ export const resolveRequeueBase = async (
 };
 
 /**
- * Decides a new Run's head (`branch`) and base (`targetBranch`). The only place
- * that decision is made; `enqueueTaskRun`, `POST /tasks`, the operator retry
- * route, the automatic retry in the completion transaction and the lost-lease
- * requeue all call this, because five copies of the expression is how step ①
- * ended up on a different branch from steps ②–⑨.
+ * Decides a new Run's head (`branch`) and base (`targetBranch`). `openRun` is
+ * its only Run-birth caller; keeping the branch rule behind that seam prevents
+ * one intent from putting a Step on a different branch from the rest of its
+ * Chain.
  *
  * Writes at most one TaskActivity row (see the chain branch below), so it takes
  * the caller's transaction.
@@ -648,13 +653,86 @@ export const resolveRunBranches = async (
 
 type IntegratorStopBypass = { integratorTaskId: string; sourceStopId: string };
 
-const enqueueTaskRunInternal = async (
+export type OpenRunIntent =
+  | { kind: "enqueue"; readyAt: Date; stopBypass?: IntegratorStopBypass | null }
+  | { kind: "task-created"; readyAt: Date }
+  | { kind: "retry"; readyAt: Date }
+  | { kind: "integrator-authorized"; readyAt: Date }
+  | {
+    kind: "retry-after-completion";
+    readyAt: Date;
+    sourceRunId: string;
+    sourceMaxRunsPerTask: number;
+    sourceBudgetGrants: number;
+    budgetGrant: 0 | 1;
+  }
+  | {
+    kind: "retry-after-lease-loss";
+    readyAt: Date;
+    sourceRunId: string;
+    sourceMaxRunsPerTask: number;
+    sourceBudgetGrants: number;
+  };
+
+export type OpenRunRefusal = {
+  reason:
+    | "invalid-request"
+    | "not-found"
+    | "conflict"
+    | "compound-implementation-assignee"
+    | "archived-assignee"
+    | "archived-task"
+    | "integrator-stopped";
+  message: string;
+  detail?: Readonly<Record<string, string | number | boolean | null>>;
+  context?: Readonly<{
+    taskId?: string;
+    taskName?: string;
+    agentName?: string;
+    condition?: string;
+    code?: string;
+  }>;
+};
+
+export type OpenRunResult =
+  | { ok: true; run: Run }
+  | { ok: false; refusal: OpenRunRefusal };
+
+const openRunRefusal = (
+  reason: OpenRunRefusal["reason"],
+  message: string,
+  detail?: OpenRunRefusal["detail"],
+  context?: OpenRunRefusal["context"],
+): OpenRunResult => ({
+  ok: false,
+  refusal: {
+    reason,
+    message,
+    ...(detail ? { detail } : {}),
+    ...(context ? { context } : {}),
+  },
+});
+
+const sourceRetryIntent = (
+  intent: OpenRunIntent,
+): intent is Extract<OpenRunIntent, { kind: "retry-after-completion" | "retry-after-lease-loss" }> =>
+  intent.kind === "retry-after-completion" || intent.kind === "retry-after-lease-loss";
+
+/**
+ * The only place a Run comes into existence.
+ *
+ * Every birth intent crosses the same task, stop-state, Agent-row, compound
+ * assignee and integrator-binding guards. The discriminated intent owns the
+ * few differences that are real domain rules: which prior configuration and
+ * branch snapshot a retry preserves, and whether a human authorization may
+ * grant enough budget for the next mechanical run.
+ */
+export const openRun = async (
   tx: Tx,
   taskId: string,
-  now: Date,
-  stopBypass: IntegratorStopBypass | null,
-) => {
-  const task = await tx.task.findUniqueOrThrow({
+  intent: OpenRunIntent,
+): Promise<OpenRunResult> => {
+  const task = await tx.task.findUnique({
     where: { id: taskId },
     include: {
       assigneeAgent: true,
@@ -663,31 +741,56 @@ const enqueueTaskRunInternal = async (
       runs: { orderBy: { runNumber: "desc" }, take: 1 },
     },
   });
-  if (task.assigneeType !== AssigneeType.AGENT || !task.assigneeAgent || !task.repo) {
-    throw new Error(`Task ${task.id} cannot be queued without an agent and repo`);
+  if (!task) return openRunRefusal("not-found", "Task not found");
+  if (task.assigneeType !== AssigneeType.AGENT) {
+    return openRunRefusal("invalid-request", `Task ${task.id} cannot open a Run without an Agent assignee`);
+  }
+  if (!task.assigneeAgent) {
+    return openRunRefusal("conflict", "Task assignee no longer exists; assign an agent before retrying");
+  }
+  if (!task.repo && (intent.kind === "enqueue" || intent.kind === "task-created" || intent.kind === "integrator-authorized")) {
+    return openRunRefusal("invalid-request", `Task ${task.id} cannot open a ${intent.kind} Run without a Repo`);
   }
   // Checked before the assignee, because an archived task is archived whoever
   // it is assigned to. The runner claims only `TODO|DOING` and unarchived tasks,
   // so a run queued here would never be claimed and never complete.
   if (task.archivedAt) {
-    throw new ArchivedTaskError(task.id, task.name);
+    const message = intent.kind === "retry"
+      ? "Cannot retry an archived task"
+      : `Task ${task.name} is archived; unarchive it before queueing a run`;
+    return openRunRefusal("archived-task", message, undefined, {
+      taskId: task.id,
+      taskName: task.name,
+    });
   }
-  // §D-P7, the last line of the exclusivity guard. This function is the single
-  // place a Run comes into existence outside the two inline creates and the
-  // answer transaction, so a route added later inherits the refusal by
-  // construction rather than by remembering to ask.
+  // §D-P7, the last line of the exclusivity guard. `openRun` is the single
+  // place a Run comes into existence, so a new birth intent inherits the
+  // refusal by construction rather than by remembering to ask.
   const stopped = await stopStateFor(tx, task.id);
+  const stopBypass = intent.kind === "enqueue" ? intent.stopBypass ?? null : null;
   if (stopped && (stopBypass?.integratorTaskId !== task.id || stopBypass.sourceStopId !== stopped.stop.stopId)) {
-    throw new IntegratorStoppedError(task.id, stopped.stop.condition);
+    return openRunRefusal(
+      "integrator-stopped",
+      `Merge integrator stopped on ${stopped.stop.condition}; answer the stop question before starting another run`,
+      undefined,
+      { taskId: task.id, condition: stopped.stop.condition },
+    );
   }
   // The assignee is re-read under the shared Agent-row mutex, not trusted from
-  // the relation above: this function is the single place a Run comes into
+  // the relation above: `openRun` is the single place a Run comes into
   // existence, so an archive committing in parallel has to lose here or be
-  // refused for the run this call is about to create. A row that vanished
-  // falls back to the relation; the foreign key decides that case.
+  // refused for the Run this call is about to create.
   const lockedAgent = await lockAgentRow(tx, task.assigneeAgent.id);
   if (!lockedAgent || lockedAgent.archivedAt) {
-    throw new ArchivedAssigneeError(task.id, task.name, task.assigneeAgent.name);
+    const message = intent.kind === "retry"
+      ? `Assignee ${task.assigneeAgent.name} is archived; unarchive it to retry`
+      : `Task ${task.name} assignee ${task.assigneeAgent.name} is archived; unarchive the agent to queue this step`;
+    return openRunRefusal(
+      "archived-assignee",
+      message,
+      undefined,
+      { taskId: task.id, taskName: task.name, agentName: task.assigneeAgent.name },
+    );
   }
   if (!compoundImplementationAssigneeValid(
     task.projectId,
@@ -695,52 +798,170 @@ const enqueueTaskRunInternal = async (
     lockedAgent,
     task.templateStep,
   )) {
-    throw new CompoundImplementationAssigneeError();
+    const error = new CompoundImplementationAssigneeError();
+    return openRunRefusal("compound-implementation-assignee", error.message, { code: error.code });
   }
-  // §D-P4, the last line of the binding invariant, for the same reason: this is
-  // the shared enqueue path, so a route added later inherits the refusal. The
+  // §D-P4, the last line of the binding invariant, for the same reason. The
   // Agent name comes from the locked re-read, never the stale task relation.
-  await assertIntegratorBinding(tx, {
+  const bindingRefusal = await integratorBindingRefusalFor(tx, {
     assigneeAgentName: lockedAgent.name,
-    templateStepId: task.templateStepId,
+    templateStep: task.templateStep,
   });
+  if (bindingRefusal) {
+    return openRunRefusal("invalid-request", bindingRefusal, undefined, { code: "INTEGRATOR_BINDING_INVALID" });
+  }
+
   const prior = task.runs[0];
+  if (intent.kind === "task-created" && prior) {
+    return openRunRefusal("conflict", `Task ${task.name} already has a Run`);
+  }
+  if ((intent.kind === "retry" || intent.kind === "integrator-authorized" || sourceRetryIntent(intent)) && !prior) {
+    return openRunRefusal("conflict", `Task ${task.name} has no Run to continue`);
+  }
+  if (sourceRetryIntent(intent) && prior?.id !== intent.sourceRunId) {
+    return openRunRefusal("conflict", `Run ${intent.sourceRunId} is no longer the latest Run for task ${task.name}`);
+  }
+  if (intent.kind === "integrator-authorized" && (!task.templateStep || stepRole(task.templateStep) !== "integrator")) {
+    return openRunRefusal("invalid-request", `Task ${task.name} is not an integrator Step`);
+  }
+
   const runNumber = (prior?.runNumber ?? 0) + 1;
-  const derived = deriveRunConfig(lockedAgent, task.templateStep, task);
-  const subagent = nativeImplementationSubagentRunConfig(derived.runner, task.templateStep);
-  const branches = await resolveRunBranches(tx, { ...task, repo: task.repo }, prior ?? null);
-  return tx.run.create({ data: {
+  let budgetGrants = prior?.budgetGrants ?? 0;
+  let maxRunsPerTask: number;
+  if (intent.kind === "integrator-authorized") {
+    budgetGrants = Math.max(budgetGrants, runNumber - task.maxSessionsPerTask);
+    maxRunsPerTask = runBudgetCeiling(task.maxSessionsPerTask, budgetGrants);
+  } else if (intent.kind === "retry-after-completion") {
+    budgetGrants = intent.sourceBudgetGrants + intent.budgetGrant;
+    maxRunsPerTask = runBudgetCeiling(intent.sourceMaxRunsPerTask, intent.budgetGrant);
+  } else if (intent.kind === "retry-after-lease-loss") {
+    budgetGrants = intent.sourceBudgetGrants + 1;
+    maxRunsPerTask = runBudgetCeiling(intent.sourceMaxRunsPerTask, 1);
+  } else {
+    maxRunsPerTask = runBudgetCeiling(task.maxSessionsPerTask, budgetGrants);
+  }
+  if (intent.kind === "retry" && prior && prior.runNumber >= maxRunsPerTask) {
+    return openRunRefusal("conflict", "Run budget exhausted");
+  }
+
+  const branches = intent.kind === "integrator-authorized"
+    ? { branch: prior?.branch ?? null, targetBranch: prior?.targetBranch ?? task.targetBranch }
+    : !task.repo
+      ? { branch: prior?.branch ?? null, targetBranch: prior?.targetBranch ?? task.targetBranch }
+      : intent.kind === "retry-after-completion"
+        ? task.chainId && (task.templateId || task.chainIndex !== null)
+          ? await resolveRunBranches(
+            tx,
+            { ...task, repo: task.repo },
+            task.templateId ? { branch: prior?.branch ?? null } : null,
+          )
+          : {
+            branch: null,
+            targetBranch: prior
+              ? await resolveRequeueBase(tx, { ...task, repo: task.repo }, prior)
+              : task.targetBranch ?? task.repo.defaultBranch,
+          }
+        : intent.kind === "retry-after-lease-loss"
+          ? task.templateStep?.baseFromStepIndex != null
+            ? await resolveRunBranches(tx, { ...task, repo: task.repo }, { branch: prior?.branch ?? null })
+            : task.chainId && task.chainIndex !== null && !task.templateId
+              ? await resolveRunBranches(tx, { ...task, repo: task.repo }, null)
+              : {
+                branch: prior?.branch ?? null,
+                targetBranch: prior
+                  ? await resolveRequeueBase(tx, { ...task, repo: task.repo }, prior)
+                  : task.targetBranch ?? task.repo.defaultBranch,
+              }
+          : await resolveRunBranches(tx, { ...task, repo: task.repo }, prior ?? null);
+
+  const preservedConfiguration = sourceRetryIntent(intent) && prior
+    ? {
+      runner: prior.runner,
+      model: prior.model,
+      codexServiceTier: prior.codexServiceTier,
+      subagentModel: prior.subagentModel,
+      subagentMaxConcurrent: prior.subagentMaxConcurrent,
+      promptHash: prior.promptHash,
+    }
+    : null;
+  const configuration = intent.kind === "integrator-authorized"
+    ? {
+      runner: prior?.runner ?? RunnerKind.CLAUDE,
+      model: lockedAgent.model,
+      promptHash: prior?.promptHash ?? "mechanical",
+    }
+    : preservedConfiguration ?? (() => {
+      const derived = deriveRunConfig(lockedAgent, task.templateStep, task);
+      return {
+        ...derived,
+        ...nativeImplementationSubagentRunConfig(derived.runner, task.templateStep),
+      };
+    })();
+  const preservesPriorTiming = intent.kind === "retry" || sourceRetryIntent(intent);
+
+  const run = await tx.run.create({ data: {
     projectId: task.projectId,
     taskId: task.id,
+    ...((intent.kind === "retry" || sourceRetryIntent(intent)) && prior?.goalId ? { goalId: prior.goalId } : {}),
     agentId: lockedAgent.id,
-    repoId: task.repo.id,
+    repoId: task.repoId,
     runNumber,
     dedupeKey: `task:${task.id}:run:${runNumber}`,
-    runner: derived.runner,
-    model: derived.model,
-    codexServiceTier: derived.codexServiceTier,
-    ...subagent,
+    ...configuration,
     targetBranch: branches.targetBranch,
     branch: branches.branch,
-    opensPullRequest: task.opensPullRequest,
-    promptHash: derived.promptHash,
-    maxDurationMin: task.maxDurationMin,
-    stallTimeoutMin: task.stallTimeoutMin,
+    opensPullRequest: intent.kind === "integrator-authorized" ? false : task.opensPullRequest,
+    maxDurationMin: preservesPriorTiming ? prior?.maxDurationMin ?? task.maxDurationMin : task.maxDurationMin,
+    stallTimeoutMin: preservesPriorTiming ? prior?.stallTimeoutMin ?? task.stallTimeoutMin : task.stallTimeoutMin,
     // The configured budget plus the grants already earned, not the budget
-    // alone. This is the fifth run-creating path (chain successors, template
-    // steps, schedules, approval rejections) and it used to reset
-    // `maxRunsPerTask` to the task's raw budget, throwing away every refund an
-    // external failure had bought — issue #113. A task whose provisioning
-    // failures had lifted the ceiling to 7 and reached run 6 would be handed
-    // `runNumber: 7, maxRunsPerTask: 5` and the runner's own boot gate
-    // (`runNumber > maxRunsPerTask`) would refuse it: a run nothing could ever
-    // claim. Recomputing from `maxSessionsPerTask` each time, rather than
-    // carrying the prior absolute ceiling forward, is what lets an operator
-    // lower a task's budget and have it take effect.
-    maxRunsPerTask: task.maxSessionsPerTask + (prior?.budgetGrants ?? 0),
-    budgetGrants: prior?.budgetGrants ?? 0,
-    readyAt: now,
+    // alone. Automatic retries deliberately use the already-authorized source
+    // ceiling as their base: a mid-Run task edit cannot retroactively revoke a
+    // Run, while later operator actions recompute from the current task budget.
+    maxRunsPerTask,
+    budgetGrants,
+    readyAt: intent.readyAt,
   } });
+  return { ok: true, run };
+};
+
+const errorForOpenRunRefusal = (refusal: OpenRunRefusal): Error => {
+  if (refusal.reason === "archived-task") {
+    return new ArchivedTaskError(
+      String(refusal.context?.taskId ?? "unknown"),
+      String(refusal.context?.taskName ?? "unknown"),
+    );
+  }
+  if (refusal.reason === "archived-assignee") {
+    return new ArchivedAssigneeError(
+      String(refusal.context?.taskId ?? "unknown"),
+      String(refusal.context?.taskName ?? "unknown"),
+      String(refusal.context?.agentName ?? "unknown"),
+    );
+  }
+  if (refusal.reason === "integrator-stopped") {
+    return new IntegratorStoppedError(
+      String(refusal.context?.taskId ?? "unknown"),
+      String(refusal.context?.condition ?? "unknown"),
+    );
+  }
+  if (refusal.reason === "compound-implementation-assignee") {
+    return new CompoundImplementationAssigneeError();
+  }
+  if (refusal.context?.code === "INTEGRATOR_BINDING_INVALID") {
+    return new IntegratorBindingError(refusal.message);
+  }
+  return new Error(refusal.message);
+};
+
+const enqueueTaskRunInternal = async (
+  tx: Tx,
+  taskId: string,
+  now: Date,
+  stopBypass: IntegratorStopBypass | null,
+): Promise<Run> => {
+  const opened = await openRun(tx, taskId, { kind: "enqueue", readyAt: now, stopBypass });
+  if (!opened.ok) throw errorForOpenRunRefusal(opened.refusal);
+  return opened.run;
 };
 
 export const enqueueTaskRun = async (tx: Tx, taskId: string, now = new Date()) =>
@@ -1895,7 +2116,12 @@ export const produceMergeAuthorization = async (
     // A renewal. The successor is already active, so activateChainSuccessor
     // would produce a run at the original ceiling that runner.ts then refuses
     // at claim. This is the only writer of a ceiling above the task's original.
-    await createAuthorizedIntegratorRun(tx, integrator.id, now);
+    const opened = await openRun(tx, integrator.id, { kind: "integrator-authorized", readyAt: now });
+    if (!opened.ok) throw errorForOpenRunRefusal(opened.refusal);
+    await tx.task.updateMany({
+      where: { id: integrator.id, status: { in: [TaskStatus.REVIEW, TaskStatus.TODO, TaskStatus.DOING] } },
+      data: { status: TaskStatus.TODO, failureReason: null },
+    });
     await tx.taskActivity.create({ data: {
       taskId: integrator.id,
       actorType: "control-plane",

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -267,6 +267,8 @@ export const executeClaim = async (
       });
       return;
     }
+    // `maxRunsPerTask` is the persisted authorization written by `openRun`;
+    // this boot gate consumes that verdict and must not recompute a Task budget.
     if (claim.run.runNumber > claim.run.maxRunsPerTask) {
       const { salvage: _salvage, ...finishedCleanup } = await cleanup(config, claim, workspace, false);
       await completeRun(config, claim, {


### PR DESCRIPTION
## Summary

- make `openRun` the single production Run-birth seam and route all six writers through it
- return W2-1-compatible refusal verdicts, with enqueue adapters restoring typed exception semantics only for internal callers
- centralize `runBudgetCeiling` in `@agentos/db` and make the runner boot gate explicitly consume the persisted ceiling

Design choice: keep `openRun` in `workflow.ts` so it reuses the existing `@agentos/db` export surface and branch/config helpers without adding a package dependency or a circular module seam.

## Corrected writer inventory

The brief counted four writers; the source has six:

1. `packages/db/src/workflow.ts` — `enqueueTaskRunInternal`: applied archived-Task, stop-state, locked archived-Agent, compound implementation assignee, and integrator binding; skipped no listed shared invariant. It inlined configured budget plus grants instead of calling the helper.
2. `packages/api/src/app.ts` — `POST /projects/:projectId/tasks`: applied Agent locking/archive and integrator binding; skipped compound implementation assignee and stop-state. An archived Task is impossible before Task creation. It wrote the raw configured budget and did not carry grants.
3. `packages/api/src/app.ts` — `POST /tasks/:taskId/retry`: applied archived-Task, chain/active-run, stop-state, locked archived-Agent, integrator binding, and the shared budget helper; skipped compound implementation assignee.
4. `packages/db/src/merge-integrator-db.ts` — `createAuthorizedIntegratorRun`: applied integrator-Step and assignee/Repo existence checks; skipped archived-Task, locked archived-Agent, compound implementation assignee, and integrator binding. It intentionally crossed the unresolved stop only as the recovered-confirmation exit, but that exception was implicit. It used an absolute `Math.max` ceiling.
5. `packages/api/src/run-completion.ts` — `completeRun` automatic retry: preserved the source Run configuration/branch snapshot and applied retry/refund gates; skipped archived-Task, stop-state, locked archived-Agent, compound implementation assignee, and integrator binding. It used source ceiling plus refund.
6. `packages/api/src/reconcile.ts` — `reconcileDatabaseRuns` lease-loss retry: preserved the source Run configuration/branch snapshot and applied lease-loss/refund gates; skipped archived-Task, stop-state, locked archived-Agent, compound implementation assignee, and integrator binding. It used source ceiling plus one.

Production `tx.run.create` / `db.run.create` now appears once, inside `openRun`.

## Intent rules

All six intents apply archived-Task, locked archived-Agent, compound implementation assignee, and integrator binding guards. Five apply the ordinary unresolved stop refusal. Named intent branches preserve the real differences:

- `enqueue` may carry the existing exact stop bypass.
- `task-created` requires no prior Run and a Repo.
- `retry` recomputes from the current Task budget plus recorded grants and rejects exhaustion.
- `integrator-authorized` requires the integrator Step and is the explicit human-approved exit from a recovered confirmation's unresolved stop; it grants only enough budget for the next mechanical Run.
- `retry-after-completion` and `retry-after-lease-loss` preserve the source Run configuration, timing, branch rules, and already-authorized ceiling.

## Behavior changes

- Behavior change: operator retry now returns the named `compound-implementation-assignee` 409 for a compound implementation Step assigned to a non-executioner Agent; asserted in `app.test.ts`.
- Behavior change: completion automatic retry now refuses archived Tasks/Agents, unresolved integrator stops, invalid compound assignees, and invalid integrator bindings; refusal parks the Task in REVIEW and writes Activity plus Inbox notice. The archived-Agent path is asserted in `app.test.ts`, and every invariant/intent pair is asserted in `open-run.test.ts`.
- Behavior change: lease-loss automatic retry applies the same refusals and visible REVIEW park; the archived-Agent path is asserted in `reconcile.test.ts`, and every invariant/intent pair is asserted in `open-run.test.ts`.
- Behavior change: renewed integrator authorization now applies archived-Task, locked archived-Agent, compound assignee and binding guards, while its named intent preserves the required recovered-confirmation stop exit. It derives its ceiling from the current Task budget plus recorded grants, granting only enough for the next Run instead of retaining an opaque historical absolute ceiling; both the exception and ceiling are asserted in `open-run.test.ts`, and the real recovery path is covered by `merge-stop-state.dbtest.ts`.
- Behavior change: eager Run creation after `POST /projects/:projectId/tasks` now rolls the Task transaction back if `openRun` refuses, rather than allowing Task creation to commit without its requested eager Run; task-created intent invariants and the route shape are asserted in `open-run.test.ts` and `workflow.test.ts`.

Existing enqueue, operator-retry configuration/branch behavior, completion refund semantics, and lease-loss refund semantics remain covered by regression assertions.

## Budget ceiling decision

`reconcile.ts`'s former `run.maxRunsPerTask + 1` is intentional in base selection: lease loss refunds the ceiling already authorized for the in-flight Run, because a concurrent Task budget edit must not retroactively revoke it. It is now expressed as `runBudgetCeiling(run.maxRunsPerTask, 1)`, so the algorithm is shared without changing that base. The runner boot gate does not recalculate; it compares `runNumber` with the persisted `maxRunsPerTask` written by `openRun`.

## Verification

- `npm run lint`
- `npm run build -w @agentos/api`
- `RUNNER_WORKSPACE_ROOT=<temporary> node --import tsx --test packages/db/src/open-run.test.ts packages/api/src/app.test.ts packages/api/src/reconcile.test.ts packages/api/src/workflow.test.ts` (114 passed before the named stop-exit assertion was added; focused `open-run.test.ts` then passed 5/5)
- production writer scan: one `run.create`, inside `openRun`
- `MERGE GATE: PASS 973cf15abaf31bc99192a109cf33809f603e8899`
