### PR TITLE
fix(inbox): base dismissal on what actually blocks a run

### DIFF
--- a/apps/web/src/lib/inbox.ts
+++ b/apps/web/src/lib/inbox.ts
@@ -1,24 +1,15 @@
 import type { InboxMessage } from "./types";
 
-/** A detached notification: an agent-authored text card that hangs off no task,
- *  goal, session, gate, or parent message. The control plane owns this exact
- *  predicate — `POST /inbox/messages/:id/close` refuses anything else, because
- *  closing such a card archives it without approving or resuming anything. The
- *  Inbox mirrors it to split cards that need a reply from cards that only
- *  report something, so the awaiting-reply count means what it says. */
-export const isNotice = (message: InboxMessage): boolean =>
-  message.from === "AGENT"
-  && message.kind === "TEXT"
-  && message.taskId === null
-  && message.goalId === null
-  && message.sessionId === null
-  && message.gateTaskId === null
-  && message.replyToMessageId === null;
-
 /** Cards the operator still owes an answer to — the badge count and the Active
- *  lane. Notices are open too, but nobody is blocked on them. */
+ *  lane. A notification is open too, but nobody is blocked on it: the control
+ *  plane decides which is which and says so in `dismissible`, the same rule
+ *  `POST /inbox/messages/:id/close` enforces. */
 export const needsReply = (message: InboxMessage): boolean =>
-  message.status === "OPEN" && !isNotice(message);
+  message.status === "OPEN" && !message.dismissible;
+
+/** Open, and safe to archive without approving or resuming anything. */
+export const isNotice = (message: InboxMessage): boolean =>
+  message.status === "OPEN" && message.dismissible;
 
 export type DeployNotice = {
   outcome: "success" | "failure";

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -583,6 +583,9 @@ export type InboxMessage = {
   taskId: string | null;
   goalId: string | null;
   gateTaskId: string | null;
+  /** Derived by the API: no decision is owed on this card and no suspended run
+   *  resumes on it, so the operator may archive it outright. */
+  dismissible: boolean;
   /** Approval gates only: the task whose step output the gate is asking about,
    *  derived by the API from the card's session. Absent on non-gate cards. */
   artifactTaskId: string | null;

--- a/apps/web/src/pages/Inbox.tsx
+++ b/apps/web/src/pages/Inbox.tsx
@@ -76,7 +76,7 @@ type InboxFilter = "active" | "notices" | "answered";
 
 const LANE: Record<InboxFilter, (message: InboxMessage) => boolean> = {
   active: needsReply,
-  notices: (message) => message.status === "OPEN" && isNotice(message),
+  notices: isNotice,
   answered: (message) => message.status !== "OPEN",
 };
 

--- a/apps/web/src/tests/inbox-artifact.test.tsx
+++ b/apps/web/src/tests/inbox-artifact.test.tsx
@@ -12,7 +12,7 @@ const now = "2026-08-25T00:00:00.000Z";
  *  preview that has to fit in a Feishu card, `taskId` is the gate step, and
  *  `artifactTaskId` is the step that produced the artifact under review. */
 const gateCard = (): InboxMessage => ({
-  id: "gate-1", from: "AGENT", agentId: "agent-1", sessionId: "session-1",
+  id: "gate-1", from: "AGENT", dismissible: false, agentId: "agent-1", sessionId: "session-1",
   taskId: "gate-task", goalId: null, gateTaskId: "gate-task", artifactTaskId: "producing-task",
   threadId: "thread-1", replyToMessageId: null, kind: "MULTIPLE_CHOICE",
   body: "审批闸门：Write a spec\n\n产物（spec）：\nPREVIEW HEAD\n…（预览已截断，完整产物见 Inbox 页的产物卡片）",

--- a/apps/web/src/tests/inbox-lanes.test.tsx
+++ b/apps/web/src/tests/inbox-lanes.test.tsx
@@ -9,7 +9,7 @@ import type { InboxMessage } from "../lib/types";
 const now = "2026-08-26T00:00:00.000Z";
 
 const card = (overrides: Partial<InboxMessage> & Pick<InboxMessage, "id" | "body">): InboxMessage => ({
-  from: "AGENT", agentId: null, sessionId: null, taskId: null, goalId: null,
+  from: "AGENT", dismissible: true, agentId: null, sessionId: null, taskId: null, goalId: null,
   gateTaskId: null, artifactTaskId: null, threadId: "thread-1", replyToMessageId: null,
   kind: "TEXT", choices: null, selectedChoiceId: null, status: "OPEN", channel: "FEISHU",
   deliveryStatus: "DELIVERED", deliveryAttempts: 1, lastDeliveryError: null,
@@ -20,7 +20,7 @@ const card = (overrides: Partial<InboxMessage> & Pick<InboxMessage, "id" | "body
 /** The three shapes the lanes have to tell apart: a gate that blocks a task, a
  *  detached notification nobody is blocked on, and an archived deploy record. */
 const gate = card({
-  id: "gate-1", body: "审批闸门：合并 PR #44", kind: "MULTIPLE_CHOICE", agentId: "agent-1",
+  id: "gate-1", body: "审批闸门：合并 PR #44", kind: "MULTIPLE_CHOICE", agentId: "agent-1", dismissible: false,
   taskId: "gate-task", gateTaskId: "gate-task", choices: [{ id: "approve", label: "批准" }],
 });
 const notice = card({ id: "notice-1", body: "Autonomous merge tail stopped: missing regression output" });

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -110,44 +110,59 @@ test("operator principal cannot impersonate a runner", async () => {
   });
 });
 
-test("operator can close only detached agent notifications", async () => {
+/* A merge-tail stop report: agent-authored text, attached to the task it
+ * happened on, and nothing resumes on a reply. It is the shape the Inbox is
+ * full of, and the old "attached to nothing" rule refused to close it. */
+const stopReport = {
+  id: "message-1", status: "OPEN", from: "AGENT", kind: "TEXT", gateTaskId: null, replyToMessageId: null,
+};
+
+const closeRequest = async (app: ReturnType<typeof createApp>, messageId: string): Promise<Response> =>
+  await app.request(`/inbox/messages/${messageId}/close`, {
+    method: "POST",
+    headers: { Authorization: "Bearer operator-unit-token", "Content-Type": "application/json" },
+    body: JSON.stringify({ requestId: `close-${messageId}` }),
+  });
+
+test("operator can close a notification attached to a task when no run waits on it", async () => {
   await withTokens(async () => {
-    const notification = {
-      status: "OPEN", from: "AGENT", kind: "TEXT", taskId: null, goalId: null,
-      sessionId: null, gateTaskId: null, replyToMessageId: null,
-    };
     let updateWhere: unknown;
     const database = {
       inboxMessage: {
-        findUnique: async () => notification,
+        findUnique: async () => stopReport,
         updateMany: async ({ where }: { where: unknown }) => { updateWhere = where; return { count: 1 }; },
       },
+      session: { findMany: async () => [] },
     } as unknown as PrismaClient;
-    const response = await createApp(database).request("/inbox/messages/message-1/close", {
-      method: "POST",
-      headers: { Authorization: "Bearer operator-unit-token", "Content-Type": "application/json" },
-      body: JSON.stringify({ requestId: "close-message-1" }),
-    });
+    const response = await closeRequest(createApp(database), "message-1");
     assert.equal(response.status, 200);
     assert.deepEqual(await response.json(), { closed: true, duplicate: false, requestId: "close-message-1" });
+    // The conditional update guards what the row itself can prove; the waiting
+    // session is checked above it, and cannot appear for an existing card.
     assert.deepEqual(updateWhere, {
-      id: "message-1", status: "OPEN", from: "AGENT", kind: "TEXT", taskId: null,
-      goalId: null, sessionId: null, gateTaskId: null, replyToMessageId: null,
+      id: "message-1", status: "OPEN", from: "AGENT", kind: "TEXT",
+      gateTaskId: null, replyToMessageId: null,
     });
+  });
+});
 
+test("operator cannot close a gate, nor a card a suspended run resumes on", async () => {
+  await withTokens(async () => {
     const gateDatabase = {
-      inboxMessage: {
-        findUnique: async () => ({ ...notification, gateTaskId: "gate-1" }),
-        updateMany: async () => { throw new Error("must not close a gate"); },
-      },
+      inboxMessage: { findUnique: async () => ({ ...stopReport, gateTaskId: "gate-1" }) },
+      session: { findMany: async () => [] },
     } as unknown as PrismaClient;
-    const refused = await createApp(gateDatabase).request("/inbox/messages/message-2/close", {
-      method: "POST",
-      headers: { Authorization: "Bearer operator-unit-token", "Content-Type": "application/json" },
-      body: JSON.stringify({ requestId: "close-message-2" }),
-    });
-    assert.equal(refused.status, 409);
-    assert.match(String((await refused.json() as { error: string }).error), /Only a detached agent notification/u);
+    const gate = await closeRequest(createApp(gateDatabase), "message-2");
+    assert.equal(gate.status, 409);
+    assert.match(String((await gate.json() as { error: string }).error), /no run is waiting on/u);
+
+    const waitingDatabase = {
+      inboxMessage: { findUnique: async () => stopReport },
+      session: { findMany: async () => [{ waitingOnMessageId: "message-1" }] },
+    } as unknown as PrismaClient;
+    const waiting = await closeRequest(createApp(waitingDatabase), "message-1");
+    assert.equal(waiting.status, 409);
+    assert.match(String((await waiting.json() as { error: string }).error), /no run is waiting on/u);
   });
 });
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -12,6 +12,8 @@ import {
   GoalStatus,
   enqueueTaskRun,
   openRun,
+  InboxKind,
+  InboxSender,
   InboxStatus,
   lockAgentRepoGrant,
   lockAgentRepoGrantForRevocation,
@@ -215,6 +217,41 @@ const withArtifactTask = <T extends { gateTaskId: string | null; session: { task
 ): Omit<T, "session"> & { artifactTaskId: string | null } => {
   const { session, ...rest } = message;
   return { ...rest, artifactTaskId: message.gateTaskId === null ? null : session?.taskId ?? null };
+};
+
+/**
+ * A card nobody is blocked on, so archiving it strands nothing.
+ *
+ * The rule used to be "attached to no task, goal, or session", which was a
+ * proxy for that and misfired on the common case: a merge-tail stop report is
+ * attached to the task it happened on, yet its run ended long ago and no reply
+ * would resume anything. What actually blocks is a suspended session pointing
+ * at the card through `Session.waitingOnMessageId` (`inbox.ts`'s
+ * `suspendForInbox`), or a decision the operator still owes — a choice list or
+ * an approval gate.
+ */
+const withDismissible = <T extends {
+  id: string; from: InboxSender; kind: InboxKind; gateTaskId: string | null; replyToMessageId: string | null;
+}>(message: T, blocked: ReadonlySet<string>): T & { dismissible: boolean } => ({
+  ...message,
+  dismissible: message.from === "AGENT"
+    && message.kind === InboxKind.TEXT
+    && message.gateTaskId === null
+    && message.replyToMessageId === null
+    && !blocked.has(message.id),
+});
+
+/** The cards a suspended session will resume on. A session only ever waits on a
+ *  message its own suspension created, so this set cannot grow for a card that
+ *  already exists — which is why the close route may check it before its
+ *  conditional update rather than inside one statement. */
+const blockedMessageIds = async (db: PrismaClient, ids: string[]): Promise<ReadonlySet<string>> => {
+  if (ids.length === 0) return new Set();
+  const waiting = await db.session.findMany({
+    where: { waitingOnMessageId: { in: ids } },
+    select: { waitingOnMessageId: true },
+  });
+  return new Set(waiting.flatMap((session) => session.waitingOnMessageId === null ? [] : [session.waitingOnMessageId]));
 };
 
 const id = z.string().min(1);
@@ -3000,7 +3037,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     include: { decisions: true, replies: { orderBy: { createdAt: "asc" } }, session: { select: { taskId: true } } },
     orderBy: { createdAt: "desc" },
     });
-    return context.json(messages.map(withArtifactTask));
+    const blocked = await blockedMessageIds(db, messages.map((message) => message.id));
+    return context.json(messages.map((message) => withDismissible(withArtifactTask(message), blocked)));
   });
   app.get("/inbox/messages/:messageId", async (context) => {
     const message = await db.inboxMessage.findUnique({
@@ -3012,7 +3050,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         session: { select: { taskId: true } },
       },
     });
-    return message ? context.json(withArtifactTask(message)) : context.json({ error: "Inbox message not found" }, 404);
+    if (!message) return context.json({ error: "Inbox message not found" }, 404);
+    return context.json(withDismissible(withArtifactTask(message), await blockedMessageIds(db, [message.id])));
   });
   app.post("/inbox/messages/:messageId/decision", async (context) => {
     const body = await readJson(context.req.raw, inboxDecisionInput);
@@ -3054,21 +3093,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const messageId = id.parse(context.req.param("messageId"));
     const message = await db.inboxMessage.findUnique({
       where: { id: messageId },
-      select: {
-        status: true, from: true, kind: true, taskId: true, goalId: true,
-        sessionId: true, gateTaskId: true, replyToMessageId: true,
-      },
+      select: { id: true, status: true, from: true, kind: true, gateTaskId: true, replyToMessageId: true },
     });
     if (!message) return context.json({ error: "Inbox message not found" }, 404);
-    const detachedNotification = message.from === "AGENT"
-      && message.kind === "TEXT"
-      && message.taskId === null
-      && message.goalId === null
-      && message.sessionId === null
-      && message.gateTaskId === null
-      && message.replyToMessageId === null;
-    if (!detachedNotification) {
-      return context.json({ error: "Only a detached agent notification can be closed without a decision" }, 409);
+    if (!withDismissible(message, await blockedMessageIds(db, [messageId])).dismissible) {
+      return context.json({ error: "Only a notification no run is waiting on can be closed without a decision" }, 409);
     }
     if (message.status === InboxStatus.CLOSED) {
       return context.json({ closed: false, duplicate: true, requestId: body.requestId });
@@ -3079,7 +3108,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const closed = await db.inboxMessage.updateMany({
       where: {
         id: messageId, status: InboxStatus.OPEN, from: "AGENT", kind: "TEXT",
-        taskId: null, goalId: null, sessionId: null, gateTaskId: null, replyToMessageId: null,
+        gateTaskId: null, replyToMessageId: null,
       },
       data: { status: InboxStatus.CLOSED, answeredAt: new Date() },
     });

--- a/packages/api/src/control-plane.test.ts
+++ b/packages/api/src/control-plane.test.ts
@@ -111,10 +111,13 @@ test("an approval gate card carries the producing step's task, so the board can 
   await withOperator(async () => {
     // The card's own taskId is the gate step; the artifact belongs to the step
     // whose run opened it, reachable only through the card's session.
-    const database = { inboxMessage: { findMany: async () => [
-      { id: "gate-1", from: "AGENT", gateTaskId: "gate-task", taskId: "gate-task", session: { taskId: "producing-task" } },
-      { id: "plain-1", from: "AGENT", gateTaskId: null, taskId: "some-task", session: { taskId: "some-task" } },
-    ] } } as unknown as PrismaClient;
+    const database = {
+      inboxMessage: { findMany: async () => [
+        { id: "gate-1", from: "AGENT", kind: "MULTIPLE_CHOICE", replyToMessageId: null, gateTaskId: "gate-task", taskId: "gate-task", session: { taskId: "producing-task" } },
+        { id: "plain-1", from: "AGENT", kind: "TEXT", replyToMessageId: null, gateTaskId: null, taskId: "some-task", session: { taskId: "some-task" } },
+      ] },
+      session: { findMany: async () => [] },
+    } as unknown as PrismaClient;
     const response = await request(database, "/inbox/messages");
     assert.equal(response.status, 200);
     const messages = await response.json() as Array<Record<string, unknown>>;
@@ -123,16 +126,23 @@ test("an approval gate card carries the producing step's task, so the board can 
     // session relation never reaches the client either way.
     assert.equal(messages[1]?.artifactTaskId, null);
     assert.equal(messages[0]?.session, undefined);
+    // A gate owes a decision; a plain text card attached to a finished task
+    // owes nothing, which is what lets the Inbox offer to archive it.
+    assert.equal(messages[0]?.dismissible, false);
+    assert.equal(messages[1]?.dismissible, true);
   });
 });
 
 test("Inbox list applies project scope and returns stored human replies", async () => {
   await withOperator(async () => {
     let query: Record<string, unknown> | undefined;
-    const database = { inboxMessage: { findMany: async (arguments_: Record<string, unknown>) => {
-      query = arguments_;
-      return [{ id: "question-1", from: "AGENT", replies: [{ id: "reply-1", from: "HUMAN", body: "continue" }] }];
-    } } } as unknown as PrismaClient;
+    const database = {
+      inboxMessage: { findMany: async (arguments_: Record<string, unknown>) => {
+        query = arguments_;
+        return [{ id: "question-1", from: "AGENT", replies: [{ id: "reply-1", from: "HUMAN", body: "continue" }] }];
+      } },
+      session: { findMany: async () => [] },
+    } as unknown as PrismaClient;
     const response = await request(database, "/inbox/messages?projectId=project-1");
     assert.equal(response.status, 200);
     const messages = await response.json() as Array<{ replies: Array<{ from: string }> }>;

--- a/packages/api/src/inbox-superseded-close.test.ts
+++ b/packages/api/src/inbox-superseded-close.test.ts
@@ -280,12 +280,10 @@ test("detached notifications retain the original close route contract", async ()
   await withTokens(async () => {
     const state = fixture();
     const notification = {
+      id: "message-1",
       status: InboxStatus.OPEN,
       from: "AGENT",
       kind: "TEXT",
-      taskId: null,
-      goalId: null,
-      sessionId: null,
       gateTaskId: null,
       replyToMessageId: null,
     };
@@ -298,6 +296,7 @@ test("detached notifications retain the original close route contract", async ()
           return { count: 1 };
         },
       },
+      session: { findMany: async () => [] },
     } as unknown as PrismaClient;
     const response = await request(database, "/inbox/messages/message-1/close");
     assert.equal(response.status, 200);


### PR DESCRIPTION
Follow-up to #162.

## Problem

`POST /inbox/messages/:id/close` accepted only cards attached to no task, goal, or session. That was a proxy for "nobody is blocked on it", and it misfires on the shape the Inbox is mostly made of: a merge-tail stop report is attached to the task it happened on, its run ended long ago, and no reply resumes anything — yet it could never be archived.

In production that is 34 open cards with no way out of the awaiting-reply lane, against ~2 that genuinely owe a decision.

## Change

- The route refuses on what actually blocks: a suspended session pointing at the card through `Session.waitingOnMessageId` (written by `suspendForInbox`), or a decision still owed — a choice list or an approval gate.
- `GET /inbox/messages` and `GET /inbox/messages/:id` return the same verdict as `dismissible`, so the Inbox reads the control plane's rule instead of keeping a second copy of it.
- The conditional update keeps only the guards the row itself can prove. A session only ever waits on a message its own suspension created, so the waiting set cannot grow for a card that already exists.

## Verification

- `npm run lint`
- `npm run test -w @agentos/api` — 544 pass, including a card attached to a finished task closing, and both refusals (gate, and a run waiting on it)
- `npm run test -w @agentos/web` — 407 pass
- `npm run test:snapshot-scan` — 20 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)