### PR TITLE
fix(agents): pin spec and blind review to Opus high in the canonical contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ by a webhook trigger, not by a standing objective. See
 
 <div align="center">
 
-<img src="docs/media/chain.png" alt="Chain view: a twelve-step assurance workflow with assigned agent roles" width="880">
-
-<sub>A task chain: each step carries its own role, prompt and review gate.</sub>
-
 <img src="docs/media/agents.png" alt="Agents view: each agent's role, model, reasoning effort and runner" width="880">
 
 <sub>Agents: a role, a prompt, a model and effort, and the runner it goes to.</sub>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,10 +46,6 @@ AgentOS 把任务、agent、仓库与文件授权、独立的运行记录、prov
 
 <div align="center">
 
-<img src="docs/media/chain.png" alt="链视图：十二步保障工作流，每一步标注其指派的 agent 角色" width="880">
-
-<sub>任务链：每一步都带着自己的角色、提示词与评审关卡。</sub>
-
 <img src="docs/media/agents.png" alt="Agents 视图：每个 agent 的角色、模型、推理档位与 runner" width="880">
 
 <sub>Agents：一个角色、一段提示词、一个模型与档位，以及它派往的 runner。</sub>

--- a/agents/roles/review-coordinator-opus.md
+++ b/agents/roles/review-coordinator-opus.md
@@ -1,7 +1,7 @@
 ---
 name: review-coordinator-opus
 title: Code Review Coordinator (Opus)
-model: claude-opus-5:medium
+model: claude-opus-5:high
 runner: claude
 inboxAccess: true
 collaborators: []

--- a/agents/roles/spec.md
+++ b/agents/roles/spec.md
@@ -1,8 +1,8 @@
 ---
 name: spec
 title: Specification Writer
-model: gpt-5.6-sol:high
-runner: codex
+model: claude-opus-5:high
+runner: claude
 inboxAccess: true
 collaborators: []
 ---

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -86,18 +86,18 @@ test("canonical profiles start at Default and native child capability replaces A
 
 test("signed AgentOS model routing stays pinned in the canonical contract", () => {
   const canonical = new Map(CANONICAL_AGENT_DEFAULTS.map((role) => [role.name, role]));
-  assert.deepEqual(canonical.get("spec"), {
-    name: "spec",
-    model: "gpt-5.6-sol:high",
-    runner: RunnerPreference.CODEX,
-  });
-  for (const name of ["frontend-dev", "review-coordinator-opus"] as const) {
+  for (const name of ["spec", "review-coordinator-opus"] as const) {
     assert.deepEqual(canonical.get(name), {
       name,
-      model: "claude-opus-5:medium",
+      model: "claude-opus-5:high",
       runner: RunnerPreference.CLAUDE,
     });
   }
+  assert.deepEqual(canonical.get("frontend-dev"), {
+    name: "frontend-dev",
+    model: "claude-opus-5:medium",
+    runner: RunnerPreference.CLAUDE,
+  });
   assert.deepEqual(canonical.get("review-coordinator"), {
     name: "review-coordinator",
     model: "openai-codex/gpt-5.6-sol:xhigh",

--- a/packages/db/src/agent-contract.ts
+++ b/packages/db/src/agent-contract.ts
@@ -18,11 +18,11 @@ export const CANONICAL_AGENT_DEFAULTS = [
   { name: "plan-reviser", model: "claude-opus-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "regression-verifier", model: "claude-opus-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "review-coordinator", model: "openai-codex/gpt-5.6-sol:xhigh", runner: RunnerPreference.PI },
-  { name: "review-coordinator-opus", model: "claude-opus-5:medium", runner: RunnerPreference.CLAUDE },
+  { name: "review-coordinator-opus", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
   { name: "review-coordinator-sol", model: "openai-codex/gpt-5.6-sol:xhigh", runner: RunnerPreference.PI },
   { name: "senior-dev", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
   { name: "senior-dev-luna", model: "gpt-5.6-luna:max", runner: RunnerPreference.CODEX },
-  { name: "spec", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
+  { name: "spec", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
 ] as const;
 
 /**
@@ -68,6 +68,17 @@ export const CANONICAL_AGENT_RUNTIME_TRANSITIONS = new Map<string, {
   ["plan-reviser", {
     from: { model: "claude-fable-5:medium", runnerPreference: RunnerPreference.CLAUDE },
     to: { model: "claude-opus-5:medium", runnerPreference: RunnerPreference.CLAUDE },
+  }],
+  // 2026-08-26 ruling: the spec is the specification of record every later step
+  // is measured against, and the blind review is the only independent second
+  // pair of eyes on the diff, so both buy frontier-tier depth.
+  ["spec", {
+    from: { model: "gpt-5.6-sol:high", runnerPreference: RunnerPreference.CODEX },
+    to: { model: "claude-opus-5:high", runnerPreference: RunnerPreference.CLAUDE },
+  }],
+  ["review-coordinator-opus", {
+    from: { model: "claude-opus-5:medium", runnerPreference: RunnerPreference.CLAUDE },
+    to: { model: "claude-opus-5:high", runnerPreference: RunnerPreference.CLAUDE },
   }],
 ]);
 


### PR DESCRIPTION
## Why

`37dcbc4` added the twelve-step table to both READMEs. It publishes step 1 as Claude Opus 5 · high and step 7 as Opus · high, but the canonical contract still seeded `spec` as `gpt-5.6-sol:high` on Codex and `review-coordinator-opus` at `medium`. A fresh install would follow Quick start, open the Agents view, and read values the README contradicts.

## What

- `spec` and `review-coordinator-opus` move to `claude-opus-5:high` on Claude, in `agents/roles/` and `CANONICAL_AGENT_DEFAULTS`. `assertCanonicalAgentSources` keeps the two in step.
- Two matching `CANONICAL_AGENT_RUNTIME_TRANSITIONS` entries, so an untouched agent row migrates on the next seed or canonical sync, and an operator-selected one stays protected by `runtimeConfigCustomized`.
- `agent-contract.test.ts` repins to the new values.
- The chain screenshot is dropped from both READMEs. It is an older build showing step 9 as regression verification and step 10 as the librarian, the reverse of the current template, sitting directly above the table that states the right order. `docs/media/chain.png` stays tracked and returns to the README when the shot is retaken.

## Verification

- `npm run lint` — exit 0
- `npm run test:snapshot-scan` — 20/20
- `npx tsx --test packages/db/prisma/agent-contract.test.ts` — 14/14

The two dbtest fixtures that set `spec` to `claude-opus-5:medium` as an operator override still differ from the new canon, so they keep exercising the preserved-override path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)