### PR TITLE
docs(license): carry the mattpocock/skills notice the chain prompts require

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,5 +191,12 @@ An independent build inspired by Danny Postma's video *How I Built My Own
 AgentOS on Claude's Agent SDK (So You Can Too)* (2026), written from scratch
 from the ideas in it.
 
+The chain's role and step prompts are a different kind of debt: five skills from
+[mattpocock/skills](https://github.com/mattpocock/skills) supply their working
+text, carried verbatim and wrapped in paragraphs written here for this
+platform's contracts. That work is MIT-licensed, `Copyright (c) 2026 Matt
+Pocock`, and the notice is in
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+
 This snapshot is licensed under the [MIT License](LICENSE); the snapshot
 boundary is defined by [`public-snapshot.json`](public-snapshot.json).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -164,5 +164,10 @@ provider 作出兼容性承诺。
 本项目是受 Danny Postma 的视频 *How I Built My Own AgentOS on Claude's Agent
 SDK (So You Can Too)*（2026）启发的独立实现，从视频中的想法出发从零构建。
 
+任务链的角色与步骤提示词则是另一种性质的欠账：其行文主体来自
+[mattpocock/skills](https://github.com/mattpocock/skills) 的五个技能，逐字沿用，
+外面包着为本平台契约另写的段落。上游以 MIT 授权，`Copyright (c) 2026 Matt
+Pocock`，声明在 [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。
+
 本快照以 [MIT License](LICENSE) 授权；快照边界由
 [`public-snapshot.json`](public-snapshot.json) 定义。

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,7 +18,7 @@ authoritative ones; the table below is an index, not a substitute.
 
 ## Third-party source carried in this repository
 
-One body of third-party code is checked in rather than installed.
+Two bodies of third-party material are checked in rather than installed.
 
 **shadcn/ui** — `apps/web/src/components/ui/*.tsx` (14 files).
 
@@ -32,6 +32,43 @@ project is MIT-licensed:
 MIT License
 
 Copyright (c) 2023 shadcn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+**mattpocock/skills** — `agents/roles/*.md` and
+`agents/templates/*/*.md` (chain role and step prompts).
+
+Five upstream skills — `to-spec`, `to-tickets`, `implement-spec`, `code-review`
+and `resolving-merge-conflicts` — supply the working text of the corresponding
+chain prompts. Each of those prompts is upstream paragraphs carried verbatim
+plus paragraphs written here to bind them to this platform's contracts: the
+JSON step outputs, the layered chain, the pinned review range, the mechanical
+merge tail. The spec template, the slice ticket format and the seam, ticket and
+review disciplines are upstream text. Upstream baseline:
+[`mattpocock/skills`](https://github.com/mattpocock/skills) at commit
+`c75f10c`. Upstream copyright: `Copyright (c) 2026 Matt Pocock`, MIT:
+
+```
+MIT License
+
+Copyright (c) 2026 Matt Pocock
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/agents/README.md
+++ b/agents/README.md
@@ -2,7 +2,7 @@
 
 Source-of-truth files for canonical agent prompts and initial runtime defaults, the mechanical merge sentinel, and task-template step prompts. The seed script imports these into the `Agent`, join, and `TaskTemplateStep` tables; `packages/db/prisma/seed.ts` is the consumer. Models and runners changed by the operator in the console are persisted runtime overrides and are not replaced by seed or canonical prompt sync. Skills remain an API-managed concept (`Skill` / `AgentSkill`), but no canonical skill is seeded from this directory.
 
-All prompts here are reconstructed from BLUEPRINT.md (itself reconstructed from Danny Postma's talk); none are his verbatim files.
+All prompts here are reconstructed from BLUEPRINT.md (itself reconstructed from Danny Postma's talk); none are his verbatim files. The chain prompts with an upstream counterpart in [mattpocock/skills](https://github.com/mattpocock/skills) do carry that text verbatim, wrapped in paragraphs written here for this platform's contracts; the notice is in [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md).
 
 ## Layout
 

--- a/docs/release/license-and-assets.md
+++ b/docs/release/license-and-assets.md
@@ -30,6 +30,7 @@ failure rather than a silent inclusion.
 | --- | --- | --- |
 | First-party source, tests, configuration and manifests | the majority | Written for this repository. MIT, per `LICENSE`. |
 | Third-party source, vendored | 14 files | shadcn/ui. See below. |
+| Chain prompts carrying upstream text | `agents/roles/`, `agents/templates/` | mattpocock/skills. See below. |
 | Data fixtures | 5 files | See below. |
 | Images, fonts, audio, video, icons, compiled binaries, archives | **0** | There are none. |
 
@@ -85,6 +86,18 @@ These files import `@radix-ui/*`, `class-variance-authority`, `clsx`,
 `tailwind-merge` and `lucide-react`. Those are installed dependencies, not
 vendored code; they are listed with their licenses in `THIRD_PARTY_NOTICES.md`
 and are not redistributed by this repository.
+
+**mattpocock/skills prompts** — the chain role and step prompts under
+`agents/roles/` and `agents/templates/` carry verbatim paragraphs from five
+upstream skills, wrapped in paragraphs written here for this platform's
+contracts. No file is wholly upstream and none is wholly first-party, so these
+are listed as a body rather than hashed per file. Upstream baseline:
+`mattpocock/skills` at commit `c75f10c`. Upstream copyright:
+`Copyright (c) 2026 Matt Pocock`; the full notice text is in
+`THIRD_PARTY_NOTICES.md`.
+
+Disposition: **published**, under the combined grant of the upstream MIT license
+and this repository's own.
 
 ## Data fixtures
 


### PR DESCRIPTION
## Why

The chain role and step prompts under `agents/` carry verbatim paragraphs from five `mattpocock/skills` skills (`to-spec`, `to-tickets`, `implement-spec`, `code-review`, `resolving-merge-conflicts`) — the spec template, the slice ticket format, and the seam, ticket and review disciplines — wrapped in paragraphs written here for this platform's contracts.

Those files are in `public-snapshot.json`, so the release distributes a substantial portion of an MIT work. MIT requires the copyright and permission notice to travel with it. Before this change `grep -i pocock` found three mentions in the tree, none of them a notice, and `README.md` credited only Danny Postma.

## What

- `THIRD_PARTY_NOTICES.md` — the notice, next to shadcn/ui, pinned to upstream commit `c75f10c`.
- `docs/release/license-and-assets.md` — the classification table counted `agents/` under "First-party source ... written for this repository", which is no longer true. New row plus a short prose entry. Listed as a body rather than hashed per file, because no file there is wholly upstream or wholly first-party.
- `README.md` / `README.zh-CN.md` — credit in Credits and license, written as a different kind of debt from the Danny Postma line: that one is an idea built from scratch, this one is carried text under someone else's copyright.
- `agents/README.md` — the provenance line named only the Postma lineage.

Deliberately not done: publishing the alignment audit. MIT does not require it, and a published upstream-baseline ledger has to be kept current with every upstream pull. `docs/runbooks/card-intake.md` already discloses that the ledger is in the operator's records.

## Verification

- `npm run lint` — exit 0
- `npm run test:snapshot-scan` — 20/20
- `node --test scripts/release-docs.test.mjs` — 4/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)