### PR TITLE
docs(readme): strip AI writing patterns from both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 **A local control plane for coding agents.**
 
-You write the spec. A chain of agents takes it from there — plan, review,
-implement, verify, merge — and every run stays observable and reviewable.
+You write the spec. A chain of agents takes it from there: plan, review,
+implement, verify, merge. Every run stays observable and reviewable.
 
 [![status](https://img.shields.io/badge/status-developer%20preview-orange)](docs/status.md)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
@@ -27,32 +27,31 @@ into one workflow that runs entirely on your own machine.
 It orchestrates the official Codex CLI, Claude Code and Pi that you have
 already installed and signed in to, so the subscription logins those CLIs
 already hold are what it runs on. AgentOS supplies no credential of its own and
-resells no subscription — see
+resells no subscription. See
 [Authentication and subscriptions](#authentication-and-subscriptions).
 
 ## What it changes
 
-A task chain carries a whole delivery path — specification, plan, plan review,
+A task chain covers the whole delivery path: specification, plan, plan review,
 implementation, two independent code reviews, fix application, regression
 verification, merge readiness and the merge itself. Each step carries its own
 role, prompt, model and reasoning effort, and each step's output becomes the
 next step's input.
 
-Once a chain starts it advances on its own. Your attention is required when an
-agent asks you something through the Inbox, when a step you marked as gated
-needs a human decision, or when a run escalates. Everything between those points
+Once a chain starts it advances on its own. You step in when an agent asks you
+something through the Inbox, when a step you marked as gated needs a human
+decision, or when a run escalates. Everything between those points
 runs unattended, including delivery: a branch, an optional pull request, and a
 merge behind the merge gate.
 
-That is the leverage. The scarce resource stops being your hours and becomes how
-many runners you have registered — chains for different tasks and different
-repositories are in flight at the same time, and you are reading review output
-instead of typing the implementation.
+That changes what limits you. Throughput comes from how many runners you have
+registered rather than from your hours: chains for different tasks and different
+repositories are in flight at the same time, and you read review output instead
+of typing the implementation.
 
-One honest limit: long-horizon autonomy is not wired yet. A Goal is stored and
-edited but nothing schedules work from it, so a chain is still started by you or
-by a webhook trigger, not by a standing objective. See
-[Status](docs/status.md).
+Long-horizon autonomy is not wired yet. A Goal is stored and edited but nothing
+schedules work from it, so a chain is still started by you or by a webhook
+trigger, not by a standing objective. See [Status](docs/status.md).
 
 <div align="center">
 
@@ -104,7 +103,7 @@ seed.
 
 ## Quick start
 
-Targets an Apple Silicon Mac with Node.js `22.17.0` from `.nvmrc` (installation requires
+You need an Apple Silicon Mac with Node.js `22.17.0` from `.nvmrc` (installation requires
 Node.js satisfying `^20.19.0 || ^22.13.0 || >=24` and refuses anything else), npm 10.9.2+,
 Docker Compose, Git, and the official Codex CLI already signed in under the same
 macOS account. Claude Code and Pi are optional.
@@ -149,7 +148,7 @@ and the authoritative matrix in
 ## Authentication and subscriptions
 
 AgentOS holds no provider credential. It launches the official CLIs you have
-already installed and signed in to — Codex CLI, Claude Code and Pi — and their
+already installed and signed in to (Codex CLI, Claude Code and Pi), and their
 authentication stays where each CLI keeps it, in that CLI's own configuration.
 AgentOS neither reads it nor forwards it, and there is no AgentOS account, no
 API proxy and no key to paste in.
@@ -159,28 +158,28 @@ ChatGPT subscription login, a Claude Pro/Max login, or each CLI's own API-key
 mode, exactly as you already configured it. Pi carries no account of its own
 either: it authenticates through the Codex login.
 
-You can check this instead of taking it on faith. The runner constructs the
+You can check this. The runner constructs the
 child environment for the provider process rather than copying the host
 environment wholesale
 ([`docs/architecture.md`](docs/architecture.md), `packages/runner/src/adapters/`),
 and the release check scans this checkout for token variables, bearer headers
 and `Authorization` ([`docs/release/security.md`](docs/release/security.md)).
 
-What none of that does is settle a provider's terms on your behalf. Plan limits,
+None of that settles a provider's terms for you. Plan limits,
 rate limits, usage allowances, and whether your plan permits this kind of
 orchestration are between you and the provider. AgentOS grants no entitlement
 and makes no compatibility promise for a CLI provider.
 
 ## Documentation
 
-- [Architecture and security model](docs/architecture.md) — how the console,
+- [Architecture and security model](docs/architecture.md): how the console,
   API, runner and provider CLIs fit together, and what the grants do and do not
   contain.
-- [Installation notes and verification](docs/install.md) — environment file,
+- [Installation notes and verification](docs/install.md): environment file,
   migrations, merge executor, and the check sequence.
-- [Security](docs/release/security.md) — read before pointing this at
+- [Security](docs/release/security.md): read before pointing this at
   anything you care about.
-- [Migration and recovery](docs/release/migration-and-recovery.md) — read
+- [Migration and recovery](docs/release/migration-and-recovery.md): read
   before putting data in it.
 - [Release notes](docs/release/v0.3.0-release-notes.md) · [Support](SUPPORT.md) ·
   [Contributing](CONTRIBUTING.md)
@@ -191,7 +190,7 @@ An independent build inspired by Danny Postma's video *How I Built My Own
 AgentOS on Claude's Agent SDK (So You Can Too)* (2026), written from scratch
 from the ideas in it.
 
-The chain's role and step prompts are a different kind of debt: five skills from
+The chain's role and step prompts owe more than inspiration: five skills from
 [mattpocock/skills](https://github.com/mattpocock/skills) supply their working
 text, carried verbatim and wrapped in paragraphs written here for this
 platform's contracts. That work is MIT-licensed, `Copyright (c) 2026 Matt

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 **面向 coding agent 的本地控制平面。**
 
-你只写规格，剩下的交给一条 agent 链——计划、评审、实现、验证、合入，
+你只写规格，剩下的交给一条 agent 链：计划、评审、实现、验证、合入。
 每一次 run 都可观察、可评审。
 
 [![status](https://img.shields.io/badge/status-developer%20preview-orange)](docs/status.zh-CN.md)
@@ -23,25 +23,25 @@
 AgentOS 把任务、agent、仓库与文件授权、独立的运行记录、provider 事件流、人工
 提问、评审关卡和 git 交付串成一个工作流，全部跑在你自己的机器上。
 
-它编排的是你已经安装并完成认证的官方 Codex CLI、Claude Code 与 Pi——这些 CLI
+它编排的是你已经安装并完成认证的官方 Codex CLI、Claude Code 与 Pi：这些 CLI
 手里已有的订阅登录，就是它运行所依赖的全部认证。AgentOS 自己不提供任何凭据，
 也不转售任何订阅，详见[认证与订阅](#认证与订阅)。
 
 ## 它改变了什么
 
-一条任务链承载完整的交付路径：写规格、计划、计划评审、实现、两轮独立代码评审、
+一条任务链覆盖完整的交付路径：写规格、计划、计划评审、实现、两轮独立代码评审、
 应用修复、回归验证、合并就绪判定，直到合并本身。每一步都带着自己的角色、提示词、
 模型与推理档位，上一步的产出就是下一步的输入。
 
 链一旦启动就自行推进。需要你出面的只有三种时刻：agent 通过 Inbox 向你提问、你
-显式设为 gated 的步骤需要人工裁决、或者某次 run 升级(escalate)。其余时间它无人
-值守地跑，交付也在其中——推分支、可选地开 PR、并在 merge gate 之后合入。
+显式设为 gated 的步骤需要人工裁决、或者某次 run 升级（escalate）。其余时间它无人
+值守地跑，交付也在其中：推分支、可选地开 PR、并在 merge gate 之后合入。
 
-杠杆就在这里。稀缺资源不再是你的工时，而是你注册了多少 runner：不同任务、不同
-仓库的链同时在飞，而你在读评审产出，不在敲实现。
+这改变的是你的瓶颈在哪里。吞吐取决于你注册了多少 runner，而不是你的工时：不同
+任务、不同仓库的链同时在飞，你在读评审产出，不在敲实现。
 
-一处诚实的边界：长时程自治还没接线。Goal 能存能编辑，但没有任何东西从 Goal 调度
-工作，所以链仍然由你或 webhook 触发启动，而不是由一个常驻目标驱动。见
+长时程自治还没接线。Goal 能存能编辑，但没有任何东西从 Goal 调度工作，所以链仍然
+由你或 webhook 触发启动，而不是由一个常驻目标驱动。见
 [支持状态](docs/status.zh-CN.md)。
 
 <div align="center">
@@ -90,7 +90,7 @@ AgentOS 自带的 Full Assurance 模板。每一步绑定一个角色，每个�
 
 ## 快速开始
 
-面向 Apple Silicon Mac，需要 `.nvmrc` 记录的 Node.js `22.17.0`（安装强制要求
+你需要一台 Apple Silicon Mac，以及 `.nvmrc` 记录的 Node.js `22.17.0`（安装强制要求
 Node.js 满足 `^20.19.0 || ^22.13.0 || >=24`，其余版本会被拒绝）、npm 10.9.2+、Docker Compose、
 Git，以及在同一 macOS 账号下**已安装且已登录**的官方 Codex CLI。Claude Code 与
 Pi 都是可选的。
@@ -132,30 +132,30 @@ npm run db:migrate:release -- --fresh
 
 ## 认证与订阅
 
-AgentOS 不持有任何 provider 凭据。它启动的是你本机已经安装并登录的官方 CLI——
-Codex CLI、Claude Code 与 Pi——认证状态留在各个 CLI 自己的配置里，AgentOS 既不
-读取也不转发。这里没有 AgentOS 账号，没有 API 反代，也没有要你粘贴的 key。
+AgentOS 不持有任何 provider 凭据。它启动的是你本机已经安装并登录的官方 CLI
+（Codex CLI、Claude Code 与 Pi），认证状态留在各个 CLI 自己的配置里，AgentOS
+既不读取也不转发。这里没有 AgentOS 账号，没有 API 反代，也没有要你粘贴的 key。
 
 因此这些 CLI 支持哪种认证，AgentOS 就跑在哪种之上：ChatGPT 订阅登录、Claude
 Pro/Max 登录，或各 CLI 自己的 API key 模式，完全按你已经配好的样子。Pi 同样没有
 自己的账号，它走的是 Codex 那份登录。
 
-这一点你可以自己核实，不必只听我们说。runner 是为 provider 子进程构造环境，而不
-是整份复制宿主环境（[`docs/architecture.zh-CN.md`](docs/architecture.zh-CN.md)、
+这一点你可以自己核实。runner 是为 provider 子进程构造环境，而不是整份复制
+宿主环境（[`docs/architecture.zh-CN.md`](docs/architecture.zh-CN.md)、
 `packages/runner/src/adapters/`）；发布检查会扫描这份 checkout 里的 token 变量、
 bearer header 与 `Authorization`（[`docs/release/security.md`](docs/release/security.md)）。
 
-它不能替你裁定 provider 的条款。套餐额度、速率限制、用量配额，以及你的套餐是否
+这些都不能替你裁定 provider 的条款。套餐额度、速率限制、用量配额，以及你的套餐是否
 允许这种编排方式，都在你和 provider 之间。AgentOS 不授予任何权益，也不替 CLI
 provider 作出兼容性承诺。
 
 ## 文档
 
-- [架构与安全模型](docs/architecture.zh-CN.md)——控制台、API、runner 与 provider
+- [架构与安全模型](docs/architecture.zh-CN.md)：控制台、API、runner 与 provider
   CLI 如何拼在一起，以及 grant 约束了什么、没约束什么。
-- [安装细节与验证](docs/install.zh-CN.md)——环境文件、迁移、merge executor 与检查序列。
-- [安全](docs/release/security.md)——在把它指向任何你在乎的东西之前先读。
-- [迁移与恢复](docs/release/migration-and-recovery.md)——在往里放数据之前先读。
+- [安装细节与验证](docs/install.zh-CN.md)：环境文件、迁移、merge executor 与检查序列。
+- [安全](docs/release/security.md)：在把它指向任何你在乎的东西之前先读。
+- [迁移与恢复](docs/release/migration-and-recovery.md)：在往里放数据之前先读。
 - [发布说明](docs/release/v0.3.0-release-notes.md) · [支持](SUPPORT.md) ·
   [贡献](CONTRIBUTING.md)
 
@@ -164,7 +164,7 @@ provider 作出兼容性承诺。
 本项目是受 Danny Postma 的视频 *How I Built My Own AgentOS on Claude's Agent
 SDK (So You Can Too)*（2026）启发的独立实现，从视频中的想法出发从零构建。
 
-任务链的角色与步骤提示词则是另一种性质的欠账：其行文主体来自
+任务链的角色与步骤提示词欠的不止是启发：其行文主体来自
 [mattpocock/skills](https://github.com/mattpocock/skills) 的五个技能，逐字沿用，
 外面包着为本平台契约另写的段落。上游以 MIT 授权，`Copyright (c) 2026 Matt
 Pocock`，声明在 [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。


### PR DESCRIPTION
Runs the humanizer pass over `README.md` and `README.zh-CN.md`.

- Em dashes replaced with colons, parentheses or periods (table `—` placeholders kept).
- `That is the leverage.` / `杠杆就在这里。` removed; the throughput claim is stated directly.
- `One honest limit:` / `一处诚实的边界：` removed.
- `You can check this instead of taking it on faith` and `What none of that does is settle...` rewritten as direct claims.
- Missing subjects restored: `Targets an Apple Silicon Mac` → `You need...`, `Your attention is required when` → `You step in when`.

Tables, badges, code blocks, links, callouts and every factual claim are unchanged.

Also updated out of band: the GitHub About description and topics, which still listed only Codex CLI and Claude Code and omitted Pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)