### PR TITLE
docs(governance): make AGENTS.md a trigger layer and move detail to owning docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,38 +7,11 @@ repository.
 ## Work directly
 
 Work in the current session by default; create or dispatch a task chain only
-when the human user explicitly requests one.
-
-When the user requests a chain:
-
-- Direct chain: one implementation context window can deliver a brief whose
-  change points are enumerable. Its `description` is the specification of
-  record — write it from [`docs/BRIEF-TEMPLATE.md`](docs/BRIEF-TEMPLATE.md)
-  before instantiating.
-- Full assurance chain: the work exceeds one implementation window or
-  decomposes into independently demonstrable slices; its spec and plan stages
-  own that decomposition. A surface too large for a brief to enumerate belongs
-  here, not to an assignee escalation.
-- Implementation assignee: keep the direct template's default. Assign
-  `senior-dev` (same rule for the review-fix step) only when the work touches
-  persisted data or a defense-list path — merge gate, gate worker, migrations,
-  merge automation — or when that classification is uncertain. Assign
-  `frontend-dev` when the work is primarily a new or redesigned web page or UI
-  surface (Leo 2026-08-27); the defense-list rule above still wins when both
-  apply.
-- A backlog card that needs a non-default implementation assignee states it as
-  the machine-readable line `Route: implementation=senior-dev` (or
-  `=frontend-dev`) in its description; the dispatcher copies it into
-  `stepOverrides`. Only the implementation step is routable this way.
-- Chain-to-chain sequencing: pass `afterTaskId` (the predecessor chain's final
-  task) to the instantiate endpoint; the bound chain dispatches when the
-  predecessor completes. Incompatible with `autoStart`; one successor per
-  predecessor task. Dependency qualification in
-  [`docs/governance/task-routing-v1.md`](docs/governance/task-routing-v1.md)
-  precedes every instantiation; ordering preferences stay in the backlog.
-- Dispatching, gating, rerouting, and the backlog card lifecycle (create,
-  route, archive at instantiation) follow
-  [`docs/governance/task-routing-v1.md`](docs/governance/task-routing-v1.md).
+when the human user explicitly requests one. Everything about chains — tier
+selection, the brief, implementation-assignee routing, chain-to-chain
+sequencing, and the backlog card lifecycle — is owned by
+[`docs/governance/task-routing-v1.md`](docs/governance/task-routing-v1.md);
+qualify dependencies there before every instantiation.
 
 Before changing canonical Agents, roles, or task templates, read
 [`agents/README.md`](agents/README.md); it and the contract files it names own
@@ -74,28 +47,22 @@ on one of those surfaces.
 ## Deliver an exact head
 
 `scripts/merge-gate.sh` is the only CI; a merge requires
-`MERGE GATE: PASS <oid>` for the exact commit being merged
-(`scripts/merge-gate.sh --expect-head <oid>`). When another gate might be
-running, dispatch through `scripts/gate-worker/gate-dispatch.sh <oid>`; read
-[`docs/runbooks/gate-worker.md`](docs/runbooks/gate-worker.md) before operating
-a remote worker.
+`MERGE GATE: PASS <oid>` for the exact commit being merged. The delivery
+procedure — gate dispatch, merge lease, pull-request timing, and worktree
+isolation — is owned by the "Delivering to main" section of
+[`CONTRIBUTING.md`](CONTRIBUTING.md). Never switch branches or commit feature
+work in the shared checkout: deliver from an isolated worktree on your own
+branch, and remove the worktree once merged.
 
-Every delivery that advances `main` acquires `scripts/merge-lease.sh` before
-running the merge gate for the final integrated head and holds it until the
-merge consumes that proof. Writing code, pushing a feature branch, and opening
-a PR need no lease. Pass `--task <id>` to both `acquire` and `release`: the
-default holder `user@host` is shared by every agent window on one machine, so
-a release without a task id cannot tell its own lease from a sibling's.
+## Platform runs
 
-Open the PR right after pushing the feature branch, before dispatching the
-gate: once the exact-head fast-forward lands, GitHub refuses a PR from a branch
-main already contains, while one opened beforehand flips to merged on its own.
-
-Several agent windows share one checkout. Deliver from a dedicated worktree
-under `~/Documents/claude_projects/agentos-public-worktrees/<task-name>/` on
-your own branch, stage only the paths you changed, and remove the worktree once
-merged — a branch switch in the shared checkout carries away another window's
-uncommitted work.
+For an agent executing inside an AgentOS run: your checkout is exclusive to
+this run. Create any worktree you need inside your own run workspace (a
+relative path such as `./worktrees/<name>`), never outside it — host-window
+rules elsewhere in this file do not move your work off the run workspace.
+Gates, merge leases, and merges belong to the mechanical merge tail, not to
+implementation or review steps. Never operate on a production or appliance
+checkout.
 
 ## Editing these instructions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,35 @@ branch".
 Some checks are deliberately outside the gate and belong to the list a developer
 runs: `npm run test:dependency-gate` and `npm run verify:compose-binding`.
 
+### Delivering to main
+
+A merge requires `MERGE GATE: PASS <oid>` for the exact integrated head being
+merged (`scripts/merge-gate.sh --expect-head <oid>`). When another gate might
+be running, dispatch through `scripts/gate-worker/gate-dispatch.sh <oid>`; read
+[`docs/runbooks/gate-worker.md`](docs/runbooks/gate-worker.md) before operating
+a remote worker.
+
+Every delivery that advances `main` acquires `scripts/merge-lease.sh` before
+running the merge gate for the final integrated head and holds it until the
+merge consumes that proof. Writing code, pushing a feature branch, and opening
+a pull request need no lease. Pass `--task <id>` to both `acquire` and
+`release`: the default holder `user@host` is shared by every agent window on
+one machine, so a release without a task id cannot tell its own lease from a
+sibling's.
+
+Open the pull request right after pushing the feature branch, before
+dispatching the gate: once the exact-head fast-forward lands, GitHub refuses a
+pull request from a branch main already contains, while one opened beforehand
+flips to merged on its own.
+
+Several agent windows share one checkout, and a branch switch there carries
+away another window's uncommitted work — the shared checkout stays on `main`
+and never receives feature commits. Deliver from an isolated worktree on your
+own branch: use your tool's native worktree mechanism when it has one, and
+otherwise create one under a fresh temporary directory
+(`git worktree add "$(mktemp -d)/checkout" <branch>`). Stage only the paths
+you changed, and remove the worktree once merged.
+
 ### Testing red lines
 
 These are not style preferences. Each one exists because ignoring it destroys

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -1,6 +1,6 @@
 # Task Routing Contract v1
 
-Version: 1.6 (2026-08-27: adds dependency qualification — every instantiation classifies chain-to-chain dependency before choosing `afterTaskId` or parallel dispatch)
+Version: 1.7 (2026-08-27: absorbs the dispatch rules formerly split into `AGENTS.md` — tier selection detail, implementation-assignee routing, and `afterTaskId` mechanics; `AGENTS.md` now carries a pointer only)
 
 Status: Active
 
@@ -45,7 +45,13 @@ Choose the shortest tier that satisfies the Product Contract. This contract defi
 
 Direct is a formal chain route, not an exemption from review or exact-head mechanical authorization. Full Assurance is required when the Product Contract calls for specification, planning, plan review, or revised-plan implementation authorization.
 
-Template choice and dispatch-time implementation-assignee escalation follow the "Work directly" section of `AGENTS.md`.
+Choose Direct when one implementation context window can deliver a brief whose change points are enumerable; write the brief from `docs/BRIEF-TEMPLATE.md` before instantiating, because the chain's implementation `description` is the specification of record. Choose Full Assurance when the work exceeds one implementation window or decomposes into independently demonstrable slices; a surface too large for a brief to enumerate belongs here, not to an assignee escalation.
+
+## Implementation assignee routing
+
+Keep the template's default implementation assignee. Assign `senior-dev` (same rule for the review-fix step) only when the work touches persisted data or a defense-list path — merge gate, gate worker, migrations, merge automation — or when that classification is uncertain. Assign `frontend-dev` when the work is primarily a new or redesigned web page or UI surface (Leo 2026-08-27); the defense-list rule wins when both apply.
+
+A backlog card that needs a non-default implementation assignee states it as the machine-readable line `Route: implementation=senior-dev` (or `=frontend-dev`) in its description; the dispatcher copies it into `stepOverrides`. Only the implementation step is routable this way.
 
 ## Critical classification
 
@@ -91,7 +97,7 @@ If risk or ambiguity increases during execution, pause before the newly unsafe w
 A backlog card is a dispatch-ready brief waiting for a decision, not a work item of its own. The board holds either the card or its chain, never both.
 
 - Create the card with `assigneeType: HUMAN` so no runner claims it, with the brief as its description (written from `docs/BRIEF-TEMPLATE.md`) plus the machine-readable `Route:` line when the implementation assignee is non-default. The create API has no status field and lands the card in TODO; move it to BACKLOG explicitly.
-- Dispatch instantiates a chain from the card: the brief becomes the instantiate `description` (the chain's implementation task is then the specification of record) and the `Route:` line becomes `stepOverrides`. Chain-to-chain ordering uses `afterTaskId` per the dispatch rules in `AGENTS.md`.
+- Dispatch instantiates a chain from the card: the brief becomes the instantiate `description` (the chain's implementation task is then the specification of record) and the `Route:` line becomes `stepOverrides`. Chain-to-chain ordering passes `afterTaskId` (the predecessor chain's final task) to the instantiate endpoint; the bound chain dispatches when the predecessor completes. `afterTaskId` is incompatible with `autoStart`, and each predecessor task takes one successor.
 - Dependency qualification precedes every instantiation: classify the new chain against every in-flight or co-dispatched chain and pick exactly one outcome.
   1. True dependency — the new chain consumes another chain's output, or needs that chain merged and deployed first: bind with `afterTaskId` and record the basis (`Depends on: <chain> — <what is consumed or why deploy-first>`) in the instantiate description or the card's activity log.
   2. Heavy overlap — no dependency, but both chains rewrite the same code area: weigh expected refresh-conflict repair cost against serial wall-clock loss; either choice is valid, and a serial choice records its reason the same way.


### PR DESCRIPTION
AGENTS.md carried full dispatch and delivery procedure that only host operator windows need, while platform run agents read the same file. Two of those sections have already misfired inside runs: the worktree-pool path pulled a run's nine worktrees into the host operator's personal pool (cross-tenancy risk, caught by session audit), and the gate instructions previously had review roles running merge gates.

Changes:
- AGENTS.md becomes the trigger/guardrail layer its own editing charter describes: chain dispatch collapses to a pointer at docs/governance/task-routing-v1.md, delivery procedure to a pointer at CONTRIBUTING.md, plus a new Platform runs section scoping run agents to their own run workspace.
- task-routing-v1.md v1.7 absorbs tier-selection criteria, implementation-assignee routing, and afterTaskId mechanics, removing its former back-pointer at AGENTS.md (the two files each claimed the other owned the rule).
- CONTRIBUTING.md gains a Delivering to main section (gate dispatch, merge lease, PR timing) next to the existing gate documentation. The shared-checkout rule now states the invariant — isolated worktree, own branch, remove once merged, native tool mechanism or a temporary-directory worktree — instead of prescribing the retired ~/Documents worktree pool path.

Verification: npm run lint PASS, npm run test:snapshot-scan PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)