### PR TITLE
fix(deploy): refresh Prisma client and restart all runners

### DIFF
--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -3,7 +3,7 @@
 This job advances one macOS launchd deployment from its currently stamped
 build to `origin/main`. It is for the checkout whose services are
 `com.agentos.api`, `com.agentos.inbox`, `com.agentos.runner`,
-`com.agentos.runner-2` through `com.agentos.runner-6`, and `com.agentos.web`.
+`com.agentos.runner-2` through `com.agentos.runner-10`, and `com.agentos.web`.
 It does not deploy an AgentOS run workspace.
 
 ## Preconditions
@@ -20,7 +20,7 @@ The checkout must have:
 - the running PostgreSQL container `agentos-postgres-1`, with executable
   `/usr/local/bin/pg_dump` inside it (the path used by the supported
   `postgres:16-alpine` image);
-- all nine service labels above already loaded.
+- all thirteen service labels above already loaded.
 
 ## Appliance checkout
 
@@ -47,7 +47,7 @@ Relocating an existing installation is a controlled cutover:
 2. Stage replacement LaunchAgent definitions from the loaded definitions,
    preserving their environment and changing only paths rooted in the old
    checkout. Validate every staged plist before touching launchd.
-3. At a quiet window, replace all nine service definitions and the auto-deploy
+3. At a quiet window, replace all thirteen service definitions and the auto-deploy
    definition as one change. Restart the services from the dedicated clone.
 4. Require all labels to be running, `/health` to pass, `/version` to report the
    prepared commit, every loaded program and working directory to resolve inside
@@ -153,9 +153,10 @@ The job then performs exactly this sequence and stops at the first failure:
    The remote revision read and fetch each make at most three attempts, waiting
    two seconds and then five seconds; only the final failure escalates;
 2. create a detached staging worktree under `.agentos-deploy/` and run `npm ci`
-   against the target lockfile. The root `postinstall` generates Prisma Client,
-   so the deploy does not run the same generation a second time; the runtime
-   client is still verified before publication;
+   against the target lockfile. The root `postinstall` generates the initial
+   Prisma Client; after the migration, the deploy runs `npm run db:generate`
+   again before canonical prompt sync. The runtime client is still verified
+   before publication;
 3. materialize the exact target revision's local merge-gate `dist/` snapshot
    when it is present and valid, otherwise run `npm run build` in staging, then
    verify the API build stamp. A missing or cache-evicted snapshot is an explicit

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -639,6 +639,7 @@ const main = async () => {
           cwd: stage,
         });
       },
+      generatePrismaClient: () => checked("prisma-client-generation-refused", loadBinaries().node, [loadBinaries().npm, "run", "db:generate"], { cwd: stage }),
       syncCanonicalPrompts: () => checked("canonical-prompt-sync-refused", loadBinaries().node, [loadBinaries().npm, "run", "db:sync-canonical-prompts"], { cwd: stage }),
       verifyRuntimePrismaClient: async () => {
         if (!generatedPrismaClientIsComplete(stage)) {

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -21,6 +21,7 @@ import test from "node:test";
 
 import {
   DeployFailure,
+  SERVICE_LABELS,
   dryRunDecision,
   executeUpgrade,
   gitPreflightFailure,
@@ -88,7 +89,11 @@ const fixture = (failure = null) => {
   const step = (name, work = async () => undefined) => async () => {
     calls.push(name);
     if (failure === name) {
-      const reason = name === "canonical-prompt-sync" ? "canonical-prompt-sync-refused" : `${name}-failed`;
+      const reason = name === "canonical-prompt-sync"
+        ? "canonical-prompt-sync-refused"
+        : name === "generate-prisma-client"
+          ? "prisma-client-generation-refused"
+          : `${name}-failed`;
       throw new DeployFailure(reason, "fixture");
     }
     return work();
@@ -100,6 +105,7 @@ const fixture = (failure = null) => {
     build: step("build"),
     backup: step("backup"),
     guardedMigration: step("guarded-migration"),
+    generatePrismaClient: step("generate-prisma-client"),
     syncCanonicalPrompts: step("canonical-prompt-sync"),
     verifyRuntimePrismaClient: step("verify-runtime-prisma-client"),
     assertQuietBeforeRestart: step("quiet-recheck"),
@@ -119,6 +125,24 @@ const fixture = (failure = null) => {
   };
   return { host, calls, state };
 };
+
+test("service label inventory covers every loaded production service", () => {
+  assert.deepEqual(SERVICE_LABELS, [
+    "com.agentos.api",
+    "com.agentos.inbox",
+    "com.agentos.runner",
+    "com.agentos.runner-2",
+    "com.agentos.runner-3",
+    "com.agentos.runner-4",
+    "com.agentos.runner-5",
+    "com.agentos.runner-6",
+    "com.agentos.runner-7",
+    "com.agentos.runner-8",
+    "com.agentos.runner-9",
+    "com.agentos.runner-10",
+    "com.agentos.web",
+  ]);
+});
 
 test("quiet-window predicate blocks only claimed, provisioning, and running", () => {
   for (const status of ["claimed", "provisioning", "running", "CLAIMED", "RUNNING"]) {
@@ -205,7 +229,7 @@ test("successful upgrade runs the safety sequence in order", async () => {
   assert.deepEqual(await executeUpgrade(host, revisions), { ok: true });
   assert.deepEqual(calls, [
     "fast-forward", "create-stage", "install-dependencies", "build", "backup",
-    "guarded-migration", "canonical-prompt-sync", "verify-runtime-prisma-client", "quiet-recheck",
+    "guarded-migration", "generate-prisma-client", "canonical-prompt-sync", "verify-runtime-prisma-client", "quiet-recheck",
     "publish-build", "restart-services", "verify-services", "notify-success", "commit-build", "cleanup-stage",
   ]);
   assert.equal(state.serving, "candidate");
@@ -236,6 +260,16 @@ test("structural sync refusal escalates without publishing or restarting", async
   assert.equal(calls.includes("restart-services"), false);
   assert.equal(state.serving, "previous");
   assert.equal(state.escalated.reason, "canonical-prompt-sync-refused");
+});
+
+test("Prisma client generation refusal escalates before canonical sync", async () => {
+  const { host, calls, state } = fixture("generate-prisma-client");
+  const result = await executeUpgrade(host, revisions);
+  assert.equal(result.ok, false);
+  assert.equal(result.failure.reason, "prisma-client-generation-refused");
+  assert.equal(calls.includes("canonical-prompt-sync"), false);
+  assert.equal(calls.includes("publish-build"), false);
+  assert.equal(state.escalated.reason, "prisma-client-generation-refused");
 });
 
 test("restart failure rolls the build back and restarts the previous services", async () => {
@@ -540,7 +574,7 @@ test("dry-run reads every decision surface and invokes no mutation", async () =>
   assert.equal(result.quiet, true);
   assert.deepEqual(new Set(calls), new Set(["revisions", "runs", "repository", "services", "backup"]));
   assert.ok(result.lines.includes("DRY-RUN backup=ready mode=container"));
-  assert.equal(result.lines.filter((line) => line.includes("mutation=skipped")).length, 10);
+  assert.equal(result.lines.filter((line) => line.includes("mutation=skipped")).length, 11);
 });
 
 const buildCacheFixture = (root, revision, buildKey) => {
@@ -640,10 +674,13 @@ test("the merge gate publishes deploy acceleration only after its final drift pr
   assert.ok(drift >= 0 && drift < buildPublication && buildPublication < releasePublication);
 });
 
-test("deployment relies on npm ci postinstall once and verifies the generated Prisma client", () => {
+test("deployment regenerates Prisma Client after migration and verifies it", () => {
   const repositoryRoot = realpathSync(new URL("../../", import.meta.url));
   const source = readFileSync(join(repositoryRoot, "scripts/deploy/quiet-window-deploy.mjs"), "utf8");
-  assert.doesNotMatch(source, /\[loadBinaries\(\)\.npm, "run", "db:generate"\]/u);
+  assert.match(source, /prisma-client-generation-refused/u);
+  assert.match(source, /\[loadBinaries\(\)\.npm, "run", "db:generate"\]/u);
+  assert.ok(source.indexOf("guardedMigration:") < source.indexOf("generatePrismaClient:"));
+  assert.ok(source.indexOf("generatePrismaClient:") < source.indexOf("syncCanonicalPrompts:"));
   assert.match(source, /npm-ci-did-not-produce-generated-prisma-client/u);
   assert.match(source, /node_modules\/\.prisma\/client\/schema\.prisma/u);
 });

--- a/scripts/deploy/quiet-window-host.mjs
+++ b/scripts/deploy/quiet-window-host.mjs
@@ -1,6 +1,6 @@
 const METHODS = Object.freeze([
   "fastForward", "createStage", "installDependencies", "build", "backup",
-  "guardedMigration", "syncCanonicalPrompts", "verifyRuntimePrismaClient",
+  "guardedMigration", "generatePrismaClient", "syncCanonicalPrompts", "verifyRuntimePrismaClient",
   "assertQuietBeforeRestart", "publishBuild", "restartServices", "verifyServices",
   "restorePreviousServices", "escalate", "notify", "cleanupStage",
 ]);

--- a/scripts/deploy/quiet-window-lib.mjs
+++ b/scripts/deploy/quiet-window-lib.mjs
@@ -6,6 +6,7 @@ export const DEPLOY_STEPS = Object.freeze([
   "build",
   "backup",
   "guarded-migration",
+  "generate-prisma-client",
   "canonical-prompt-sync",
   "verify-runtime-prisma-client",
   "publish-build",
@@ -22,6 +23,10 @@ export const SERVICE_LABELS = Object.freeze([
   "com.agentos.runner-4",
   "com.agentos.runner-5",
   "com.agentos.runner-6",
+  "com.agentos.runner-7",
+  "com.agentos.runner-8",
+  "com.agentos.runner-9",
+  "com.agentos.runner-10",
   "com.agentos.web",
 ]);
 
@@ -67,6 +72,7 @@ export const executeUpgrade = async (host, initialRevisions) => {
     await host.build();
     await host.backup();
     await host.guardedMigration();
+    await host.generatePrismaClient();
     await host.syncCanonicalPrompts();
     await host.verifyRuntimePrismaClient();
     await host.assertQuietBeforeRestart();


### PR DESCRIPTION
## Summary
- restart runner-7 through runner-10 during quiet-window deploys
- regenerate Prisma Client after migrations and before canonical prompt sync
- keep generation failures fail-loud and update deploy regression coverage/runbook

## Verification
- npm install
- RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm run test:auto-deploy
- npm run lint