### PR TITLE
docs: correct rollover and runner dependency comments

### DIFF
--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -63,7 +63,7 @@ Critical is a risk label, not a routing tier or a model route: it marks the slic
 
 The seeded templates under `agents/templates/` are the execution canon: step prompts, layer structure, blind-review isolation, and the mechanical merge tail live in those Markdown sources, and `agents/README.md` owns the structural rules that bind them. Model and runner defaults live in `agents/roles/` frontmatter and `packages/db/src/agent-contract.ts`.
 
-Chains instantiated before a template change keep their stored prompts, assignments, and behavior; canonical sync preserves superseded templates under deterministic legacy identities instead of rewriting instantiated work. One exception, added with prompt-only rollovers (2026-08-26): a task that has not started — no Run at all — has its stored prompt recomposed from the current canonical step, since a prompt-only rollover is the declaration that the old text stopped being true. Anything that has run keeps what it was dispatched under.
+Chains instantiated before a template change keep their stored prompts, assignments, and behavior; canonical sync preserves superseded templates under deterministic legacy identities instead of rewriting instantiated work. A rollover leaves each task's stored prompt unchanged.
 
 ## Human approval placement
 

--- a/packages/runner/src/envelope.ts
+++ b/packages/runner/src/envelope.ts
@@ -9,9 +9,9 @@ import { isTransientNetworkError } from "./network-retry.js";
  *
  * `packages/db/src/failure-envelope.ts` is the canonical definition; this is a
  * hand-kept mirror, for the same reason `FailureClass` and `CleanupStatus` are
- * mirrored in api.ts — this package deliberately has no `@agentos/db`
- * dependency, so a compromised or buggy runner cannot reach a database. The
- * API's zod schema for the complete route is the boundary that catches drift.
+ * mirrored in api.ts — this package deliberately does not import the Prisma
+ * client. The API's zod schema for the complete route is the boundary that
+ * catches drift.
  *
  * What this module does *not* do is decide anything. It reports facts: which
  * phase the run was in, what exited with what, which channel each piece of text


### PR DESCRIPTION
## Deliverables

- M1: update `docs/governance/task-routing-v1.md` so a template rollover leaves every instantiated task's stored prompt unchanged; remove the retired prompt-recomposition exception.
- M2: update `packages/runner/src/envelope.ts` to document the actual boundary: the runner does not import the Prisma client.

No runtime behavior or persisted data changed.

## Acceptance

- `npm install` (fresh worktree; Prisma client generated)
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm run lint` — PASS (Biome and ESLint)
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm run build -w @agentos/web` — PASS (required by web tests)
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm test` — PASS (all workspace suites; environment-gated cases reported as skipped by the suite)
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm run test:snapshot-scan` — PASS
- `git diff --check` — PASS

The first `npm test` attempt was run before the web build and stopped only at the repository's explicit build prerequisites; the required build was then run and the complete suite passed.

## Decisions made in this lane

- Removed the prompt-only rollover exception rather than preserving a compatibility sentence: the sweep that recomposed not-yet-started tasks was deleted in `c1fe290`, so documenting it would describe behavior that no longer exists.
- Kept the broader canonical-sync sentence and added one direct invariant, “A rollover leaves each task's stored prompt unchanged,” so the rule applies uniformly to instantiated tasks.
- Replaced the runner comment's claim that it has no `@agentos/db` dependency and cannot reach a database: `packages/runner/package.json` declares that dependency and `adapters.ts` imports `stepRole` at runtime. The surviving, verifiable boundary is that this package does not import the Prisma client.
- Created this branch from the actual current `main` (`3dd37d3`, while the task brief recorded `7fd6fc5`) because `main` had already advanced; following the live branch preserves append-only history and avoids building on stale state.
