### PR TITLE
refactor(api): type workflow refusals

### DIFF
--- a/packages/api/src/refusal.test.ts
+++ b/packages/api/src/refusal.test.ts
@@ -9,6 +9,8 @@ import {
   MergeConfirmationError,
   MergeEvidenceError,
   PinnedBaseCommitError,
+  WorkflowRefusalError,
+  type WorkflowRefusalReason,
 } from "@agentos/db";
 
 import {
@@ -96,18 +98,21 @@ test("the five error families formerly missed by app.onError never reach its 500
   assert.equal(responseFor(new MergeEvidenceError("Merge evidence is incomplete")).status, 409);
 });
 
-test("the five Inbox decision messages formerly matched by regex have concrete reasons", () => {
-  const cases = {
-    "No matching Inbox question": "inbox-question-not-found",
-    "Approval gate decision must be approve or reject": "approval-gate-decision-invalid",
-    "Decision must match an Inbox choice id": "inbox-choice-mismatch",
-    "No matching waiting Inbox question": "inbox-run-not-waiting",
-    "Approval gate has no executable previous task to reject to": "approval-gate-rejection-target-missing",
-  } as const;
-  for (const [message, reason] of Object.entries(cases)) {
-    const refusal = refusalFor(new Error(message));
+test("workflow refusals are classified by reason independently of prose", () => {
+  const messagesByReason = {
+    "invalid-request": "changed configuration wording",
+    conflict: "changed concurrency wording",
+    "inbox-question-not-found": "changed missing-question wording",
+    "approval-gate-decision-invalid": "changed decision wording",
+    "inbox-choice-mismatch": "changed choice wording",
+    "inbox-run-not-waiting": "changed run-state wording",
+    "approval-gate-rejection-target-missing": "changed rejection-target wording",
+  } as const satisfies Record<WorkflowRefusalReason, string>;
+  for (const [reason, message] of Object.entries(messagesByReason) as Array<[WorkflowRefusalReason, string]>) {
+    const refusal = refusalFor(new WorkflowRefusalError(reason, message));
     assert.equal(refusal?.reason, reason);
-    assert.equal(refusal && refusalResponse(refusal).status, 409);
+    assert.equal(refusal?.message, message);
+    assert.equal(refusal && refusalResponse(refusal).status, reason === "invalid-request" ? 400 : 409);
   }
   assert.equal(refusalFor(new Error("unclassified")), null);
 });

--- a/packages/api/src/refusal.ts
+++ b/packages/api/src/refusal.ts
@@ -6,25 +6,21 @@ import {
   isMergeConfirmationError,
   isMergeEvidenceError,
   isPinnedBaseCommitError,
+  isWorkflowRefusalError,
+  type WorkflowRefusalReason,
 } from "@agentos/db";
 
 export type RefusalReason =
-  | "invalid-request"
+  | WorkflowRefusalReason
   | "forbidden"
   | "not-found"
-  | "conflict"
   | "compound-implementation-assignee"
   | "archived-assignee"
   | "archived-task"
   | "integrator-stopped"
   | "pinned-base-commit"
   | "merge-evidence"
-  | "merge-confirmation"
-  | "inbox-question-not-found"
-  | "approval-gate-decision-invalid"
-  | "inbox-choice-mismatch"
-  | "inbox-run-not-waiting"
-  | "approval-gate-rejection-target-missing";
+  | "merge-confirmation";
 
 export type RefusalValue =
   | string
@@ -46,14 +42,6 @@ export type RefusalResponse = {
   body: Readonly<{ error: string } & Record<string, RefusalValue>>;
   status: 400 | 403 | 404 | 409;
 };
-
-const inboxReasonByMessage = {
-  "No matching Inbox question": "inbox-question-not-found",
-  "Approval gate decision must be approve or reject": "approval-gate-decision-invalid",
-  "Decision must match an Inbox choice id": "inbox-choice-mismatch",
-  "No matching waiting Inbox question": "inbox-run-not-waiting",
-  "Approval gate has no executable previous task to reject to": "approval-gate-rejection-target-missing",
-} as const satisfies Readonly<Record<string, RefusalReason>>;
 
 export const refusalResponse = (refusal: Refusal): RefusalResponse => {
   let status: RefusalResponse["status"];
@@ -96,6 +84,7 @@ export const refusalResponse = (refusal: Refusal): RefusalResponse => {
 };
 
 export const refusalFor = (error: unknown): Refusal | null => {
+  if (isWorkflowRefusalError(error)) return { reason: error.reason, message: error.message };
   if (isCompoundImplementationAssigneeError(error)) {
     return {
       reason: "compound-implementation-assignee",
@@ -109,7 +98,5 @@ export const refusalFor = (error: unknown): Refusal | null => {
   if (isPinnedBaseCommitError(error)) return { reason: "pinned-base-commit", message: error.message };
   if (isMergeEvidenceError(error)) return { reason: "merge-evidence", message: error.message };
   if (isMergeConfirmationError(error)) return { reason: "merge-confirmation", message: error.message };
-  if (!(error instanceof Error)) return null;
-  const reason = inboxReasonByMessage[error.message as keyof typeof inboxReasonByMessage];
-  return reason === undefined ? null : { reason, message: error.message };
+  return null;
 };

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -53,6 +53,26 @@ export const runBudgetCeiling = (
   budgetGrants: number | null | undefined,
 ): number => maxSessionsPerTask + Math.max(0, budgetGrants ?? 0);
 
+export type WorkflowRefusalReason =
+  | "invalid-request"
+  | "conflict"
+  | "inbox-question-not-found"
+  | "approval-gate-decision-invalid"
+  | "inbox-choice-mismatch"
+  | "inbox-run-not-waiting"
+  | "approval-gate-rejection-target-missing";
+
+/** A caller-reachable workflow refusal whose classification must not depend on its prose. */
+export class WorkflowRefusalError extends Error {
+  constructor(readonly reason: WorkflowRefusalReason, message: string) {
+    super(message);
+    this.name = "WorkflowRefusalError";
+  }
+}
+
+export const isWorkflowRefusalError = (error: unknown): error is WorkflowRefusalError =>
+  error instanceof Error && error.name === "WorkflowRefusalError";
+
 // The runner rule moved to the pure `@agentos/db/model-routing` subpath, which
 // the browser can import without pulling in Prisma. Imported here beside its
 // re-export so this module's own callers and its importers read the same rule.
@@ -76,7 +96,7 @@ export const deriveRunConfig = (
   const runner = templateStep?.runner ?? runnerFor(agent.runnerPreference, agent.model);
   if (compoundExecutioner
     && (runner !== RunnerKind.CODEX || catalogRunnerForModel(agent.model) !== RunnerPreference.CODEX)) {
-    throw new Error("Compound implementation root requires a Codex gpt-* model");
+    throw new WorkflowRefusalError("invalid-request", "Compound implementation root requires a Codex gpt-* model");
   }
   return {
     runner,
@@ -983,6 +1003,8 @@ export const gateQuestion = async (tx: Tx, gateTaskId: string, sourceRunId: stri
     tx.task.findUniqueOrThrow({ where: { id: gateTaskId } }),
     tx.run.findUniqueOrThrow({ where: { id: sourceRunId }, include: { session: true } }),
   ]);
+  // A gate can only follow a completed Run, and every dispatched Run owns a
+  // Session. Missing one means persisted control-plane state is corrupt.
   if (!run.session) throw new Error(`Run ${sourceRunId} has no session for approval gate`);
   const thread = chatId ? await tx.inboxThread.upsert({
     where: { channel_externalChatId_sessionId: { channel: "FEISHU", externalChatId: chatId, sessionId: run.session.id } },
@@ -1262,6 +1284,8 @@ const dispatchBoundSuccessor = async (
       repo: true,
     },
   }) as BoundSuccessor | null;
+  // The binding foreign key and the successor chain mutex make disappearance
+  // an integrity violation rather than a caller-recoverable refusal.
   if (!successor) throw new Error(`Bound successor ${successorId} disappeared while dispatching`);
 
   if (!predecessorTerminal) {
@@ -1668,7 +1692,7 @@ const activateChainSuccessorInternal = async (
 
   const nextRows = chainRows.filter((row) => layerOf(row) === nextLayer).sort(layerOrder);
   if (nextRows.some((row) => row.approvalGate) && nextRows.length > 1) {
-    throw new Error(`Approval gate is not allowed in multi-node chain layer ${nextLayer}`);
+    throw new WorkflowRefusalError("invalid-request", `Approval gate is not allowed in multi-node chain layer ${nextLayer}`);
   }
   if (nextRows.some((row) => row.approvalGate
       && (row.assigneeType !== AssigneeType.AGENT || !row.assigneeAgentId || !row.repoId))
@@ -1676,7 +1700,7 @@ const activateChainSuccessorInternal = async (
       || currentRows[0]!.assigneeType !== AssigneeType.AGENT
       || !currentRows[0]!.assigneeAgentId
       || !currentRows[0]!.repoId)) {
-    throw new Error("Server-owned approval gate must follow one executable predecessor");
+    throw new WorkflowRefusalError("invalid-request", "Server-owned approval gate must follow one executable predecessor");
   }
 
   let firstNextTaskId: string | null = null;
@@ -1840,6 +1864,9 @@ export const activateRecoveryIntegratorSuccessor = async (
   },
   now = new Date(),
 ): Promise<{ nextTaskId: string | null; gated: boolean }> => {
+  // Every failure below checks authority written by control-plane workers after
+  // their candidate was selected. A mismatch is an internal recovery invariant,
+  // not an operator input error, and therefore deliberately remains a 500.
   const identity = await tx.task.findUnique({
     where: { id: input.readinessTaskId },
     select: { projectId: true, chainId: true },
@@ -1982,7 +2009,9 @@ export const advanceTemplateTask = async (
             : { chainIndex: task.chainIndex }),
         },
       });
-      if (siblingCount > 1) throw new Error("Approval gate is not allowed in a multi-node chain layer");
+      if (siblingCount > 1) {
+        throw new WorkflowRefusalError("invalid-request", "Approval gate is not allowed in a multi-node chain layer");
+      }
     }
     if (expectedStatus) {
       const claimed = await tx.task.updateMany({ where: { id: task.id, status: expectedStatus }, data: { status: TaskStatus.REVIEW } });
@@ -2152,17 +2181,24 @@ export const applyInboxDecisionTx = async (
       thread: true,
     },
   });
-  if (!question?.session?.run) throw new Error("No matching Inbox question");
+  if (!question?.session?.run) {
+    throw new WorkflowRefusalError("inbox-question-not-found", "No matching Inbox question");
+  }
   const gateDecision = Boolean(question.gateTaskId);
   if (gateDecision && input.decision !== "approve" && input.decision !== "reject") {
-    throw new Error("Approval gate decision must be approve or reject");
+    throw new WorkflowRefusalError(
+      "approval-gate-decision-invalid",
+      "Approval gate decision must be approve or reject",
+    );
   }
   if (!gateDecision && question.kind === InboxKind.MULTIPLE_CHOICE && !input.allowFreeText) {
     const choices = Array.isArray(question.choices) ? question.choices : [];
     const matchesChoice = choices.some((choice) => (
       typeof choice === "object" && choice !== null && "id" in choice && choice.id === input.decision
     ));
-    if (!matchesChoice) throw new Error("Decision must match an Inbox choice id");
+    if (!matchesChoice) {
+      throw new WorkflowRefusalError("inbox-choice-mismatch", "Decision must match an Inbox choice id");
+    }
   }
   // §D-P7. A stop question is answered long after its run ended, so it cannot
   // travel the WAITING_INBOX path — and it is not a gate card either, because a
@@ -2170,7 +2206,7 @@ export const applyInboxDecisionTx = async (
   // to the stop it answers by a server-written dedupeKey.
   const stopBinding = gateDecision ? null : parseStopQuestionKey(question.dedupeKey);
   if (!gateDecision && !stopBinding && question.session.run.status !== RunStatus.WAITING_INBOX) {
-    throw new Error("No matching waiting Inbox question");
+    throw new WorkflowRefusalError("inbox-run-not-waiting", "No matching waiting Inbox question");
   }
   if (stopBinding) {
     const claimedStop = await tx.inboxMessage.updateMany({
@@ -2261,7 +2297,12 @@ export const applyInboxDecisionTx = async (
         orderBy: { chainIndex: "desc" },
       });
     }
-    if (!rejectionTarget) throw new Error("Approval gate has no executable previous task to reject to");
+    if (!rejectionTarget) {
+      throw new WorkflowRefusalError(
+        "approval-gate-rejection-target-missing",
+        "Approval gate has no executable previous task to reject to",
+      );
+    }
   }
   const lockedRejectionTarget = rejectionTarget && rejectionTarget.id !== question.gateTaskId
     ? await lockTaskRow(tx, rejectionTarget.id)
@@ -2358,7 +2399,9 @@ export const applyInboxDecisionTx = async (
     where: { id: question.session.run.id, status: RunStatus.WAITING_INBOX },
     data: { status: RunStatus.QUEUED, readyAt: now, runnerId: null, fencingToken: null, leaseExpiresAt: null },
   });
-  if (queued.count !== 1) throw new Error("Waiting Run changed while applying Inbox decision");
+  if (queued.count !== 1) {
+    throw new WorkflowRefusalError("conflict", "Waiting Run changed while applying Inbox decision");
+  }
   await tx.session.update({ where: { id: question.session.id }, data: {
     executionStatus: SessionExecutionStatus.REQUESTED,
     waitingOnMessageId: null,


### PR DESCRIPTION
## Deliverables

- Add `WorkflowRefusalError` and `WorkflowRefusalReason` at the db-to-api seam.
- Type all 10 caller-reachable bare workflow throws: compound execution configuration, Approval gate shape, and Inbox decision refusals.
- Keep the remaining 11 persisted-state and recovery-authority invariant failures loud, with their classification documented.
- Remove `inboxReasonByMessage`; `refusalFor` now consumes the structured reason directly.
- Replace the prose-coupled refusal test with an exhaustive reason-driven test whose messages deliberately differ from production wording.

## Acceptance and validation

- Editing Inbox refusal prose can no longer change a typed 409 into a 500.
- `npm run lint`: PASS.
- `node --import tsx --test src/refusal.test.ts` in `packages/api`: PASS (5/5).
- `npm test`: run twice. All changed-surface tests passed both times, including the API suite (245/245 on the first run). The workspace command exposed unrelated existing timing flakes in Web onboarding and API readiness; readiness passed immediately on isolated retry. The fresh-worktree Web asset precondition was also corrected before the second run.
- Exact integrated head: `118cc7abb1a1de8676a0bf784a91e3fb0f5d21c1`.
- `MERGE GATE: PASS 118cc7abb1a1de8676a0bf784a91e3fb0f5d21c1` (full profile, including unit and database tests).

## Decisions made for Leo

1. Use a reason-carrying error class instead of returning `{ ok: false, refusal }`. Reason: late Inbox refusals occur after transactional writes; throwing preserves rollback, while returning would commit partial decision state.
2. Reuse `invalid-request` and `conflict` for general workflow refusals while retaining the five existing Inbox-specific reasons. Reason: this removes prose coupling without inventing redundant HTTP status categories.
3. Type only caller-reachable failures and keep persisted-state/control-plane authority violations as ordinary errors. Reason: operators can correct the former; the latter must remain visible as 500s rather than masquerade as recoverable input.
4. Start from current `main` (`3dd37d3`) rather than the planning snapshot (`7fd6fc5`), then merge current `origin/main` (`4e1f5f1`) before publication. Reason: concurrent lanes had already advanced the append-only delivery line, and delivery must prove an integrated exact head.
