### PR TITLE
refactor(db): centralize canonical output schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6286,7 +6286,8 @@
       "name": "@agentos/db",
       "version": "0.3.0",
       "dependencies": {
-        "@prisma/client": "6.19.0"
+        "@prisma/client": "6.19.0",
+        "zod": "^4.1.12"
       },
       "devDependencies": {
         "dotenv-cli": "^11.0.0",

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -1,4 +1,8 @@
 import {
+  canonicalClosedReviewArtifactSchema as closedReviewArtifact,
+  canonicalFixedImplementationArtifactSchema as fixedImplementationArtifact,
+  canonicalOutputSchema,
+  canonicalReviewArtifactSchema as reviewArtifact,
   isRegressionVerificationOutputKind,
   Prisma,
   recordGateAttestation,
@@ -6,9 +10,11 @@ import {
   REGRESSION_VERIFICATION_SCHEMA_VERSION,
   RunStatus,
   stepRole,
+  type CanonicalClosedReviewArtifact,
+  type CanonicalFixedImplementationArtifact,
+  type CanonicalReviewArtifact,
   type TaskStepOutput,
 } from "@agentos/db";
-import { z } from "zod";
 
 import {
   fenceRefusalResponse,
@@ -93,54 +99,8 @@ const metadataPhase = (metadata: Prisma.JsonValue | Prisma.InputJsonValue | unde
   return typeof phase === "string" ? phase : null;
 };
 
-const commitSha = z.string().regex(/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u);
-const nonEmptyString = z.string().trim().min(1);
-const passGateProof = z.string().regex(/^MERGE GATE: PASS [0-9a-f]{40}$/u);
-const failGateProof = z.string().regex(/^MERGE GATE: FAIL \(.+\)$/u);
-const stringList = z.array(nonEmptyString);
-const canonicalEnvelope = z.object({ schemaVersion: z.literal(1), headSha: commitSha });
-const reviewFinding = z.object({
-  id: nonEmptyString,
-  severity: z.enum(["P0", "P1", "P2"]),
-  file: nonEmptyString,
-  line: z.number().int().positive(),
-  title: nonEmptyString,
-  evidence: nonEmptyString,
-  requiredFix: nonEmptyString,
-});
-const reviewArtifact = canonicalEnvelope.extend({
-  reviewedBase: commitSha,
-  reviewedHead: commitSha,
-  findings: z.array(reviewFinding),
-});
-const closedReviewArtifact = reviewArtifact.extend({
-  dispositions: z.array(z.object({
-    id: nonEmptyString,
-    disposition: z.enum(["ADOPTED", "REJECTED", "MERGED"]),
-    reason: nonEmptyString,
-  })),
-  mustFixIds: stringList,
-});
-
-/**
- * The adjudication node the canonical graphs used to carry. No current
- * template has one, but the `must-fix` kind is still the registered contract
- * for the renamed rows that do, so the schema stays.
- */
-const adjudicationArtifact = canonicalEnvelope.extend({
-  reviewedBase: commitSha,
-  reviewedHead: commitSha,
-  dispositions: z.array(z.object({
-    id: nonEmptyString,
-    disposition: z.enum(["ADOPTED", "REJECTED", "MERGED"]),
-    reason: nonEmptyString,
-  })),
-  mustFixIds: stringList,
-  findings: z.array(reviewFinding).optional(),
-});
-
-type ReviewArtifact = z.infer<typeof reviewArtifact>;
-type ClosedReviewArtifact = z.infer<typeof closedReviewArtifact>;
+type ReviewArtifact = CanonicalReviewArtifact;
+type ClosedReviewArtifact = CanonicalClosedReviewArtifact;
 
 const duplicateValues = (values: string[]): string[] => {
   const seen = new Set<string>();
@@ -202,24 +162,7 @@ const closedReviewRunRefusal = (
  * both immutable reports and decides each finding itself, so its output is the
  * only place that record can live.
  */
-const fixedImplementationArtifact = canonicalEnvelope.extend({
-  sourceHead: commitSha,
-  dispositions: z.array(z.object({
-    id: nonEmptyString,
-    disposition: z.enum(["ADOPTED", "REJECTED", "MERGED"]),
-    reason: nonEmptyString,
-  })),
-  closedFindings: z.array(z.object({
-    id: nonEmptyString,
-    status: z.literal("CLOSED"),
-    codeEvidence: nonEmptyString,
-    testEvidence: nonEmptyString,
-  })),
-  testsRun: stringList,
-  residualRisks: z.array(z.string()),
-});
-
-type FixedImplementationArtifact = z.infer<typeof fixedImplementationArtifact>;
+type FixedImplementationArtifact = CanonicalFixedImplementationArtifact;
 
 const fixedImplementationSelfRefusal = (artifact: FixedImplementationArtifact): string | null => {
   const duplicateDispositions = duplicateValues(artifact.dispositions.map(({ id }) => id));
@@ -337,96 +280,13 @@ const fixedImplementationPersistenceRefusal = async (
   return null;
 };
 
-const canonicalOutputSchemas: Record<string, z.ZodType> = {
-  spec: canonicalEnvelope.extend({ spec: nonEmptyString }),
-  plan: canonicalEnvelope.extend({ summary: nonEmptyString, sliceIds: stringList }),
-  "plan-review": canonicalEnvelope.extend({ findings: z.array(reviewFinding) }),
-  "revised-plan": canonicalEnvelope.extend({
-    summary: nonEmptyString,
-    addressedFindingIds: stringList,
-    declinedFindings: z.array(z.object({ id: nonEmptyString, reason: nonEmptyString })),
-  }),
-  implementation: canonicalEnvelope.extend({
-    baseSha: commitSha,
-    summary: nonEmptyString,
-    testsRun: stringList,
-  }),
-  "sol-findings": reviewArtifact.extend({ commandsRun: stringList }),
-  "blind-findings": reviewArtifact,
-  "must-fix": adjudicationArtifact,
-  "fixed-implementation": fixedImplementationArtifact,
-  "regression-verification": z.discriminatedUnion("outcome", [
-    canonicalEnvelope.extend({
-      outcome: z.literal("pass"),
-      baseHeadSha: commitSha,
-      gateVerdict: z.literal("PASS"),
-    }),
-    canonicalEnvelope.extend({
-      outcome: z.literal("review-fail"),
-      baseHeadSha: commitSha,
-      summary: nonEmptyString,
-    }),
-    canonicalEnvelope.extend({
-      outcome: z.literal("gate-fail"),
-      baseHeadSha: commitSha,
-      gateVerdict: z.literal("FAIL"),
-      summary: nonEmptyString,
-    }),
-    canonicalEnvelope.extend({
-      outcome: z.literal("refresh-conflict"),
-      baseHeadSha: commitSha,
-      summary: nonEmptyString,
-    }),
-  ]),
-  [REGRESSION_VERIFICATION_OUTPUT_KIND]: z.discriminatedUnion("outcome", [
-    canonicalEnvelope.extend({
-      schemaVersion: z.literal(REGRESSION_VERIFICATION_SCHEMA_VERSION),
-      outcome: z.literal("pass"),
-      baseHeadSha: commitSha,
-      gateVerdict: z.literal("PASS"),
-      gateProof: passGateProof,
-    }),
-    canonicalEnvelope.extend({
-      schemaVersion: z.literal(REGRESSION_VERIFICATION_SCHEMA_VERSION),
-      outcome: z.literal("review-fail"),
-      baseHeadSha: commitSha,
-      summary: nonEmptyString,
-    }),
-    canonicalEnvelope.extend({
-      schemaVersion: z.literal(REGRESSION_VERIFICATION_SCHEMA_VERSION),
-      outcome: z.literal("gate-fail"),
-      baseHeadSha: commitSha,
-      gateVerdict: z.literal("FAIL"),
-      gateProof: failGateProof,
-      summary: nonEmptyString,
-    }),
-    canonicalEnvelope.extend({
-      schemaVersion: z.literal(REGRESSION_VERIFICATION_SCHEMA_VERSION),
-      outcome: z.literal("refresh-conflict"),
-      baseHeadSha: commitSha,
-      summary: nonEmptyString,
-    }),
-  ]).superRefine((verdict, context) => {
-    if (verdict.outcome === "pass" && verdict.gateProof !== `MERGE GATE: PASS ${verdict.headSha}`) {
-      context.addIssue({
-        code: "custom",
-        path: ["gateProof"],
-        message: "gate proof oid must match headSha",
-      });
-    }
-  }),
-  documentation: canonicalEnvelope.extend({
-    summary: nonEmptyString,
-    changes: z.array(z.object({ path: nonEmptyString, action: z.enum(["ADDED", "UPDATED", "DELETED"]) })),
-  }),
-};
-
 const canonicalBodyRefusal = (
-  kind: string,
+  step: TemplateStepIdentity,
   body: string,
   authoredHead: string | null,
   phase: string | null,
 ): string | null => {
+  const kind = step.outputKind;
   let value: unknown;
   try {
     value = JSON.parse(body);
@@ -438,7 +298,7 @@ const canonicalBodyRefusal = (
     : kind === "must-fix"
       && (phase === BLIND_REVIEW_PHASE.independent || phase === BLIND_REVIEW_PHASE.evidenceUnlocked)
       ? reviewArtifact
-      : canonicalOutputSchemas[kind];
+      : canonicalOutputSchema(step);
   if (!schema) return `canonical output kind ${kind} has no versioned JSON contract`;
   const parsed = schema.safeParse(value);
   if (!parsed.success) {
@@ -483,7 +343,7 @@ export const canonicalOutputRefusal = (
     return `${step.outputKind} task output is bound to ${output.commitSha ?? "no commit"}, not completion head ${completionHeadSha}`;
   }
   const bodyRefusal = canonicalBodyRefusal(
-    output.kind,
+    step,
     output.body,
     output.commitSha,
     metadataPhase(output.metadata),
@@ -564,8 +424,8 @@ export const persistSessionTaskOutput = async (
   if (immutableReviewOutput && existing) {
     return { ok: false, reason: `${step?.outputKind ?? input.kind} task output is immutable once persisted` };
   }
-  if (isCanonicalAgentStep(step)) {
-    const bodyRefusal = canonicalBodyRefusal(input.kind, input.body, input.commitSha, phase);
+  if (step && isCanonicalAgentStep(step)) {
+    const bodyRefusal = canonicalBodyRefusal(step, input.body, input.commitSha, phase);
     if (bodyRefusal) return { ok: false, reason: bodyRefusal };
   }
   if (isCanonicalFixStep(step)) {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -53,7 +53,8 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
-    "@prisma/client": "6.19.0"
+    "@prisma/client": "6.19.0",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "dotenv-cli": "^11.0.0",

--- a/packages/db/src/canonical-output-schema.ts
+++ b/packages/db/src/canonical-output-schema.ts
@@ -1,0 +1,188 @@
+import { z } from "zod";
+
+import { REGRESSION_VERIFICATION_SCHEMA_VERSION } from "./merge-tail.js";
+import { stepGeneration, stepRole, type StepRole, type TemplateStepLike } from "./step-role.js";
+
+const commitSha = z.string().regex(/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u);
+const nonEmptyString = z.string().trim().min(1);
+const passGateProof = z.string().regex(/^MERGE GATE: PASS [0-9a-f]{40}$/u);
+const failGateProof = z.string().regex(/^MERGE GATE: FAIL \(.+\)$/u);
+const stringList = z.array(nonEmptyString);
+const canonicalEnvelope = z.object({ schemaVersion: z.literal(1), headSha: commitSha });
+const reviewFinding = z.object({
+  id: nonEmptyString,
+  severity: z.enum(["P0", "P1", "P2"]),
+  file: nonEmptyString,
+  line: z.number().int().positive(),
+  title: nonEmptyString,
+  evidence: nonEmptyString,
+  requiredFix: nonEmptyString,
+});
+
+export const canonicalReviewArtifactSchema = canonicalEnvelope.extend({
+  reviewedBase: commitSha,
+  reviewedHead: commitSha,
+  findings: z.array(reviewFinding),
+});
+
+export const canonicalClosedReviewArtifactSchema = canonicalReviewArtifactSchema.extend({
+  dispositions: z.array(z.object({
+    id: nonEmptyString,
+    disposition: z.enum(["ADOPTED", "REJECTED", "MERGED"]),
+    reason: nonEmptyString,
+  })),
+  mustFixIds: stringList,
+});
+
+/** The retired adjudication Step contract remains valid for instantiated Chains. */
+const canonicalAdjudicationArtifactSchema = canonicalEnvelope.extend({
+  reviewedBase: commitSha,
+  reviewedHead: commitSha,
+  dispositions: z.array(z.object({
+    id: nonEmptyString,
+    disposition: z.enum(["ADOPTED", "REJECTED", "MERGED"]),
+    reason: nonEmptyString,
+  })),
+  mustFixIds: stringList,
+  findings: z.array(reviewFinding).optional(),
+});
+
+export const canonicalFixedImplementationArtifactSchema = canonicalEnvelope.extend({
+  sourceHead: commitSha,
+  dispositions: z.array(z.object({
+    id: nonEmptyString,
+    disposition: z.enum(["ADOPTED", "REJECTED", "MERGED"]),
+    reason: nonEmptyString,
+  })),
+  closedFindings: z.array(z.object({
+    id: nonEmptyString,
+    status: z.literal("CLOSED"),
+    codeEvidence: nonEmptyString,
+    testEvidence: nonEmptyString,
+  })),
+  testsRun: stringList,
+  residualRisks: z.array(z.string()),
+});
+
+export type CanonicalReviewArtifact = z.infer<typeof canonicalReviewArtifactSchema>;
+export type CanonicalClosedReviewArtifact = z.infer<typeof canonicalClosedReviewArtifactSchema>;
+export type CanonicalFixedImplementationArtifact = z.infer<typeof canonicalFixedImplementationArtifactSchema>;
+
+type SchemaByGeneration = Readonly<Record<string, z.ZodType>>;
+
+export const canonicalOutputSchemas: Readonly<Partial<Record<StepRole, SchemaByGeneration>>> = {
+  spec: {
+    v1: canonicalEnvelope.extend({ spec: nonEmptyString }),
+  },
+  plan: {
+    v1: canonicalEnvelope.extend({ summary: nonEmptyString, sliceIds: stringList }),
+  },
+  "plan-review": {
+    v1: canonicalEnvelope.extend({ findings: z.array(reviewFinding) }),
+  },
+  "revised-plan": {
+    v1: canonicalEnvelope.extend({
+      summary: nonEmptyString,
+      addressedFindingIds: stringList,
+      declinedFindings: z.array(z.object({ id: nonEmptyString, reason: nonEmptyString })),
+    }),
+  },
+  implementation: {
+    v1: canonicalEnvelope.extend({
+      baseSha: commitSha,
+      summary: nonEmptyString,
+      testsRun: stringList,
+    }),
+  },
+  "sol-findings": {
+    v1: canonicalReviewArtifactSchema.extend({ commandsRun: stringList }),
+  },
+  "blind-findings": {
+    v1: canonicalReviewArtifactSchema,
+  },
+  "must-fix": {
+    v1: canonicalAdjudicationArtifactSchema,
+  },
+  "fixed-implementation": {
+    v1: canonicalFixedImplementationArtifactSchema,
+  },
+  regression: {
+    v1: z.discriminatedUnion("outcome", [
+      canonicalEnvelope.extend({
+        outcome: z.literal("pass"),
+        baseHeadSha: commitSha,
+        gateVerdict: z.literal("PASS"),
+      }),
+      canonicalEnvelope.extend({
+        outcome: z.literal("review-fail"),
+        baseHeadSha: commitSha,
+        summary: nonEmptyString,
+      }),
+      canonicalEnvelope.extend({
+        outcome: z.literal("gate-fail"),
+        baseHeadSha: commitSha,
+        gateVerdict: z.literal("FAIL"),
+        summary: nonEmptyString,
+      }),
+      canonicalEnvelope.extend({
+        outcome: z.literal("refresh-conflict"),
+        baseHeadSha: commitSha,
+        summary: nonEmptyString,
+      }),
+    ]),
+    v2: z.discriminatedUnion("outcome", [
+      canonicalEnvelope.extend({
+        schemaVersion: z.literal(REGRESSION_VERIFICATION_SCHEMA_VERSION),
+        outcome: z.literal("pass"),
+        baseHeadSha: commitSha,
+        gateVerdict: z.literal("PASS"),
+        gateProof: passGateProof,
+      }),
+      canonicalEnvelope.extend({
+        schemaVersion: z.literal(REGRESSION_VERIFICATION_SCHEMA_VERSION),
+        outcome: z.literal("review-fail"),
+        baseHeadSha: commitSha,
+        summary: nonEmptyString,
+      }),
+      canonicalEnvelope.extend({
+        schemaVersion: z.literal(REGRESSION_VERIFICATION_SCHEMA_VERSION),
+        outcome: z.literal("gate-fail"),
+        baseHeadSha: commitSha,
+        gateVerdict: z.literal("FAIL"),
+        gateProof: failGateProof,
+        summary: nonEmptyString,
+      }),
+      canonicalEnvelope.extend({
+        schemaVersion: z.literal(REGRESSION_VERIFICATION_SCHEMA_VERSION),
+        outcome: z.literal("refresh-conflict"),
+        baseHeadSha: commitSha,
+        summary: nonEmptyString,
+      }),
+    ]).superRefine((verdict, context) => {
+      if (verdict.outcome === "pass" && verdict.gateProof !== `MERGE GATE: PASS ${verdict.headSha}`) {
+        context.addIssue({
+          code: "custom",
+          path: ["gateProof"],
+          message: "gate proof oid must match headSha",
+        });
+      }
+    }),
+  },
+  documentation: {
+    v1: canonicalEnvelope.extend({
+      summary: nonEmptyString,
+      changes: z.array(z.object({ path: nonEmptyString, action: z.enum(["ADDED", "UPDATED", "DELETED"]) })),
+    }),
+  },
+};
+
+/** Resolve one Step output contract through the role and output protocol generation seam. */
+export const canonicalOutputSchema = (step: TemplateStepLike): z.ZodType | null => {
+  const role = stepRole(step);
+  if (role === null) return null;
+  // Template rollovers preserve an output protocol unless outputKind itself
+  // changes; omit template identity so stepGeneration's -vN parser stays the
+  // only implementation of protocol versioning.
+  const generation = stepGeneration({ outputKind: step.outputKind });
+  return canonicalOutputSchemas[role]?.[generation] ?? null;
+};

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -29,4 +29,5 @@ export * from "./agent-sources.js";
 export * from "./agent-contract.js";
 export * from "./template-sources.js";
 export * from "./canonical-template-transition.js";
+export * from "./canonical-output-schema.js";
 export * from "./verify-starter-onboarding.js";

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -221,6 +221,7 @@ const DEFENSE_EXACT = new Set([
   "packages/db/src/merge-integrator-db.ts",
   "packages/db/src/merge-tail.ts",
   "packages/db/src/merge-tail-markers.ts",
+  "packages/db/src/canonical-output-schema.ts",
   "packages/db/src/template-sources.ts",
   "packages/db/src/agent-contract.ts",
   "packages/db/prisma/seed.ts",

--- a/packages/db/src/template-sources.test.ts
+++ b/packages/db/src/template-sources.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { test } from "node:test";
+import { z } from "zod";
 
 import { DIRECT_TEMPLATE_NAME } from "./agent-contract.js";
+import { canonicalOutputSchema } from "./canonical-output-schema.js";
 import { INTEGRATOR_TEMPLATE_NAME } from "./merge-integrator.js";
 import {
   loadTemplateStepSources,
@@ -38,6 +40,26 @@ const updateFrontmatter = async (
 ): Promise<void> => {
   const path = join(root, templateName, filename);
   await writeFile(path, replace(await readFile(path, "utf8")));
+};
+
+type PromptContract = {
+  format: "json" | "field-list";
+  keys: string[];
+};
+
+const promptContract = (prompt: string): PromptContract | null => {
+  const jsonLiteral = prompt.match(/`(\{"schemaVersion":[^`]+\})`/u)?.[1];
+  if (jsonLiteral) {
+    const parsed = JSON.parse(jsonLiteral) as unknown;
+    assert.ok(parsed && typeof parsed === "object" && !Array.isArray(parsed));
+    return { format: "json", keys: Object.keys(parsed).sort() };
+  }
+  const fieldList = prompt.match(/Persist exactly one immutable `blind-findings` JSON object with([\s\S]+?);/u)?.[1];
+  if (!fieldList) return null;
+  return {
+    format: "field-list",
+    keys: [...fieldList.matchAll(/`([a-z][A-Za-z]+)`/gu)].map((match) => match[1]!).sort(),
+  };
 };
 
 test("canonical sources expose the exact layered Direct and Full graphs", async () => {
@@ -84,6 +106,25 @@ test("canonical sources expose the exact layered Direct and Full graphs", async 
     assert.match(regression.prompt, /script persists the one allowed v2 outcome/u);
     assert.doesNotMatch(regression.prompt, /merge-lease\.sh|gate-dispatch\.sh|\{"schemaVersion":2/u);
     assert.ok(regression.prompt.split("\n").length < 30, "the semantic prompt stays materially shorter than the retired 62-line procedure");
+  }
+});
+
+test("nine authored Full Assurance output contracts match their canonical schemas", async () => {
+  const steps = await loadTemplateStepSources(INTEGRATOR_TEMPLATE_NAME);
+  const contracts = steps
+    .map((step) => ({ step, contract: promptContract(step.prompt) }))
+    .filter((entry): entry is { step: typeof entry.step; contract: PromptContract } => entry.contract !== null);
+
+  assert.equal(contracts.length, 9);
+  assert.equal(contracts.filter(({ contract }) => contract.format === "json").length, 8);
+  assert.deepEqual(
+    contracts.filter(({ contract }) => contract.format === "field-list").map(({ step }) => step.outputKind),
+    ["blind-findings"],
+  );
+  for (const { step, contract } of contracts) {
+    const schema = canonicalOutputSchema(step);
+    assert.ok(schema instanceof z.ZodObject, `${step.outputKind} must resolve to an object schema`);
+    assert.deepEqual(contract.keys, Object.keys(schema.shape).sort(), step.outputKind);
   }
 });
 


### PR DESCRIPTION
## Delivery

- Move the pure Zod canonical Step output schemas from `@agentos/api` into the new `@agentos/db` `canonical-output-schema` module beside `step-role`.
- Expose the schema seam as a role-by-generation registry plus `canonicalOutputSchema(step)`; API persistence keeps only DB/I/O and cross-output semantic checks.
- Add a binding test for all nine model-authored Full Assurance Step contracts, comparing prompt top-level keys with the resolved Zod object schema.
- Declare `zod` as a direct `@agentos/db` runtime dependency.
- Register the new output-schema module in the merge-tail defense list required by the repository integrity contract.

## Validation

- `npm run build -w @agentos/db`
- `node --import tsx --test packages/db/src/template-sources.test.ts packages/api/src/canonical-task-output.test.ts` (18 passed)
- `node --import tsx --test src/merge-tail.test.ts src/template-sources.test.ts` from `packages/db` (19 passed)
- `npm run build -w @agentos/web`
- `npm test` (passed after building the web assets required by two web tests)
- `npm run lint`
- First exact-head merge gate correctly found the missing defense-list registration; fixed in `752a48d`.
- `MERGE GATE: PASS 752a48db3e2eabffc41eea74c75dc9d4264607a2`

## Choices made for Leo

1. I created a focused schema module beside `step-role` instead of adding schema implementation to `step-role.ts`: this keeps role normalization and executable output validation as adjacent deep modules with small interfaces.
2. I keyed `canonicalOutputSchemas` by `StepRole` and output protocol generation, and resolve generation through `stepGeneration({ outputKind })`: template rollover markers must not change an unchanged output protocol, while the existing `-vN` parser remains the single implementation.
3. I moved only pure Zod schemas and inferred types into `@agentos/db`: persistence, fencing, and cross-Step semantic checks remain in `@agentos/api` because they require DB state and do not belong behind the pure schema seam.
4. I did not rewrite `07-code-review-opus-blind.md` as JSON: changing that prompt changes the compound prompt digest, while the registered prompt-only rollover successors are pinned to digest `79845a3badc75200d30ac22cb4fb10c6efa38308c31156e7b15f4c8475e9f7ff`; canonical sync would refuse an unregistered successor. The binding test therefore reads 07's explicit field list as the temporary adapter and still covers all nine authored Step contracts. The JSON rewrite remains a report item for the next registered rollover.
5. I added `zod` directly to `@agentos/db` instead of relying on workspace hoisting: the package now owns executable Zod schemas at runtime and must declare that dependency explicitly.
6. I added one narrow line to `packages/db/src/merge-tail.ts`, outside the original lane-I write-surface enumeration: the gate's tracked-machinery test discovered the new schema module through its Regression contract and requires it to be guarded. Registering the file preserves the existing defense invariant; weakening discovery or hiding the dependency would make the module boundary less honest.
