### PR TITLE
refactor(runner): centralize session tool contract

### DIFF
--- a/packages/runner/assets/pi-agentos-extension.ts
+++ b/packages/runner/assets/pi-agentos-extension.ts
@@ -1,17 +1,141 @@
 /** AgentOS tools for pi.
  *
  *  pi deliberately ships no MCP client ("It intentionally does not include
- *  built-in MCP..."), so the same four AgentOS tools are registered as pi
+ *  built-in MCP..."), so the same eight AgentOS tools are registered as pi
  *  extension tools instead. The runner injects this file with `--extension`;
  *  credentials come from the inherited environment, exactly as the MCP server
  *  reads them, so the tool surface matches across all three CLIs.
  *
  *  Loaded by pi's own loader, not compiled by the runner's tsc — keep it
- *  dependency-free and self-contained. */
+ *  dependency-free and self-contained. SessionToolContract is inlined here at
+ *  build time; session-tool-contract.test.ts checks the inlined adapter against
+ *  the canonical definitions and request shapes. */
 
 import { execFileSync } from "node:child_process";
 
 type ToolResult = { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> };
+type ToolName = "task_activity_log" | "task_output" | "task_status" | "inbox_ask"
+  | "files_list" | "files_read" | "files_write" | "files_delete";
+type ToolRequest = {
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  path: string;
+  body?: Record<string, unknown>;
+  query?: Record<string, string>;
+};
+
+const SESSION_TOOLS: ReadonlyArray<{
+  name: ToolName;
+  label: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}> = [
+  {
+    name: "task_activity_log",
+    label: "Append to the task activity log",
+    description: "Record notable progress on the current AgentOS task. This is the routine progress channel; it never interrupts a human.",
+    parameters: {
+      type: "object",
+      properties: {
+        body: { type: "string", description: "What happened, in one or two sentences." },
+        metadata: { type: "object", description: "Optional structured detail stored alongside the entry.", additionalProperties: true },
+      },
+      required: ["body"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "task_output",
+    label: "Persist the task output",
+    description: "Persist this Step's deliverable as the AgentOS task output. Later Steps in the Chain read it, and the Approval gate shows it to the human. Canonical Steps may require a phase-specific write sequence from the task contract. A rejected write changes nothing; never probe the contract with placeholder content. A closed final output may be immutable.",
+    parameters: {
+      type: "object",
+      properties: {
+        kind: { type: "string", description: "Output kind, e.g. spec, plan, review, result." },
+        body: { type: "string", description: "The deliverable itself, in full." },
+        metadata: { type: "object", description: "Optional structured detail, e.g. branch or commit.", additionalProperties: true },
+      },
+      required: ["kind", "body"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "task_status",
+    label: "Read the task and Run status",
+    description: "Read the current AgentOS task and Run: name, status, Approval gate, Run number and budget, branch, and whether an output has already been persisted.",
+    parameters: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "inbox_ask",
+    label: "Ask the human a question",
+    description: "Ask the human a question through the AgentOS Inbox. This SUSPENDS the Session until they answer, and the Session resumes in place with their reply. Routine progress belongs in task_activity_log, not here.",
+    parameters: {
+      type: "object",
+      properties: {
+        body: { type: "string", description: "The question, with enough context for a human to answer it cold." },
+        choices: {
+          type: "array",
+          description: "Optional fixed choices. Omit for a free-text question.",
+          items: {
+            type: "object",
+            properties: { id: { type: "string" }, label: { type: "string" } },
+            required: ["id", "label"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["body"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "files_list",
+    label: "List files",
+    description: "List one granted Files Root directory non-recursively.",
+    parameters: {
+      type: "object",
+      properties: { dir: { type: "string", description: "Files-Root-relative POSIX directory path; empty means root." } },
+      required: ["dir"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "files_read",
+    label: "Read a file",
+    description: "Read one granted file; binary content is returned with encoding base64.",
+    parameters: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "files_write",
+    label: "Write a file",
+    description: "Write one granted file, creating parent directories as needed.",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+        encoding: { type: "string", enum: ["utf8", "base64"] },
+      },
+      required: ["path", "content"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "files_delete",
+    label: "Delete a file",
+    description: "Delete one granted file or empty directory.",
+    parameters: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+      additionalProperties: false,
+    },
+  },
+];
 
 const credentials = () => {
   const apiUrl = process.env.AGENTOS_API_URL;
@@ -34,12 +158,99 @@ const workspaceHead = (): string => {
   return head;
 };
 
-const call = async (method: string, path: string, body?: Record<string, unknown>): Promise<unknown> => {
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
+
+const nonEmptyString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value : null;
+
+const requestFor = (tool: ToolName, rawArguments: Record<string, unknown>): ToolRequest => {
   const session = credentials();
-  const response = await fetch(`${session.apiUrl}/session/runs/${session.runId}${path}`, {
-    method,
+  if (tool === "task_activity_log") {
+    const body = nonEmptyString(rawArguments.body);
+    if (!body) throw new Error("task_activity_log requires a non-empty body");
+    return {
+      method: "POST",
+      path: "/activity",
+      body: {
+        fencingToken: session.fencingToken,
+        actorType: "agent",
+        body,
+        ...(rawArguments.metadata ? { metadata: asRecord(rawArguments.metadata) } : {}),
+      },
+    };
+  }
+  if (tool === "task_output") {
+    const kind = nonEmptyString(rawArguments.kind);
+    const body = nonEmptyString(rawArguments.body);
+    if (!kind || !body) throw new Error("task_output requires kind and body");
+    return {
+      method: "PUT",
+      path: "/output",
+      body: {
+        fencingToken: session.fencingToken,
+        kind,
+        body,
+        commitSha: workspaceHead(),
+        ...(rawArguments.metadata ? { metadata: asRecord(rawArguments.metadata) } : {}),
+      },
+    };
+  }
+  if (tool === "task_status") return { method: "GET", path: "/status" };
+  if (tool === "inbox_ask") {
+    const body = nonEmptyString(rawArguments.body);
+    if (!body) throw new Error("inbox_ask requires a non-empty body");
+    const choices = Array.isArray(rawArguments.choices)
+      ? rawArguments.choices.flatMap((choice) => {
+        const record = asRecord(choice);
+        const id = nonEmptyString(record.id);
+        const label = nonEmptyString(record.label);
+        return id && label ? [{ id, label }] : [];
+      })
+      : [];
+    return {
+      method: "POST",
+      path: "/inbox/questions",
+      body: {
+        fencingToken: session.fencingToken,
+        requestId: `pi:${session.runId}:${body.slice(0, 80)}`,
+        body,
+        choices,
+      },
+    };
+  }
+  if (tool === "files_list") {
+    const dir = typeof rawArguments.dir === "string" ? rawArguments.dir : null;
+    if (dir === null) throw new Error("files_list requires dir");
+    return { method: "GET", path: "/files", query: { dir } };
+  }
+  if (tool === "files_read") {
+    const path = nonEmptyString(rawArguments.path);
+    if (!path) throw new Error("files_read requires path");
+    return { method: "GET", path: "/files/content", query: { path } };
+  }
+  if (tool === "files_write") {
+    const path = nonEmptyString(rawArguments.path);
+    const content = typeof rawArguments.content === "string" ? rawArguments.content : null;
+    const encoding = rawArguments.encoding === undefined ? "utf8" : rawArguments.encoding;
+    if (!path || content === null || (encoding !== "utf8" && encoding !== "base64")) {
+      throw new Error("files_write requires path, content, and optional encoding utf8 or base64");
+    }
+    return { method: "PUT", path: "/files/content", body: { path, content, encoding } };
+  }
+  const path = nonEmptyString(rawArguments.path);
+  if (!path) throw new Error("files_delete requires path");
+  return { method: "DELETE", path: "/files", query: { path } };
+};
+
+const call = async (request: ToolRequest): Promise<unknown> => {
+  const session = credentials();
+  const url = new URL(`${session.apiUrl}/session/runs/${session.runId}${request.path}`);
+  for (const [key, value] of Object.entries(request.query ?? {})) url.searchParams.set(key, value);
+  const response = await fetch(url, {
+    method: request.method,
     headers: { Authorization: `Bearer ${session.sessionToken}`, "Content-Type": "application/json" },
-    ...(body ? { body: JSON.stringify({ fencingToken: session.fencingToken, ...body }) } : {}),
+    ...(request.body ? { body: JSON.stringify(request.body) } : {}),
   });
   const text = await response.text();
   if (!response.ok) throw new Error(`AgentOS API ${response.status}: ${text.slice(0, 500)}`);
@@ -47,6 +258,26 @@ const call = async (method: string, path: string, body?: Record<string, unknown>
 };
 
 const said = (text: string): ToolResult => ({ content: [{ type: "text", text }], details: {} });
+
+const invokeTool = async (name: ToolName, params: Record<string, unknown>): Promise<ToolResult> => {
+  const result = await call(requestFor(name, params));
+  if (name === "task_activity_log") return said("Activity recorded.");
+  if (name === "task_output") {
+    const body = params.body as string;
+    const kind = params.kind as string;
+    const predecessorOutputs = (result as { predecessorOutputs?: unknown } | null)?.predecessorOutputs;
+    return said([
+      `Output persisted as '${kind}' (${body.length} characters).`,
+      ...(Array.isArray(predecessorOutputs) && predecessorOutputs.length > 0
+        ? ["Predecessor Step outputs are now available:", JSON.stringify(predecessorOutputs, null, 2)]
+        : []),
+    ].join("\n\n"));
+  }
+  if (name === "inbox_ask") {
+    return said("Question sent. This Session is suspended until the human answers; the Session resumes with their reply.");
+  }
+  return said(JSON.stringify(result, null, 2));
+};
 
 export default function (pi: {
   registerTool(tool: Record<string, unknown>): void;
@@ -86,98 +317,13 @@ export default function (pi: {
     };
   });
 
-  pi.registerTool({
-    name: "task_activity_log",
-    label: "AgentOS activity",
-    description: "Record notable progress on the current AgentOS task. Routine progress channel; it never interrupts a human.",
-    promptSnippet: "Record progress on the current AgentOS task",
-    promptGuidelines: ["Use task_activity_log to record notable progress instead of narrating it only in your final answer."],
-    parameters: {
-      type: "object",
-      properties: {
-        body: { type: "string", description: "What happened, in one or two sentences." },
-        metadata: { type: "object", description: "Optional structured detail.", additionalProperties: true },
+  for (const tool of SESSION_TOOLS) {
+    pi.registerTool({
+      ...tool,
+      promptSnippet: tool.description,
+      async execute(_toolCallId: string, params: Record<string, unknown>): Promise<ToolResult> {
+        return invokeTool(tool.name, params);
       },
-      required: ["body"],
-    },
-    async execute(_toolCallId: string, params: { body: string; metadata?: Record<string, unknown> }): Promise<ToolResult> {
-      await call("POST", "/activity", { actorType: "agent", body: params.body, ...(params.metadata ? { metadata: params.metadata } : {}) });
-      return said("Activity recorded.");
-    },
-  });
-
-  pi.registerTool({
-    name: "task_output",
-    label: "AgentOS output",
-    description: "Persist this step's deliverable as the AgentOS task output. Later chain steps read it and the approval gate shows it to the human.",
-    promptSnippet: "Persist the deliverable as the AgentOS task output",
-    promptGuidelines: ["Use task_output to persist the final deliverable before you finish; a deliverable that is only in your answer is not delivered."],
-    parameters: {
-      type: "object",
-      properties: {
-        kind: { type: "string", description: "Output kind, e.g. spec, plan, review, result." },
-        body: { type: "string", description: "The deliverable itself, in full." },
-        metadata: { type: "object", description: "Optional structured detail.", additionalProperties: true },
-      },
-      required: ["kind", "body"],
-    },
-    async execute(_toolCallId: string, params: { kind: string; body: string; metadata?: Record<string, unknown> }): Promise<ToolResult> {
-      const persisted = await call("PUT", "/output", {
-        kind: params.kind,
-        body: params.body,
-        commitSha: workspaceHead(),
-        ...(params.metadata ? { metadata: params.metadata } : {}),
-      }) as { predecessorOutputs?: unknown } | null;
-      const predecessorOutputs = persisted?.predecessorOutputs;
-      return said([
-        `Output persisted as '${params.kind}' (${params.body.length} characters).`,
-        ...(Array.isArray(predecessorOutputs) && predecessorOutputs.length > 0
-          ? ["Predecessor step outputs are now available:", JSON.stringify(predecessorOutputs, null, 2)]
-          : []),
-      ].join("\n\n"));
-    },
-  });
-
-  pi.registerTool({
-    name: "task_status",
-    label: "AgentOS status",
-    description: "Read the current AgentOS task and run: status, approval gate, run number and budget, branch, and whether an output exists.",
-    promptSnippet: "Read the current AgentOS task and run status",
-    parameters: { type: "object", properties: {} },
-    async execute(): Promise<ToolResult> {
-      return said(JSON.stringify(await call("GET", "/status"), null, 2));
-    },
-  });
-
-  pi.registerTool({
-    name: "inbox_ask",
-    label: "AgentOS inbox",
-    description: "Ask the human a question through the AgentOS Inbox. SUSPENDS this session until they answer; you resume in place with their reply.",
-    promptSnippet: "Ask the human a blocking question through the AgentOS Inbox",
-    promptGuidelines: ["Use inbox_ask only when genuinely blocked; finish everything that does not depend on the answer first."],
-    parameters: {
-      type: "object",
-      properties: {
-        body: { type: "string", description: "The question, with enough context to answer it cold." },
-        choices: {
-          type: "array",
-          description: "Optional fixed choices; omit for free text.",
-          items: {
-            type: "object",
-            properties: { id: { type: "string" }, label: { type: "string" } },
-            required: ["id", "label"],
-          },
-        },
-      },
-      required: ["body"],
-    },
-    async execute(_toolCallId: string, params: { body: string; choices?: Array<{ id: string; label: string }> }): Promise<ToolResult> {
-      await call("POST", "/inbox/questions", {
-        requestId: `pi:${credentials().runId}:${params.body.slice(0, 80)}`,
-        body: params.body,
-        choices: params.choices ?? [],
-      });
-      return said("Question sent. This session is suspended until the human answers.");
-    },
-  });
+    });
+  }
 }

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -326,7 +326,7 @@ test("the prompt manifest names the AgentOS tools the session actually got", () 
     "task_activity_log", "task_output", "task_status", "inbox_ask",
     "files_list", "files_read", "files_write", "files_delete",
   ]) assert.match(prompt, new RegExp(tool));
-  assert.match(prompt, /without a grant they return 403/);
+  assert.match(prompt, /Requires a matching FilesystemGrant or returns 403/u);
   // codex/claude see MCP tool names; pi gets the same tools as extension tools.
   assert.match(prompt, /MCP server 'agentos'/);
   assert.match(buildPrompt({ ...claim, runner: "PI" }), /pi extension tools/);

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -9,6 +9,7 @@ import type { ClaimedTask, FailureClass } from "./api.js";
 import type { InFlightTool } from "./budget.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
 import { isTransientNetworkError } from "./network-retry.js";
+import { manifestLines, toolsFor, type SessionToolTransport } from "./session-tool-contract.js";
 import type { AgentScratch } from "./workspace.js";
 import { createClaudeAdapter, claudeArgs, claudeChildEnvironment, provisionClaudeSessionConfig } from "./adapters/claude.js";
 import {
@@ -38,20 +39,7 @@ export const PI_TOOL_NAMES: Partial<Record<ToolKey, string>> = {
 const toolManifest = (claim: ClaimedTask): string[] => [
   "",
   RUNNER_DEFINITIONS[claim.runner].toolIntroduction,
-  "- task_activity_log(body): record notable progress in the task activity log. Routine channel; never interrupts a human.",
-  "- task_output(kind, body, metadata?): persist this step's deliverable using the task's exact output contract. Rejected writes change nothing; never submit placeholder probes. Closed final outputs may be immutable.",
-  "- task_status(): read the current task and run status, budget, branch, and whether an output exists.",
-  "- inbox_ask(body, choices?): ask the human. Suspends this session until they answer; you resume in place with the reply.",
-  "- files_list(dir): list one Files Root directory non-recursively. Empty dir means the root.",
-  "- files_read(path): read one file; binary content comes back with encoding base64.",
-  "- files_write(path, content, encoding?): write one file, creating parent directories as needed.",
-  "- files_delete(path): delete one file or empty directory.",
-  // The four files_* tools are advertised to every session and authorized server-side per
-  // request: without a matching FilesystemGrant they return 403. They are named here
-  // anyway, and unconditionally, because the manifest is the only place a session learns
-  // what exists -- discovering a capability by having a tool call fail is worse than
-  // seeing a tool that may be denied.
-  "  files_* are authorized per request against this agent's FilesystemGrant rows; without a grant they return 403.",
+  ...manifestLines(RUNNER_DEFINITIONS[claim.runner].toolTransport),
 ];
 
 export const buildPrompt = (claim: ClaimedTask): string => {
@@ -850,7 +838,7 @@ export type RunnerDefinition = {
   binaryEnvironment: string;
   defaultBinary: string;
   toolIntroduction: string;
-  toolTransport: "mcp-stdio" | "pi-extension";
+  toolTransport: SessionToolTransport;
   toolEntrypoint(): string;
   adapter: CliAdapter;
   args(spec: RunSpec, resume?: ResumeSpec): string[];
@@ -945,6 +933,6 @@ export const manifestFor = (spec: RunSpec, dispatchedPrompt: string): Record<str
   agentosTools: {
     transport: RUNNER_DEFINITIONS[spec.claim.runner].toolTransport,
     entrypoint: RUNNER_DEFINITIONS[spec.claim.runner].toolEntrypoint(),
-    tools: ["task_activity_log", "task_output", "task_status", "inbox_ask"],
+    tools: toolsFor(RUNNER_DEFINITIONS[spec.claim.runner].toolTransport).map((tool) => tool.name),
   },
 });

--- a/packages/runner/src/mcp-server.ts
+++ b/packages/runner/src/mcp-server.ts
@@ -13,6 +13,8 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
+import { requestFor, toolsFor, type SessionToolRequest } from "./session-tool-contract.js";
+
 type JsonRpcRequest = {
   jsonrpc: "2.0";
   id?: string | number | null;
@@ -87,124 +89,20 @@ const asRecord = (value: unknown): Record<string, unknown> =>
 
 const asString = (value: unknown): string | null => typeof value === "string" && value.trim().length > 0 ? value : null;
 
-export const TOOLS = [
-  {
-    name: "task_activity_log",
-    title: "Append to the task activity log",
-    description: "Record notable progress on the current AgentOS task. This is the routine progress channel — "
-      + "it never interrupts a human. Use it whenever you finish a meaningful step or make a decision worth auditing.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        body: { type: "string", description: "What happened, in one or two sentences." },
-        metadata: { type: "object", description: "Optional structured detail stored alongside the entry.", additionalProperties: true },
-      },
-      required: ["body"],
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "task_output",
-    title: "Persist the task output",
-    description: "Persist this step's deliverable as the AgentOS task output. Later steps in the chain read it, and "
-      + "the approval gate shows it to the human. Canonical steps may require a phase-specific write sequence from the task contract. "
-      + "A rejected write changes nothing; never probe the contract with placeholder content. A closed final output may be immutable.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        kind: { type: "string", description: "Output kind, e.g. spec, plan, review, result." },
-        body: { type: "string", description: "The deliverable itself, in full." },
-        metadata: { type: "object", description: "Optional structured detail, e.g. branch or commit.", additionalProperties: true },
-      },
-      required: ["kind", "body"],
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "task_status",
-    title: "Read the task and run status",
-    description: "Read the current AgentOS task and run: name, status, approval gate, run number and budget, branch, "
-      + "and whether an output has already been persisted.",
-    inputSchema: { type: "object", properties: {}, additionalProperties: false },
-  },
-  {
-    name: "inbox_ask",
-    title: "Ask the human a question",
-    description: "Ask the human a question through the AgentOS Inbox. This SUSPENDS the session until they answer, and "
-      + "you resume in place with their reply — so finish everything that does not depend on the answer first. "
-      + "Routine progress belongs in task_activity_log, not here.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        body: { type: "string", description: "The question, with enough context for a human to answer it cold." },
-        choices: {
-          type: "array",
-          description: "Optional fixed choices. Omit for a free-text question.",
-          items: {
-            type: "object",
-            properties: { id: { type: "string" }, label: { type: "string" } },
-            required: ["id", "label"],
-            additionalProperties: false,
-          },
-        },
-      },
-      required: ["body"],
-      additionalProperties: false,
-    },
-  },
-  {
-    name: "files_list",
-    title: "List files",
-    description: "List one granted Files Root directory non-recursively.",
-    inputSchema: {
-      type: "object",
-      properties: { dir: { type: "string", description: "Files-Root-relative POSIX directory path; empty means root." } },
-      required: ["dir"], additionalProperties: false,
-    },
-  },
-  {
-    name: "files_read",
-    title: "Read a file",
-    description: "Read one granted file; binary content is returned with encoding base64.",
-    inputSchema: {
-      type: "object", properties: { path: { type: "string" } }, required: ["path"], additionalProperties: false,
-    },
-  },
-  {
-    name: "files_write",
-    title: "Write a file",
-    description: "Write one granted file, creating parent directories as needed.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        path: { type: "string" }, content: { type: "string" }, encoding: { type: "string", enum: ["utf8", "base64"] },
-      },
-      required: ["path", "content"], additionalProperties: false,
-    },
-  },
-  {
-    name: "files_delete",
-    title: "Delete a file",
-    description: "Delete one granted file or empty directory.",
-    inputSchema: {
-      type: "object", properties: { path: { type: "string" } }, required: ["path"], additionalProperties: false,
-    },
-  },
-] as const;
+export const TOOLS = toolsFor("mcp-stdio").map(({ name, title, description, inputSchema }) => ({
+  name, title, description, inputSchema,
+}));
 
 const call = async (
   credentials: SessionCredentials,
-  method: "GET" | "POST" | "PUT" | "DELETE",
-  path: string,
-  body?: Record<string, unknown>,
-  query?: Record<string, string>,
+  request: SessionToolRequest,
 ): Promise<unknown> => {
-  const url = new URL(`/session/runs/${credentials.runId}${path}`, credentials.apiUrl);
-  for (const [key, value] of Object.entries(query ?? {})) url.searchParams.set(key, value);
+  const url = new URL(`/session/runs/${credentials.runId}${request.path}`, credentials.apiUrl);
+  for (const [key, value] of Object.entries(request.query ?? {})) url.searchParams.set(key, value);
   const response = await fetch(url, {
-    method,
+    method: request.method,
     headers: { Authorization: `Bearer ${credentials.sessionToken}`, "Content-Type": "application/json" },
-    ...(body ? { body: JSON.stringify(body) } : {}),
+    ...(request.body ? { body: JSON.stringify(request.body) } : {}),
   });
   const text = await response.text();
   if (!response.ok) throw new Error(`AgentOS API ${response.status}: ${text.slice(0, 500)}`);
@@ -217,28 +115,19 @@ export const invokeTool = async (
   rawArguments: Record<string, unknown>,
 ): Promise<ToolResult> => {
   const text = (value: string): ToolResult => ({ content: [{ type: "text", text: value }] });
+  const request = requestFor(name, rawArguments, {
+    fencingToken: credentials.fencingToken,
+    ...(name === "task_output" ? { commitSha: workspaceHead(credentials) } : {}),
+    ...(name === "inbox_ask" ? { requestIdPrefix: `mcp:${credentials.runId}` } : {}),
+  });
+  const result = await call(credentials, request);
   if (name === "task_activity_log") {
-    const body = asString(rawArguments.body);
-    if (!body) throw new Error("task_activity_log requires a non-empty body");
-    await call(credentials, "POST", "/activity", {
-      fencingToken: credentials.fencingToken,
-      actorType: "agent",
-      body,
-      ...(rawArguments.metadata ? { metadata: asRecord(rawArguments.metadata) } : {}),
-    });
     return text("Activity recorded.");
   }
   if (name === "task_output") {
-    const kind = asString(rawArguments.kind);
-    const body = asString(rawArguments.body);
-    if (!kind || !body) throw new Error("task_output requires kind and body");
-    const persisted = await call(credentials, "PUT", "/output", {
-      fencingToken: credentials.fencingToken,
-      kind,
-      body,
-      commitSha: workspaceHead(credentials),
-      ...(rawArguments.metadata ? { metadata: asRecord(rawArguments.metadata) } : {}),
-    }) as { predecessorOutputs?: unknown } | null;
+    const body = rawArguments.body as string;
+    const kind = rawArguments.kind as string;
+    const persisted = result as { predecessorOutputs?: unknown } | null;
     const predecessorOutputs = persisted?.predecessorOutputs;
     return text([
       `Output persisted as '${kind}' (${body.length} characters).`,
@@ -248,51 +137,22 @@ export const invokeTool = async (
     ].join("\n\n"));
   }
   if (name === "task_status") {
-    return text(JSON.stringify(await call(credentials, "GET", "/status"), null, 2));
+    return text(JSON.stringify(result, null, 2));
   }
   if (name === "inbox_ask") {
-    const body = asString(rawArguments.body);
-    if (!body) throw new Error("inbox_ask requires a non-empty body");
-    const choices = Array.isArray(rawArguments.choices)
-      ? rawArguments.choices.flatMap((choice) => {
-        const record = asRecord(choice);
-        const choiceId = asString(record.id);
-        const label = asString(record.label);
-        return choiceId && label ? [{ id: choiceId, label }] : [];
-      })
-      : [];
-    await call(credentials, "POST", "/inbox/questions", {
-      fencingToken: credentials.fencingToken,
-      // Idempotency key: a retried tool call must not queue a second question.
-      requestId: `mcp:${credentials.runId}:${body.slice(0, 80)}`,
-      body,
-      choices,
-    });
     return text("Question sent. This session is suspended until the human answers; you will resume with their reply.");
   }
   if (name === "files_list") {
-    const dir = typeof rawArguments.dir === "string" ? rawArguments.dir : null;
-    if (dir === null) throw new Error("files_list requires dir");
-    return text(JSON.stringify(await call(credentials, "GET", "/files", undefined, { dir }), null, 2));
+    return text(JSON.stringify(result, null, 2));
   }
   if (name === "files_read") {
-    const path = asString(rawArguments.path);
-    if (!path) throw new Error("files_read requires path");
-    return text(JSON.stringify(await call(credentials, "GET", "/files/content", undefined, { path }), null, 2));
+    return text(JSON.stringify(result, null, 2));
   }
   if (name === "files_write") {
-    const path = asString(rawArguments.path);
-    const content = typeof rawArguments.content === "string" ? rawArguments.content : null;
-    const encoding = rawArguments.encoding === undefined ? "utf8" : rawArguments.encoding;
-    if (!path || content === null || (encoding !== "utf8" && encoding !== "base64")) {
-      throw new Error("files_write requires path, content, and optional encoding utf8 or base64");
-    }
-    return text(JSON.stringify(await call(credentials, "PUT", "/files/content", { path, content, encoding }), null, 2));
+    return text(JSON.stringify(result, null, 2));
   }
   if (name === "files_delete") {
-    const path = asString(rawArguments.path);
-    if (!path) throw new Error("files_delete requires path");
-    return text(JSON.stringify(await call(credentials, "DELETE", "/files", undefined, { path }), null, 2));
+    return text(JSON.stringify(result, null, 2));
   }
   throw new Error(`Unknown tool ${name}`);
 };

--- a/packages/runner/src/regression-verification-script.test.ts
+++ b/packages/runner/src/regression-verification-script.test.ts
@@ -6,6 +6,8 @@ import { dirname, join, resolve } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { requestFor } from "./session-tool-contract.js";
+
 const script = resolve(dirname(fileURLToPath(import.meta.url)), "../../../scripts/regression-verification.sh");
 const SHA = /^[0-9a-f]{40}$/u;
 
@@ -158,6 +160,10 @@ test("finalize persists the dispatch PASS line verbatim and retains the lease", 
   });
   assert.equal(request?.kind, "regression-verification-v2");
   assert.equal(request?.commitSha, headSha);
+  assert.deepEqual(request, requestFor("task_output", {
+    kind: "regression-verification-v2",
+    body: JSON.stringify(verdict),
+  }, { fencingToken: "fence-1", commitSha: headSha }).body);
   assert.equal(finalized.stdout, `REGRESSION FINALIZE: pass ${headSha}\n`);
   assert.doesNotMatch(finalized.stdout, /verbose gate detail/u);
 });

--- a/packages/runner/src/session-tool-contract.test.ts
+++ b/packages/runner/src/session-tool-contract.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { type AddressInfo } from "node:net";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  manifestLines,
+  requestFor,
+  SESSION_TOOL_TRANSPORTS,
+  toolsFor,
+  type SessionToolName,
+  type SessionToolRequest,
+} from "./session-tool-contract.js";
+
+const piExtension = fileURLToPath(new URL("../assets/pi-agentos-extension.ts", import.meta.url));
+
+const toolNameFromManifest = (line: string): string => {
+  const match = /^- ([a-z_]+)(?:\(|:)/u.exec(line);
+  assert.ok(match, `manifest line has no tool name: ${line}`);
+  return match[1]!;
+};
+
+test("each transport manifest is generated from exactly the tools it exposes", () => {
+  for (const transport of SESSION_TOOL_TRANSPORTS) {
+    assert.deepEqual(
+      manifestLines(transport).map(toolNameFromManifest),
+      toolsFor(transport).map((tool) => tool.name),
+      transport,
+    );
+  }
+  assert.equal(toolsFor("mcp-stdio").length, 8);
+  assert.equal(toolsFor("pi-extension").length, 8);
+  assert.deepEqual(toolsFor("script").map((tool) => tool.name), ["task_activity_log", "task_output"]);
+});
+
+test("requestFor owns every session control-plane request shape", () => {
+  const credentials = { fencingToken: "fence-1", commitSha: "a".repeat(40), requestIdPrefix: "mcp:run-1" };
+  assert.deepEqual(requestFor("task_activity_log", { body: "Progress", metadata: { phase: "review" } }, credentials), {
+    method: "POST",
+    path: "/activity",
+    body: { fencingToken: "fence-1", actorType: "agent", body: "Progress", metadata: { phase: "review" } },
+  });
+  assert.deepEqual(requestFor("task_output", { kind: "result", body: "Done" }, credentials), {
+    method: "PUT",
+    path: "/output",
+    body: { fencingToken: "fence-1", kind: "result", body: "Done", commitSha: "a".repeat(40) },
+  });
+  assert.deepEqual(requestFor("task_status", {}, credentials), { method: "GET", path: "/status" });
+  assert.deepEqual(requestFor("inbox_ask", {
+    body: "Ship?",
+    choices: [{ id: "yes", label: "Yes" }, { id: "", label: "Dropped" }],
+  }, credentials), {
+    method: "POST",
+    path: "/inbox/questions",
+    body: {
+      fencingToken: "fence-1",
+      requestId: "mcp:run-1:Ship?",
+      body: "Ship?",
+      choices: [{ id: "yes", label: "Yes" }],
+    },
+  });
+  assert.deepEqual(requestFor("files_list", { dir: "" }, credentials), {
+    method: "GET", path: "/files", query: { dir: "" },
+  });
+  assert.deepEqual(requestFor("files_read", { path: "reports/a b.md" }, credentials), {
+    method: "GET", path: "/files/content", query: { path: "reports/a b.md" },
+  });
+  assert.deepEqual(requestFor("files_write", { path: "binary.bin", content: "AA==", encoding: "base64" }, credentials), {
+    method: "PUT", path: "/files/content", body: { path: "binary.bin", content: "AA==", encoding: "base64" },
+  });
+  assert.deepEqual(requestFor("files_delete", { path: "empty" }, credentials), {
+    method: "DELETE", path: "/files", query: { path: "empty" },
+  });
+  assert.throws(() => requestFor("task_output", { kind: "result", body: "Done" }, { fencingToken: "fence-1" }), /commitSha/u);
+  assert.throws(() => requestFor("unknown", {}, credentials), /Unknown tool unknown/u);
+});
+
+type RegisteredPiTool = {
+  name: SessionToolName;
+  label: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute(toolCallId: string, params: Record<string, unknown>): Promise<unknown>;
+};
+
+type Received = { method: string; path: string; query: Record<string, string>; body?: Record<string, unknown> };
+
+const normalizedRequest = (runId: string, request: SessionToolRequest): Received => ({
+  method: request.method,
+  path: `/session/runs/${runId}${request.path}`,
+  query: { ...request.query },
+  ...(request.body ? { body: { ...request.body } } : {}),
+});
+
+test("the dependency-free PI adapter inlines the canonical definitions and request shapes", async () => {
+  const source = readFileSync(piExtension, "utf8");
+  for (const specifier of source.matchAll(/from\s+"([^"]+)"/gu)) {
+    assert.match(specifier[1]!, /^node:/u, `PI extension runtime import ${specifier[1]}`);
+  }
+
+  const received: Received[] = [];
+  const server: Server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk: Buffer) => { body += chunk.toString("utf8"); });
+    request.on("end", () => {
+      const url = new URL(request.url ?? "", "http://local");
+      received.push({
+        method: request.method ?? "",
+        path: url.pathname,
+        query: Object.fromEntries(url.searchParams.entries()),
+        ...(body ? { body: JSON.parse(body) as Record<string, unknown> } : {}),
+      });
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  const environment = {
+    AGENTOS_API_URL: process.env.AGENTOS_API_URL,
+    AGENTOS_RUN_ID: process.env.AGENTOS_RUN_ID,
+    AGENTOS_SESSION_TOKEN: process.env.AGENTOS_SESSION_TOKEN,
+    AGENTOS_FENCING_TOKEN: process.env.AGENTOS_FENCING_TOKEN,
+    AGENTOS_WORKSPACE_PATH: process.env.AGENTOS_WORKSPACE_PATH,
+  };
+  const runId = "run-pi-contract";
+  const fencingToken = "fence-pi";
+  const registered: RegisteredPiTool[] = [];
+  try {
+    process.env.AGENTOS_API_URL = `http://127.0.0.1:${port}`;
+    process.env.AGENTOS_RUN_ID = runId;
+    process.env.AGENTOS_SESSION_TOKEN = "session-pi";
+    process.env.AGENTOS_FENCING_TOKEN = fencingToken;
+    process.env.AGENTOS_WORKSPACE_PATH = process.cwd();
+    const loaded = await import(pathToFileURL(piExtension).href) as {
+      default(pi: { registerTool(tool: RegisteredPiTool): void; on(): void }): void;
+    };
+    loaded.default({ registerTool: (tool) => registered.push(tool), on: () => undefined });
+
+    assert.deepEqual(
+      registered.map(({ name, label, description, parameters }) => ({ name, label, description, parameters })),
+      toolsFor("pi-extension").map(({ name, title, description, inputSchema }) => ({
+        name, label: title, description, parameters: inputSchema,
+      })),
+    );
+
+    const cases: Array<[SessionToolName, Record<string, unknown>]> = [
+      ["task_activity_log", { body: "Progress", metadata: { phase: "test" } }],
+      ["task_output", { kind: "result", body: "Done" }],
+      ["task_status", {}],
+      ["inbox_ask", { body: "Continue?", choices: [{ id: "yes", label: "Yes" }] }],
+      ["files_list", { dir: "reports" }],
+      ["files_read", { path: "reports/a b.md" }],
+      ["files_write", { path: "reports/out.txt", content: "ok" }],
+      ["files_delete", { path: "reports/empty" }],
+    ];
+    for (const [name, params] of cases) {
+      await registered.find((tool) => tool.name === name)!.execute("call-1", params);
+    }
+    const commitSha = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    assert.deepEqual(received, cases.map(([name, params]) => normalizedRequest(runId, requestFor(name, params, {
+      fencingToken,
+      ...(name === "task_output" ? { commitSha } : {}),
+      ...(name === "inbox_ask" ? { requestIdPrefix: `pi:${runId}` } : {}),
+    }))));
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    for (const [name, value] of Object.entries(environment)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+});

--- a/packages/runner/src/session-tool-contract.ts
+++ b/packages/runner/src/session-tool-contract.ts
@@ -1,0 +1,265 @@
+export const SESSION_TOOL_TRANSPORTS = ["mcp-stdio", "pi-extension", "script"] as const;
+
+export type SessionToolTransport = typeof SESSION_TOOL_TRANSPORTS[number];
+
+export type SessionToolName =
+  | "task_activity_log"
+  | "task_output"
+  | "task_status"
+  | "inbox_ask"
+  | "files_list"
+  | "files_read"
+  | "files_write"
+  | "files_delete";
+
+export type SessionToolDefinition = Readonly<{
+  name: SessionToolName;
+  title: string;
+  description: string;
+  inputSchema: Readonly<Record<string, unknown>>;
+  manifest: string;
+  transports: readonly SessionToolTransport[];
+}>;
+
+export type SessionToolRequest = Readonly<{
+  method: "GET" | "POST" | "PUT" | "DELETE";
+  path: string;
+  body?: Readonly<Record<string, unknown>>;
+  query?: Readonly<Record<string, string>>;
+}>;
+
+export type SessionToolRequestCredentials = Readonly<{
+  fencingToken: string;
+  commitSha?: string;
+  requestIdPrefix?: string;
+}>;
+
+const INTERACTIVE_TRANSPORTS = ["mcp-stdio", "pi-extension"] as const;
+const ALL_TRANSPORTS = [...INTERACTIVE_TRANSPORTS, "script"] as const;
+
+const SESSION_TOOLS: readonly SessionToolDefinition[] = Object.freeze([
+  {
+    name: "task_activity_log",
+    title: "Append to the task activity log",
+    description: "Record notable progress on the current AgentOS task. This is the routine progress channel; it never interrupts a human.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        body: { type: "string", description: "What happened, in one or two sentences." },
+        metadata: { type: "object", description: "Optional structured detail stored alongside the entry.", additionalProperties: true },
+      },
+      required: ["body"],
+      additionalProperties: false,
+    },
+    manifest: "- task_activity_log(body): record notable progress in the task activity log. Routine channel; never interrupts a human.",
+    transports: ALL_TRANSPORTS,
+  },
+  {
+    name: "task_output",
+    title: "Persist the task output",
+    description: "Persist this Step's deliverable as the AgentOS task output. Later Steps in the Chain read it, and the Approval gate shows it to the human. Canonical Steps may require a phase-specific write sequence from the task contract. A rejected write changes nothing; never probe the contract with placeholder content. A closed final output may be immutable.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        kind: { type: "string", description: "Output kind, e.g. spec, plan, review, result." },
+        body: { type: "string", description: "The deliverable itself, in full." },
+        metadata: { type: "object", description: "Optional structured detail, e.g. branch or commit.", additionalProperties: true },
+      },
+      required: ["kind", "body"],
+      additionalProperties: false,
+    },
+    manifest: "- task_output(kind, body, metadata?): persist this Step's deliverable using the task's exact output contract. Rejected writes change nothing; never submit placeholder probes. Closed final outputs may be immutable.",
+    transports: ALL_TRANSPORTS,
+  },
+  {
+    name: "task_status",
+    title: "Read the task and Run status",
+    description: "Read the current AgentOS task and Run: name, status, Approval gate, Run number and budget, branch, and whether an output has already been persisted.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    manifest: "- task_status(): read the current task and Run status, budget, branch, and whether an output exists.",
+    transports: INTERACTIVE_TRANSPORTS,
+  },
+  {
+    name: "inbox_ask",
+    title: "Ask the human a question",
+    description: "Ask the human a question through the AgentOS Inbox. This SUSPENDS the Session until they answer, and the Session resumes in place with their reply. Routine progress belongs in task_activity_log, not here.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        body: { type: "string", description: "The question, with enough context for a human to answer it cold." },
+        choices: {
+          type: "array",
+          description: "Optional fixed choices. Omit for a free-text question.",
+          items: {
+            type: "object",
+            properties: { id: { type: "string" }, label: { type: "string" } },
+            required: ["id", "label"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["body"],
+      additionalProperties: false,
+    },
+    manifest: "- inbox_ask(body, choices?): ask the human. Suspends this Session until they answer; the Session resumes in place with the reply.",
+    transports: INTERACTIVE_TRANSPORTS,
+  },
+  {
+    name: "files_list",
+    title: "List files",
+    description: "List one granted Files Root directory non-recursively.",
+    inputSchema: {
+      type: "object",
+      properties: { dir: { type: "string", description: "Files-Root-relative POSIX directory path; empty means root." } },
+      required: ["dir"],
+      additionalProperties: false,
+    },
+    manifest: "- files_list(dir): list one Files Root directory non-recursively. Empty dir means the root. Requires a matching FilesystemGrant or returns 403.",
+    transports: INTERACTIVE_TRANSPORTS,
+  },
+  {
+    name: "files_read",
+    title: "Read a file",
+    description: "Read one granted file; binary content is returned with encoding base64.",
+    inputSchema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+      additionalProperties: false,
+    },
+    manifest: "- files_read(path): read one file; binary content comes back with encoding base64. Requires a matching FilesystemGrant or returns 403.",
+    transports: INTERACTIVE_TRANSPORTS,
+  },
+  {
+    name: "files_write",
+    title: "Write a file",
+    description: "Write one granted file, creating parent directories as needed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+        encoding: { type: "string", enum: ["utf8", "base64"] },
+      },
+      required: ["path", "content"],
+      additionalProperties: false,
+    },
+    manifest: "- files_write(path, content, encoding?): write one file, creating parent directories as needed. Requires a matching FilesystemGrant or returns 403.",
+    transports: INTERACTIVE_TRANSPORTS,
+  },
+  {
+    name: "files_delete",
+    title: "Delete a file",
+    description: "Delete one granted file or empty directory.",
+    inputSchema: {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+      additionalProperties: false,
+    },
+    manifest: "- files_delete(path): delete one file or empty directory. Requires a matching FilesystemGrant or returns 403.",
+    transports: INTERACTIVE_TRANSPORTS,
+  },
+]);
+
+export const toolsFor = (transport: SessionToolTransport): readonly SessionToolDefinition[] =>
+  SESSION_TOOLS.filter((tool) => tool.transports.includes(transport));
+
+export const manifestLines = (transport: SessionToolTransport): readonly string[] =>
+  toolsFor(transport).map((tool) => tool.manifest);
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
+
+const nonEmptyString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim().length > 0 ? value : null;
+
+const credential = (value: string | undefined, name: string, tool: SessionToolName): string => {
+  if (!value) throw new Error(`${tool} requires session credential ${name}`);
+  return value;
+};
+
+export const requestFor = (
+  toolName: SessionToolName | string,
+  rawArguments: Readonly<Record<string, unknown>>,
+  credentials: SessionToolRequestCredentials,
+): SessionToolRequest => {
+  const tool = SESSION_TOOLS.find((candidate) => candidate.name === toolName);
+  if (!tool) throw new Error(`Unknown tool ${toolName}`);
+
+  if (tool.name === "task_activity_log") {
+    const body = nonEmptyString(rawArguments.body);
+    if (!body) throw new Error("task_activity_log requires a non-empty body");
+    return {
+      method: "POST",
+      path: "/activity",
+      body: {
+        fencingToken: credentials.fencingToken,
+        actorType: "agent",
+        body,
+        ...(rawArguments.metadata ? { metadata: asRecord(rawArguments.metadata) } : {}),
+      },
+    };
+  }
+  if (tool.name === "task_output") {
+    const kind = nonEmptyString(rawArguments.kind);
+    const body = nonEmptyString(rawArguments.body);
+    if (!kind || !body) throw new Error("task_output requires kind and body");
+    return {
+      method: "PUT",
+      path: "/output",
+      body: {
+        fencingToken: credentials.fencingToken,
+        kind,
+        body,
+        commitSha: credential(credentials.commitSha, "commitSha", tool.name),
+        ...(rawArguments.metadata ? { metadata: asRecord(rawArguments.metadata) } : {}),
+      },
+    };
+  }
+  if (tool.name === "task_status") return { method: "GET", path: "/status" };
+  if (tool.name === "inbox_ask") {
+    const body = nonEmptyString(rawArguments.body);
+    if (!body) throw new Error("inbox_ask requires a non-empty body");
+    const choices = Array.isArray(rawArguments.choices)
+      ? rawArguments.choices.flatMap((choice) => {
+        const record = asRecord(choice);
+        const id = nonEmptyString(record.id);
+        const label = nonEmptyString(record.label);
+        return id && label ? [{ id, label }] : [];
+      })
+      : [];
+    return {
+      method: "POST",
+      path: "/inbox/questions",
+      body: {
+        fencingToken: credentials.fencingToken,
+        requestId: `${credential(credentials.requestIdPrefix, "requestIdPrefix", tool.name)}:${body.slice(0, 80)}`,
+        body,
+        choices,
+      },
+    };
+  }
+  if (tool.name === "files_list") {
+    const dir = typeof rawArguments.dir === "string" ? rawArguments.dir : null;
+    if (dir === null) throw new Error("files_list requires dir");
+    return { method: "GET", path: "/files", query: { dir } };
+  }
+  if (tool.name === "files_read") {
+    const path = nonEmptyString(rawArguments.path);
+    if (!path) throw new Error("files_read requires path");
+    return { method: "GET", path: "/files/content", query: { path } };
+  }
+  if (tool.name === "files_write") {
+    const path = nonEmptyString(rawArguments.path);
+    const content = typeof rawArguments.content === "string" ? rawArguments.content : null;
+    const encoding = rawArguments.encoding === undefined ? "utf8" : rawArguments.encoding;
+    if (!path || content === null || (encoding !== "utf8" && encoding !== "base64")) {
+      throw new Error("files_write requires path, content, and optional encoding utf8 or base64");
+    }
+    return { method: "PUT", path: "/files/content", body: { path, content, encoding } };
+  }
+  const path = nonEmptyString(rawArguments.path);
+  if (!path) throw new Error("files_delete requires path");
+  return { method: "DELETE", path: "/files", query: { path } };
+};


### PR DESCRIPTION
## Deliverables

- Add the `SessionToolContract` module with the `toolsFor`, `manifestLines`, and `requestFor` interface as the single source of truth for session tool definitions and control-plane request shapes.
- Generate the prompt tool manifest, runtime `agentosTools` manifest, and MCP `tools/list` surface from that module.
- Make MCP stdio and the dependency-free PI extension transport adapters over the same interface.
- Add the four `files_*` registrations to PI, eliminating the observed 8-vs-4 drift.
- Bind the mechanical regression script output request shape to `requestFor` through its existing integration test.

## Acceptance

- `npm run lint`: PASS
- `npm test`: PASS after the fresh worktree required web build (`npm run build -w @agentos/web`)
- Focused runner contract, MCP, adapter, and regression-script tests: PASS
- Runner typecheck: PASS
- Post-integration Runner suite: 302 PASS, 2 SKIP
- `MERGE GATE: PASS e50929c2c4a5fc2afca1d1508b42fee50219dcb8`
- `npm run test:db`: not applicable; no `*.dbtest.ts` file changed

## Decisions made for Leo

1. **PI registers `files_*` instead of narrowing its manifest.** The session file routes already exist and MCP exercises them; adding the PI adapter preserves one transport-independent interface and the existing per-request `FilesystemGrant` refusal semantics.
2. **The PI contract is inlined and remains dependency-free.** PI loads the extension with its own loader, so a runtime import from the runner module would violate the deployment contract; the parameterized test compares all inlined definitions and request shapes against `SessionToolContract`.
3. **The regression script stays self-contained.** Its shell/curl execution and failure semantics are intentionally independent, while its integration test now proves the emitted output body equals the canonical `requestFor` shape.
4. **The branch started from the then-current clean `main` (`3dd37d3`) rather than the dispatch-time `7fd6fc5`.** Concurrent lanes had already advanced `main`; retaining their merged work avoided rebuilding on a stale branch.
5. **The final candidate merged `origin/main` with an ordinary merge commit.** Published history is append-only, and the merge preserved concurrent lane commits while producing one exact head for the gate.