### PR TITLE
feat(db): derive canonical template identity

### DIFF
--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -8,6 +8,8 @@ import { promisify } from "node:util";
 
 import {
   AssigneeType,
+  INTEGRATOR_TEMPLATE_NAME,
+  legacyTemplateName,
   PrismaClient,
   TaskStatus,
   latestMarker,
@@ -39,7 +41,9 @@ const IMPLEMENTATION_BODY = "Feature brief: reject unregistered graphs at every 
 const SOL_FINDINGS_BODY = "sol-findings: MF-2 the HTTP layer validates but the webhook path calls the executor directly.";
 const BLIND_FINDINGS_BODY = "blind-findings: the manual fire path repeats the same bypass and the board reads the retired field.";
 
-const seedRegression = async (options: { withLibrarian?: boolean } = {}) => {
+type RegressionSeedOptions = { withLibrarian?: boolean; templateName?: string };
+
+const seedRegression = async (options: RegressionSeedOptions = {}) => {
   // A test may seed several chains in one millisecond, and both the slug and the
   // chain id have to stay distinct across them.
   const seedId = `${Date.now()}-${(seedCounter += 1)}`;
@@ -63,7 +67,8 @@ const seedRegression = async (options: { withLibrarian?: boolean } = {}) => {
     } });
   }
   const template = await db.taskTemplate.create({ data: {
-    projectId: project.id, name: options.withLibrarian ? "compound-engineer-workflow" : "direct-engineer-workflow",
+    projectId: project.id,
+    name: options.templateName ?? (options.withLibrarian ? INTEGRATOR_TEMPLATE_NAME : "direct-engineer-workflow"),
     description: "tail", variables: [],
   } });
   const fixIndex = options.withLibrarian ? 8 : 4;
@@ -162,7 +167,7 @@ type RegressionOutcome = "refresh-conflict" | "review-fail" | "gate-fail";
 
 const exercise = async (
   outcome: RegressionOutcome,
-  options: { withLibrarian?: boolean; branch?: string } = {},
+  options: RegressionSeedOptions & { branch?: string } = {},
 ) => {
   const seeded = await seedRegression(options);
   await db.taskStepOutput.create({ data: {
@@ -419,6 +424,29 @@ test("a Full Assurance repair revalidates documentation before Regression", asyn
   assert.equal(await db.run.count({ where: { taskId: seeded.librarian.id } }), 1);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } })).status, TaskStatus.REVIEW);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 1);
+});
+
+test("repairs on every previously omitted legacy generation reopen the Librarian Step", async () => {
+  for (const marker of [
+    "pre-narrow-regression-lease",
+    "pre-blind-review-retirement",
+    "pre-regression-step-split",
+  ]) {
+    const seeded = await exercise("review-fail", {
+      withLibrarian: true,
+      templateName: legacyTemplateName(INTEGRATOR_TEMPLATE_NAME, marker, `template-${marker}`),
+    });
+    const repair = await repairFor(seeded, "review-fix");
+    await completeRepair(seeded, repair.id, `Closed ${marker} findings.`);
+    assert.ok(seeded.librarian, marker);
+    assert.equal(
+      (await db.task.findUniqueOrThrow({ where: { id: seeded.librarian.id } })).status,
+      TaskStatus.TODO,
+      marker,
+    );
+    assert.equal(await db.run.count({ where: { taskId: seeded.librarian.id } }), 1, marker);
+    assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 1, marker);
+  }
 });
 
 test("invalid Regression output opens a stop notice with no unusable operator choices", async () => {

--- a/packages/api/src/parallel-review.dbtest.ts
+++ b/packages/api/src/parallel-review.dbtest.ts
@@ -10,7 +10,7 @@ import {
   DIRECT_TEMPLATE_NAME,
   enqueueTaskRun,
   INTEGRATOR_TEMPLATE_NAME,
-  LEGACY_PRE_ZERO_GATE_TEMPLATE_PREFIX,
+  legacyTemplateName,
   PrismaClient,
   RepoPermission,
   RunStatus,
@@ -546,7 +546,7 @@ test("a faithful rolled-over compound chain still resolves the approved specific
   const fixture = await instantiateFullAtReviewFrontier();
   await db.taskTemplate.update({
     where: { id: fixture.fullTemplateId },
-    data: { name: `${LEGACY_PRE_ZERO_GATE_TEMPLATE_PREFIX}${fixture.fullTemplateId}` },
+    data: { name: legacyTemplateName(INTEGRATOR_TEMPLATE_NAME, "pre-zero-gate", fixture.fullTemplateId) },
   });
   await completeImplementation(fixture, "legacy-compound-implementation");
   const reviewed = await claim("legacy-compound-review");

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -3,6 +3,8 @@ import {
   type ClaimantClass,
   ACTIVE_RUN_STATUSES,
   advanceTemplateTask,
+  canonicalStepOrdinals,
+  canonicalTemplateIdentity,
   enqueueTaskRun,
   executionModeFor,
   FAILURE_ENVELOPE_VERSION,
@@ -17,8 +19,6 @@ import {
   isMergeReadinessStep,
   isRegressionVerificationOutputKind,
   latestMarker,
-  LEGACY_PRE_ADJUDICATION_TEMPLATE_PREFIX,
-  LEGACY_PRE_ZERO_GATE_TEMPLATE_PREFIX,
   lockChainRows,
   lockRunRow,
   MERGE_TAIL_KIND,
@@ -60,10 +60,6 @@ import {
 import { explainFenceRefusal, fenceRefusalResponse, fencedRunWhere, type RunFence } from "./run-fence.js";
 import type { Refusal } from "./refusal.js";
 import { lockTask, lockTaskMutationRows } from "./task-write.js";
-
-/** Full Assurance regression and the documentation node a repair must reopen. */
-const FULL_REPAIR_DOCUMENTATION_ORDINALS = { regression: 10, documentation: 9 } as const;
-const LEGACY_PRE_ADJUDICATION_REPAIR_DOCUMENTATION_ORDINALS = { regression: 11, documentation: 10 } as const;
 
 const failureEnvelopeV1Input = z.object({
   version: z.number().int().positive(),
@@ -361,24 +357,26 @@ export const completeRun = async (
             chainId: true,
             templateId: true,
             chainIndex: true,
-            templateStep: { select: { stepIndex: true, taskTemplate: { select: { name: true } } } },
+            templateStep: { select: { stepIndex: true, outputKind: true, taskTemplate: { select: { name: true } } } },
           },
         })
       : null;
-    // The ordinals are the Full Assurance graph's, and the renamed
-    // adjudication-era rows keep the ones they were created under: a repair
-    // that lands on a chain from either graph still has to put its
-    // documentation node back.
-    const repairDocumentationOrdinals = repairRegression?.templateStep?.taskTemplate.name === INTEGRATOR_TEMPLATE_NAME
-        || repairRegression?.templateStep?.taskTemplate.name.startsWith(LEGACY_PRE_ZERO_GATE_TEMPLATE_PREFIX)
-      ? FULL_REPAIR_DOCUMENTATION_ORDINALS
-      : repairRegression?.templateStep?.taskTemplate.name.startsWith(LEGACY_PRE_ADJUDICATION_TEMPLATE_PREFIX)
-        ? LEGACY_PRE_ADJUDICATION_REPAIR_DOCUMENTATION_ORDINALS
-        : null;
+    // A repair on any registered compound generation must put its
+    // Documentation Step back before Regression. Identity and ordinals come
+    // from the same registry that authorized the rollover.
+    const repairTemplateIdentity = repairRegression?.templateStep?.taskTemplate.name
+      ? canonicalTemplateIdentity(repairRegression.templateStep.taskTemplate.name)
+      : null;
+    const repairDocumentationOrdinals = repairTemplateIdentity?.canonicalName === INTEGRATOR_TEMPLATE_NAME
+      ? canonicalStepOrdinals(repairTemplateIdentity.canonicalName, repairTemplateIdentity.generation)
+      : null;
     const repairDocumentationTask = repairRegression?.chainId && repairRegression.templateId
       && repairDocumentationOrdinals
+      && repairRegression.templateStep
+      && isRegressionVerificationOutputKind(repairRegression.templateStep.outputKind)
       && repairRegression.chainIndex === repairDocumentationOrdinals.regression
-      && repairRegression.templateStep?.stepIndex === repairDocumentationOrdinals.regression
+      && repairRegression.templateStep.stepIndex === repairDocumentationOrdinals.regression
+      && repairDocumentationOrdinals.documentation !== undefined
       ? await tx.task.findFirst({
           where: {
             projectId: repairRegression.projectId,

--- a/packages/db/src/canonical-template-transition.test.ts
+++ b/packages/db/src/canonical-template-transition.test.ts
@@ -2,12 +2,16 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  canonicalStepOrdinals,
+  canonicalTemplateIdentity,
   LEGACY_TEMPLATE_GENERATIONS,
   legacyGenerationMatches,
+  legacyTemplateName,
   matchedLegacyGeneration,
   successorPromptDrift,
   templatePromptGenerationDigest,
   templateRolloverBlockerCount,
+  type CanonicalTemplateRegistryName,
   type PersistedTransitionStep,
 } from "./canonical-template-transition.js";
 import { loadAllTemplateStepSources, type TemplateStepSource } from "./template-sources.js";
@@ -47,13 +51,50 @@ const asPersisted = (steps: readonly TemplateStepSource[]): PersistedTransitionS
     prompt: step.prompt,
   }));
 
-const generationOf = (templateName: string, marker: string) => {
+const generationOf = (templateName: CanonicalTemplateRegistryName, marker: string) => {
   const generation = LEGACY_TEMPLATE_GENERATIONS[templateName]?.find((candidate) => candidate.marker === marker);
   assert.ok(generation, `${templateName} must register ${marker}`);
   return generation;
 };
 
 const PROMPT_ROLLOVER_TEMPLATES = ["direct-engineer-workflow", "compound-engineer-workflow"] as const;
+
+test("canonical identity parses current names and every registered generation", () => {
+  for (const [canonicalName, generations] of Object.entries(LEGACY_TEMPLATE_GENERATIONS)) {
+    assert.deepEqual(canonicalTemplateIdentity(canonicalName), { canonicalName, generation: null });
+    for (const generation of generations) {
+      assert.deepEqual(
+        canonicalTemplateIdentity(legacyTemplateName(canonicalName, generation.marker, "template-row")),
+        { canonicalName, generation: generation.marker },
+      );
+    }
+  }
+  assert.equal(canonicalTemplateIdentity("compound-engineer-workflow-legacy-pre-zero-gate-"), null);
+  assert.equal(canonicalTemplateIdentity("unregistered-workflow"), null);
+});
+
+test("every registered compound generation derives its repair Step ordinals", () => {
+  for (const generation of LEGACY_TEMPLATE_GENERATIONS["compound-engineer-workflow"]) {
+    const ordinals = canonicalStepOrdinals("compound-engineer-workflow", generation.marker);
+    assert.ok(ordinals, generation.marker);
+    assert.equal(ordinals.documentation, generation.shape.findIndex((tuple) => tuple[3] === "documentation") + 1);
+    assert.equal(
+      ordinals.regression,
+      generation.shape.findIndex((tuple) => tuple[3].startsWith("regression-verification")) + 1,
+    );
+  }
+  assert.deepEqual(
+    canonicalStepOrdinals("compound-engineer-workflow", "pre-narrow-regression-lease"),
+    { spec: 1, plan: 2, "plan-review": 3, "revised-plan": 4, implementation: 5,
+      "sol-findings": 6, "blind-findings": 7, "fixed-implementation": 8,
+      documentation: 9, regression: 10, readiness: 11, integrator: 12 },
+  );
+  for (const marker of ["pre-blind-review-retirement", "pre-regression-step-split"] as const) {
+    const ordinals = canonicalStepOrdinals("compound-engineer-workflow", marker);
+    assert.equal(ordinals?.documentation, 9, marker);
+    assert.equal(ordinals?.regression, 10, marker);
+  }
+});
 
 test("a prompt generation is decided by step index and text, not by array order", () => {
   const forward = [{ stepIndex: 1, prompt: "one" }, { stepIndex: 2, prompt: "two" }];

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 
 import { AssigneeType, Prisma, RunStatus } from "@prisma/client";
 
+import { stepRole, type StepRole } from "./step-role.js";
+
 export type LegacyStepTuple = readonly [
   string,
   AssigneeType,
@@ -72,7 +74,7 @@ export type LegacyTemplateGeneration = Readonly<{
   successorPromptDigest?: string;
 }>;
 
-export const LEGACY_TEMPLATE_GENERATIONS: Readonly<Record<string, readonly LegacyTemplateGeneration[]>> = {
+const legacyTemplateGenerations = {
   "direct-engineer-workflow": [
     {
       marker: "pre-narrow-regression-lease",
@@ -242,6 +244,71 @@ export const LEGACY_TEMPLATE_GENERATIONS: Readonly<Record<string, readonly Legac
       ],
     },
   ],
+} as const satisfies Readonly<Record<string, readonly LegacyTemplateGeneration[]>>;
+
+export type CanonicalTemplateRegistryName = keyof typeof legacyTemplateGenerations;
+
+export const LEGACY_TEMPLATE_GENERATIONS: Readonly<
+  Record<CanonicalTemplateRegistryName, readonly LegacyTemplateGeneration[]>
+> = legacyTemplateGenerations;
+
+export type CanonicalTemplateIdentity = Readonly<{
+  canonicalName: CanonicalTemplateRegistryName;
+  generation: string | null;
+}>;
+
+export type CanonicalStepOrdinals = Readonly<Partial<Record<StepRole, number>>>;
+
+const registeredGenerations = (canonicalName: string): readonly LegacyTemplateGeneration[] | null =>
+  Object.hasOwn(LEGACY_TEMPLATE_GENERATIONS, canonicalName)
+    ? LEGACY_TEMPLATE_GENERATIONS[canonicalName as CanonicalTemplateRegistryName]
+    : null;
+
+/**
+ * Resolve a current or registered retired canonical template name through the
+ * registry. Legacy names include a row id after the generation marker; a bare
+ * prefix is not an identity minted by `legacyTemplateName`.
+ */
+export const canonicalTemplateIdentity = (templateName: string): CanonicalTemplateIdentity | null => {
+  for (const canonicalName of Object.keys(LEGACY_TEMPLATE_GENERATIONS) as CanonicalTemplateRegistryName[]) {
+    if (templateName === canonicalName) return { canonicalName, generation: null };
+    for (const generation of LEGACY_TEMPLATE_GENERATIONS[canonicalName]) {
+      const prefix = `${canonicalName}-legacy-${generation.marker}-`;
+      if (templateName.startsWith(prefix) && templateName.length > prefix.length) {
+        return { canonicalName, generation: generation.marker };
+      }
+    }
+  }
+  return null;
+};
+
+/**
+ * Derive Step role ordinals from one registered graph. The current graph is
+ * derivable only when the newest registry entry is a prompt-only transition:
+ * its shape is then also the successor's shape. A future structural rollover
+ * must extend this interface rather than silently reusing stale ordinals.
+ */
+export const canonicalStepOrdinals = (
+  canonicalName: CanonicalTemplateRegistryName,
+  generation: string | null,
+): CanonicalStepOrdinals | null => {
+  const generations = LEGACY_TEMPLATE_GENERATIONS[canonicalName];
+  const registered = generation === null
+    ? generations.at(-1)
+    : generations.find((candidate) => candidate.marker === generation);
+  if (!registered) return null;
+  if (generation === null && (registered.promptDigest === undefined || registered.successorPromptDigest === undefined)) {
+    throw new Error(`Current ${canonicalName} Step ordinals are not derivable from its latest structural transition`);
+  }
+
+  const ordinals: Partial<Record<StepRole, number>> = {};
+  for (const [index, tuple] of registered.shape.entries()) {
+    const role = stepRole({ outputKind: tuple[3] });
+    if (role === null) throw new Error(`Registered ${canonicalName} generation ${registered.marker} has unknown outputKind ${tuple[3]}`);
+    if (ordinals[role] !== undefined) throw new Error(`Registered ${canonicalName} generation ${registered.marker} repeats Step role ${role}`);
+    ordinals[role] = index + 1;
+  }
+  return ordinals;
 };
 
 /**
@@ -265,14 +332,8 @@ export const templatePromptGenerationDigest = (
   return hash.digest("hex");
 };
 
-export const legacyGenerationMarkerForTemplateName = (templateName: string): string | null => {
-  for (const [canonicalName, generations] of Object.entries(LEGACY_TEMPLATE_GENERATIONS)) {
-    for (const generation of generations) {
-      if (templateName.startsWith(`${canonicalName}-legacy-${generation.marker}-`)) return generation.marker;
-    }
-  }
-  return null;
-};
+export const legacyGenerationMarkerForTemplateName = (templateName: string): string | null =>
+  canonicalTemplateIdentity(templateName)?.generation ?? null;
 
 /**
  * The rename target is minted per row and per generation: fixed identities
@@ -373,7 +434,7 @@ export const successorPromptDrift = (
   marker: string,
   sourceSteps: readonly { stepIndex: number; prompt: string }[],
 ): string | null => {
-  const generation = LEGACY_TEMPLATE_GENERATIONS[templateName]?.find((candidate) => candidate.marker === marker);
+  const generation = registeredGenerations(templateName)?.find((candidate) => candidate.marker === marker);
   if (!generation?.successorPromptDigest) return null;
   const actual = templatePromptGenerationDigest(sourceSteps);
   if (actual === generation.successorPromptDigest) return null;
@@ -397,7 +458,7 @@ export const matchedLegacyGeneration = (
   templateName: string,
   steps: readonly PersistedTransitionStep[],
 ): string | null =>
-  LEGACY_TEMPLATE_GENERATIONS[templateName]
+  registeredGenerations(templateName)
     ?.find((generation) => legacyGenerationMatches(generation, steps))?.marker ?? null;
 
 /**
@@ -410,6 +471,6 @@ export const legacyTemplateShapeRefusal = (
   templateName: string,
   steps: readonly PersistedTransitionStep[],
 ): string | null => {
-  if (!LEGACY_TEMPLATE_GENERATIONS[templateName]) return `unknown canonical template ${templateName}`;
+  if (!registeredGenerations(templateName)) return `unknown canonical template ${templateName}`;
   return matchedLegacyGeneration(templateName, steps) === null ? null : "legacy";
 };

--- a/packages/db/src/merge-integrator.ts
+++ b/packages/db/src/merge-integrator.ts
@@ -10,6 +10,7 @@
  * them is a second thing to get wrong.
  */
 
+import { legacyTemplateName } from "./canonical-template-transition.js";
 import { stepRole } from "./step-role.js";
 
 export { stepGeneration, stepRole, type StepRole, type TemplateStepLike } from "./step-role.js";
@@ -51,16 +52,6 @@ export const INTEGRATOR_TEMPLATE_NAME = "compound-engineer-workflow";
 export const DIRECT_INTEGRATOR_TEMPLATE_NAME = "direct-engineer-workflow";
 export const LEGACY_INTEGRATOR_TEMPLATE_NAME = `${INTEGRATOR_TEMPLATE_NAME}-legacy-v1`;
 export const LEGACY_DIRECT_INTEGRATOR_TEMPLATE_NAME = `${DIRECT_INTEGRATOR_TEMPLATE_NAME}-legacy-v1`;
-export const LEGACY_NINE_STEP_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-9-`;
-export const LEGACY_TEN_STEP_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-10-`;
-export const LEGACY_HUMAN_TWELVE_STEP_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-human-12-`;
-export const LEGACY_REGRESSION_FIRST_THIRTEEN_STEP_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-regression-first-13-`;
-export const LEGACY_PRE_ADJUDICATION_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-pre-adjudication-`;
-export const LEGACY_PRE_ADJUDICATION_DIRECT_TEMPLATE_PREFIX = `${DIRECT_INTEGRATOR_TEMPLATE_NAME}-legacy-pre-adjudication-`;
-/** The pre-zero-gate graph only regated steps, so its ordinals match the current graph's. */
-export const LEGACY_PRE_ZERO_GATE_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-pre-zero-gate-`;
-export const LEGACY_PRE_NARROW_REGRESSION_LEASE_TEMPLATE_PREFIX = `${INTEGRATOR_TEMPLATE_NAME}-legacy-pre-narrow-regression-lease-`;
-export const LEGACY_PRE_NARROW_REGRESSION_LEASE_DIRECT_TEMPLATE_PREFIX = `${DIRECT_INTEGRATOR_TEMPLATE_NAME}-legacy-pre-narrow-regression-lease-`;
 /** Sentinel model. `catalogRunnerForModel` returns null for it, so no runner/model assertion fires. */
 export const INTEGRATOR_SENTINEL_MODEL = "mechanical/merge-executor-v1";
 
@@ -70,16 +61,16 @@ export const INTEGRATOR_SENTINEL_MODEL = "mechanical/merge-executor-v1";
  * this marker makes the rename deterministic and collision-free on retries.
  */
 export const legacyTenStepTemplateName = (templateId: string): string =>
-  `${LEGACY_TEN_STEP_TEMPLATE_PREFIX}${templateId}`;
+  legacyTemplateName(INTEGRATOR_TEMPLATE_NAME, "10", templateId);
 
 export const legacyNineStepTemplateName = (templateId: string): string =>
-  `${LEGACY_NINE_STEP_TEMPLATE_PREFIX}${templateId}`;
+  legacyTemplateName(INTEGRATOR_TEMPLATE_NAME, "9", templateId);
 
 export const legacyHumanTwelveStepTemplateName = (templateId: string): string =>
-  `${LEGACY_HUMAN_TWELVE_STEP_TEMPLATE_PREFIX}${templateId}`;
+  legacyTemplateName(INTEGRATOR_TEMPLATE_NAME, "human-12", templateId);
 
 export const legacyRegressionFirstThirteenStepTemplateName = (templateId: string): string =>
-  `${LEGACY_REGRESSION_FIRST_THIRTEEN_STEP_TEMPLATE_PREFIX}${templateId}`;
+  legacyTemplateName(INTEGRATOR_TEMPLATE_NAME, "regression-first-13", templateId);
 
 // ---------------------------------------------------------------------------
 // §D-P4 — the bidirectional binding invariant

--- a/packages/db/src/step-role.test.ts
+++ b/packages/db/src/step-role.test.ts
@@ -42,6 +42,9 @@ for (const [templateName, generations] of Object.entries(LEGACY_TEMPLATE_GENERAT
         assert.equal(stepRole({ outputKind, taskTemplateName: persistedName }), EXPECTED_ROLES[outputKind]);
         assert.equal(stepGeneration({ outputKind, taskTemplateName: persistedName }), generation.marker);
       }
+      const implementation = { outputKind: "implementation", taskTemplate: { name: persistedName } };
+      assert.equal(isCompoundImplementationStep(implementation), templateName === "compound-engineer-workflow");
+      assert.equal(isDirectImplementationStep(implementation), templateName === "direct-engineer-workflow");
     });
   }
 }

--- a/packages/db/src/workflow.ts
+++ b/packages/db/src/workflow.ts
@@ -18,6 +18,7 @@ import {
 } from "@prisma/client";
 
 import { sharedChainBranch } from "./chain-branch.js";
+import { canonicalTemplateIdentity } from "./canonical-template-transition.js";
 import { requireGateAttestation } from "./gate-attestation.js";
 import { catalogRunnerForModel, DIRECT_TEMPLATE_NAME } from "./agent-contract.js";
 import {
@@ -95,7 +96,8 @@ export type CompoundImplementationStepShape = {
 } | null;
 
 export const isCompoundImplementationStep = (templateStep: CompoundImplementationStepShape): boolean =>
-  templateStep?.taskTemplate?.name === INTEGRATOR_TEMPLATE_NAME
+  templateStep?.taskTemplate?.name !== undefined
+  && canonicalTemplateIdentity(templateStep.taskTemplate.name)?.canonicalName === INTEGRATOR_TEMPLATE_NAME
   && templateStep.outputKind !== undefined
   && stepRole({ outputKind: templateStep.outputKind }) === "implementation";
 
@@ -134,7 +136,8 @@ export const NATIVE_IMPLEMENTATION_SUBAGENT_MODEL = "gpt-5.6-luna:max";
 export const NATIVE_IMPLEMENTATION_SUBAGENT_MAX_CONCURRENT = 8;
 
 export const isDirectImplementationStep = (templateStep: CompoundImplementationStepShape): boolean =>
-  templateStep?.taskTemplate?.name === DIRECT_TEMPLATE_NAME
+  templateStep?.taskTemplate?.name !== undefined
+  && canonicalTemplateIdentity(templateStep.taskTemplate.name)?.canonicalName === DIRECT_TEMPLATE_NAME
   && templateStep.outputKind !== undefined
   && stepRole({ outputKind: templateStep.outputKind }) === "implementation";
 


### PR DESCRIPTION
## 交付物

- 在既有 canonical template registry module 中加入 `canonicalTemplateIdentity(name)` 与 `canonicalStepOrdinals(canonicalName, generation)`，统一 current/legacy identity 与 Step ordinal 派生。
- 将 compound/direct implementation 的 name-exact 谓词改为经 identity interface 判定，rollover 后继续保持 runner、assignee 与 native subagent 契约。
- 将 repair completion 的两张手写 ordinal 表替换为 registry 查表，覆盖所有已注册 compound generation。
- 删除 `merge-integrator.ts` 的九个 `LEGACY_*_TEMPLATE_PREFIX`，旧 graph name factory 改走 `legacyTemplateName`。
- 保持 `LEGACY_TEMPLATE_GENERATIONS` 数据本体及 `LegacyStepTuple` 八元组载体不变。

## 验收结果

- `npm run lint`: PASS
- `npm test`: PASS；首次执行因仓库既有 bundle test 前置条件缺少 web production build 而停止，补跑 `npm run build -w @agentos/web` 后原样重跑通过。
- `npm run test -w @agentos/db`: PASS，247/247。
- `npm run test:dependency-gate`: PASS，15/15。
- `npm run test:db -w @agentos/api -- src/merge-tail-repair.dbtest.ts src/parallel-review.dbtest.ts`: PASS，29/29，使用独立 scratch databases。
- 新回归测试逐一证明 `pre-narrow-regression-lease`、`pre-blind-review-retirement`、`pre-regression-step-split` 的 repair completion 都会重开 Librarian Step。

## 替 Leo 做的选择

- 从执行时最新 `main` 而非任务单历史 oid 开工：并发车道已合入，避免倒退已交付工作。
- direct implementation 谓词也改走 identity：它与 compound 谓词属于同一 name-exact 失效家族，统一后 rollover 不再静默失去 native subagent config。
- current ordinals 仅在 registry 最新项为 prompt-only transition 时从其 shape 派生，否则 fail loudly：registry 当前没有未来 structural successor 的 shape，拒绝用过期 ordinal 静默降级。
- 回归测试落在真实 repair transaction 路径，而不只测 helper：验收要求钉住 Librarian Step 重开这一可观察结果。
- `parallel-review.dbtest.ts` 改用 `legacyTemplateName`：这是删除最后一个 exported prefix consumer 所必需，保留原 fixture 语义。
- 保留旧 9/10/human-12/regression-first name factory，但其实现改用通用 legacy name function：现有 seed caller 仍需要这些 interface，删除 prefix 常量不等于删除兼容中的历史 row identity。