### PR TITLE
fix(runner): harden task output remediation

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -3825,6 +3825,12 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       },
     });
     if (!run) return context.json({ error: "Run not found" }, 404);
+    const outputPersisted = run.task?.stepOutput?.runId === run.id;
+    const outputSatisfiedByPriorRun = Boolean(
+      run.task?.stepOutput
+      && !outputPersisted
+      && outputIsImmutableOncePersisted(run.task.templateStep),
+    );
     return context.json({
       run: {
         id: run.id,
@@ -3848,9 +3854,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         outputRequired: requiredOutputKind(run.task.templateStep) !== null,
         outputRemediationAllowed:
           !(run.task.stepOutput && outputIsImmutableOncePersisted(run.task.templateStep)),
+        outputSatisfiedByPriorRun,
         // A retry must not mistake an earlier Run's artifact for its own. This
         // is the same run-scoped fact completion validates before it advances.
-        outputPersisted: run.task.stepOutput?.runId === run.id,
+        outputPersisted,
       } : null,
     });
   });

--- a/packages/api/src/run-output.dbtest.ts
+++ b/packages/api/src/run-output.dbtest.ts
@@ -195,6 +195,14 @@ const regressionOutput = (summary: string, headSha = SHA) => JSON.stringify({
   gateVerdict: "FAIL",
   summary,
 });
+const solFindingsOutput = (headSha = SHA) => JSON.stringify({
+  schemaVersion: 1,
+  headSha,
+  reviewedBase: "b".repeat(40),
+  reviewedHead: headSha,
+  findings: [],
+  commandsRun: ["git diff --check"],
+});
 const specOutput = (spec: string, headSha = SHA) => JSON.stringify({ schemaVersion: 1, headSha, spec });
 
 const failedCompletion = (runnerId: string, fencingToken: string, branch: string) => ({
@@ -473,6 +481,7 @@ test("a run that authored nothing is re-queued even when a prior run's output is
   assert.equal(status.status, 200, JSON.stringify(status.body));
   assert.equal(status.body.task.outputRequired, true);
   assert.equal(status.body.task.outputRemediationAllowed, true);
+  assert.equal(status.body.task.outputSatisfiedByPriorRun, false);
   assert.equal(status.body.task.outputPersisted, false, "the prior Run's output is not this Run's deliverable");
 
   const completed = await call(
@@ -487,6 +496,40 @@ test("a run that authored nothing is re-queued even when a prior run's output is
   assert.equal((await db.taskStepOutput.findUniqueOrThrow({ where: { taskId: task.id } })).runId, firstRunId);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: task.id } })).status, TaskStatus.DOING);
   assert.equal((await db.run.findFirstOrThrow({ where: { taskId: task.id, runNumber: 3 } })).status, "QUEUED");
+});
+
+test("an immutable prior Run output disables remediation and explicitly satisfies the task", async () => {
+  const { task } = await seedTask({
+    chained: true,
+    outputKind: "sol-findings",
+    templateName: DIRECT_TEMPLATE_NAME,
+    stepIndex: 2,
+  });
+  const firstRunId = await enqueue(task.id);
+  const first = await claimRun(firstRunId, "immutable-output-runner-1");
+  const written = await call("PUT", `/session/runs/${firstRunId}/output`, first.sessionToken, {
+    fencingToken: first.fencingToken,
+    kind: "sol-findings",
+    body: solFindingsOutput(),
+    commitSha: SHA,
+  });
+  assert.equal(written.status, 200, JSON.stringify(written.body));
+  assert.equal((await call(
+    "POST", `/runner/runs/${firstRunId}/complete`, RUNNER,
+    failedCompletion("immutable-output-runner-1", first.fencingToken, first.run.branch ?? "master"),
+  )).status, 200);
+  const retried = await call("POST", `/tasks/${task.id}/retry`, OPERATOR);
+  assert.equal(retried.status, 201, JSON.stringify(retried.body));
+  const secondRunId = retried.body.id as string;
+  const second = await claimRun(secondRunId, "immutable-output-runner-2");
+
+  const status = await call("GET", `/session/runs/${secondRunId}/status`, second.sessionToken);
+
+  assert.equal(status.status, 200, JSON.stringify(status.body));
+  assert.equal(status.body.task.outputRequired, true);
+  assert.equal(status.body.task.outputRemediationAllowed, false);
+  assert.equal(status.body.task.outputSatisfiedByPriorRun, true);
+  assert.equal(status.body.task.outputPersisted, false);
 });
 
 test("a required deliverable that is present still settles SUCCEEDED", async () => {

--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -146,6 +146,8 @@ export type SessionEventPayload = {
 const request = async (config: RunnerConfig, path: string, init: RequestInit): Promise<Response> => {
   const response = await fetch(`${config.apiUrl}${path}`, {
     ...init,
+    // Endpoint-specific credentials intentionally come last. Session routes
+    // must replace the runner principal rather than sending runner auth.
     headers: { Authorization: `Bearer ${config.runnerToken}`, "Content-Type": "application/json", ...init.headers },
     signal: AbortSignal.timeout(config.apiTimeoutMs),
   }).catch((error: unknown) => {
@@ -264,6 +266,7 @@ export type SessionTaskOutputStatus = {
   outputKind: string | null;
   outputRequired: boolean;
   outputRemediationAllowed: boolean;
+  outputSatisfiedByPriorRun: boolean;
   outputPersisted: boolean;
 };
 
@@ -282,6 +285,7 @@ export const readSessionTaskOutputStatus = async (
       outputKind?: unknown;
       outputRequired?: unknown;
       outputRemediationAllowed?: unknown;
+      outputSatisfiedByPriorRun?: unknown;
       outputPersisted?: unknown;
     } | null;
   };
@@ -290,6 +294,7 @@ export const readSessionTaskOutputStatus = async (
     || (typeof payload.task.outputKind !== "string" && payload.task.outputKind !== null)
     || typeof payload.task.outputRequired !== "boolean"
     || typeof payload.task.outputRemediationAllowed !== "boolean"
+    || typeof payload.task.outputSatisfiedByPriorRun !== "boolean"
     || typeof payload.task.outputPersisted !== "boolean") {
     throw new Error(`AgentOS API returned an invalid task output status for Run ${claim.run.id}`);
   }
@@ -297,6 +302,7 @@ export const readSessionTaskOutputStatus = async (
     outputKind: payload.task.outputKind,
     outputRequired: payload.task.outputRequired,
     outputRemediationAllowed: payload.task.outputRemediationAllowed,
+    outputSatisfiedByPriorRun: payload.task.outputSatisfiedByPriorRun,
     outputPersisted: payload.task.outputPersisted,
   };
 };

--- a/packages/runner/src/run-output.test.ts
+++ b/packages/runner/src/run-output.test.ts
@@ -7,8 +7,9 @@ import { join } from "node:path";
 import { afterEach, test } from "node:test";
 
 import type { ClaimedTask } from "./api.js";
+import { adapters, type RuntimeHandle } from "./adapters.js";
 import type { RunnerConfig } from "./config.js";
-import { RUNNER_EXCEPTION_REASON } from "./envelope.js";
+import { RUNNER_EXCEPTION_REASON, summarizeEvidence } from "./envelope.js";
 import { executeClaim } from "./runner.js";
 
 /**
@@ -64,7 +65,11 @@ const succeedingAgent = [
   "exit 0",
 ].join("\n");
 
-const remediatingAgent = (remediationPrompt: string): string => [
+const remediatingAgent = (
+  remediationPrompt: string,
+  resumeCommands: string[] = [],
+  remediationResult = "task output persisted",
+): string => [
   "#!/bin/sh",
   'case "$1" in',
   '  --version) echo "1.2.3-stub"; exit 0 ;;',
@@ -74,8 +79,15 @@ const remediatingAgent = (remediationPrompt: string): string => [
   'case " $* " in',
   '  *" --resume conversation-114 "*)',
   `    cat > ${JSON.stringify(remediationPrompt)}`,
+  ...resumeCommands.map((command) => `    ${command}`),
   '    echo \'{"type":"system","session_id":"conversation-114"}\'',
-  '    echo \'{"type":"result","is_error":false,"terminal_reason":"completed","session_id":"conversation-114","result":"task output persisted"}\'',
+  `    echo ${JSON.stringify(JSON.stringify({
+    type: "result",
+    is_error: false,
+    terminal_reason: "completed",
+    session_id: "conversation-114",
+    result: remediationResult,
+  }))}`,
   "    ;;",
   "  *)",
   "    cat > /dev/null",
@@ -178,6 +190,38 @@ const claim = (remoteUrl: string): ClaimedTask => ({
   regressionRepairHandoff: null,
 });
 
+const requiredOutputClaim = (remoteUrl: string): ClaimedTask => {
+  const base = claim(remoteUrl);
+  return {
+    ...base,
+    task: {
+      ...base.task,
+      templateStep: { name: "Implementation", outputKind: "implementation" },
+    },
+  };
+};
+
+const outputStatus = (overrides: Partial<{
+  outputKind: string | null;
+  outputRequired: boolean;
+  outputRemediationAllowed: boolean;
+  outputSatisfiedByPriorRun: boolean;
+  outputPersisted: boolean;
+}> = {}) => ({
+  task: {
+    outputKind: "implementation",
+    outputRequired: true,
+    outputRemediationAllowed: true,
+    outputSatisfiedByPriorRun: false,
+    outputPersisted: false,
+    ...overrides,
+  },
+});
+
+const runnerEvents = (posts: Array<{ path: string; body: Record<string, unknown> }>) => posts
+  .filter((post) => post.path.endsWith("/events"))
+  .flatMap((post) => (post.body.events as Array<{ type: string; payload: Record<string, unknown> }> | undefined) ?? []);
+
 /**
  * The succeeding stub again, with one addition: it drops a sentinel file on its
  * way out. The fetch stub below watches for that file, so a request can be
@@ -267,26 +311,14 @@ test("a successful run remediates its missing required output in the same provid
       posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       if (path.endsWith("/status")) {
         statusReads += 1;
-        return new Response(JSON.stringify({
-          task: {
-            outputKind: "implementation",
-            outputRequired: true,
-            outputRemediationAllowed: true,
-            outputPersisted: statusReads >= 2,
-          },
-        }), { status: 200, headers: { "content-type": "application/json" } });
+        return new Response(JSON.stringify(outputStatus({ outputPersisted: statusReads >= 2 })), {
+          status: 200, headers: { "content-type": "application/json" },
+        });
       }
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
     }) as typeof fetch;
 
-    const baseClaim = claim(remote);
-    await executeClaim(config(join(root, "workspaces"), agentBinary), {
-      ...baseClaim,
-      task: {
-        ...baseClaim.task,
-        templateStep: { name: "Implementation", outputKind: "implementation" },
-      },
-    });
+    await executeClaim(config(join(root, "workspaces"), agentBinary), requiredOutputClaim(remote));
 
     assert.equal(
       statusReads,
@@ -296,16 +328,290 @@ test("a successful run remediates its missing required output in the same provid
     const prompt = await readFile(remediationPrompt, "utf8");
     assert.match(prompt, /call task_output with kind 'implementation'/u);
     assert.match(prompt, /Do not redo the task/u);
-    const eventTypes = posts
-      .filter((post) => post.path.endsWith("/events"))
-      .flatMap((post) => (post.body.events as Array<{ type: string }> | undefined) ?? [])
-      .map(({ type }) => type);
+    const eventTypes = runnerEvents(posts).map(({ type }) => type);
     assert.ok(eventTypes.includes("TASK_OUTPUT_REMEDIATION_STARTED"));
     assert.ok(eventTypes.includes("TASK_OUTPUT_REMEDIATION_FINISHED"));
     const completion = posts.find((post) => post.path.endsWith("/complete"));
     assert.ok(completion);
     assert.equal(completion.body.terminalSuccess, true);
     assert.equal(completion.body.output, "implemented the requested change");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("an immutable output satisfied by a prior Run skips remediation", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-output-remediation-immutable-"));
+  try {
+    const remote = await seedRemote(root);
+    const remediationPrompt = join(root, "remediation-prompt.txt");
+    const agentBinary = join(root, "remediating-agent.sh");
+    await writeFile(agentBinary, remediatingAgent(remediationPrompt));
+    await chmod(agentBinary, 0o755);
+    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      if (path.endsWith("/status")) {
+        return new Response(JSON.stringify(outputStatus({
+          outputRemediationAllowed: false,
+          outputSatisfiedByPriorRun: true,
+        })), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    await executeClaim(config(join(root, "workspaces"), agentBinary), requiredOutputClaim(remote));
+
+    assert.equal(existsSync(remediationPrompt), false);
+    assert.ok(runnerEvents(posts).some(({ type }) => type === "TASK_OUTPUT_REMEDIATION_SKIPPED"));
+    assert.equal(posts.find((post) => post.path.endsWith("/complete"))?.body.terminalSuccess, true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("missing output with no provider conversation reports remediation unavailable", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-output-remediation-no-conversation-"));
+  try {
+    const remote = await seedRemote(root);
+    const agentBinary = join(root, "agent.sh");
+    await writeFile(agentBinary, succeedingAgent);
+    await chmod(agentBinary, 0o755);
+    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      if (path.endsWith("/status")) {
+        return new Response(JSON.stringify(outputStatus()), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    await executeClaim(config(join(root, "workspaces"), agentBinary), requiredOutputClaim(remote));
+
+    const unavailable = runnerEvents(posts).find(({ type }) => type === "TASK_OUTPUT_REMEDIATION_UNAVAILABLE");
+    assert.ok(unavailable);
+    assert.equal(unavailable.payload.providerConversationIdAvailable, false);
+    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    assert.equal(completion?.body.terminalSuccess, false);
+    assert.equal(completion?.body.failureClass, "PROTOCOL_ERROR");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a failed output status read is diagnosed without attempting remediation", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-output-remediation-check-failed-"));
+  try {
+    const remote = await seedRemote(root);
+    const remediationPrompt = join(root, "remediation-prompt.txt");
+    const agentBinary = join(root, "remediating-agent.sh");
+    await writeFile(agentBinary, remediatingAgent(remediationPrompt));
+    await chmod(agentBinary, 0o755);
+    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      if (path.endsWith("/status")) {
+        return new Response(JSON.stringify({ error: "status unavailable" }), {
+          status: 503, headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    await executeClaim(config(join(root, "workspaces"), agentBinary), requiredOutputClaim(remote));
+
+    assert.equal(existsSync(remediationPrompt), false);
+    const failed = runnerEvents(posts).find(({ type }) => type === "TASK_OUTPUT_REMEDIATION_CHECK_FAILED");
+    assert.ok(failed);
+    assert.match(String(failed.payload.message), /503/u);
+    assert.equal(runnerEvents(posts).some(({ type }) => type === "TASK_OUTPUT_REMEDIATION_STARTED"), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("remediation that still leaves output missing fails with provider evidence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-output-remediation-still-missing-"));
+  try {
+    const remote = await seedRemote(root);
+    const remediationPrompt = join(root, "remediation-prompt.txt");
+    const agentBinary = join(root, "remediating-agent.sh");
+    const remediationResult = `${"x".repeat(5_000)}diagnostic final output`;
+    await writeFile(agentBinary, remediatingAgent(remediationPrompt, [], remediationResult));
+    await chmod(agentBinary, 0o755);
+    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      if (path.endsWith("/status")) {
+        return new Response(JSON.stringify(outputStatus()), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    await executeClaim(config(join(root, "workspaces"), agentBinary), requiredOutputClaim(remote));
+
+    const finished = runnerEvents(posts).find(({ type }) => type === "TASK_OUTPUT_REMEDIATION_FINISHED");
+    assert.ok(finished);
+    assert.equal(finished.payload.outputPersisted, false);
+    const evidence = finished.payload.evidence as Record<string, unknown>;
+    assert.equal(evidence.finalOutputTail, summarizeEvidence(remediationResult));
+    assert.match(String(evidence.finalOutputTail), /^…\[\d+ earlier characters truncated\]/u);
+    assert.match(String(evidence.finalOutputTail), /diagnostic final output$/u);
+    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    assert.equal(completion?.body.terminalSuccess, false);
+    assert.equal(completion?.body.failureClass, "PROTOCOL_ERROR");
+    assert.match(String(completion?.body.failureReason), /finished without persisting implementation output/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("cancellation during remediation drains the resumed handle before ACK", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-output-remediation-cancel-"));
+  try {
+    const remote = await seedRemote(root);
+    const remediationPrompt = join(root, "remediation-prompt.txt");
+    const agentBinary = join(root, "remediating-agent.sh");
+    await writeFile(agentBinary, remediatingAgent(remediationPrompt, ["sleep 30"]));
+    await chmod(agentBinary, 0o755);
+    let resumedHandle: RuntimeHandle | null = null;
+    let resumeReturning = false;
+    let resumedHandleDrained = false;
+    const adapter = {
+      ...adapters.CLAUDE,
+      resume: async (...args: Parameters<typeof adapters.CLAUDE.resume>) => {
+        const launched = await adapters.CLAUDE.resume(...args);
+        resumedHandle = launched;
+        resumeReturning = true;
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+        return launched;
+      },
+      kill: async (...args: Parameters<typeof adapters.CLAUDE.kill>) => {
+        const result = await adapters.CLAUDE.kill(...args);
+        if (args[0] === resumedHandle) resumedHandleDrained = !result.processAlive;
+        return result;
+      },
+    };
+    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
+    let cancellationSent = false;
+    let ackObservedAfterDrain = false;
+    const configured = { ...config(join(root, "workspaces"), agentBinary), heartbeatIntervalMs: 10 };
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      if (path.endsWith("/status")) {
+        return new Response(JSON.stringify(outputStatus()), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (path.endsWith("/heartbeat") && resumeReturning && !cancellationSent) {
+        cancellationSent = true;
+        return new Response(JSON.stringify({
+          ok: false,
+          cancellation: { requestId: "cancel-remediation", reason: "operator stop", requestedAt: new Date(0).toISOString() },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (path.endsWith("/cancel/acknowledge")) ackObservedAfterDrain = resumedHandleDrained;
+      return new Response(JSON.stringify({ ok: true, cancellation: null }), {
+        status: 200, headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await executeClaim(configured, requiredOutputClaim(remote), { adapter });
+
+    assert.equal(cancellationSent, true);
+    assert.equal(resumedHandleDrained, true);
+    assert.equal(ackObservedAfterDrain, true);
+    assert.equal(posts.filter((post) => post.path.endsWith("/cancel/acknowledge")).length, 1);
+    assert.equal(posts.some((post) => post.path.endsWith("/complete")), false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("remediation cannot change workspace HEAD or publish its changes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-output-remediation-head-drift-"));
+  try {
+    const remote = await seedRemote(root);
+    const originalHead = git(root, `--git-dir=${remote}`, "rev-parse", "refs/heads/master");
+    const remediationPrompt = join(root, "remediation-prompt.txt");
+    const agentBinary = join(root, "remediating-agent.sh");
+    await writeFile(agentBinary, remediatingAgent(remediationPrompt, [
+      "printf 'remediation edit\\n' > tree.txt",
+      "git add tree.txt",
+      "git -c user.name='AgentOS Test' -c user.email='runner@agentos.local' commit -m 'forbidden remediation edit' >/dev/null",
+    ]));
+    await chmod(agentBinary, 0o755);
+    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
+    let statusReads = 0;
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      if (path.endsWith("/status")) {
+        statusReads += 1;
+        return new Response(JSON.stringify(outputStatus({ outputPersisted: statusReads >= 2 })), {
+          status: 200, headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    }) as typeof fetch;
+
+    await executeClaim(config(join(root, "workspaces"), agentBinary), requiredOutputClaim(remote));
+
+    const finished = runnerEvents(posts).find(({ type }) => type === "TASK_OUTPUT_REMEDIATION_FINISHED");
+    assert.ok(finished);
+    assert.equal(finished.payload.workspaceChanged, true);
+    assert.notEqual(
+      (finished.payload.workspaceBefore as Record<string, unknown>).headSha,
+      (finished.payload.workspaceAfter as Record<string, unknown>).headSha,
+    );
+    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    assert.equal(completion?.body.failureClass, "PROTOCOL_ERROR");
+    assert.equal(completion?.body.pushStatus, "NOT_REQUESTED");
+    assert.equal(git(root, `--git-dir=${remote}`, "rev-parse", "refs/heads/master"), originalHead);
+    assert.deepEqual(git(root, `--git-dir=${remote}`, "for-each-ref", "--format=%(refname)", "refs/heads").split("\n"), ["refs/heads/master"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the original Run budget continues through remediation", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-output-remediation-budget-"));
+  try {
+    const remote = await seedRemote(root);
+    const remediationPrompt = join(root, "remediation-prompt.txt");
+    const agentBinary = join(root, "remediating-agent.sh");
+    await writeFile(agentBinary, remediatingAgent(remediationPrompt, ["sleep 30"]));
+    await chmod(agentBinary, 0o755);
+    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const path = String(input);
+      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+      if (path.endsWith("/status")) {
+        return new Response(JSON.stringify(outputStatus()), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({ ok: true, cancellation: null }), {
+        status: 200, headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    const configured = { ...config(join(root, "workspaces"), agentBinary), heartbeatIntervalMs: 10 };
+    const claimed = requiredOutputClaim(remote);
+    claimed.run.maxDurationMin = 0.002;
+
+    await executeClaim(configured, claimed);
+    // Let the heartbeat callback that performed the budget kill finish its
+    // best-effort API report before afterEach restores the real global fetch.
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    assert.equal(completion?.body.terminalSuccess, false);
+    assert.equal(completion?.body.failureClass, "BUDGET_EXCEEDED");
+    assert.match(String(completion?.body.failureReason), /walltime budget exceeded/u);
+    const finished = runnerEvents(posts).find(({ type }) => type === "TASK_OUTPUT_REMEDIATION_FINISHED");
+    assert.ok(finished);
+    assert.equal(finished.payload.outputPersisted, false);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   ADAPTER_VERSION,
   adapterExecutionSucceeded,
@@ -31,6 +33,7 @@ import {
   type ClaimedTask,
   type CancellationRequest,
   type SessionEventPayload,
+  type SessionTaskOutputStatus,
 } from "./api.js";
 import {
   probeSupportedCliAvailability,
@@ -47,12 +50,13 @@ import {
   type FailurePhase,
   RUNNER_EXCEPTION_REASON,
   runnerExceptionEnvelope,
+  summarizeEvidence,
 } from "./envelope.js";
 import { deliverUnderLease, openDeliveryLease, type DeliveryLease } from "./lease.js";
 import {
-  captureWorkspaceResult, cleanupAgentScratch, provisionAgentScratch, provisionSessionConfig,
+  captureWorkspaceResult, captureWorkspaceSnapshot, cleanupAgentScratch, provisionAgentScratch, provisionSessionConfig,
   provisionWorkspace, reuseWorkspace, sessionConfigRootExists, workspaceEnvironment, writeSessionCredentials,
-  type AgentScratch, type Workspace,
+  type AgentScratch, type Workspace, type WorkspaceSnapshot,
 } from "./workspace.js";
 import { observeExternalWorktrees } from "./worktree-observer.js";
 
@@ -79,6 +83,27 @@ const missingOutputRemediationInput = (outputKind: string): string => [
   `Using the work and evidence already produced in this conversation, call task_output with kind '${outputKind}' and a body that satisfies the task's exact output contract and current HEAD binding.`,
   "If the write is rejected, correct the body and retry. Then call task_status and finish only after it reports outputPersisted: true for this Run.",
 ].join("\n");
+
+const sameWorkspaceSnapshot = (left: WorkspaceSnapshot, right: WorkspaceSnapshot): boolean =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+const workspaceSnapshotEvidence = (snapshot: WorkspaceSnapshot): Record<string, unknown> => ({
+  headSha: snapshot.headSha,
+  treeDigest: createHash("sha256").update(JSON.stringify(snapshot)).digest("hex"),
+  dirty: snapshot.status.length > 0,
+});
+
+const exitEvidencePayload = (evidence: ExitEvidence): Record<string, unknown> => ({
+  exitCode: evidence.exitCode,
+  signal: evidence.signal,
+  terminalEventSeen: evidence.terminalEventSeen,
+  terminalSuccess: evidence.terminalSuccess,
+  terminationReason: evidence.terminationReason,
+  finalOutputTail: summarizeEvidence(evidence.finalOutput),
+  providerErrorTail: summarizeEvidence(evidence.providerError),
+  stdoutTail: summarizeEvidence(evidence.stdout),
+  stderrTail: summarizeEvidence(evidence.stderr),
+});
 
 const cleanup = async (
   config: RunnerConfig,
@@ -133,16 +158,33 @@ export const executeClaim = async (
   let waitingInbox = false;
   let cancellation: CancellationRequest | null = null;
   let cancellationPromise: Promise<void> | null = null;
-  let closeProviderLaunch!: () => void;
-  const providerLaunchSettled = new Promise<void>((resolve) => {
+  let providerLaunchSettled = Promise.resolve();
+  let closeProviderLaunch = (): void => undefined;
+  const openProviderLaunch = (): void => {
     let closed = false;
+    let resolveLaunch!: () => void;
+    providerLaunchSettled = new Promise<void>((resolve) => { resolveLaunch = resolve; });
     closeProviderLaunch = () => {
       if (closed) return;
       closed = true;
-      resolve();
+      resolveLaunch();
     };
-  });
+  };
+  // Cancellation may arrive at any provisioning point before the first start.
+  openProviderLaunch();
+  const providerKillPromises = new WeakMap<RuntimeHandle, Promise<void>>();
+  const drainProviderHandle = (target: RuntimeHandle, reason: string): Promise<void> => {
+    const active = providerKillPromises.get(target);
+    if (active) return active;
+    const draining = adapter.kill(target, reason).then((killed) => {
+      if (killed.processAlive) throw new Error(`Run ${claim.run.id} still owns a live provider process`);
+    });
+    providerKillPromises.set(target, draining);
+    return draining;
+  };
   let budgetReason: string | null = null;
+  let remediationFailureReason: string | null = null;
+  let workspacePublicationForbidden = false;
   // A session CLI's root is retained until the run is known to have succeeded, so a
   // provisioning or execution failure can be inspected and resumed without
   // ever falling back to the host CLI configuration.
@@ -228,8 +270,7 @@ export const executeClaim = async (
     fencingRejected = true;
     if (handle) {
       try {
-        const killed = await adapter.kill(handle, waitingInbox ? "waiting for Inbox reply" : "fencing token rejected");
-        if (killed.processAlive) throw new Error(`Run ${claim.run.id} still owns a live provider process`);
+        await drainProviderHandle(handle, waitingInbox ? "waiting for Inbox reply" : "fencing token rejected");
       } catch (killError: unknown) {
         console.error(`Unable to drain fenced Run ${claim.run.id}: ${errorMessage(killError)}`);
       }
@@ -246,8 +287,7 @@ export const executeClaim = async (
       // either abandoned or has produced the handle that must be killed.
       await providerLaunchSettled;
       if (handle) {
-        const killed = await adapter.kill(handle, request.reason);
-        if (killed.processAlive) throw new Error(`Run ${claim.run.id} still owns a live provider process`);
+        await drainProviderHandle(handle, request.reason);
       }
       await acknowledgeCancellation(
         config,
@@ -259,6 +299,11 @@ export const executeClaim = async (
     })();
     await cancellationPromise;
   };
+
+  // Cancellation and fencing are mutated by heartbeat continuations, which
+  // TypeScript cannot observe across the awaited provider launch.
+  const providerStopReason = (): string => cancellation?.reason
+    ?? (waitingInbox ? "waiting for Inbox reply" : "fencing token rejected");
 
   const observeEventFlush = async (error: unknown): Promise<void> => {
     await noteFencingError(error);
@@ -468,7 +513,7 @@ export const executeClaim = async (
         });
         if (!decision.allowed && snapshot.processAlive) {
           budgetReason = `${decision.gate}: ${decision.reason}`;
-          await adapter.kill(heartbeatHandle, budgetReason);
+          await drainProviderHandle(heartbeatHandle, budgetReason);
         }
         try {
           const result = await sendHeartbeat(config, claim, {
@@ -498,7 +543,7 @@ export const executeClaim = async (
     if (adapterExecutionSucceeded(evidence)
       && claim.task.templateStep?.outputKind
       && !fencingRejected) {
-      let outputStatus: Awaited<ReturnType<typeof readSessionTaskOutputStatus>> = null;
+      let outputStatus: SessionTaskOutputStatus | null = null;
       try {
         outputStatus = await readSessionTaskOutputStatus(config, claim);
       } catch (error: unknown) {
@@ -508,48 +553,109 @@ export const executeClaim = async (
           payload: { message: errorMessage(error) },
         });
       }
-      if (outputStatus?.outputRequired
-        && outputStatus.outputRemediationAllowed
-        && !outputStatus.outputPersisted) {
+      if (outputStatus?.outputRequired && !outputStatus.outputPersisted) {
         const outputKind = outputStatus.outputKind;
         const providerConversationId = completedHandle.providerConversationId;
-        if (outputKind && providerConversationId && !fencingRejected) {
+        if (outputStatus.outputSatisfiedByPriorRun) {
           sink({
             source: "RUNNER",
-            type: "TASK_OUTPUT_REMEDIATION_STARTED",
-            payload: { outputKind },
+            type: "TASK_OUTPUT_REMEDIATION_SKIPPED",
+            payload: { outputKind, reason: "immutable-output-satisfied-by-prior-run" },
           });
-          handle = await adapter.resume({
-            ...spec,
-            providerConversationId,
-            input: missingOutputRemediationInput(outputKind),
-          }, sink);
-          const remediationEvidence = await handle.exit;
-          let remediated = false;
-          try {
-            remediated = (await readSessionTaskOutputStatus(config, claim))?.outputPersisted === true;
-          } catch (error: unknown) {
+        } else if (outputStatus.outputRemediationAllowed
+          && outputKind
+          && providerConversationId
+          && !fencingRejected) {
+          const beforeRemediation = await captureWorkspaceSnapshot(config, workspace);
+          // Snapshotting is asynchronous. Cancellation may have been ACKed
+          // against the already-closed first launch while it ran, so no second
+          // provider launch may be opened without this fresh fence check.
+          if (!fencingRejected) {
             sink({
               source: "RUNNER",
-              type: "TASK_OUTPUT_REMEDIATION_CHECK_FAILED",
-              payload: { message: errorMessage(error) },
+              type: "TASK_OUTPUT_REMEDIATION_STARTED",
+              payload: { outputKind, workspace: workspaceSnapshotEvidence(beforeRemediation) },
             });
+            let remediationHandle: RuntimeHandle | null = null;
+            openProviderLaunch();
+            try {
+              remediationHandle = await adapter.resume({
+                ...spec,
+                providerConversationId,
+                input: missingOutputRemediationInput(outputKind),
+              }, sink);
+              handle = remediationHandle;
+            } finally {
+              closeProviderLaunch();
+            }
+            // A cancellation can win while adapter.resume is constructing the
+            // process group. Recheck before awaiting its exit and drain the newly
+            // returned handle; the ACK waits on this same deduplicated kill.
+            if (fencingRejected && remediationHandle) {
+              await drainProviderHandle(
+                remediationHandle,
+                providerStopReason(),
+              );
+              if (cancellation) await cancellationPromise;
+            }
+            if (!fencingRejected && remediationHandle) {
+              const remediationEvidence = await remediationHandle.exit;
+              const afterRemediation = await captureWorkspaceSnapshot(config, workspace);
+              const workspaceChanged = !sameWorkspaceSnapshot(beforeRemediation, afterRemediation);
+              let remediated = false;
+              let statusCheckError: string | null = null;
+              if (!workspaceChanged) {
+                try {
+                  const remediatedStatus = await readSessionTaskOutputStatus(config, claim);
+                  remediated = remediatedStatus?.outputPersisted === true
+                    || remediatedStatus?.outputSatisfiedByPriorRun === true;
+                } catch (error: unknown) {
+                  statusCheckError = errorMessage(error);
+                  sink({
+                    source: "RUNNER",
+                    type: "TASK_OUTPUT_REMEDIATION_CHECK_FAILED",
+                    payload: { message: statusCheckError },
+                  });
+                }
+              }
+              if (workspaceChanged) {
+                workspacePublicationForbidden = true;
+                remediationFailureReason = `Task output remediation changed workspace HEAD or tree for Run ${claim.run.id}`;
+              } else if (!remediated) {
+                remediationFailureReason = statusCheckError
+                  ? `Task output remediation status check failed for Run ${claim.run.id}: ${statusCheckError}`
+                  : `Task output remediation finished without persisting ${outputKind} output for Run ${claim.run.id}`;
+              }
+              sink({
+                source: "RUNNER",
+                type: "TASK_OUTPUT_REMEDIATION_FINISHED",
+                payload: {
+                  outputKind,
+                  outputPersisted: remediated,
+                  terminalSuccess: adapterExecutionSucceeded(remediationEvidence),
+                  evidence: exitEvidencePayload(remediationEvidence),
+                  workspaceChanged,
+                  ...(workspaceChanged ? {
+                    workspaceBefore: workspaceSnapshotEvidence(beforeRemediation),
+                    workspaceAfter: workspaceSnapshotEvidence(afterRemediation),
+                  } : {}),
+                  ...(statusCheckError ? { statusCheckError } : {}),
+                },
+              });
+            }
           }
-          sink({
-            source: "RUNNER",
-            type: "TASK_OUTPUT_REMEDIATION_FINISHED",
-            payload: {
-              outputKind,
-              outputPersisted: remediated,
-              terminalSuccess: adapterExecutionSucceeded(remediationEvidence),
-            },
-          });
         } else {
+          remediationFailureReason = `Task output remediation unavailable for Run ${claim.run.id}: ${
+            !outputStatus.outputRemediationAllowed ? "remediation is not allowed"
+              : !outputKind ? "output kind is unavailable"
+                : "provider conversation id is unavailable"
+          }`;
           sink({
             source: "RUNNER",
             type: "TASK_OUTPUT_REMEDIATION_UNAVAILABLE",
             payload: {
               outputKind,
+              outputRemediationAllowed: outputStatus.outputRemediationAllowed,
               providerConversationIdAvailable: providerConversationId !== null,
             },
           });
@@ -594,7 +700,9 @@ export const executeClaim = async (
       });
       return;
     }
-    const executionSucceeded = adapterExecutionSucceeded(evidence);
+    const executionSucceeded = adapterExecutionSucceeded(evidence)
+      && remediationFailureReason === null
+      && budgetReason === null;
     let delivery: Awaited<ReturnType<typeof deliverWorkspace>> | null = null;
     let gitResult = { branch: workspace.branch, baseSha: workspace.baseSha, headSha: workspace.baseSha };
     try { gitResult = await captureWorkspaceResult(config, workspace); } catch (error: unknown) {
@@ -636,7 +744,10 @@ export const executeClaim = async (
       // A failed PR operation can follow a successful, acknowledged push. That
       // branch is already durable even though the run must fail, so salvaging it
       // would publish a second ref and replace the primary delivery evidence.
-      succeeded || Boolean(workspace.pinnedBaseSha) || Boolean(primaryDelivery?.pushedBranch),
+      succeeded
+        || workspacePublicationForbidden
+        || Boolean(workspace.pinnedBaseSha)
+        || Boolean(primaryDelivery?.pushedBranch),
     );
     if (!succeeded && cleaned.salvage) {
       delivery = cleaned.salvage;
@@ -664,9 +775,14 @@ export const executeClaim = async (
       }
     }
     const { salvage: _salvage, ...finishedCleanup } = cleaned;
-    const classified = succeeded ? null : primaryDelivery?.failureClass
-      ? { failureClass: primaryDelivery.failureClass, retryable: false }
-      : adapter.classifyError(evidence);
+    const classified = succeeded ? null
+      : budgetReason
+        ? { failureClass: "BUDGET_EXCEEDED" as const, retryable: false }
+        : remediationFailureReason
+          ? { failureClass: "PROTOCOL_ERROR" as const, retryable: true }
+          : primaryDelivery?.failureClass
+            ? { failureClass: primaryDelivery.failureClass, retryable: false }
+            : adapter.classifyError(evidence);
     // The normal delivery failure remains the failure-envelope evidence even
     // when terminal salvage subsequently succeeds. The wire publication is the
     // salvage result, because it names the ref that actually became durable.
@@ -687,17 +803,28 @@ export const executeClaim = async (
     // one heartbeat interval old — half the lease — and the completion call is
     // itself bounded by RUNNER_API_TIMEOUT_MS, so it cannot outlive that.
     lease.close();
+    // The primary provider may have ended cleanly while the required
+    // remediation protocol failed afterwards. Reflect that protocol failure in
+    // the structured envelope too; otherwise the API correctly distrusts the
+    // runner's asserted class and would classify the clean primary evidence as
+    // TASK_FAILED instead of PROTOCOL_ERROR.
+    const completionEvidence = remediationFailureReason
+      ? { ...evidence, terminalSuccess: false }
+      : evidence;
     await completeRun(config, claim, {
       exitCode: evidence.exitCode,
       signal: evidence.signal,
       terminalEventSeen: evidence.terminalEventSeen,
       terminalSuccess: succeeded && evidence.terminalSuccess,
       terminationReason: budgetReason ?? evidence.terminationReason,
-      ...(classified ? { failureClass: budgetReason ? "BUDGET_EXCEEDED" : classified.failureClass, retryable: budgetReason ? false : classified.retryable } : {}),
+      ...(classified ? { failureClass: classified.failureClass, retryable: classified.retryable } : {}),
       // A salvage push failure must not mask why the run itself failed.
       ...(!succeeded ? {
         failureReason: appendRetainedSessionConfig(
-          budgetReason ?? (executionSucceeded ? primaryDelivery?.pushError : null) ?? failureReasonFromEvidence(evidence),
+          budgetReason
+            ?? remediationFailureReason
+            ?? (executionSucceeded ? primaryDelivery?.pushError : null)
+            ?? failureReasonFromEvidence(evidence),
           retainedPath,
         ),
       } : {}),
@@ -709,9 +836,9 @@ export const executeClaim = async (
       ...(succeeded ? {} : {
         failureEnvelope: completionEnvelope({
           executionSucceeded,
-          evidence,
+          evidence: completionEvidence,
           deliveryFailure,
-          runnerClass: budgetReason ? "BUDGET_EXCEEDED" : classified?.failureClass ?? null,
+          runnerClass: classified?.failureClass ?? null,
           terminationReason: budgetReason ?? evidence.terminationReason,
         }),
       }),

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -449,6 +449,36 @@ export const captureWorkspaceResult = async (
   return { branch, baseSha: workspace.baseSha, headSha };
 };
 
+export type WorkspaceSnapshot = {
+  headSha: string;
+  status: string;
+  trackedDiff: string;
+  untrackedFiles: Array<{ path: string; objectId: string }>;
+};
+
+/** Capture enough of HEAD, the index and the working tree to prove that a
+ * runner-owned continuation did not mutate the deliverable it was asked only
+ * to describe. Untracked contents are hashed separately because `git diff`
+ * does not include them. */
+export const captureWorkspaceSnapshot = async (
+  config: RunnerConfig,
+  workspace: Workspace,
+): Promise<WorkspaceSnapshot> => {
+  const env = workspaceEnvironment(config);
+  const [headSha, status, trackedDiff, untrackedOutput] = await Promise.all([
+    command(config, "git", ["rev-parse", "HEAD"], workspace.path, env),
+    command(config, "git", ["status", "--porcelain=v1", "-z", "--untracked-files=all"], workspace.path, env),
+    command(config, "git", ["diff", "--binary", "HEAD", "--"], workspace.path, env),
+    command(config, "git", ["ls-files", "-z", "--others", "--exclude-standard"], workspace.path, env),
+  ]);
+  const untrackedPaths = untrackedOutput.split("\0").filter(Boolean);
+  const untrackedFiles = await Promise.all(untrackedPaths.map(async (path) => ({
+    path,
+    objectId: await command(config, "git", ["hash-object", "--", path], workspace.path, env),
+  })));
+  return { headSha, status, trackedDiff, untrackedFiles };
+};
+
 export const cleanupWorkspace = async (
   config: RunnerConfig,
   workspacePath: string,


### PR DESCRIPTION
## Summary

Follow-up remediation for the review findings on PR #187.

## Finding disposition

1. Cancellation race: re-open the provider launch barrier around remediation `resume`, re-check fencing immediately after it returns, and drain the resumed handle before cancellation ACK.
2. Resumed-session side effects: snapshot HEAD, index, tracked content, and untracked content before/after remediation. Workspace drift fails with `PROTOCOL_ERROR`, suppresses normal delivery, and disables WIP salvage publication.
3. Coverage: add runner tests for immutable skip, unavailable conversation, status-read failure, still-missing output, cancellation during remediation, workspace drift, and budget kill; add API coverage for immutable remediation status.
4. Budget semantics: remediation remains inside the original Run budget; a remediation budget kill completes coherently as `terminalSuccess: false` and `BUDGET_EXCEEDED`.
5. Transcript diagnostics: attach bounded remediation evidence tails to the finished event, including truncation coverage.
6. Immutable retries: add `outputSatisfiedByPriorRun` so agents can distinguish prior immutable satisfaction from a missing current-Run write.
7. Session auth ordering: document that endpoint headers intentionally override runner auth.
8. Status typing: use the exported `SessionTaskOutputStatus` type directly.

No Goals, coordinator, or DoD paths were changed.

## Verification

- `npm run lint`
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) node --import tsx --test packages/runner/src/run-output.test.ts` (12/12 pass)
- `npm run test:db -w @agentos/api -- src/run-output.dbtest.ts` against a disposable PostgreSQL server and dedicated scratch schema (19/19 pass)
