### PR TITLE
refactor(api): deepen task brief encoding

### DIFF
--- a/packages/api/src/specification-fidelity.ts
+++ b/packages/api/src/specification-fidelity.ts
@@ -9,7 +9,7 @@ import { abortableDelay, abortReason } from "./abortable-delay.js";
 import { isCanonicalBlindFindingsStep, isCanonicalSolFindingsStep } from "./canonical-task-output.js";
 import { isValidBranchName } from "./branch-name.js";
 import { GitHubReadError } from "./github-read.js";
-import { featureBriefFromTaskDescription } from "./templates.js";
+import { readBrief } from "./task-brief.js";
 
 /** Stable, operator-visible reasons for the distinct fail-closed outcomes. */
 export const SPEC_TRANSCRIPTION_REFUSAL_REASON = "spec-transcription-mismatch";
@@ -53,14 +53,13 @@ export const specificationMaterializationForDirectImplementation = (
   if (!task.templateId || !task.chainId
     || !isDirectImplementationStep(task.templateStep ?? null)
     || !branch || !isValidBranchName(branch)) return null;
-  const body = featureBriefFromTaskDescription(
-    task.description,
-    (task.templateStep?.priorOutputKinds.length ?? 0) > 0,
-  );
-  return body === null ? null : {
+  const parsed = readBrief(task.description, {
+    legacyAttachmentsFromPrevious: (task.templateStep?.priorOutputKinds.length ?? 0) > 0,
+  });
+  return "unparseable" in parsed ? null : {
     kind: "direct-implementation",
     path: specificationPathForBranch(branch),
-    body,
+    body: parsed.brief,
   };
 };
 
@@ -161,13 +160,12 @@ const directAuthority = (source: AuthoritySource): AuthorityResult => {
   if (!source.templateStep) {
     return { error: refusal(SPEC_TRANSCRIPTION_AUTHORITY_MISSING_REASON, "direct-chain implementation step metadata is missing") };
   }
-  const text = featureBriefFromTaskDescription(
-    source.description,
-    source.templateStep.priorOutputKinds.length > 0,
-  );
-  return text === null
+  const parsed = readBrief(source.description, {
+    legacyAttachmentsFromPrevious: source.templateStep.priorOutputKinds.length > 0,
+  });
+  return "unparseable" in parsed
     ? { error: refusal(SPEC_TRANSCRIPTION_AUTHORITY_MISSING_REASON, "direct-chain task brief is unavailable") }
-    : { text };
+    : { text: parsed.brief };
 };
 
 type AuthorityResult = { text: string } | { error: SpecificationRefusal };

--- a/packages/api/src/task-brief.test.ts
+++ b/packages/api/src/task-brief.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { composeBrief, readBrief, rewriteBrief } from "./task-brief.js";
+
+const briefEndingLikeGeneratedContext = [
+  "Keep both decoys.",
+  "<!-- agentos:task-brief:v1 length=9 -->",
+  "Persist the final decoy output for this step through the AgentOS task output endpoint.",
+  "Read the prior template steps' persisted outputs before working.",
+].join("\n");
+
+test("a fenced task brief is self-describing even when its content resembles the encoding", () => {
+  const description = composeBrief({
+    prompt: "Implement the Specification of record.",
+    brief: briefEndingLikeGeneratedContext,
+    attachmentsFromPrevious: false,
+    outputKind: "implementation",
+  });
+
+  assert.deepEqual(readBrief(description), {
+    prompt: "Implement the Specification of record.",
+    brief: briefEndingLikeGeneratedContext,
+    hadReminder: false,
+  });
+});
+
+test("rewriting a fenced task brief preserves platform-authored context", () => {
+  const description = composeBrief({
+    prompt: "Review the implementation.",
+    brief: "Original brief",
+    attachmentsFromPrevious: true,
+    outputKind: "sol-findings",
+  });
+  const rewritten = rewriteBrief(description, "Operator-edited brief");
+
+  assert.equal(typeof rewritten, "string");
+  assert.deepEqual(readBrief(rewritten as string), {
+    prompt: "Review the implementation.",
+    brief: "Operator-edited brief",
+    hadReminder: true,
+  });
+  assert.match(rewritten as string, /Persist the final sol-findings output/u);
+});
+
+test("rewriting a legacy task brief upgrades it to the self-describing format", () => {
+  const legacy = [
+    "Implement the feature.",
+    "Feature brief:",
+    "Original brief",
+    "Read the prior template steps' persisted outputs before working.",
+    "Persist the final implementation output for this step through the AgentOS task output endpoint.",
+  ].join("\n");
+  const rewritten = rewriteBrief(legacy, "Migrated brief", { legacyAttachmentsFromPrevious: true });
+
+  assert.equal(typeof rewritten, "string");
+  assert.doesNotMatch(rewritten as string, /\nFeature brief:\n/u);
+  assert.deepEqual(readBrief(rewritten as string), {
+    prompt: "Implement the feature.",
+    brief: "Migrated brief",
+    hadReminder: true,
+  });
+});
+
+test("the legacy adapter preserves a brief that only resembles a reminder", () => {
+  const brief = "Keep this suffix.\nRead the prior template steps' persisted outputs before working.";
+  const legacy = [
+    "Implement the feature.",
+    "Feature brief:",
+    brief,
+    "Persist the final implementation output for this step through the AgentOS task output endpoint.",
+  ].join("\n");
+
+  assert.deepEqual(readBrief(legacy, { legacyAttachmentsFromPrevious: false }), {
+    prompt: "Implement the feature.",
+    brief,
+    hadReminder: false,
+  });
+});
+
+test("a damaged fenced task brief fails instead of falling back to legacy parsing", () => {
+  assert.deepEqual(
+    readBrief("Prompt\n<!-- agentos:task-brief:v1 length=4 -->\nbrief\n<!-- /agentos:task-brief:v1 -->"),
+    { unparseable: "task brief fence does not match its declared length" },
+  );
+});

--- a/packages/api/src/task-brief.ts
+++ b/packages/api/src/task-brief.ts
@@ -25,9 +25,9 @@ type LegacyBriefMigration = {
   legacyAttachmentsFromPrevious: boolean;
 };
 
-const isMechanicalTemplateStep = (outputKind: string): boolean => {
+export const stepHasTaskBrief = (outputKind: string): boolean => {
   const role = stepRole({ outputKind });
-  return role === "readiness" || role === "integrator";
+  return role !== "readiness" && role !== "integrator";
 };
 
 const outputIsPlatformAuthored = (outputKind: string): boolean => {
@@ -48,7 +48,7 @@ export const composeBrief = (input: {
   // Readiness and merge execution are server-owned mechanical Steps. Their
   // task cards preview the canonical prompt, but no model reads generated
   // brief, predecessor, or output-persistence context from them.
-  if (isMechanicalTemplateStep(input.outputKind)) return input.prompt;
+  if (!stepHasTaskBrief(input.outputKind)) return input.prompt;
   return [
     input.prompt,
     input.brief ? frameBrief(input.brief) : "",

--- a/packages/api/src/task-brief.ts
+++ b/packages/api/src/task-brief.ts
@@ -1,0 +1,140 @@
+import { stepRole } from "@agentos/db";
+
+const FEATURE_BRIEF_PREFIX = "\nFeature brief:\n";
+const PRIOR_OUTPUTS_REMINDER = "\nRead the prior template steps' persisted outputs before working.";
+const PERSIST_OUTPUT_PREFIX = "\nPersist the final ";
+const PERSIST_OUTPUT_SUFFIX = " output for this step through the AgentOS task output endpoint.";
+
+const BRIEF_HEADER_PREFIX = "\n<!-- agentos:task-brief:v1 length=";
+const BRIEF_HEADER_SUFFIX = " -->\n";
+const BRIEF_FOOTER = "\n<!-- /agentos:task-brief:v1 -->";
+
+export type TaskBrief = {
+  prompt: string;
+  brief: string;
+  hadReminder: boolean;
+};
+
+export type UnparseableTaskBrief = { unparseable: string };
+
+type LocatedTaskBrief = TaskBrief & {
+  suffix: string;
+};
+
+type LegacyBriefMigration = {
+  legacyAttachmentsFromPrevious: boolean;
+};
+
+const isMechanicalTemplateStep = (outputKind: string): boolean => {
+  const role = stepRole({ outputKind });
+  return role === "readiness" || role === "integrator";
+};
+
+const outputIsPlatformAuthored = (outputKind: string): boolean => {
+  const role = stepRole({ outputKind });
+  return role === "readiness" || role === "integrator" || role === "regression";
+};
+
+const frameBrief = (brief: string): string => (
+  `${BRIEF_HEADER_PREFIX}${brief.length}${BRIEF_HEADER_SUFFIX}${brief}${BRIEF_FOOTER}`
+);
+
+export const composeBrief = (input: {
+  prompt: string;
+  brief?: string | undefined;
+  attachmentsFromPrevious: boolean;
+  outputKind: string;
+}): string => {
+  // Readiness and merge execution are server-owned mechanical Steps. Their
+  // task cards preview the canonical prompt, but no model reads generated
+  // brief, predecessor, or output-persistence context from them.
+  if (isMechanicalTemplateStep(input.outputKind)) return input.prompt;
+  return [
+    input.prompt,
+    input.brief ? frameBrief(input.brief) : "",
+    input.attachmentsFromPrevious ? PRIOR_OUTPUTS_REMINDER : "",
+    outputIsPlatformAuthored(input.outputKind)
+      ? ""
+      : `${PERSIST_OUTPUT_PREFIX}${input.outputKind}${PERSIST_OUTPUT_SUFFIX}`,
+  ].join("");
+};
+
+const readFencedBrief = (description: string): LocatedTaskBrief | UnparseableTaskBrief | null => {
+  const headerStart = description.indexOf(BRIEF_HEADER_PREFIX);
+  if (headerStart < 0) return null;
+  const lengthStart = headerStart + BRIEF_HEADER_PREFIX.length;
+  const headerEnd = description.indexOf(BRIEF_HEADER_SUFFIX, lengthStart);
+  if (headerEnd < 0) return { unparseable: "task brief fence header is incomplete" };
+  const encodedLength = description.slice(lengthStart, headerEnd);
+  if (!/^\d+$/u.test(encodedLength)) return { unparseable: "task brief fence length is invalid" };
+  const briefLength = Number(encodedLength);
+  if (!Number.isSafeInteger(briefLength)) return { unparseable: "task brief fence length is unsafe" };
+  const briefStart = headerEnd + BRIEF_HEADER_SUFFIX.length;
+  const briefEnd = briefStart + briefLength;
+  if (description.slice(briefEnd, briefEnd + BRIEF_FOOTER.length) !== BRIEF_FOOTER) {
+    return { unparseable: "task brief fence does not match its declared length" };
+  }
+  const suffix = description.slice(briefEnd + BRIEF_FOOTER.length);
+  return {
+    prompt: description.slice(0, headerStart),
+    brief: description.slice(briefStart, briefEnd),
+    hadReminder: suffix.startsWith(PRIOR_OUTPUTS_REMINDER),
+    suffix,
+  };
+};
+
+/** Read descriptions written before fenced briefs were introduced. */
+const readLegacyBrief = (
+  description: string,
+  attachmentsFromPrevious: boolean,
+): LocatedTaskBrief | UnparseableTaskBrief => {
+  const markerStart = description.indexOf(FEATURE_BRIEF_PREFIX);
+  if (markerStart < 0) return { unparseable: "task brief marker is missing" };
+  const briefStart = markerStart + FEATURE_BRIEF_PREFIX.length;
+  const persistStart = description.lastIndexOf(PERSIST_OUTPUT_PREFIX);
+  const suffixStart = persistStart >= briefStart ? persistStart : description.length;
+  const reminderStart = suffixStart - PRIOR_OUTPUTS_REMINDER.length;
+  const hadReminder = attachmentsFromPrevious
+    && reminderStart >= briefStart
+    && description.slice(reminderStart, suffixStart) === PRIOR_OUTPUTS_REMINDER;
+  const briefEnd = hadReminder ? reminderStart : suffixStart;
+  return {
+    prompt: description.slice(0, markerStart),
+    brief: description.slice(briefStart, briefEnd),
+    hadReminder,
+    suffix: description.slice(briefEnd),
+  };
+};
+
+const locateBrief = (
+  description: string,
+  migration?: LegacyBriefMigration,
+): LocatedTaskBrief | UnparseableTaskBrief => {
+  const fenced = readFencedBrief(description);
+  if (fenced !== null) return fenced;
+  return migration
+    ? readLegacyBrief(description, migration.legacyAttachmentsFromPrevious)
+    : { unparseable: "task brief fence is missing" };
+};
+
+/** Read the direct Chain's Specification of record without caller-supplied encoding facts. */
+export const readBrief = (
+  description: string,
+  migration?: LegacyBriefMigration,
+): TaskBrief | UnparseableTaskBrief => {
+  const result = locateBrief(description, migration);
+  if ("unparseable" in result) return result;
+  const { suffix: _suffix, ...brief } = result;
+  return brief;
+};
+
+/** Replace only the brief and preserve the platform-authored prompt and suffix. */
+export const rewriteBrief = (
+  description: string,
+  newBrief: string,
+  migration?: LegacyBriefMigration,
+): string | UnparseableTaskBrief => {
+  const result = locateBrief(description, migration);
+  if ("unparseable" in result) return result;
+  return `${result.prompt}${frameBrief(newBrief)}${result.suffix}`;
+};

--- a/packages/api/src/task-patch.test.ts
+++ b/packages/api/src/task-patch.test.ts
@@ -6,11 +6,11 @@ import { AssigneeType, type PrismaClient, TaskStatus } from "@agentos/db";
 import { composeBrief, readBrief } from "./task-brief.js";
 import { patchTask } from "./task-patch.js";
 
-const patchFixture = (description: string) => {
+const patchFixture = (description: string, outputKind = "implementation") => {
   let update: Record<string, unknown> | null = null;
   const templateStep = {
     stepIndex: 1,
-    outputKind: "implementation",
+    outputKind,
     priorOutputKinds: [],
     taskTemplate: { name: "direct-engineer-workflow" },
   };
@@ -84,4 +84,13 @@ test("a template Chain description patch refuses an unparseable stored brief", a
     message: "Cannot rewrite task brief: task brief marker is missing",
   });
   assert.equal(fixture.update(), null);
+});
+
+test("a mechanical template Step keeps its free-form description patch", async () => {
+  const fixture = patchFixture("Run the merge readiness gate.", "merge-authorization");
+
+  const result = await patchTask(fixture.db, "task-1", { description: "concurrent writer completed after recovery" });
+
+  assert.ok("task" in result);
+  assert.equal(fixture.update()?.description, "concurrent writer completed after recovery");
 });

--- a/packages/api/src/task-patch.test.ts
+++ b/packages/api/src/task-patch.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AssigneeType, type PrismaClient, TaskStatus } from "@agentos/db";
+
+import { composeBrief, readBrief } from "./task-brief.js";
+import { patchTask } from "./task-patch.js";
+
+const patchFixture = (description: string) => {
+  let update: Record<string, unknown> | null = null;
+  const templateStep = {
+    stepIndex: 1,
+    outputKind: "implementation",
+    priorOutputKinds: [],
+    taskTemplate: { name: "direct-engineer-workflow" },
+  };
+  const task = {
+    id: "task-1",
+    projectId: "project-1",
+    templateId: "template-1",
+    templateStepId: "step-1",
+    chainId: "chain-1",
+    description,
+    name: "Direct implementation",
+    approvalGate: false,
+    archivedAt: null,
+    status: TaskStatus.TODO,
+    dispatchAfterTaskId: null,
+    dispatchAfter: null,
+    assigneeType: AssigneeType.HUMAN,
+    assigneeAgentId: null,
+    repoId: null,
+    scheduleKind: null,
+    templateStep,
+  };
+  const tx = {
+    $queryRaw: async () => [{ id: task.id }],
+    task: {
+      findUnique: async () => task,
+      findUniqueOrThrow: async () => task,
+      update: async ({ data }: { data: Record<string, unknown> }) => {
+        update = data;
+        return { ...task, ...data };
+      },
+    },
+    taskTemplateStep: { findUnique: async () => templateStep },
+  };
+  const db = {
+    ...tx,
+    $transaction: async (operation: (client: typeof tx) => Promise<unknown>) => operation(tx),
+  } as unknown as PrismaClient;
+  return { db, update: () => update };
+};
+
+test("an operator description edit rewrites only a template Chain task's brief", async () => {
+  const description = composeBrief({
+    prompt: "Implement the Specification of record.",
+    brief: "Original brief",
+    attachmentsFromPrevious: false,
+    outputKind: "implementation",
+  });
+  const fixture = patchFixture(description);
+
+  const result = await patchTask(fixture.db, "task-1", { description: "Operator-edited brief" });
+
+  assert.ok("task" in result);
+  const written = fixture.update()?.description;
+  assert.equal(typeof written, "string");
+  assert.deepEqual(readBrief(written as string), {
+    prompt: "Implement the Specification of record.",
+    brief: "Operator-edited brief",
+    hadReminder: false,
+  });
+  assert.match(written as string, /Persist the final implementation output/u);
+});
+
+test("a template Chain description patch refuses an unparseable stored brief", async () => {
+  const fixture = patchFixture("operator-corrupted description");
+
+  const result = await patchTask(fixture.db, "task-1", { description: "Replacement brief" });
+
+  assert.deepEqual(result, {
+    reason: "invalid-request",
+    message: "Cannot rewrite task brief: task brief marker is missing",
+  });
+  assert.equal(fixture.update(), null);
+});

--- a/packages/api/src/task-patch.ts
+++ b/packages/api/src/task-patch.ts
@@ -18,6 +18,7 @@ import type { TaskPatchInput } from "./app.js";
 import { blockingPredecessor } from "./chain.js";
 import { type Refusal, refusalFor } from "./refusal.js";
 import { validateSchedule } from "./scheduler.js";
+import { rewriteBrief } from "./task-brief.js";
 import {
   hasActiveRun,
   isLiveStatus,
@@ -146,8 +147,30 @@ export const patchTask = async (
       return { reason: "invalid-request", message: error instanceof Error ? error.message : "Invalid schedule" };
     }
   }
+  let patch = body;
+  if (body.description !== undefined && before.templateId != null && before.chainId != null) {
+    const templateStep = before.templateStepId
+      ? await db.taskTemplateStep.findUnique({
+        where: { id: before.templateStepId },
+        select: { priorOutputKinds: true },
+      })
+      : null;
+    if (!templateStep) {
+      return { reason: "invalid-request", message: "Cannot rewrite task brief: template Step metadata is missing" };
+    }
+    const rewritten = rewriteBrief(before.description, body.description, {
+      legacyAttachmentsFromPrevious: templateStep.priorOutputKinds.length > 0,
+    });
+    if (typeof rewritten !== "string") {
+      return {
+        reason: "invalid-request",
+        message: `Cannot rewrite task brief: ${rewritten.unparseable}`,
+      };
+    }
+    patch = { ...body, description: rewritten };
+  }
   const updateData = {
-    ...withoutUndefined(body),
+    ...withoutUndefined(patch),
     ...(scheduleTouched ? schedule : {}),
   } as Prisma.TaskUncheckedUpdateInput;
   // A status write joins the Task-row mutex, like start / retry / archive /

--- a/packages/api/src/task-patch.ts
+++ b/packages/api/src/task-patch.ts
@@ -18,7 +18,7 @@ import type { TaskPatchInput } from "./app.js";
 import { blockingPredecessor } from "./chain.js";
 import { type Refusal, refusalFor } from "./refusal.js";
 import { validateSchedule } from "./scheduler.js";
-import { rewriteBrief } from "./task-brief.js";
+import { rewriteBrief, stepHasTaskBrief } from "./task-brief.js";
 import {
   hasActiveRun,
   isLiveStatus,
@@ -148,26 +148,30 @@ export const patchTask = async (
     }
   }
   let patch = body;
-  if (body.description !== undefined && before.templateId != null && before.chainId != null) {
+  if (body.description !== undefined
+    && before.templateId != null
+    && before.chainId != null) {
     const templateStep = before.templateStepId
       ? await db.taskTemplateStep.findUnique({
         where: { id: before.templateStepId },
-        select: { priorOutputKinds: true },
+        select: { outputKind: true, priorOutputKinds: true },
       })
       : null;
     if (!templateStep) {
       return { reason: "invalid-request", message: "Cannot rewrite task brief: template Step metadata is missing" };
     }
-    const rewritten = rewriteBrief(before.description, body.description, {
-      legacyAttachmentsFromPrevious: templateStep.priorOutputKinds.length > 0,
-    });
-    if (typeof rewritten !== "string") {
-      return {
-        reason: "invalid-request",
-        message: `Cannot rewrite task brief: ${rewritten.unparseable}`,
-      };
+    if (stepHasTaskBrief(templateStep.outputKind)) {
+      const rewritten = rewriteBrief(before.description, body.description, {
+        legacyAttachmentsFromPrevious: templateStep.priorOutputKinds.length > 0,
+      });
+      if (typeof rewritten !== "string") {
+        return {
+          reason: "invalid-request",
+          message: `Cannot rewrite task brief: ${rewritten.unparseable}`,
+        };
+      }
+      patch = { ...body, description: rewritten };
     }
-    patch = { ...body, description: rewritten };
   }
   const updateData = {
     ...withoutUndefined(patch),

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -18,9 +18,9 @@ import {
 
 import {
   composeTemplateTaskDescription,
-  featureBriefFromTaskDescription,
   instantiateTemplate,
 } from "./templates.js";
+import { readBrief } from "./task-brief.js";
 import { isTemplateInstantiationRefusal } from "./template-errors.js";
 
 test("composed task descriptions derive the prior-output reminder from declared kinds", () => {
@@ -32,7 +32,10 @@ test("composed task descriptions derive the prior-output reminder from declared 
       priorOutputKinds,
       outputKind: "implementation",
     });
-    assert.equal(featureBriefFromTaskDescription(description, priorOutputKinds.length > 0), featureBrief);
+    const parsed = readBrief(description);
+    assert.ok(!("unparseable" in parsed));
+    assert.equal(parsed.brief, featureBrief);
+    assert.equal(parsed.hadReminder, priorOutputKinds.length > 0);
     if (priorOutputKinds.length > 0) assert.match(description, /implementation/u);
     else assert.doesNotMatch(description, /prior template steps/u);
   }
@@ -46,7 +49,9 @@ test("a direct brief ending in the prior-output reminder round-trips without tru
     priorOutputKinds: [],
     outputKind: "implementation",
   });
-  assert.equal(featureBriefFromTaskDescription(description, false), featureBrief);
+  const parsed = readBrief(description);
+  assert.ok(!("unparseable" in parsed));
+  assert.equal(parsed.brief, featureBrief);
 });
 
 test("mechanical cards retain only their canonical prompt while model cards retain generated context", () => {
@@ -63,20 +68,21 @@ test("mechanical cards retain only their canonical prompt while model cards reta
     );
   }
   for (const outputKind of ["regression-verification", "regression-verification-v2", "regression-verification-v3"]) {
-    assert.equal(
-      composeTemplateTaskDescription({ ...common, outputKind }),
-      `${common.prompt}\nFeature brief:\n${common.featureBrief}\nRead the prior template steps' persisted outputs before working.`,
-    );
+    assert.deepEqual(readBrief(composeTemplateTaskDescription({ ...common, outputKind })), {
+      prompt: common.prompt,
+      brief: common.featureBrief,
+      hadReminder: true,
+    });
   }
   const regressionDescription = composeTemplateTaskDescription({
     ...common,
     outputKind: "regression-verification-v2",
   });
-  assert.equal(
-    featureBriefFromTaskDescription(regressionDescription, true),
-    common.featureBrief,
-    "a platform-authored regression output must not make its brief unreadable",
-  );
+  assert.deepEqual(readBrief(regressionDescription), {
+    prompt: common.prompt,
+    brief: common.featureBrief,
+    hadReminder: true,
+  }, "a platform-authored regression output must not make its brief unreadable");
 });
 
 test("instantiating the canonical feature template copies every layer and writes no follow-up links", async () => {

--- a/packages/api/src/templates.ts
+++ b/packages/api/src/templates.ts
@@ -13,10 +13,10 @@ import {
   TaskSource,
   TaskStatus,
   type TriggerFireSource,
-  stepRole,
 } from "@agentos/db";
 
 import { isValidBranchName } from "./branch-name.js";
+import { composeBrief } from "./task-brief.js";
 import { TemplateInstantiationRefusal } from "./template-errors.js";
 import { serializable } from "./transaction.js";
 
@@ -120,59 +120,17 @@ export const interpolate = (source: string, variables: Record<string, string>): 
   (_match, name: string) => variables[name] ?? `{{${name}}}`,
 );
 
-const FEATURE_BRIEF_PREFIX = "\nFeature brief:\n";
-const PRIOR_OUTPUTS_REMINDER = "\nRead the prior template steps' persisted outputs before working.";
-const PERSIST_OUTPUT_PREFIX = "\nPersist the final ";
-const PERSIST_OUTPUT_SUFFIX = " output for this step through the AgentOS task output endpoint.";
-
-const isMechanicalTemplateStep = (outputKind: string): boolean => {
-  const role = stepRole({ outputKind });
-  return role === "readiness" || role === "integrator";
-};
-
-const outputIsPlatformAuthored = (outputKind: string): boolean => {
-  const role = stepRole({ outputKind });
-  return role === "readiness" || role === "integrator" || role === "regression";
-};
-
 export const composeTemplateTaskDescription = (input: {
   prompt: string;
   featureBrief?: string | undefined;
   priorOutputKinds: readonly string[];
   outputKind: string;
-}): string => {
-  // Readiness and merge execution are server-owned mechanical steps. Their
-  // task cards are still useful as a prompt/source preview, but no model reads
-  // the generated brief, predecessor reminder, or output-persistence contract.
-  if (isMechanicalTemplateStep(input.outputKind)) return input.prompt;
-  return [
-    input.prompt,
-    input.featureBrief ? `${FEATURE_BRIEF_PREFIX}${input.featureBrief}` : "",
-    input.priorOutputKinds.length > 0 ? PRIOR_OUTPUTS_REMINDER : "",
-    outputIsPlatformAuthored(input.outputKind)
-      ? ""
-      : `${PERSIST_OUTPUT_PREFIX}${input.outputKind}${PERSIST_OUTPUT_SUFFIX}`,
-  ].join("");
-};
-
-/** Recover exactly the user-authored brief from a platform-composed task description. */
-export const featureBriefFromTaskDescription = (
-  description: string,
-  hasPriorOutputsReminder: boolean,
-): string | null => {
-  const startMarker = description.indexOf(FEATURE_BRIEF_PREFIX);
-  const persistMarker = description.lastIndexOf(PERSIST_OUTPUT_PREFIX);
-  if (startMarker < 0) return null;
-  const start = startMarker + FEATURE_BRIEF_PREFIX.length;
-  const endMarker = persistMarker >= start ? persistMarker : description.length;
-  const reminderStart = endMarker - PRIOR_OUTPUTS_REMINDER.length;
-  const end = hasPriorOutputsReminder
-    && reminderStart >= start
-    && description.slice(reminderStart, endMarker) === PRIOR_OUTPUTS_REMINDER
-    ? reminderStart
-    : endMarker;
-  return description.slice(start, end);
-};
+}): string => composeBrief({
+  prompt: input.prompt,
+  brief: input.featureBrief,
+  attachmentsFromPrevious: input.priorOutputKinds.length > 0,
+  outputKind: input.outputKind,
+});
 
 export const isUsableTemplateVariable = (value: string | undefined): value is string => (
   value !== undefined && value.trim().length > 0


### PR DESCRIPTION
## Deliverables
- add a task brief module with `composeBrief`, self-describing `readBrief`, and structure-preserving `rewriteBrief`
- encode new briefs in explicit length-bound fences while keeping the previous marker parser as a migration adapter
- route Specification of record reads and template Chain description patches through the shared interface
- reject unparseable model-authored template Chain description patches as `invalid-request`
- preserve free-form description PATCH behavior for mechanical readiness and integrator Steps, which do not carry generated briefs
- cover operator-edited descriptions, damaged fences, legacy migration, adversarial marker/reminder content, and mechanical Step PATCH behavior

## Validation
- `npm run lint` — PASS
- `npm test -w @agentos/api` — PASS (570 passed, 1 skipped)
- `npm test` — PASS after building the Web artifacts required by its bundle/CSS tests
- `MERGE GATE: PASS c9b166d634b7d0f1603d581aef53fefab857b2c3` — authoritative full Gate, including database tests
- the first Gate on `c37e0b3` exposed a recovery-flow regression for a mechanical Step description PATCH; `c9b166d` fixes it and the exact-head Gate passes

## Decisions made for Leo
- Started from current `main` (`3dd37d3`), which contains requested baseline `7fd6fc5`, because preserving already-integrated concurrent work avoids a stale delivery head.
- Used a UTF-16-length-bound explicit fence instead of delimiter search alone, because a user brief may itself contain fence-like or persistence-contract text and still must round-trip exactly.
- Kept legacy parsing behind an explicit migration hint derived from persisted Step metadata, because the old format cannot distinguish a real reminder from identical user-authored suffix text by description bytes alone.
- Applied `rewriteBrief` only to instantiated template Chain Steps that actually carry a generated brief; ordinary tasks and mechanical readiness/integrator Steps keep free-form PATCH behavior because their descriptions have no brief seam.
- On first successful edit of a legacy description, rewrote it into the fenced format, because migration-on-write removes the ambiguity without a database migration or compatibility layer in callers.
- Preserved the platform-authored prompt, reminder, and persistence suffix during PATCH and treated the submitted `description` as the replacement brief, because that keeps the Specification of record writable without allowing surrounding structure to drift.
- Failed damaged fenced descriptions closed instead of falling back to legacy parsing, because fallback would silently reinterpret corrupted new-format data.
- Added the mechanical-role discriminator to the task brief module rather than duplicating role knowledge in the PATCH action, because the module should own whether a Step has a brief.