### PR TITLE
refactor(api): deepen readiness evaluation seam

### DIFF
--- a/packages/api/src/github-read.test.ts
+++ b/packages/api/src/github-read.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { createGitHubReader, GitHubReadError } from "./github-read.js";
-import { readinessDecision } from "./readiness-decision.js";
 
 test("compare preserves ancestry, rename identity, and fails completeness closed at GitHub's file ceiling", async () => {
   const files = Array.from({ length: 300 }, (_, index) => ({
@@ -60,25 +59,11 @@ test("transport backoff stops immediately when the read deadline aborts", async 
     throw new TypeError("fetch failed");
   })!;
 
-  let failure: GitHubReadError | null = null;
   await assert.rejects(
     reader.compareCommits!("owner/repo", "a".repeat(40), "b".repeat(40), deadline.signal),
-    (error: unknown) => {
-      if (!(error instanceof GitHubReadError)) return false;
-      failure = error;
-      return error.kind === "timeout";
-    },
+    (error: unknown) => error instanceof GitHubReadError && error.kind === "timeout",
   );
   assert.equal(calls, 1);
-  assert.deepEqual(readinessDecision({
-    readiness: { id: "readiness", chainId: "chain", projectId: "project", repoId: "repo" },
-    now: new Date("2026-08-27T00:00:00.000Z"),
-    stage: "read-failed",
-    failure: { kind: failure!.kind, message: failure!.message },
-  }), {
-    kind: "defer",
-    reason: "readiness evaluation failed: GitHub read aborted at its deadline",
-  });
 });
 
 test("claim-side file reads are single-shot so the outer claim policy owns retries", async () => {

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -21,10 +21,10 @@ import {
 
 import { lockTaskMutationRows } from "./task-write.js";
 import { openDefenseAuditNotice } from "./merge-tail-actions.js";
-import { evidenceFromSnapshot } from "./merge-evidence-worker.js";
-import { createGitHubReader, GitHubReadError, type PullRequestReader } from "./github-read.js";
+import { createGitHubReader, type PullRequestReader } from "./github-read.js";
 import {
-  readinessDecision,
+  evaluateReadiness,
+  READINESS_READ_BUDGET_MS,
   type ReadinessDecision,
   type ReadinessInput,
 } from "./readiness-decision.js";
@@ -41,7 +41,7 @@ export const readinessPollIntervalMs = (): number => {
 };
 
 const READINESS_CLAIM_PREFIX = "merge-readiness-claim:";
-export const READINESS_READ_BUDGET_MS = 20_000;
+export { READINESS_READ_BUDGET_MS };
 export const READINESS_CLAIM_LEASE_MS = 60_000;
 const READINESS_CANDIDATE_INCLUDE = {
   templateStep: { include: { taskTemplate: { select: { name: true } } } },
@@ -294,7 +294,6 @@ const decisionContext = (readiness: ReadinessCandidate, now: Date) => ({
 
 const readReadiness = async (
   db: PrismaClient,
-  reader: PullRequestReader | null,
   readiness: ReadinessCandidate,
   now: Date,
 ): Promise<ReadinessRead> => {
@@ -329,7 +328,6 @@ const readReadiness = async (
   if (claimed.count !== 1) return { claimed: false, input: { ...context, stage: "claim-lost" } };
 
   let recovery: RecoveryContext | null = null;
-  let timer: ReturnType<typeof setTimeout> | null = null;
   try {
     recovery = await recoveryContextFor(db, regression.id, readiness.id, regression.runs[0]?.id ?? null);
     if (recovery) {
@@ -354,60 +352,18 @@ const readReadiness = async (
       || regression.stepOutput.commitSha !== verdict.verdict.headSha) {
       return claimedRead({ ...context, stage: "invalid-regression-evidence" });
     }
-    if (!reader?.compareCommits) {
-      return claimedRead({ ...context, stage: "reader-unavailable" });
-    }
     const target = await db.$transaction((tx) => resolveChainTarget(tx, readiness));
-    if (!target.resolved) {
-      return claimedRead({ ...context, stage: "target-unresolved", unresolvable: target.unresolvable });
-    }
-
-    const controller = new AbortController();
-    timer = setTimeout(() => controller.abort(), READINESS_READ_BUDGET_MS);
-    const snapshot = await reader.readPullRequest(
-      target.repository,
-      target.prNumber,
-      readiness.repo?.defaultBranch ?? "main",
-      controller.signal,
-    );
-    const readyInput = (
-      values: Partial<Extract<ReadinessInput, { stage: "ready" }>> = {},
-    ): ClaimedReadiness => claimedRead({
+    return claimedRead({
       ...context,
       stage: "ready",
       regression: {
         headSha: verdict.verdict.headSha,
         baseHeadSha: verdict.verdict.baseHeadSha,
       },
-      target: { repository: target.repository, prNumber: target.prNumber },
-      snapshot,
-      comparison: null,
-      evidence: null,
-      ...values,
-    });
-    if (snapshot.headRefOid !== verdict.verdict.headSha
-      || !snapshot.baseSha
-      || !snapshot.baseRefName
-      || snapshot.baseSha !== verdict.verdict.baseHeadSha) {
-      return readyInput();
-    }
-    const comparison = await reader.compareCommits(
-      target.repository,
-      snapshot.baseSha,
-      verdict.verdict.headSha,
-      controller.signal,
-    );
-    if (!comparison.filesComplete
-      || ((comparison.status !== "ahead" && comparison.status !== "identical")
-        || comparison.behindBy !== 0)) {
-      return readyInput({ comparison });
-    }
-    return readyInput({
-      comparison,
-      evidence: evidenceFromSnapshot(snapshot, randomUUID()),
+      target,
+      defaultBranch: readiness.repo?.defaultBranch ?? "main",
     });
   } catch (error: unknown) {
-    const kind = error instanceof GitHubReadError ? error.kind : "unexpected";
     const message = error instanceof Error ? error.message : String(error);
     return {
       claimed: true,
@@ -415,10 +371,8 @@ const readReadiness = async (
       regression,
       recovery,
       claimReason,
-      input: { ...context, stage: "read-failed", failure: { kind, message } },
+      input: { ...context, stage: "read-failed", failure: { kind: "unexpected", message } },
     };
-  } finally {
-    if (timer) clearTimeout(timer);
   }
 };
 
@@ -634,8 +588,8 @@ export const readinessTick = async (
     if (result.claimed >= limit) break;
     if (!isMergeReadinessStep(readiness.templateStep)) continue;
 
-    const read = await readReadiness(db, reader, readiness, now);
-    const decision = readinessDecision(read.input);
+    const read = await readReadiness(db, readiness, now);
+    const decision = await evaluateReadiness(reader, read.input);
     if (!read.claimed) continue;
     result.claimed += 1;
     try {

--- a/packages/api/src/readiness-decision.test.ts
+++ b/packages/api/src/readiness-decision.test.ts
@@ -3,8 +3,8 @@ import test from "node:test";
 
 import type { MergeEvidence } from "@agentos/db";
 
-import { readinessDecision, type ReadinessInput } from "./readiness-decision.js";
-import type { PullRequestSnapshot } from "./github-read.js";
+import { evaluateReadiness, type ReadinessInput } from "./readiness-decision.js";
+import { GitHubReadError, type PullRequestReader, type PullRequestSnapshot } from "./github-read.js";
 
 const HEAD = "a".repeat(40);
 const BASE = "b".repeat(40);
@@ -34,7 +34,7 @@ const snapshot = (overrides: Partial<PullRequestSnapshot> = {}): PullRequestSnap
 });
 
 const evidence: MergeEvidence = {
-  schemaVersion: 2,
+  schemaVersion: 1,
   nonce: "nonce",
   repository: "mosonlab/agentos",
   prNumber: 42,
@@ -51,19 +51,38 @@ const context = {
   now: NOW,
 } as const;
 
-const ready = (overrides: Partial<Extract<ReadinessInput, { stage: "ready" }>> = {}): Extract<ReadinessInput, { stage: "ready" }> => ({
+const ready = (): Extract<ReadinessInput, { stage: "ready" }> => ({
   ...context,
   stage: "ready",
   regression: { headSha: HEAD, baseHeadSha: BASE },
-  target: { repository: "mosonlab/agentos", prNumber: 42 },
-  snapshot: snapshot(),
-  comparison: { status: "ahead", behindBy: 0, filesComplete: true, files: [] },
-  evidence,
-  ...overrides,
+  target: { resolved: true, repository: "mosonlab/agentos", prNumber: 42 },
+  defaultBranch: "main",
 });
 
-test("authorize carries the exact head evidence into apply", () => {
-  assert.deepEqual(readinessDecision(ready()), {
+type Comparison = Awaited<ReturnType<NonNullable<PullRequestReader["compareCommits"]>>>;
+
+const compared: Comparison = {
+  status: "ahead",
+  behindBy: 0,
+  filesComplete: true,
+  files: [],
+};
+
+const reader = (values: {
+  snapshot?: PullRequestSnapshot;
+  comparison?: Comparison;
+} = {}): PullRequestReader => ({
+  readPullRequest: async () => values.snapshot ?? snapshot(),
+  compareCommits: async () => values.comparison ?? compared,
+});
+
+test("authorize carries the exact head evidence into apply", async () => {
+  const decision = await evaluateReadiness(reader(), ready());
+  assert.equal(decision.kind, "authorize");
+  if (decision.kind !== "authorize") return;
+  assert.equal(typeof decision.evidence.nonce, "string");
+  assert.deepEqual({ ...decision.evidence, nonce: "nonce" }, evidence);
+  assert.deepEqual({ ...decision, evidence: { ...decision.evidence, nonce: "nonce" } }, {
     kind: "authorize",
     evidence,
     repository: "mosonlab/agentos",
@@ -75,63 +94,96 @@ test("authorize carries the exact head evidence into apply", () => {
   });
 });
 
-test("a defense-list path authorizes the merge and is reported as audit triggers", () => {
+test("a defense-list path authorizes the merge and is reported as audit triggers", async () => {
   // The defence list used to hold the merge for a blind review. It now only
   // names what a human would want to have seen move, and the merge proceeds.
-  const decision = readinessDecision(ready({
+  const decision = await evaluateReadiness(reader({
     comparison: {
-      status: "ahead",
-      behindBy: 0,
-      filesComplete: true,
+      ...compared,
       files: [{ filename: "packages/api/src/app.ts", previousFilename: null, patch: null }],
     },
-  }));
+  }), ready());
   assert.equal(decision.kind, "authorize");
   assert.deepEqual(decision.kind === "authorize" ? decision.auditTriggers : null, [
     { path: "packages/api/src/app.ts", reason: "merge-tail-machinery" },
   ]);
 });
 
-test("head drift requeues Regression", () => {
-  const decision = readinessDecision(ready({ snapshot: snapshot({ headRefOid: "c".repeat(40) }) }));
+test("head drift requeues Regression without comparing commits", async () => {
+  const calls: string[] = [];
+  const recordingReader: PullRequestReader = {
+    readPullRequest: async () => {
+      calls.push("readPullRequest");
+      return snapshot({ headRefOid: "c".repeat(40) });
+    },
+    compareCommits: async () => {
+      calls.push("compareCommits");
+      return compared;
+    },
+  };
+  const decision = await evaluateReadiness(recordingReader, ready());
   assert.equal(decision.kind, "requeue-regression");
-  assert.match(decision.reason, /stale PASS head/u);
+  assert.match(decision.kind === "requeue-regression" ? decision.reason : "", /stale PASS head/u);
+  assert.deepEqual(calls, ["readPullRequest"]);
 });
 
-test("timeout and transport failures defer without a terminal stop", () => {
-  for (const kind of ["timeout", "transport"] as const) {
-    assert.deepEqual(readinessDecision({
-      ...context,
-      stage: "read-failed",
-      failure: { kind, message: `${kind} failure` },
-    }), {
-      kind: "defer",
-      reason: `readiness evaluation failed: ${kind} failure`,
-    });
+test("timeout and transport failures defer from either remote read", async () => {
+  for (const phase of ["readPullRequest", "compareCommits"] as const) {
+    for (const kind of ["timeout", "transport"] as const) {
+      const failingReader: PullRequestReader = {
+        readPullRequest: async () => {
+          if (phase === "readPullRequest") throw new GitHubReadError(`${kind} failure`, kind);
+          return snapshot();
+        },
+        compareCommits: async () => {
+          if (phase === "compareCommits") throw new GitHubReadError(`${kind} failure`, kind);
+          return compared;
+        },
+      };
+      assert.deepEqual(await evaluateReadiness(failingReader, ready()), {
+        kind: "defer",
+        reason: `readiness evaluation failed: ${kind} failure`,
+      });
+    }
   }
 });
 
-test("deterministic GitHub response failures stop", () => {
-  const decision = readinessDecision({
-    ...context,
-    stage: "read-failed",
-    failure: { kind: "response", message: "malformed comparison" },
+test("a reader without commit comparison stops before reading the pull request", async () => {
+  let reads = 0;
+  const incompleteReader: PullRequestReader = {
+    readPullRequest: async () => {
+      reads += 1;
+      return snapshot();
+    },
+  };
+  assert.deepEqual(await evaluateReadiness(incompleteReader, ready()), {
+    kind: "stop",
+    condition: "github-reader-unavailable",
+    evidence: "server-side GitHub comparison reader is unavailable",
   });
-  assert.deepEqual(decision, {
+  assert.equal(reads, 0);
+});
+
+test("deterministic GitHub response failures stop", async () => {
+  const failingReader: PullRequestReader = {
+    readPullRequest: async () => { throw new GitHubReadError("malformed comparison", "response"); },
+    compareCommits: async () => compared,
+  };
+  assert.deepEqual(await evaluateReadiness(failingReader, ready()), {
     kind: "stop",
     condition: "readiness-read-failed",
     evidence: "readiness evaluation failed: malformed comparison",
   });
 });
 
-test("an unclaimed candidate skips", () => {
-  assert.deepEqual(readinessDecision({ ...context, stage: "claim-lost" }), { kind: "skip" });
+test("an unclaimed candidate skips", async () => {
+  assert.deepEqual(await evaluateReadiness(null, { ...context, stage: "claim-lost" }), { kind: "skip" });
 });
 
-test("an incomplete comparison is a named stop", () => {
-  const decision = readinessDecision(ready({
-    comparison: { status: "ahead", behindBy: 0, filesComplete: false, files: [] },
-  }));
+test("an incomplete comparison is a named stop", async () => {
+  const decision = await evaluateReadiness(reader({
+    comparison: { ...compared, filesComplete: false },
+  }), ready());
   assert.equal(decision.kind, "stop");
-  assert.equal(decision.condition, "comparison-incomplete");
+  assert.equal(decision.kind === "stop" ? decision.condition : null, "comparison-incomplete");
 });

--- a/packages/api/src/readiness-decision.ts
+++ b/packages/api/src/readiness-decision.ts
@@ -1,17 +1,9 @@
-import {
-  defenseTriggers,
-  type ChangedFile,
-  type MergeEvidence,
-} from "@agentos/db";
+import { randomUUID } from "node:crypto";
 
-import type { GitHubReadError, PullRequestSnapshot } from "./github-read.js";
+import { defenseTriggers, type MergeEvidence } from "@agentos/db";
 
-type Comparison = {
-  status: "ahead" | "behind" | "diverged" | "identical";
-  behindBy: number;
-  filesComplete: boolean;
-  files: ChangedFile[];
-};
+import { evidenceFromSnapshot } from "./merge-evidence-worker.js";
+import { GitHubReadError, type PullRequestReader } from "./github-read.js";
 
 type ReadinessContext = {
   readiness: {
@@ -28,12 +20,12 @@ type RegressionPass = {
   baseHeadSha: string;
 };
 
+export const READINESS_READ_BUDGET_MS = 20_000;
+
 export type ReadinessInput = ReadinessContext & (
   | { stage: "claim-lost" | "regression-pending" }
   | { stage: "missing-regression-evidence" }
   | { stage: "invalid-regression-evidence" }
-  | { stage: "reader-unavailable" }
-  | { stage: "target-unresolved"; unresolvable: "none" | "ambiguous" | "repository" }
   | {
       stage: "read-failed";
       failure: {
@@ -44,10 +36,10 @@ export type ReadinessInput = ReadinessContext & (
   | {
       stage: "ready";
       regression: RegressionPass;
-      target: { repository: string; prNumber: number };
-      snapshot: PullRequestSnapshot;
-      comparison: Comparison | null;
-      evidence: MergeEvidence | { error: string } | null;
+      target:
+        | { resolved: true; repository: string; prNumber: number }
+        | { resolved: false; unresolvable: "none" | "ambiguous" | "repository" };
+      defaultBranch: string;
     }
 );
 
@@ -80,7 +72,26 @@ const stop = (condition: string, evidence: string): ReadinessDecision => (
   { kind: "stop", condition, evidence }
 );
 
-export const readinessDecision = (input: ReadinessInput): ReadinessDecision => {
+const readFailureDecision = (failure: {
+  kind: GitHubReadError["kind"] | "unexpected";
+  message: string;
+}): ReadinessDecision => {
+  const evidence = `readiness evaluation failed: ${failure.message}`;
+  if (failure.kind === "timeout" || failure.kind === "transport") {
+    return { kind: "defer", reason: evidence };
+  }
+  return stop("readiness-read-failed", evidence);
+};
+
+/**
+ * Owns the complete remote-read sequence and the decision derived from it.
+ * The worker supplies durable facts and applies the result; this module alone
+ * decides which GitHub facts are needed and when a later read can be skipped.
+ */
+export const evaluateReadiness = async (
+  facts: PullRequestReader | null,
+  input: ReadinessInput,
+): Promise<ReadinessDecision> => {
   switch (input.stage) {
     case "claim-lost":
     case "regression-pending":
@@ -89,74 +100,90 @@ export const readinessDecision = (input: ReadinessInput): ReadinessDecision => {
       return stop("regression-evidence-missing", "missing head-bound regression PASS evidence");
     case "invalid-regression-evidence":
       return stop("regression-evidence-invalid", "missing or stale head-bound regression PASS evidence");
-    case "reader-unavailable":
-      return stop("github-reader-unavailable", "server-side GitHub comparison reader is unavailable");
-    case "target-unresolved":
-      return stop("pull-request-target-unresolved", `pull-request target is ${input.unresolvable}`);
-    case "read-failed": {
-      const evidence = `readiness evaluation failed: ${input.failure.message}`;
-      if (input.failure.kind === "timeout" || input.failure.kind === "transport") {
-        return { kind: "defer", reason: evidence };
-      }
-      return stop("readiness-read-failed", evidence);
-    }
+    case "read-failed":
+      return readFailureDecision(input.failure);
     case "ready":
       break;
   }
 
-  const { regression, snapshot } = input;
-  if (snapshot.headRefOid !== regression.headSha) {
-    return {
-      kind: "requeue-regression",
-      staleBaseSha: regression.baseHeadSha,
-      currentBaseSha: snapshot.baseSha ?? "missing",
-      reason: `stale PASS head ${regression.headSha}; current PR head is ${snapshot.headRefOid ?? "missing"}`,
-    };
+  if (!facts?.compareCommits) {
+    return stop("github-reader-unavailable", "server-side GitHub comparison reader is unavailable");
   }
-  if (!snapshot.baseSha || !snapshot.baseRefName) {
-    return stop("pull-request-base-missing", "pull request base identity is unavailable");
-  }
-  if (snapshot.baseSha !== regression.baseHeadSha) {
-    return {
-      kind: "requeue-regression",
-      staleBaseSha: regression.baseHeadSha,
-      currentBaseSha: snapshot.baseSha,
-      reason: "target base advanced after regression PASS",
-    };
-  }
-  const comparison = input.comparison;
-  if (!comparison) {
-    return stop("readiness-facts-incomplete", "server-side comparison facts are unavailable");
-  }
-  if (!comparison.filesComplete) {
-    return stop(
-      "comparison-incomplete",
-      "GitHub comparison file list is truncated or completeness is unproven",
-    );
-  }
-  if ((comparison.status !== "ahead" && comparison.status !== "identical") || comparison.behindBy !== 0) {
-    return {
-      kind: "requeue-regression",
-      staleBaseSha: regression.baseHeadSha,
-      currentBaseSha: snapshot.baseSha,
-      reason: `server-side ancestry check refused ${comparison.status} comparison with behind_by=${comparison.behindBy}`,
-    };
+  if (!input.target.resolved) {
+    return stop("pull-request-target-unresolved", `pull-request target is ${input.target.unresolvable}`);
   }
 
-  if (!input.evidence) {
-    return stop("readiness-facts-incomplete", "merge evidence facts are unavailable");
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), READINESS_READ_BUDGET_MS);
+  try {
+    const snapshot = await facts.readPullRequest(
+      input.target.repository,
+      input.target.prNumber,
+      input.defaultBranch,
+      controller.signal,
+    );
+    if (snapshot.headRefOid !== input.regression.headSha) {
+      return {
+        kind: "requeue-regression",
+        staleBaseSha: input.regression.baseHeadSha,
+        currentBaseSha: snapshot.baseSha ?? "missing",
+        reason: `stale PASS head ${input.regression.headSha}; current PR head is ${snapshot.headRefOid ?? "missing"}`,
+      };
+    }
+    if (!snapshot.baseSha || !snapshot.baseRefName) {
+      return stop("pull-request-base-missing", "pull request base identity is unavailable");
+    }
+    if (snapshot.baseSha !== input.regression.baseHeadSha) {
+      return {
+        kind: "requeue-regression",
+        staleBaseSha: input.regression.baseHeadSha,
+        currentBaseSha: snapshot.baseSha,
+        reason: "target base advanced after regression PASS",
+      };
+    }
+
+    const comparison = await facts.compareCommits(
+      input.target.repository,
+      snapshot.baseSha,
+      input.regression.headSha,
+      controller.signal,
+    );
+    if (!comparison.filesComplete) {
+      return stop(
+        "comparison-incomplete",
+        "GitHub comparison file list is truncated or completeness is unproven",
+      );
+    }
+    if ((comparison.status !== "ahead" && comparison.status !== "identical")
+      || comparison.behindBy !== 0) {
+      return {
+        kind: "requeue-regression",
+        staleBaseSha: input.regression.baseHeadSha,
+        currentBaseSha: snapshot.baseSha,
+        reason: `server-side ancestry check refused ${comparison.status} comparison with behind_by=${comparison.behindBy}`,
+      };
+    }
+
+    const evidence = evidenceFromSnapshot(snapshot, randomUUID());
+    if ("error" in evidence) {
+      return stop("merge-evidence-invalid", evidence.error);
+    }
+    return {
+      kind: "authorize",
+      evidence,
+      repository: input.target.repository,
+      prNumber: input.target.prNumber,
+      issuedAt: input.now.toISOString(),
+      baseSha: snapshot.baseSha,
+      headSha: input.regression.headSha,
+      auditTriggers: defenseTriggers(comparison.files),
+    };
+  } catch (error: unknown) {
+    return readFailureDecision({
+      kind: error instanceof GitHubReadError ? error.kind : "unexpected",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    clearTimeout(timer);
   }
-  if ("error" in input.evidence) {
-    return stop("merge-evidence-invalid", input.evidence.error);
-  }
-  return {
-    kind: "authorize",
-    evidence: input.evidence,
-    repository: input.target.repository,
-    prNumber: input.target.prNumber,
-    issuedAt: input.now.toISOString(),
-    baseSha: snapshot.baseSha,
-    headSha: regression.headSha,
-    auditTriggers: defenseTriggers(comparison.files),
-  };
 };


### PR DESCRIPTION
## 交付物

- 将 readiness module 的 interface 深化为 async `evaluateReadiness(PullRequestReader, input)`，统一拥有 `readPullRequest -> drift checks -> compareCommits -> completeness/ancestry -> evidence -> decision` 的完整顺序。
- 从 worker 删除 `readReadiness` 中的 GitHub 读取和影子谓词；worker 仅保留 candidate scan、claim、Recovery facts、renew 与 apply。
- 将 20 秒 remote read deadline 下移到 evaluator，使是否继续读取成为 module implementation，而非 caller 的平行规则。
- 迁移原有 7 个 decision 测试语义，并用 recording fake 断言 head drift 时 `readPullRequest=1`、`compareCommits=0`；补钉 optional compare 缺失和 compare 阶段错误分类。

## 验收结果

- `npm run lint`: PASS
- targeted unit tests (`readiness-decision`, `merge-readiness-worker`, `github-read`): PASS, 20/20
- `npm run test:db -w @agentos/api -- src/merge-tail-readiness.dbtest.ts`: PASS, 16/16（独立 disposable PostgreSQL）
- fresh-eyes review: 无 correctness/regression finding；确认 `stopReadiness` 与 `applyReadinessDecision` 的 Lease disposition 无 diff
- `npm test`: 两次执行；API/DB/runner 等相关 suites 通过。第二次 Web suite 483/484，通过 production build 前置后仅 `onboarding.test.tsx` 的 timing boundary flake 失败；本车道未改 Web。exact-head merge gate: `MERGE GATE: PASS be8945980dc04a2ec2a73f698e12300a64d36836`。

## 我替 Leo 做的选择

1. 在现有 `readiness-decision.ts` 内深化 module，不重命名文件：减少与并行车道的无意义文件级冲突，同时删除旧 `readinessDecision` interface。
2. 保留 `PullRequestReader.compareCommits` optional：`merge-base-drift-worker` 仍依赖 unavailable 语义，收紧 port 会越过车道 D 文件域；evaluator 在 interface 内 fail closed。
3. 把 deadline 与 AbortController 一并下移：读的顺序和“何时不再读”是 evaluation implementation 的一部分。
4. 复用现有纯 `evidenceFromSnapshot`：避免为单一实现新增 speculative seam，也不扩写冲突矩阵外的 `merge-evidence-worker.ts`。
5. DB/claim/Recovery facts 留在 worker：这些是 orchestration 职责；evaluator 只消费 durable input 并通过 port 读取 remote facts。
6. 将 unresolved target 作为 evaluator input，而非 worker 直接判决：既保持 reader-unavailable 优先级，又让 readiness decision 只存在于一个 module。
7. 随机 nonce 留在 implementation 内，测试只归一化其值：不为测试扩大 production interface。
8. 保留 `claim-lost -> skip` 语义：存量 7 个 decision 测试的行为原样存活，且不会触发 remote read。
