### PR TITLE
refactor(runner): deepen control plane seams

### DIFF
--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -8,12 +8,12 @@ import { pathToFileURL } from "node:url";
 import test from "node:test";
 
 import {
-  adapterExecutionSucceeded, adapters, argsForRunner, buildChildEnvironment, buildPrompt, CODEX_STARTER_MODEL, createAdapterState, failureReasonFromEvidence,
+  adapterExecutionSucceeded, adapters, argsForRunner, buildChildEnvironment, buildPrompt, createAdapterState, failureReasonFromEvidence,
   claudePlatformSettingsPath, inputForRunner, launchArgv, mcpConfig, mcpServerPath, nodeBinaryPath, piExtensionPath,
   PREFLIGHT_REASONS, RUNNER_DEFINITIONS, RUNNER_KINDS, runtimeDescriptor, type AdapterState, type ExitEvidence,
 } from "./adapters.js";
 import { parseClaudeTranscript } from "./adapters/claude.js";
-import { parseCodexEvent, parseCodexTranscript } from "./adapters/codex.js";
+import { CODEX_STARTER_MODEL, parseCodexEvent, parseCodexTranscript } from "./adapters/codex.js";
 import { parsePiTranscript } from "./adapters/pi.js";
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
@@ -1618,4 +1618,18 @@ test("an adapter is substituted by injection, never by writing over the exported
   assert.notEqual(adapters.CODEX.kill, adapters.PI.kill);
   assert.notEqual(adapters.CLAUDE.classifyError, adapters.CODEX.classifyError);
   assert.notEqual(adapters.CODEX.classifyError, adapters.PI.classifyError);
+});
+
+test("the runner registry owns session isolation and startup preflight model identity", () => {
+  assert.deepEqual(
+    Object.fromEntries(RUNNER_KINDS.map((runner) => [runner, {
+      isolatesSessionConfig: RUNNER_DEFINITIONS[runner].isolatesSessionConfig,
+      startupPreflightModel: RUNNER_DEFINITIONS[runner].startupPreflightModel,
+    }])),
+    {
+      CLAUDE: { isolatesSessionConfig: false, startupPreflightModel: null },
+      CODEX: { isolatesSessionConfig: true, startupPreflightModel: CODEX_STARTER_MODEL },
+      PI: { isolatesSessionConfig: true, startupPreflightModel: "openai-codex/gpt-5.6-luna" },
+    },
+  );
 });

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -12,14 +12,12 @@ import { isTransientNetworkError } from "./network-retry.js";
 import type { AgentScratch } from "./workspace.js";
 import { createClaudeAdapter, claudeArgs, claudeChildEnvironment, provisionClaudeSessionConfig } from "./adapters/claude.js";
 import {
-  codexArgs, codexChildEnvironment, codexNativeSubagentProfile, codexPlatformBaselinePath, createCodexAdapter,
+  CODEX_STARTER_MODEL, codexArgs, codexChildEnvironment, codexNativeSubagentProfile, codexPlatformBaselinePath, createCodexAdapter,
   provisionCodexSessionConfig,
 } from "./adapters/codex.js";
 import { workspaceEnvironment } from "./adapters/environment.js";
 import { createPiAdapter, piArgs, piChildEnvironment, provisionPiSessionConfig } from "./adapters/pi.js";
 import type { SessionConfigOptions } from "./adapters/session-config.js";
-
-export { CODEX_STARTER_MODEL } from "./adapters/codex.js";
 
 export const ADAPTER_VERSION = "2.1.0";
 
@@ -394,7 +392,7 @@ export type RuntimeHandle = AdapterState & {
 export type PreflightSpec = {
   config: RunnerConfig;
   runner: RunnerKind;
-  model: string;
+  model: string | null;
   env: NodeJS.ProcessEnv;
 };
 
@@ -853,6 +851,10 @@ export type RunnerDefinition = {
   toolTransport: "mcp-stdio" | "pi-extension";
   toolEntrypoint(): string;
   adapter: CliAdapter;
+  /** Whether this CLI owns a per-Session config root outside disposable scratch. */
+  isolatesSessionConfig: boolean;
+  /** Model identity used only for daemon startup preflight, when that adapter requires one. */
+  startupPreflightModel: string | null;
   args(spec: RunSpec, resume?: ResumeSpec): string[];
   childEnvironment(claim: Pick<ClaimedTask, "run">, scratch: AgentScratch): NodeJS.ProcessEnv;
   provisionSessionConfig(
@@ -890,6 +892,8 @@ export const RUNNER_DEFINITIONS: Readonly<Record<RunnerKind, Readonly<RunnerDefi
     toolTransport: "mcp-stdio",
     toolEntrypoint: mcpServerPath,
     adapter: deferredAdapter(() => createClaudeAdapter()),
+    isolatesSessionConfig: false,
+    startupPreflightModel: null,
     args: (spec, resume) => claudeArgs(spec, resume),
     childEnvironment: (claim, scratch) => claudeChildEnvironment(claim, scratch),
     provisionSessionConfig: (config, scratch, options) => provisionClaudeSessionConfig(config, scratch, options),
@@ -901,6 +905,8 @@ export const RUNNER_DEFINITIONS: Readonly<Record<RunnerKind, Readonly<RunnerDefi
     toolTransport: "mcp-stdio",
     toolEntrypoint: mcpServerPath,
     adapter: deferredAdapter(() => createCodexAdapter()),
+    isolatesSessionConfig: true,
+    startupPreflightModel: CODEX_STARTER_MODEL,
     args: (spec, resume) => codexArgs(spec, resume),
     childEnvironment: (claim, scratch) => codexChildEnvironment(claim, scratch),
     provisionSessionConfig: (config, scratch, options) => provisionCodexSessionConfig(config, scratch, options),
@@ -912,6 +918,8 @@ export const RUNNER_DEFINITIONS: Readonly<Record<RunnerKind, Readonly<RunnerDefi
     toolTransport: "pi-extension",
     toolEntrypoint: piExtensionPath,
     adapter: deferredAdapter(() => createPiAdapter()),
+    isolatesSessionConfig: true,
+    startupPreflightModel: "openai-codex/gpt-5.6-luna",
     args: (spec, resume) => piArgs(spec, resume),
     childEnvironment: (claim, scratch) => piChildEnvironment(claim, scratch),
     provisionSessionConfig: (config, scratch, options) => provisionPiSessionConfig(config, scratch, options),

--- a/packages/runner/src/adapters/claude.ts
+++ b/packages/runner/src/adapters/claude.ts
@@ -129,7 +129,10 @@ const preflight = async (spec: PreflightSpec): Promise<PreflightResult> => {
       error: PREFLIGHT_REASONS.cliIncompatible,
     };
   }
-  Object.assign(capabilities, { verifiedModel: spec.model, cliProtocol: "print-stream-json-user-source-isolated" });
+  Object.assign(capabilities, {
+    ...(spec.model === null ? {} : { verifiedModel: spec.model }),
+    cliProtocol: "print-stream-json-user-source-isolated",
+  });
   const auth = await capturePreflight(spec.config, "CLAUDE", ["auth", "status"], spec.env);
   const text = `${auth.stdout}\n${auth.stderr}`;
   const ok = auth.code === 0 && /"loggedIn"\s*:\s*true/u.test(text);

--- a/packages/runner/src/adapters/codex.ts
+++ b/packages/runner/src/adapters/codex.ts
@@ -178,6 +178,9 @@ const execHelpIsCompatible = (help: string, resumeHelp: string): boolean => [
 
 const preflight = async (spec: PreflightSpec): Promise<PreflightResult> => {
   const capabilities = { structuredEvents: true, resume: true, killProcessGroup: true, heartbeat: true, classifyError: true };
+  if (spec.model === null) {
+    return { ok: false, cliVersion: null, authMode: null, capabilities, error: PREFLIGHT_REASONS.unsupportedModel };
+  }
   const version = await capturePreflight(spec.config, "CODEX", ["--version"], spec.env);
   if (version.code !== 0) {
     return { ok: false, cliVersion: null, authMode: null, capabilities, error: preflightFailure(PREFLIGHT_REASONS.cliMissing, version.code) };

--- a/packages/runner/src/adapters/pi.ts
+++ b/packages/runner/src/adapters/pi.ts
@@ -204,7 +204,7 @@ const helpIsCompatible = (help: string): boolean => [
 
 const preflight = async (spec: PreflightSpec): Promise<PreflightResult> => {
   const capabilities = { structuredEvents: true, resume: true, killProcessGroup: true, heartbeat: true, classifyError: true };
-  if (!spec.model.includes("/")) {
+  if (spec.model === null || !spec.model.includes("/")) {
     return { ok: false, cliVersion: null, authMode: null, capabilities, error: PREFLIGHT_REASONS.unsupportedModel };
   }
   if (spec.model.startsWith("openai-codex/") && spec.env.AGENTOS_RUN_ID

--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -21,6 +21,41 @@ export type CodexServiceTier = "DEFAULT" | "FAST";
 export type CancellationRequest = { requestId: string; reason: string; requestedAt: string };
 export type HeartbeatResult = { ok: boolean; cancellation: CancellationRequest | null };
 
+export class ControlPlaneError extends Error {
+  readonly status: number;
+  readonly code: string | undefined;
+
+  constructor(status: number, responseBody: string, code?: string) {
+    super(`AgentOS API ${status}: ${responseBody}`);
+    this.name = "ControlPlaneError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+/** The runner's domain verdict for whether its current Run authority remains. */
+export type Authority =
+  | { held: true }
+  | { held: false; reason: "revoked" }
+  | { held: false; reason: "waiting-inbox" }
+  | { held: false; reason: "cancelled"; request: CancellationRequest };
+
+export const authorityFor = (error: unknown): Authority => {
+  if (!(error instanceof ControlPlaneError) || error.status !== 409) return { held: true };
+  return error.code === "WAITING_INBOX"
+    ? { held: false, reason: "waiting-inbox" }
+    : { held: false, reason: "revoked" };
+};
+
+export const authorityAfterHeartbeat = (result: HeartbeatResult): Authority =>
+  result.cancellation
+    ? { held: false, reason: "cancelled", request: result.cancellation }
+    : { held: true };
+
+/** Startup may retry transport failures and control-plane 5xx responses only. */
+export const retriableStartupError = (error: unknown): boolean =>
+  !(error instanceof ControlPlaneError) || error.status >= 500;
+
 export type ClaimedTask = {
   /**
    * Server-computed from the claimed task's template step (§D-P1 rule 4).
@@ -162,9 +197,7 @@ const request = async (config: RunnerConfig, path: string, init: RequestInit): P
     const responseBody = await response.text();
     let code: string | undefined;
     try { code = (JSON.parse(responseBody) as { code?: string }).code; } catch { /* non-JSON error */ }
-    const error = new Error(`AgentOS API ${response.status}: ${responseBody}`);
-    Object.assign(error, { status: response.status, code });
-    throw error;
+    throw new ControlPlaneError(response.status, responseBody, code);
   }
   return response;
 };
@@ -465,7 +498,7 @@ export const fetchReclaimPlan = async (
     method: "POST",
     body: JSON.stringify(inventory),
   }).catch((error: unknown) => {
-    if ((error as { status?: number }).status === 404) return null;
+    if (error instanceof ControlPlaneError && error.status === 404) return null;
     throw error;
   });
   return response ? await response.json() as ReclaimPlan : null;
@@ -479,7 +512,7 @@ export const reportReclaimOutcomes = async (
     method: "POST",
     body: JSON.stringify(report),
   }).catch((error: unknown) => {
-    if ((error as { status?: number }).status === 404) return null;
+    if (error instanceof ControlPlaneError && error.status === 404) return null;
     throw error;
   });
 };
@@ -522,3 +555,50 @@ export const reportCliAvailability = async (
   const body = JSON.parse(responseBody) as { revalidatePreflight?: boolean };
   return { revalidatePreflight: body.revalidatePreflight === true };
 };
+
+/**
+ * The runner-to-control-plane seam. The HTTP adapter below owns route paths,
+ * fencing envelopes, timeout translation, and error decoding; callers consume
+ * domain operations and classify authority through this interface.
+ */
+export interface ControlPlane {
+  claim: typeof claimTask;
+  startRun: typeof startRun;
+  heartbeat: typeof heartbeat;
+  appendEvents: typeof appendEvents;
+  appendActivity: typeof appendActivity;
+  completeRun: typeof completeRun;
+  readSessionTaskOutputStatus: typeof readSessionTaskOutputStatus;
+  recordPublishedBranch: typeof recordPublishedBranch;
+  recordLeaseIndependentCleanup: typeof recordLeaseIndependentCleanup;
+  acknowledgeCancellation: typeof acknowledgeCancellation;
+  fetchReclaimPlan: typeof fetchReclaimPlan;
+  reportReclaimOutcomes: typeof reportReclaimOutcomes;
+  recordReclaimPublication: typeof recordReclaimPublication;
+  reportPreflight: typeof reportPreflight;
+  reportCliAvailability: typeof reportCliAvailability;
+  authorityFor(error: unknown): Authority;
+  authorityAfterHeartbeat(result: HeartbeatResult): Authority;
+  retriableStartupError(error: unknown): boolean;
+}
+
+export const controlPlane: ControlPlane = Object.freeze({
+  claim: claimTask,
+  startRun,
+  heartbeat,
+  appendEvents,
+  appendActivity,
+  completeRun,
+  readSessionTaskOutputStatus,
+  recordPublishedBranch,
+  recordLeaseIndependentCleanup,
+  acknowledgeCancellation,
+  fetchReclaimPlan,
+  reportReclaimOutcomes,
+  recordReclaimPublication,
+  reportPreflight,
+  reportCliAvailability,
+  authorityFor,
+  authorityAfterHeartbeat,
+  retriableStartupError,
+});

--- a/packages/runner/src/control-plane.test.ts
+++ b/packages/runner/src/control-plane.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { authorityAfterHeartbeat, authorityFor, ControlPlaneError, retriableStartupError } from "./api.js";
+
+test("ControlPlaneError classifies Run authority without leaking HTTP casts to callers", () => {
+  assert.deepEqual(authorityFor(new ControlPlaneError(409, "stale fence")), {
+    held: false,
+    reason: "revoked",
+  });
+  assert.deepEqual(authorityFor(new ControlPlaneError(409, "suspended", "WAITING_INBOX")), {
+    held: false,
+    reason: "waiting-inbox",
+  });
+  assert.deepEqual(authorityFor(new ControlPlaneError(503, "unavailable")), { held: true });
+  assert.deepEqual(authorityFor(new Error("connection reset")), { held: true });
+});
+
+test("heartbeat cancellation is an Authority verdict with its durable request", () => {
+  const request = { requestId: "cancel-1", reason: "operator stop", requestedAt: new Date(0).toISOString() };
+  assert.deepEqual(authorityAfterHeartbeat({ ok: false, cancellation: request }), {
+    held: false,
+    reason: "cancelled",
+    request,
+  });
+  assert.deepEqual(authorityAfterHeartbeat({ ok: true, cancellation: null }), { held: true });
+});
+
+test("startup retries only transport failures and control-plane server errors", () => {
+  assert.equal(retriableStartupError(new Error("connection reset")), true);
+  assert.equal(retriableStartupError(new ControlPlaneError(503, "unavailable")), true);
+  assert.equal(retriableStartupError(new ControlPlaneError(401, "unauthorized")), false);
+  assert.equal(retriableStartupError(new ControlPlaneError(409, "refused")), false);
+});

--- a/packages/runner/src/dispose-workspace.test.ts
+++ b/packages/runner/src/dispose-workspace.test.ts
@@ -2,13 +2,14 @@ import assert from "node:assert/strict";
 import { access, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test, { afterEach } from "node:test";
+import test from "node:test";
 
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import {
   disposeWorkspace, type WorkspaceDisposalIdentity,
 } from "./dispose-workspace.js";
+import { createControlPlaneDouble } from "./test-control-plane.js";
 
 const config = (workspaceRoot: string): RunnerConfig => ({
   apiUrl: "http://api.invalid",
@@ -28,9 +29,6 @@ const config = (workspaceRoot: string): RunnerConfig => ({
   runAsPrefix: [],
   binaries: { CLAUDE: "claude", CODEX: "codex", PI: "pi" },
 });
-
-const originalFetch = globalThis.fetch;
-afterEach(() => { globalThis.fetch = originalFetch; });
 
 const cases: Array<{ label: string; identity: WorkspaceDisposalIdentity }> = [
   {
@@ -57,9 +55,7 @@ for (const { label, identity } of cases) {
     const workspacePath = join(root, "workspace");
     await mkdir(workspacePath);
     await writeFile(join(workspacePath, "review.txt"), "scratch only\n");
-    globalThis.fetch = (async () => {
-      throw new Error("pinned disposal must not acknowledge a publication");
-    }) as typeof fetch;
+    const controlPlane = createControlPlaneDouble();
 
     const result = await disposeWorkspace(config(root), identity, {
       path: workspacePath,
@@ -69,13 +65,15 @@ for (const { label, identity } of cases) {
     }, {
       alreadyDurable: false,
       retain: false,
-    });
+    }, controlPlane.controlPlane);
 
     assert.deepEqual(result, {
       cleanupStatus: "SUCCEEDED",
       workspaceRetained: false,
       salvage: null,
     });
+    assert.deepEqual(controlPlane.publishedBranches, []);
+    assert.deepEqual(controlPlane.reclaimPublications, []);
     await assert.rejects(access(workspacePath));
   });
 }

--- a/packages/runner/src/dispose-workspace.ts
+++ b/packages/runner/src/dispose-workspace.ts
@@ -1,6 +1,6 @@
 import {
-  appendActivity, recordPublishedBranch, recordReclaimPublication,
-  type ClaimedTask, type CleanupStatus,
+  controlPlane as defaultControlPlane,
+  type ClaimedTask, type CleanupStatus, type ControlPlane,
 } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { salvageWorkspace, type DeliveryResult } from "./delivery.js";
@@ -69,12 +69,13 @@ const acknowledgePublication = async (
   config: RunnerConfig,
   identity: WorkspaceDisposalIdentity,
   pushedBranch: string,
+  controlPlane: ControlPlane,
 ): Promise<void> => {
   if (identity.source === "runner") {
-    await recordPublishedBranch(config, identity.claim, pushedBranch);
+    await controlPlane.recordPublishedBranch(config, identity.claim, pushedBranch);
     return;
   }
-  await recordReclaimPublication(config, {
+  await controlPlane.recordReclaimPublication(config, {
     runnerId: config.runnerId,
     runId: identity.runId,
     pushedBranch,
@@ -85,10 +86,11 @@ const recordNothingToSalvage = async (
   config: RunnerConfig,
   identity: WorkspaceDisposalIdentity,
   reason: string,
+  controlPlane: ControlPlane,
 ): Promise<void> => {
   audit("nothing-to-salvage", identity, { reason });
   if (identity.source !== "runner") return;
-  await appendActivity(config, identity.claim,
+  await controlPlane.appendActivity(config, identity.claim,
     `Workspace disposal verified there was nothing to salvage: ${reason}`,
     { stream: "runner" }).catch((error: unknown) => {
     audit("nothing-to-salvage-activity-failed", identity, { error: errorMessage(error) });
@@ -108,6 +110,7 @@ export const disposeWorkspace = async (
   identity: WorkspaceDisposalIdentity,
   workspace: DisposableWorkspace,
   policy: WorkspaceDisposalPolicy,
+  controlPlane: ControlPlane = defaultControlPlane,
 ): Promise<WorkspaceDisposal> => {
   let salvage: DeliveryResult | null = null;
   if (!policy.alreadyDurable) {
@@ -117,7 +120,7 @@ export const disposeWorkspace = async (
         pinnedBaseSha: workspace.pinnedBaseSha,
       });
     } else if (workspace.baseSha === null) {
-      await recordNothingToSalvage(config, identity, "run never completed provisioning and has no clone base");
+      await recordNothingToSalvage(config, identity, "run never completed provisioning and has no clone base", controlPlane);
     } else {
       let captured: Workspace;
       try {
@@ -146,17 +149,17 @@ export const disposeWorkspace = async (
       }
       if (salvage?.pushedBranch) {
         try {
-          await acknowledgePublication(config, identity, salvage.pushedBranch);
+          await acknowledgePublication(config, identity, salvage.pushedBranch, controlPlane);
         } catch (error: unknown) {
           if (identity.source === "runner") {
-            await appendActivity(config, identity.claim,
+            await controlPlane.appendActivity(config, identity.claim,
               `Salvage ref '${salvage.pushedBranch}' is durable, but its publication ACK failed: ${errorMessage(error)}`,
               { stream: "runner" }).catch(() => undefined);
           }
           return failed(`Salvage publication ACK failed: ${errorMessage(error)}`, salvage);
         }
       } else {
-        await recordNothingToSalvage(config, identity, "clean tree with no commits past the clone base");
+        await recordNothingToSalvage(config, identity, "clean tree with no commits past the clone base", controlPlane);
       }
     }
   }

--- a/packages/runner/src/lease.test.ts
+++ b/packages/runner/src/lease.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import type { ClaimedTask } from "./api.js";
+import { ControlPlaneError, type ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { deliverUnderLease, openDeliveryLease, type LeaseHeartbeat } from "./lease.js";
 import { DELIVERY_LEASE_RESERVE_MS, MIN_DELIVERY_BUDGET_MS } from "./network-retry.js";
@@ -9,7 +9,7 @@ import { DELIVERY_LEASE_RESERVE_MS, MIN_DELIVERY_BUDGET_MS } from "./network-ret
 const config = { leaseSeconds: 60, heartbeatIntervalMs: 30_000 } as unknown as RunnerConfig;
 const claim = { run: { id: "run-1" } } as ClaimedTask;
 
-const rejection = (status: number, code?: string): Error => Object.assign(new Error("rejected"), { status, code });
+const rejection = (status: number, code?: string): Error => new ControlPlaneError(status, "rejected", code);
 
 const openWith = async (send: LeaseHeartbeat, lastRenewalAt = 0, now: () => number = () => 0) =>
   openDeliveryLease(config, claim, lastRenewalAt, { send, now, startedAt: new Date(0) });

--- a/packages/runner/src/lease.ts
+++ b/packages/runner/src/lease.ts
@@ -1,4 +1,11 @@
-import { heartbeat as sendHeartbeat, type CancellationRequest, type ClaimedTask } from "./api.js";
+import {
+  authorityFor as defaultAuthorityFor,
+  authorityAfterHeartbeat as defaultAuthorityAfterHeartbeat,
+  heartbeat as sendHeartbeat,
+  type Authority,
+  type CancellationRequest,
+  type ClaimedTask,
+} from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { deliveryDeadline, type RetryOptions } from "./network-retry.js";
 
@@ -32,9 +39,6 @@ export type DeliveryLease = {
   close: () => void;
 };
 
-const statusOf = (error: unknown): number | undefined => (error as { status?: number }).status;
-const codeOf = (error: unknown): string | undefined => (error as { code?: string }).code;
-
 /**
  * Renew once up front, then keep renewing, and report whether this runner may
  * still act. The opening renewal is awaited so the phase deadline starts from
@@ -44,9 +48,17 @@ export const openDeliveryLease = async (
   config: RunnerConfig,
   claim: ClaimedTask,
   lastKnownRenewalAt: number,
-  options: { send?: LeaseHeartbeat; now?: () => number; startedAt?: Date } = {},
+  options: {
+    send?: LeaseHeartbeat;
+    authorityFor?: (error: unknown) => Authority;
+    authorityAfterHeartbeat?: (result: Awaited<ReturnType<LeaseHeartbeat>>) => Authority;
+    now?: () => number;
+    startedAt?: Date;
+  } = {},
 ): Promise<DeliveryLease> => {
   const send = options.send ?? sendHeartbeat;
+  const authorityFor = options.authorityFor ?? defaultAuthorityFor;
+  const authorityAfterHeartbeat = options.authorityAfterHeartbeat ?? defaultAuthorityAfterHeartbeat;
   const now = options.now ?? (() => Date.now());
   const startedAt = options.startedAt ?? new Date(now());
   const tool = {
@@ -71,16 +83,18 @@ export const openDeliveryLease = async (
         lastProgressEventAt: startedAt,
         inFlightTool: tool,
       });
-      if (result.cancellation) {
+      const authority = authorityAfterHeartbeat(result);
+      if (!authority.held && authority.reason === "cancelled") {
         state.rejected = true;
-        state.cancellation = result.cancellation;
+        state.cancellation = authority.request;
         return;
       }
       state.renewedAt = sentAt;
     } catch (error: unknown) {
-      if (statusOf(error) === 409) {
+      const authority = authorityFor(error);
+      if (!authority.held) {
         state.rejected = true;
-        state.waitingInbox = codeOf(error) === "WAITING_INBOX";
+        state.waitingInbox = authority.reason === "waiting-inbox";
       } else console.error("Delivery lease renewal failed", error);
     }
   };

--- a/packages/runner/src/provision-failure.test.ts
+++ b/packages/runner/src/provision-failure.test.ts
@@ -2,13 +2,14 @@ import assert from "node:assert/strict";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, test } from "node:test";
+import { test } from "node:test";
 
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { type FailureEnvelope, RUNNER_EXCEPTION_REASON, runnerExceptionEnvelope } from "./envelope.js";
 import { runCommand } from "./exec.js";
 import { executeClaim } from "./runner.js";
+import { createControlPlaneDouble } from "./test-control-plane.js";
 import { provisionWorkspace } from "./workspace.js";
 
 /**
@@ -105,22 +106,15 @@ const claim = (remoteUrl: string): ClaimedTask => ({
   regressionRepairHandoff: null,
 });
 
-const originalFetch = globalThis.fetch;
-afterEach(() => { globalThis.fetch = originalFetch; });
-
 test("a clone that cannot succeed reaches the API as a PROVISION envelope stamped 'runner exception'", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-provision-"));
-  const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
-    return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-  }) as typeof fetch;
+  const controlPlane = createControlPlaneDouble();
 
-  await executeClaim(config(root), claim(UNREACHABLE_REMOTE));
+  await executeClaim(config(root), claim(UNREACHABLE_REMOTE), { controlPlane: controlPlane.controlPlane });
 
-  const completion = posts.find((post) => post.path.endsWith("/complete"));
+  const completion = controlPlane.completions.at(-1);
   assert.ok(completion, "provisioning failure must still complete the run");
-  const envelope = completion.body.failureEnvelope as FailureEnvelope;
+  const envelope = completion.failureEnvelope as FailureEnvelope;
   // The three facts the API's verdict turns on, none of which the old
   // hand-written fixture had right.
   assert.equal(envelope.phase, "PROVISION", "no agent was started, so this is the runner's own plumbing");
@@ -131,8 +125,8 @@ test("a clone that cannot succeed reaches the API as a PROVISION envelope stampe
   assert.equal(envelope.transient, false);
   assert.equal(envelope.timedOut, false);
   assert.match(String(envelope.stderrSummary), /repository|not a git|does not exist/i);
-  assert.equal(completion.body.externalFailure, true);
-  assert.equal(completion.body.terminationReason, RUNNER_EXCEPTION_REASON);
+  assert.equal(completion.externalFailure, true);
+  assert.equal(completion.terminationReason, RUNNER_EXCEPTION_REASON);
 });
 
 test("a transient mirror fetch failure escapes provisioning as a transient error, and the envelope says so", async () => {

--- a/packages/runner/src/reclaim.test.ts
+++ b/packages/runner/src/reclaim.test.ts
@@ -3,10 +3,12 @@ import { execFileSync } from "node:child_process";
 import { access, chmod, mkdir, mkdtemp, rename, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import test, { afterEach } from "node:test";
+import test from "node:test";
 
+import { ControlPlaneError, type ControlPlane } from "./api.js";
 import type { RunnerConfig } from "./config.js";
-import { authorizeOffer, reclaimWorkspaces } from "./reclaim.js";
+import { authorizeOffer, reclaimWorkspaces, type ReclaimDeps } from "./reclaim.js";
+import { createControlPlaneDouble } from "./test-control-plane.js";
 
 const config = (workspaceRoot: string): RunnerConfig => ({
   apiUrl: "http://api.invalid",
@@ -27,10 +29,8 @@ const config = (workspaceRoot: string): RunnerConfig => ({
   binaries: { CLAUDE: "claude", CODEX: "codex", PI: "pi" },
 });
 
-const originalFetch = globalThis.fetch;
-afterEach(() => { globalThis.fetch = originalFetch; });
-
 type Call = { path: string; body: Record<string, any> };
+type StubControlPlane = Call[] & { controlPlane: ControlPlane };
 
 /** Stands in for the control plane: answers the plan, records the report. */
 const stubApi = (
@@ -38,7 +38,7 @@ const stubApi = (
   status = 200,
   addCompatibilityEvidence = true,
   salvageStatus = 200,
-): Call[] => {
+): StubControlPlane => {
   const calls: Call[] = [];
   const compatiblePlan = plan && typeof plan === "object" && "reclaim" in plan
     ? {
@@ -48,26 +48,29 @@ const stubApi = (
         : offer),
     }
     : plan;
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    const path = String(input);
-    calls.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
-    if (path.endsWith("/runner/workspaces/reclaimable")) {
-      return new Response(status === 200 ? JSON.stringify(compatiblePlan) : "no such route", {
-        status, headers: { "content-type": status === 200 ? "application/json" : "text/plain" },
-      });
-    }
-    if (path.endsWith("/runner/workspaces/salvaged")) {
-      return new Response(JSON.stringify(salvageStatus === 200
-        ? { ok: true, replacementRepair: "none" }
-        : { error: "Salvage is durable, but the replacement already started from its prior base" }), {
-        status: salvageStatus,
-        headers: { "content-type": "application/json" },
-      });
-    }
-    return new Response(JSON.stringify({ closed: 0, failed: 0 }), { status: 200, headers: { "content-type": "application/json" } });
-  }) as typeof fetch;
-  return calls;
+  const double = createControlPlaneDouble({
+    fetchReclaimPlan: async (_config, inventory) => {
+      calls.push({ path: "controlPlane.fetchReclaimPlan", body: inventory });
+      return status === 200 ? compatiblePlan as Awaited<ReturnType<ControlPlane["fetchReclaimPlan"]>> : null;
+    },
+    recordReclaimPublication: async (_config, body) => {
+      calls.push({ path: "controlPlane.recordReclaimPublication", body });
+      if (salvageStatus !== 200) {
+        throw new ControlPlaneError(salvageStatus, "Salvage is durable, but the replacement already started from its prior base");
+      }
+    },
+    reportReclaimOutcomes: async (_config, report) => {
+      calls.push({ path: "controlPlane.reportReclaimOutcomes", body: report });
+    },
+  });
+  return Object.assign(calls, { controlPlane: double.controlPlane });
 };
+
+const reclaimWith = (
+  stub: StubControlPlane,
+  runnerConfig: RunnerConfig,
+  deps: ReclaimDeps = {},
+) => reclaimWorkspaces(runnerConfig, { ...deps, controlPlane: stub.controlPlane });
 
 const root = async (label: string): Promise<string> => resolve(await mkdtemp(join(tmpdir(), `agentos-reclaim-${label}-`)));
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -78,14 +81,14 @@ test("removes exactly the directory the control plane offered and reports it", a
   await mkdir(join(workspaceRoot, "bystander"));
   const calls = stubApi({ reclaim: [{ runId: "done-run", workspacePath: join(workspaceRoot, "done-run") }], verify: [], keep: [] });
 
-  const sweep = await reclaimWorkspaces(config(workspaceRoot));
+  const sweep = await reclaimWith(calls, config(workspaceRoot));
 
   assert.deepEqual(sweep, { offered: 1, removed: 1, refused: 0, failed: 0, settled: 0 });
   await assert.rejects(access(join(workspaceRoot, "done-run")));
   await access(join(workspaceRoot, "bystander"));
   assert.deepEqual(calls.map(({ path }) => path), [
-    "http://api.invalid/runner/workspaces/reclaimable",
-    "http://api.invalid/runner/workspaces/reclaimed",
+    "controlPlane.fetchReclaimPlan",
+    "controlPlane.reportReclaimOutcomes",
   ]);
   // The inventory is names, not paths: this process is the only one that turns
   // a run id into a path, and it does so against its own configured root.
@@ -118,7 +121,7 @@ test("a delayed reclaim salvages an unpublished retained workspace before deleti
     verify: [], keep: [],
   });
 
-  const sweep = await reclaimWorkspaces(config(workspaceRoot), {
+  const sweep = await reclaimWith(calls, config(workspaceRoot), {
     listDirectories: async () => ["run-1"],
   });
 
@@ -126,7 +129,7 @@ test("a delayed reclaim salvages an unpublished retained workspace before deleti
   await assert.rejects(access(runPath));
   const salvage = "agentos/task-1/run-3";
   assert.match(git(workspaceRoot, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
-  assert.equal(calls[1]!.path, "http://api.invalid/runner/workspaces/salvaged");
+  assert.equal(calls[1]!.path, "controlPlane.recordReclaimPublication");
   assert.deepEqual(calls[1]!.body, { runnerId: "runner-1", runId: "run-1", pushedBranch: salvage });
   assert.deepEqual(calls[2]!.body.results, [{ runId: "run-1", outcome: "REMOVED" }]);
 });
@@ -156,15 +159,15 @@ test("a delayed reclaim removes a dirty pinned checkout without salvage publicat
     verify: [], keep: [],
   });
 
-  const sweep = await reclaimWorkspaces(config(workspaceRoot), {
+  const sweep = await reclaimWith(calls, config(workspaceRoot), {
     listDirectories: async () => ["run-1"],
   });
 
   assert.deepEqual(sweep, { offered: 1, removed: 1, refused: 0, failed: 0, settled: 0 });
   await assert.rejects(access(runPath));
   assert.deepEqual(calls.map(({ path }) => path), [
-    "http://api.invalid/runner/workspaces/reclaimable",
-    "http://api.invalid/runner/workspaces/reclaimed",
+    "controlPlane.fetchReclaimPlan",
+    "controlPlane.reportReclaimOutcomes",
   ]);
   assert.throws(() => git(workspaceRoot, `--git-dir=${remote}`, "show-ref", "refs/heads/agentos/task-1/run-3"));
 });
@@ -194,7 +197,7 @@ test("a delayed salvage ACK refusal retains the workspace after publishing its r
     verify: [], keep: [],
   }, 200, true, 409);
 
-  const sweep = await reclaimWorkspaces(config(workspaceRoot), {
+  const sweep = await reclaimWith(calls, config(workspaceRoot), {
     listDirectories: async () => ["run-1"],
   });
 
@@ -202,7 +205,7 @@ test("a delayed salvage ACK refusal retains the workspace after publishing its r
   await access(runPath);
   const salvage = "agentos/task-1/run-3";
   assert.match(git(workspaceRoot, `--git-dir=${remote}`, "show-ref", `refs/heads/${salvage}`), new RegExp(`refs/heads/${salvage}$`, "u"));
-  assert.equal(calls[1]!.path, "http://api.invalid/runner/workspaces/salvaged");
+  assert.equal(calls[1]!.path, "controlPlane.recordReclaimPublication");
   assert.equal(calls[2]!.body.results[0].outcome, "FAILED");
   assert.match(String(calls[2]!.body.results[0].failureReason), /replacement already started/u);
 });
@@ -218,7 +221,7 @@ test("a pre-start workspace with no clone base is audited as nothing to salvage 
     }],
     verify: [], keep: [],
   });
-  const sweep = await reclaimWorkspaces(config(workspaceRoot));
+  const sweep = await reclaimWith(calls, config(workspaceRoot));
   assert.deepEqual(sweep, { offered: 1, removed: 1, refused: 0, failed: 0, settled: 0 });
   await assert.rejects(access(runPath));
   assert.deepEqual(calls[1]!.body.results, [{ runId: "clone-died", outcome: "REMOVED" }]);
@@ -231,7 +234,7 @@ test("a legacy reclaim offer without pushedBranch refuses deletion", async () =>
   const calls = stubApi({
     reclaim: [{ runId: "legacy-run", workspacePath: runPath }], verify: [], keep: [],
   }, 200, false);
-  const sweep = await reclaimWorkspaces(config(workspaceRoot));
+  const sweep = await reclaimWith(calls, config(workspaceRoot));
   assert.deepEqual(sweep, { offered: 1, removed: 0, refused: 1, failed: 0, settled: 0 });
   await access(runPath);
   assert.match(String(calls[1]!.body.results[0].failureReason), /omitted salvage publication evidence/u);
@@ -245,7 +248,7 @@ test("a reclaim offer without pinned checkout evidence refuses deletion", async 
     reclaim: [{ runId: "legacy-run", workspacePath: runPath, pushedBranch: "already/durable" }],
     verify: [], keep: [],
   }, 200, false);
-  const sweep = await reclaimWorkspaces(config(workspaceRoot));
+  const sweep = await reclaimWith(calls, config(workspaceRoot));
   assert.deepEqual(sweep, { offered: 1, removed: 0, refused: 1, failed: 0, settled: 0 });
   await access(runPath);
   assert.match(String(calls[1]!.body.results[0].failureReason), /omitted pinned checkout evidence/u);
@@ -261,7 +264,7 @@ test("refuses an offer that escapes the configured root and deletes nothing", as
   // reconstructed here, never followed.
   const calls = stubApi({ reclaim: [{ runId: "done-run", workspacePath: outside }], verify: [], keep: [] });
 
-  const sweep = await reclaimWorkspaces(config(workspaceRoot));
+  const sweep = await reclaimWith(calls, config(workspaceRoot));
 
   assert.deepEqual(sweep, { offered: 1, removed: 0, refused: 1, failed: 0, settled: 0 });
   await access(join(outside, "precious"));
@@ -291,7 +294,7 @@ test("refuses an offer for a directory this sweep never reported", async () => {
   });
 
   // Only "listed" is reported as inventory; the answer names the other one.
-  const sweep = await reclaimWorkspaces(config(workspaceRoot), { listDirectories: async () => ["listed"] });
+  const sweep = await reclaimWith(calls, config(workspaceRoot), { listDirectories: async () => ["listed"] });
 
   assert.deepEqual(sweep, { offered: 1, removed: 0, refused: 1, failed: 0, settled: 0 });
   await access(join(workspaceRoot, "unlisted"));
@@ -303,11 +306,11 @@ test("an API too old to publish intents leaves every directory in place", async 
   await mkdir(join(workspaceRoot, "done-run"));
   const calls = stubApi(null, 404);
 
-  const sweep = await reclaimWorkspaces(config(workspaceRoot));
+  const sweep = await reclaimWith(calls, config(workspaceRoot));
 
   assert.deepEqual(sweep, { offered: 0, removed: 0, refused: 0, failed: 0, settled: 0 });
   await access(join(workspaceRoot, "done-run"));
-  assert.deepEqual(calls.map(({ path }) => path), ["http://api.invalid/runner/workspaces/reclaimable"]);
+  assert.deepEqual(calls.map(({ path }) => path), ["controlPlane.fetchReclaimPlan"]);
 });
 
 test("a removal this process may not perform is reported as FAILED, not swallowed", async (t) => {
@@ -321,7 +324,7 @@ test("a removal this process may not perform is reported as FAILED, not swallowe
   await chmod(locked, 0o500);
   const calls = stubApi({ reclaim: [{ runId: "denied-run", workspacePath: join(workspaceRoot, "denied-run") }], verify: [], keep: [] });
   try {
-    const sweep = await reclaimWorkspaces(config(workspaceRoot));
+    const sweep = await reclaimWith(calls, config(workspaceRoot));
     assert.deepEqual(sweep, { offered: 1, removed: 0, refused: 0, failed: 1, settled: 0 });
     await access(join(workspaceRoot, "denied-run"));
     assert.equal(calls[1]!.body.results[0].outcome, "FAILED");
@@ -333,8 +336,8 @@ test("a removal this process may not perform is reported as FAILED, not swallowe
 test("an empty root still asks, because stale intents can only be settled there", async () => {
   const workspaceRoot = await root("empty");
   const calls = stubApi({ reclaim: [], verify: [], keep: [] });
-  assert.deepEqual(await reclaimWorkspaces(config(workspaceRoot)), { offered: 0, removed: 0, refused: 0, failed: 0, settled: 0 });
-  assert.deepEqual(calls.map(({ path }) => path), ["http://api.invalid/runner/workspaces/reclaimable"]);
+  assert.deepEqual(await reclaimWith(calls, config(workspaceRoot)), { offered: 0, removed: 0, refused: 0, failed: 0, settled: 0 });
+  assert.deepEqual(calls.map(({ path }) => path), ["controlPlane.fetchReclaimPlan"]);
   assert.deepEqual(calls[0]!.body.directories, []);
 });
 
@@ -344,8 +347,8 @@ test("a workspace root that does not exist asks nothing and settles nothing", as
   // as removed while the directories are still on disk somewhere.
   const workspaceRoot = join(await root("missing"), "not-created");
   const calls = stubApi({ reclaim: [], verify: [{ runId: "ghost", workspacePath: null }], keep: [] });
-  assert.deepEqual(await reclaimWorkspaces(config(workspaceRoot)), { offered: 0, removed: 0, refused: 0, failed: 0, settled: 0 });
-  assert.deepEqual(calls, []);
+  assert.deepEqual(await reclaimWith(calls, config(workspaceRoot)), { offered: 0, removed: 0, refused: 0, failed: 0, settled: 0 });
+  assert.equal(calls.length, 0);
 });
 
 test("an open intent whose directory is gone is settled, so a lost report converges", async () => {
@@ -354,7 +357,7 @@ test("an open intent whose directory is gone is settled, so a lost report conver
   const workspaceRoot = await root("settle");
   const calls = stubApi({ reclaim: [], verify: [{ runId: "already-gone", workspacePath: join(workspaceRoot, "already-gone") }], keep: [] });
 
-  const sweep = await reclaimWorkspaces(config(workspaceRoot));
+  const sweep = await reclaimWith(calls, config(workspaceRoot));
 
   assert.deepEqual(sweep, { offered: 0, removed: 0, refused: 0, failed: 0, settled: 1 });
   assert.deepEqual(calls[1]!.body.results, [{ runId: "already-gone", outcome: "REMOVED" }]);
@@ -367,11 +370,11 @@ test("an open intent whose directory is still present is left open, never report
   // settlement path while the directory is on disk.
   const calls = stubApi({ reclaim: [], verify: [{ runId: "still-here", workspacePath: join(workspaceRoot, "still-here") }], keep: [] });
 
-  const sweep = await reclaimWorkspaces(config(workspaceRoot), { listDirectories: async () => [] });
+  const sweep = await reclaimWith(calls, config(workspaceRoot), { listDirectories: async () => [] });
 
   assert.deepEqual(sweep, { offered: 0, removed: 0, refused: 0, failed: 0, settled: 0 });
   await access(join(workspaceRoot, "still-here"));
-  assert.deepEqual(calls.map(({ path }) => path), ["http://api.invalid/runner/workspaces/reclaimable"]);
+  assert.deepEqual(calls.map(({ path }) => path), ["controlPlane.fetchReclaimPlan"]);
 });
 
 test("a symlinked component in the configured root does not let a removal escape it", async () => {
@@ -393,7 +396,7 @@ test("a symlinked component in the configured root does not let a removal escape
   // The runner lists through the link, so the entry it sees is the real root's.
   await mkdir(join(realRoot, "victim-run"));
   // Now repoint the link at the decoy between the scan and the removal.
-  const sweep = await reclaimWorkspaces(config(configuredRoot), {
+  const sweep = await reclaimWith(calls, config(configuredRoot), {
     listDirectories: async () => {
       await rename(configuredRoot, join(base, "link-old"));
       await symlink(decoy, configuredRoot);
@@ -413,7 +416,7 @@ test("a directory entry replaced by a symlink between scan and delete is refused
   await mkdir(join(workspaceRoot, "swapped"));
   const calls = stubApi({ reclaim: [{ runId: "swapped", workspacePath: join(workspaceRoot, "swapped") }], verify: [], keep: [] });
 
-  const sweep = await reclaimWorkspaces(config(workspaceRoot), {
+  const sweep = await reclaimWith(calls, config(workspaceRoot), {
     listDirectories: async (scanned) => {
       const names = ["swapped"];
       // The entry was a directory when it was scanned; by the time the offer

--- a/packages/runner/src/reclaim.ts
+++ b/packages/runner/src/reclaim.ts
@@ -2,8 +2,8 @@ import { lstat, readdir, realpath } from "node:fs/promises";
 import { join, resolve, sep } from "node:path";
 
 import {
-  fetchReclaimPlan, reportReclaimOutcomes,
-  type ReclaimOffer, type ReclaimResult,
+  controlPlane as defaultControlPlane,
+  type ControlPlane, type ReclaimOffer, type ReclaimResult,
 } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { disposeWorkspace } from "./dispose-workspace.js";
@@ -36,6 +36,7 @@ const empty: ReclaimSweep = { offered: 0, removed: 0, refused: 0, failed: 0, set
 
 export type ReclaimDeps = {
   listDirectories?: (root: string) => Promise<string[]>;
+  controlPlane?: ControlPlane;
 };
 
 const missing = (error: unknown): boolean => (error as NodeJS.ErrnoException).code === "ENOENT";
@@ -139,6 +140,7 @@ export const reclaimWorkspaces = async (
 ): Promise<ReclaimSweep> => {
   const root = resolve(config.workspaceRoot);
   const list = deps.listDirectories ?? listRunDirectories;
+  const controlPlane = deps.controlPlane ?? defaultControlPlane;
   // Pinned once, re-checked before every removal. A root that cannot be
   // resolved has not been provisioned yet, and an unreadable root is not
   // evidence that anything under it is gone — in both cases the sweep asks
@@ -150,7 +152,7 @@ export const reclaimWorkspaces = async (
   });
   if (physicalRoot === null) return { ...empty };
   const directories = await list(physicalRoot);
-  const plan = await fetchReclaimPlan(config, { runnerId: config.runnerId, workspaceRoot: root, directories });
+  const plan = await controlPlane.fetchReclaimPlan(config, { runnerId: config.runnerId, workspaceRoot: root, directories });
   // An API too old to know the route answers 404. Nothing is reclaimed, nothing
   // is deleted, and the directories stay until an API that speaks the protocol
   // asks for them — leaking beats guessing.
@@ -208,7 +210,7 @@ export const reclaimWorkspaces = async (
       }, {
         alreadyDurable: offer.pushedBranch !== null,
         retain: false,
-      });
+      }, controlPlane);
       if (disposed.cleanupStatus !== "SUCCEEDED") {
         throw new Error(disposed.cleanupFailureReason ?? `Workspace disposal returned ${disposed.cleanupStatus}`);
       }
@@ -250,6 +252,8 @@ export const reclaimWorkspaces = async (
     results.push({ runId: offer.runId, outcome: "REMOVED" });
   }
 
-  if (results.length > 0) await reportReclaimOutcomes(config, { runnerId: config.runnerId, workspaceRoot: root, results });
+  if (results.length > 0) {
+    await controlPlane.reportReclaimOutcomes(config, { runnerId: config.runnerId, workspaceRoot: root, results });
+  }
   return sweep;
 };

--- a/packages/runner/src/run-output.test.ts
+++ b/packages/runner/src/run-output.test.ts
@@ -4,12 +4,13 @@ import { existsSync } from "node:fs";
 import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, test } from "node:test";
+import { test } from "node:test";
 
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { RUNNER_EXCEPTION_REASON } from "./envelope.js";
 import { executeClaim } from "./runner.js";
+import { createControlPlaneDouble } from "./test-control-plane.js";
 
 /**
  * What a failed run actually hands the API.
@@ -187,9 +188,6 @@ const claim = (remoteUrl: string): ClaimedTask => ({
 const succeedingAgentThatSignalsExit = (sentinel: string): string =>
   succeedingAgent.replace(/exit 0$/u, `touch ${sentinel}\nexit 0`);
 
-const originalFetch = globalThis.fetch;
-afterEach(() => { globalThis.fetch = originalFetch; });
-
 test("a failed run's completion carries the output tail the run produced", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-output-"));
   try {
@@ -198,26 +196,22 @@ test("a failed run's completion carries the output tail the run produced", async
     await writeFile(agentBinary, failingAgent);
     await chmod(agentBinary, 0o755);
 
-    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-      posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
-      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    const controlPlane = createControlPlaneDouble();
 
-    await executeClaim(config(join(root, "workspaces"), agentBinary), claim(remote));
+    await executeClaim(config(join(root, "workspaces"), agentBinary), claim(remote), { controlPlane: controlPlane.controlPlane });
 
-    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    const completion = controlPlane.completions.at(-1);
     assert.ok(completion, "the run must complete even though the agent failed");
-    assert.equal(completion.body.terminalSuccess, false, "this is the failing case, not a success in disguise");
+    assert.equal(completion.terminalSuccess, false, "this is the failing case, not a success in disguise");
     // The two facts issue #114 turns on: the tail exists on the wire, and it is
     // the agent's own account of what it found — the thing that used to be
     // dropped by the handler that received it.
-    assert.equal(typeof completion.body.output, "string");
+    assert.equal(typeof completion.output, "string");
     assert.match(
-      String(completion.body.output),
+      String(completion.output),
       /reproduced the deadlock: workers 3 and 7 both hold the inbox advisory lock/,
     );
-    assert.match(String(completion.body.output), /lock ordering inverted in reconcile\.ts$/);
+    assert.match(String(completion.output), /lock ordering inverted in reconcile\.ts$/);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -231,19 +225,15 @@ test("a successful run's completion carries its final output as the same tail", 
     await writeFile(agentBinary, succeedingAgent);
     await chmod(agentBinary, 0o755);
 
-    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-      posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
-      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    const controlPlane = createControlPlaneDouble();
 
-    await executeClaim(config(join(root, "workspaces"), agentBinary), claim(remote));
+    await executeClaim(config(join(root, "workspaces"), agentBinary), claim(remote), { controlPlane: controlPlane.controlPlane });
 
-    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    const completion = controlPlane.completions.at(-1);
     assert.ok(completion, "the run must complete");
-    assert.equal(completion.body.terminalSuccess, true);
+    assert.equal(completion.terminalSuccess, true);
     assert.equal(
-      completion.body.output,
+      completion.output,
       "inverted the lock ordering in reconcile.ts and added the regression test",
     );
   } finally {
@@ -260,24 +250,18 @@ test("a successful run remediates its missing required output in the same provid
     await writeFile(agentBinary, remediatingAgent(remediationPrompt));
     await chmod(agentBinary, 0o755);
 
-    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
     let statusReads = 0;
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-      const path = String(input);
-      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
-      if (path.endsWith("/status")) {
+    const controlPlane = createControlPlaneDouble({
+      readSessionTaskOutputStatus: async () => {
         statusReads += 1;
-        return new Response(JSON.stringify({
-          task: {
-            outputKind: "implementation",
-            outputRequired: true,
-            outputRemediationAllowed: true,
-            outputPersisted: statusReads >= 2,
-          },
-        }), { status: 200, headers: { "content-type": "application/json" } });
-      }
-      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+        return {
+          outputKind: "implementation",
+          outputRequired: true,
+          outputRemediationAllowed: true,
+          outputPersisted: statusReads >= 2,
+        };
+      },
+    });
 
     const baseClaim = claim(remote);
     await executeClaim(config(join(root, "workspaces"), agentBinary), {
@@ -286,26 +270,25 @@ test("a successful run remediates its missing required output in the same provid
         ...baseClaim.task,
         templateStep: { name: "Implementation", outputKind: "implementation" },
       },
-    });
+    }, { controlPlane: controlPlane.controlPlane });
 
     assert.equal(
       statusReads,
       2,
-      `runner must confirm both the miss and its repair; calls: ${posts.map(({ path }) => path).join(", ")}`,
+      "runner must confirm both the miss and its repair",
     );
     const prompt = await readFile(remediationPrompt, "utf8");
     assert.match(prompt, /call task_output with kind 'implementation'/u);
     assert.match(prompt, /Do not redo the task/u);
-    const eventTypes = posts
-      .filter((post) => post.path.endsWith("/events"))
-      .flatMap((post) => (post.body.events as Array<{ type: string }> | undefined) ?? [])
+    const eventTypes = controlPlane.eventBatches
+      .flatMap((batch) => batch)
       .map(({ type }) => type);
     assert.ok(eventTypes.includes("TASK_OUTPUT_REMEDIATION_STARTED"));
     assert.ok(eventTypes.includes("TASK_OUTPUT_REMEDIATION_FINISHED"));
-    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    const completion = controlPlane.completions.at(-1);
     assert.ok(completion);
-    assert.equal(completion.body.terminalSuccess, true);
-    assert.equal(completion.body.output, "implemented the requested change");
+    assert.equal(completion.terminalSuccess, true);
+    assert.equal(completion.output, "implemented the requested change");
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -320,30 +303,28 @@ test("output the agent already produced survives a delivery-phase failure", asyn
     await writeFile(agentBinary, succeedingAgentThatSignalsExit(sentinel));
     await chmod(agentBinary, 0o755);
 
-    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-      const path = String(input);
-      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
+    const controlPlane = createControlPlaneDouble({
+      appendEvents: async () => {
       // The event flush the runner performs once the agent is gone, on its way
       // into delivery. A dropped connection there is ordinary — and it throws
       // out of the try block, into the catch that reports the run.
-      if (path.endsWith("/events") && existsSync(sentinel)) throw new Error("connection reset by peer");
-      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+        if (existsSync(sentinel)) throw new Error("connection reset by peer");
+      },
+    });
 
-    await executeClaim(config(join(root, "workspaces"), agentBinary), claim(remote));
+    await executeClaim(config(join(root, "workspaces"), agentBinary), claim(remote), { controlPlane: controlPlane.controlPlane });
 
-    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    const completion = controlPlane.completions.at(-1);
     assert.ok(completion, "the run must still be completed");
     // The failure is the runner's own, reported as such: this is the exception
     // path, not the ordinary one.
-    assert.equal(completion.body.terminationReason, RUNNER_EXCEPTION_REASON);
-    assert.match(String(completion.body.failureReason), /connection reset by peer/);
+    assert.equal(completion.terminationReason, RUNNER_EXCEPTION_REASON);
+    assert.match(String(completion.failureReason), /connection reset by peer/);
     // And the agent's work is still in it. This path used to rebuild its
     // evidence from the error message alone, so a run that had produced a real
     // answer reported nothing but the plumbing fault that followed it.
     assert.equal(
-      completion.body.output,
+      completion.output,
       "inverted the lock ordering in reconcile.ts and added the regression test",
     );
   } finally {
@@ -354,11 +335,7 @@ test("output the agent already produced survives a delivery-phase failure", asyn
 test("a run that fails before its agent exists sends no output at all", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-output-none-"));
   try {
-    const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-      posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
-      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    const controlPlane = createControlPlaneDouble();
 
     // A remote no clone can reach: the run dies in PROVISION, before any agent
     // has run. The carried tail must stay null rather than report an empty
@@ -366,11 +343,12 @@ test("a run that fails before its agent exists sends no output at all", async ()
     await executeClaim(
       config(join(root, "workspaces"), join(root, "never-spawned.sh")),
       claim("/nonexistent/agentos-issue-114-no-such-repo.git"),
+      { controlPlane: controlPlane.controlPlane },
     );
 
-    const completion = posts.find((post) => post.path.endsWith("/complete"));
+    const completion = controlPlane.completions.at(-1);
     assert.ok(completion, "a provisioning failure still completes the run");
-    assert.equal(completion.body.output ?? null, null);
+    assert.equal(completion.output ?? null, null);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -4,17 +4,18 @@ import { createHash } from "node:crypto";
 import { access, chmod, mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { afterEach, test } from "node:test";
+import { test } from "node:test";
 
 import { adapters, buildPrompt, type CliAdapter } from "./adapters.js";
-import type { ClaimedTask } from "./api.js";
+import type { ClaimedTask, ControlPlane } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import {
   cliAvailabilityHeartbeatSchedule,
-  executeClaim,
-  reportCliAvailabilityHeartbeat,
-  runStartupPreflight,
+  executeClaim as executeClaimProduction,
+  reportCliAvailabilityHeartbeat as reportCliAvailabilityHeartbeatProduction,
+  runStartupPreflight as runStartupPreflightProduction,
 } from "./runner.js";
+import { createControlPlaneDouble, createRoutedControlPlaneDouble, type ControlPlaneFetchHandler } from "./test-control-plane.js";
 import {
   cleanupAgentScratch, provisionSessionConfig, writeSessionCredentials, type AgentScratch,
 } from "./workspace.js";
@@ -102,16 +103,29 @@ const mechanicalClaim: ClaimedTask = {
   regressionRepairHandoff: null,
 };
 
-const originalFetch = globalThis.fetch;
-afterEach(() => { globalThis.fetch = originalFetch; });
+let injectedControlPlane: ControlPlane = createControlPlaneDouble().controlPlane;
+const setControlPlane = (handler: ControlPlaneFetchHandler): void => {
+  injectedControlPlane = createRoutedControlPlaneDouble(handler).controlPlane;
+};
+const executeClaim = (
+  ...[runnerConfig, claim, dependencies = {}]: Parameters<typeof executeClaimProduction>
+) => executeClaimProduction(runnerConfig, claim, { ...dependencies, controlPlane: injectedControlPlane });
+const runStartupPreflight = (
+  runnerConfig: Parameters<typeof runStartupPreflightProduction>[0],
+  options: Parameters<typeof runStartupPreflightProduction>[1] = {},
+) => runStartupPreflightProduction(runnerConfig, { ...options, controlPlane: injectedControlPlane });
+const reportCliAvailabilityHeartbeat = (
+  runnerConfig: Parameters<typeof reportCliAvailabilityHeartbeatProduction>[0],
+  options: Parameters<typeof reportCliAvailabilityHeartbeatProduction>[1] = {},
+) => reportCliAvailabilityHeartbeatProduction(runnerConfig, { ...options, controlPlane: injectedControlPlane });
 
 test("a mechanical claim is refused before any adapter, workspace or child environment exists", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "runner-mechanical-"));
   const calls: Array<{ path: string; body: Record<string, unknown> }> = [];
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+  setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
     calls.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
     return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-  }) as typeof fetch;
+  });
 
   // Any adapter entry point reached at all is the failure this test exists to
   // catch: a merge credential must never be in a process that spawns a CLI.
@@ -134,10 +148,10 @@ test("a mechanical claim is refused before any adapter, workspace or child envir
 test("an ordinary claim is not short-circuited by the mechanical refusal", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "runner-agent-"));
   const calls: string[] = [];
-  globalThis.fetch = (async (input: string | URL | Request) => {
+  setControlPlane(async (input: string | URL | Request) => {
     calls.push(String(input));
     return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-  }) as typeof fetch;
+  });
   // Over budget, so it exits on the very next guard — enough to prove the
   // mechanical branch did not swallow it, without provisioning anything.
   await executeClaim(config(workspaceRoot), {
@@ -301,10 +315,10 @@ test("Codex provision auth failure is PROVISION, retains its root, and never spa
     await chmod(binary, 0o755);
     const configured = codexOnly(join(root, "workspaces"), root, binary);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     let preflightCalls = 0;
     let startCalls = 0;
     const adapter: CliAdapter = {
@@ -346,10 +360,10 @@ test("Codex baseline-copy failure is PROVISION and never reaches preflight or th
       sessionConfigBaselineRoot: join(root, "missing-baseline"),
     };
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     let preflightCalls = 0;
     let startCalls = 0;
     const adapter: CliAdapter = {
@@ -407,10 +421,10 @@ test("Codex rejects a run-as config-root symlink in PROVISION without copying ho
       runAsPrefix: [launcher],
     };
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     let preflightCalls = 0;
     let startCalls = 0;
     const adapter: CliAdapter = {
@@ -482,7 +496,7 @@ test("event delivery failures do not starve heartbeats and recover in seq order"
     const maybeResolveActiveFailures = (): void => {
       if (heartbeatAttempts >= 2 && eventFailures >= 2) resolveActiveFailures();
     };
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       const path = String(input);
       const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, any>;
       posts.push({ path, body });
@@ -503,7 +517,7 @@ test("event delivery failures do not starve heartbeats and recover in seq order"
         acceptedBatches.push((body.events as Array<{ seq: number }>).map((event) => event.seq));
       }
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     const adapter: CliAdapter = {
       ...adapters.CLAUDE,
@@ -594,10 +608,10 @@ test("startup reports Claude and Pi blocked, keeps their telemetry, and passes C
     await writeFile(binary, codexStub(log));
     await chmod(binary, 0o755);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     const availability: Array<{ runner: string; available: boolean; resolvedPath: string | null }> = [];
     const results = await runStartupPreflight(codexOnly(join(root, "workspaces"), root, binary), {
@@ -652,10 +666,10 @@ test("startup blocks a Codex CLI that lacks the exec protocol AgentOS invokes", 
     ].join("\n"));
     await chmod(binary, 0o755);
     const posts: Array<{ body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (_input: string | URL | Request, init?: RequestInit) => {
       posts.push({ body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     assert.deepEqual(
       await runStartupPreflight(codexOnly(join(root, "workspaces"), root, binary)),
@@ -678,12 +692,12 @@ test("startup retries a temporarily unavailable API without rerunning CLI probes
     await chmod(binary, 0o755);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
     let calls = 0;
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       calls += 1;
       if (calls <= 2) throw new TypeError("fetch failed");
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     const waits: number[] = [];
     const retries: Array<{ runner: string; attempt: number; attempts: number }> = [];
 
@@ -713,10 +727,10 @@ test("startup does not retry an API authentication refusal", async () => {
   try {
     const waits: number[] = [];
     let calls = 0;
-    globalThis.fetch = (async () => {
+    setControlPlane(async () => {
       calls += 1;
       return new Response(JSON.stringify({ code: "unauthorized" }), { status: 401, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     await assert.rejects(
       runStartupPreflight(codexOnly(join(root, "workspaces"), root, join(root, "codex")), {
@@ -743,10 +757,10 @@ test("a Codex claim passes its own preflight and starts while the others stay bl
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     const configured = codexOnly(join(root, "workspaces"), root, binary);
     // Startup first, exactly as `index.ts` orders it: the claim below runs on a
@@ -796,10 +810,10 @@ test("an outside worktree is reported without changing a successful run outcome"
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     await executeClaim({ ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 }, {
       ...mechanicalClaim,
@@ -843,10 +857,10 @@ test("Codex records success after reconnecting and reaching terminal completion"
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     await executeClaim({ ...codexOnly(join(root, "workspaces"), root, binary), failedWorkspaceRetention: 0 }, {
       ...mechanicalClaim,
@@ -883,10 +897,10 @@ test("Codex preserves reconnect evidence when the stream ends before terminal co
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     await executeClaim({ ...codexOnly(join(root, "workspaces"), root, binary), failedWorkspaceRetention: 0 }, {
       ...mechanicalClaim,
@@ -927,10 +941,10 @@ test("Codex preserves reconnect evidence when terminal completion is followed by
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     await executeClaim({ ...codexOnly(join(root, "workspaces"), root, binary), failedWorkspaceRetention: 0 }, {
       ...mechanicalClaim,
@@ -964,14 +978,14 @@ test("a failed first completion request restores and retains CODEX_HOME", async 
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
     let completionAttempts = 0;
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       const post = { path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> };
       posts.push(post);
       if (post.path.endsWith("/complete") && completionAttempts++ === 0) {
         return new Response(JSON.stringify({ error: "completion unavailable" }), { status: 503, headers: { "content-type": "application/json" } });
       }
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     await executeClaim(codexOnly(join(root, "workspaces"), root, binary), {
       ...mechanicalClaim,
@@ -1040,10 +1054,10 @@ test("session-config cleanup failure does not turn delivered work into a failed 
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     await executeClaim(codexOnly(join(root, "workspaces"), root, binary), {
       ...mechanicalClaim,
@@ -1087,10 +1101,10 @@ test("default failed-workspace retention still salvages and records the exact du
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     const configured = codexOnly(workspaces, root, binary);
 
     await executeClaim(configured, {
@@ -1131,7 +1145,7 @@ test("a dead delivery lease still salvages before cleanup without terminal API a
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     let started = false;
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       const path = String(input);
       posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       if (path.endsWith("/start")) started = true;
@@ -1139,7 +1153,7 @@ test("a dead delivery lease still salvages before cleanup without terminal API a
         return new Response(JSON.stringify({ error: "Stale fencing token" }), { status: 409, headers: { "content-type": "application/json" } });
       }
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
 
     await executeClaim(configured, {
@@ -1180,7 +1194,7 @@ test("a heartbeat cancellation kills the provider group, acknowledges once, and 
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     let started = false;
     let cancellationSent = false;
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       const path = String(input);
       posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       if (path.endsWith("/start")) started = true;
@@ -1197,7 +1211,7 @@ test("a heartbeat cancellation kills the provider group, acknowledges once, and 
         }), { status: 200, headers: { "content-type": "application/json" } });
       }
       return new Response(JSON.stringify({ ok: true, cancellation: null }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     const configured = { ...codexOnly(workspaces, root, binary), heartbeatIntervalMs: 20 };
 
     await executeClaim(configured, {
@@ -1238,7 +1252,7 @@ test("a provisioning cancellation is acknowledged only after provider launch is 
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     let credentialsWriting = false;
     let cancellationSent = false;
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       const path = String(input);
       posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       if (credentialsWriting && path.endsWith("/heartbeat") && !cancellationSent) {
@@ -1249,7 +1263,7 @@ test("a provisioning cancellation is acknowledged only after provider launch is 
         }), { status: 200, headers: { "content-type": "application/json" } });
       }
       return new Response(JSON.stringify({ ok: true, cancellation: null }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     const configured = { ...codexOnly(workspaces, root, binary), heartbeatIntervalMs: 20 };
 
     await executeClaim(configured, {
@@ -1294,10 +1308,10 @@ test("a clean failed run records that there is nothing to salvage before cleanup
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
 
     await executeClaim(configured, {
@@ -1338,10 +1352,10 @@ test("failed-run salvage excludes worktrees created at the instructed in-workspa
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     await executeClaim({ ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 }, {
       ...mechanicalClaim,
@@ -1377,10 +1391,10 @@ test("a failed salvage keeps the workspace and reports cleanup failure", async (
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
 
     await executeClaim(configured, {
@@ -1424,10 +1438,10 @@ test("successful execution with failed delivery salvages before removing the wor
     ].join("\n"));
     await chmod(hook, 0o755);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     const configured = { ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 };
     await executeClaim(configured, {
       ...mechanicalClaim,
@@ -1481,10 +1495,10 @@ test("a pull-request failure after publication keeps the primary delivery eviden
     git(root, "config", "--file", join(root, ".gitconfig"), `url.${remote}.insteadOf`, githubRemote);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     const configured = {
       ...codexOnly(workspaces, root, binary),
       path: `${root}:${process.env.PATH ?? "/usr/bin:/bin"}`,
@@ -1535,10 +1549,10 @@ test("a successful pinned review never publishes its dirty detached checkout", a
     await seedCodexAuth(root);
     const pinned = git(root, `--git-dir=${remote}`, "rev-parse", "refs/heads/master");
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     await executeClaim({ ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 }, {
       ...mechanicalClaim,
       executionMode: "agent",
@@ -1577,10 +1591,10 @@ test("a failed pinned review reports failure without publishing its dirty detach
     await seedCodexAuth(root);
     const pinned = git(root, `--git-dir=${remote}`, "rev-parse", "refs/heads/master");
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     await executeClaim({ ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 }, {
       ...mechanicalClaim,
@@ -1627,7 +1641,7 @@ test("a dead-lease salvage failure is durably reported and retains the workspace
     await chmod(hook, 0o755);
     const posts: Array<{ path: string; body: Record<string, any> }> = [];
     let started = false;
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       const path = String(input);
       posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
       if (path.endsWith("/start")) started = true;
@@ -1635,7 +1649,7 @@ test("a dead-lease salvage failure is durably reported and retains the workspace
         return new Response(JSON.stringify({ error: "Stale fencing token" }), { status: 409, headers: { "content-type": "application/json" } });
       }
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
     await executeClaim({ ...codexOnly(workspaces, root, binary), failedWorkspaceRetention: 0 }, {
       ...mechanicalClaim,
       executionMode: "agent",
@@ -1682,10 +1696,10 @@ test("a signed-out Codex reports a class and an exit code, never what the CLI pr
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     const configured = codexOnly(join(root, "workspaces"), root, binary);
     assert.deepEqual(await runStartupPreflight(configured), { CLAUDE: false, CODEX: false, PI: false });
@@ -1734,10 +1748,10 @@ test("a Codex CLI that is not installed is a class of its own, and still reads a
     const remote = await seedRemote(root);
     await seedCodexAuth(root);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
-    }) as typeof fetch;
+    });
 
     const configured = codexOnly(join(root, "workspaces"), root, join(root, "no-codex-here"));
     assert.deepEqual(await runStartupPreflight(configured), { CLAUDE: false, CODEX: false, PI: false });
@@ -1770,10 +1784,10 @@ test("an availability heartbeat reports a CLI recovery without restarting the ru
     const binary = join(root, "codex");
     const configured = codexOnly(join(root, "workspaces"), root, binary);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       posts.push({ path: String(input), body: JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown> });
       return new Response(null, { status: 200 });
-    }) as typeof fetch;
+    });
 
     await reportCliAvailabilityHeartbeat(configured);
     await writeFile(binary, "#!/bin/sh\nexit 0\n");
@@ -1808,7 +1822,7 @@ test("an availability heartbeat runs one requested preflight and reports its rec
     await chmod(binary, 0o755);
     const configured = codexOnly(join(root, "workspaces"), root, binary);
     const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
-    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
       const path = String(input);
       const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
       posts.push({ path, body });
@@ -1817,7 +1831,7 @@ test("an availability heartbeat runs one requested preflight and reports its rec
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as typeof fetch;
+    });
 
     await reportCliAvailabilityHeartbeat(configured);
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -9,27 +9,17 @@ import {
   outputTail,
   PREFLIGHT_CLASS,
   promptHashFor,
-  CODEX_STARTER_MODEL,
+  RUNNER_DEFINITIONS,
   type AdapterEvent,
   type CliAdapter,
   type ExitEvidence,
   type RuntimeHandle,
 } from "./adapters.js";
 import {
-  appendActivity,
-  appendEvents,
-  acknowledgeCancellation,
-  claimTask,
-  completeRun,
-  heartbeat as sendHeartbeat,
-  readSessionTaskOutputStatus,
-  recordPublishedBranch,
-  recordLeaseIndependentCleanup,
-  reportCliAvailability,
-  reportPreflight,
-  startRun,
+  controlPlane as defaultControlPlane,
   type ClaimedTask,
   type CancellationRequest,
+  type ControlPlane,
   type SessionEventPayload,
 } from "./api.js";
 import {
@@ -49,9 +39,10 @@ import {
   runnerExceptionEnvelope,
 } from "./envelope.js";
 import { deliverUnderLease, openDeliveryLease, type DeliveryLease } from "./lease.js";
+import { openSessionConfig, type SessionConfigLease } from "./session-config-lease.js";
 import {
   captureWorkspaceResult, cleanupAgentScratch, provisionAgentScratch, provisionSessionConfig,
-  provisionWorkspace, reuseWorkspace, sessionConfigRootExists, workspaceEnvironment, writeSessionCredentials,
+  provisionWorkspace, reuseWorkspace, workspaceEnvironment, writeSessionCredentials,
   type AgentScratch, type Workspace,
 } from "./workspace.js";
 import { observeExternalWorktrees } from "./worktree-observer.js";
@@ -64,11 +55,6 @@ const serializeTool = (tool: RuntimeHandle["inFlightTool"]): Record<string, unkn
 } : null;
 
 const errorMessage = (error: unknown): string => error instanceof Error ? error.message : String(error);
-
-const runnerUsesSessionConfig = (runner: RunnerKind): boolean => runner !== "CLAUDE";
-
-const retainedSessionConfigPath = async (runner: RunnerKind, scratch: AgentScratch | null): Promise<string | null> =>
-  runnerUsesSessionConfig(runner) && scratch && await sessionConfigRootExists(scratch) ? scratch.configRoot : null;
 
 const appendRetainedSessionConfig = (reason: string, path: string | null): string =>
   `${reason}${path ? `; session CLI config retained at ${path}` : ""}`;
@@ -86,12 +72,13 @@ const cleanup = async (
   workspace: Workspace | null,
   retain: boolean,
   alreadyDurable = false,
+  controlPlane: ControlPlane = defaultControlPlane,
 ): Promise<WorkspaceDisposal> => {
   if (!workspace) return { cleanupStatus: "SUCCEEDED", workspaceRetained: false, salvage: null };
   return disposeWorkspace(config, { source: "runner", claim }, {
     ...workspace,
     pinnedBaseSha: workspace.pinnedBaseSha ?? null,
-  }, { retain, alreadyDurable });
+  }, { retain, alreadyDurable }, controlPlane);
 };
 
 const preflightEvidence = (message: string): ExitEvidence => ({
@@ -115,6 +102,7 @@ export type ExecuteClaimDependencies = {
   writeSessionCredentials?: typeof writeSessionCredentials;
   /** The CLI the run is executed through. Defaults to the claim's runner kind. */
   adapter?: CliAdapter;
+  controlPlane?: ControlPlane;
 };
 
 export const executeClaim = async (
@@ -123,11 +111,13 @@ export const executeClaim = async (
   dependencies: ExecuteClaimDependencies = {},
 ): Promise<void> => {
   const adapter = dependencies.adapter ?? adapters[claim.runner];
+  const controlPlane = dependencies.controlPlane ?? defaultControlPlane;
   let workspace: Workspace | null = null;
   let scratch: AgentScratch | null = null;
   let handle: RuntimeHandle | null = null;
   let heartbeatTimer: NodeJS.Timeout | undefined;
   let lease: DeliveryLease | null = null;
+  let sessionConfigLease: SessionConfigLease | null = null;
   let heartbeatBusy = false;
   let fencingRejected = false;
   let waitingInbox = false;
@@ -143,11 +133,6 @@ export const executeClaim = async (
     };
   });
   let budgetReason: string | null = null;
-  // A session CLI's root is retained until the run is known to have succeeded, so a
-  // provisioning or execution failure can be inspected and resumed without
-  // ever falling back to the host CLI configuration.
-  let retainSessionConfig = false;
-  let sessionConfigRemoved = false;
   // Where the run is, for the failure envelope. The API reads this to decide
   // whether a failed attempt spends the task's budget: only EXECUTE is the
   // agent's own work, everything else is this process's plumbing.
@@ -176,7 +161,7 @@ export const executeClaim = async (
           workspace.path,
         );
       } catch (error: unknown) {
-        await appendActivity(
+        await controlPlane.appendActivity(
           config,
           claim,
           `Unable to observe run worktree containment: ${errorMessage(error)}`,
@@ -212,19 +197,17 @@ export const executeClaim = async (
         // therefore remains the head of the queue for the next flush attempt,
         // while the single worker prevents a later batch overtaking it.
         const batch = pendingEvents.slice(0, 250);
-        await appendEvents(config, claim, batch, handle?.providerConversationId);
+        await controlPlane.appendEvents(config, claim, batch, handle?.providerConversationId);
         pendingEvents.splice(0, batch.length);
       }
     })().finally(() => { eventFlushPromise = null; });
     return eventFlushPromise;
   };
 
-  const isFencingError = (error: unknown): error is { status: number; code?: string } =>
-    typeof error === "object" && error !== null && (error as { status?: number }).status === 409;
-
   const noteFencingError = async (error: unknown): Promise<void> => {
-    if (!isFencingError(error)) return;
-    waitingInbox = (error as { code?: string }).code === "WAITING_INBOX";
+    const authority = controlPlane.authorityFor(error);
+    if (authority.held) return;
+    waitingInbox = authority.reason === "waiting-inbox";
     fencingRejected = true;
     if (handle) {
       try {
@@ -249,7 +232,7 @@ export const executeClaim = async (
         const killed = await adapter.kill(handle, request.reason);
         if (killed.processAlive) throw new Error(`Run ${claim.run.id} still owns a live provider process`);
       }
-      await acknowledgeCancellation(
+      await controlPlane.acknowledgeCancellation(
         config,
         claim,
         request,
@@ -262,7 +245,7 @@ export const executeClaim = async (
 
   const observeEventFlush = async (error: unknown): Promise<void> => {
     await noteFencingError(error);
-    if (!isFencingError(error)) console.error("Event flush failed", error);
+    if (controlPlane.authorityFor(error).held) console.error("Event flush failed", error);
   };
 
   const drainEventsUnderLease = async (openLease: DeliveryLease): Promise<void> => {
@@ -296,7 +279,7 @@ export const executeClaim = async (
     // misconfigured; the run is failed closed and non-retryable rather than
     // executed, because retrying it here would just repeat the violation.
     if (claim.executionMode === "mechanical") {
-      await completeRun(config, claim, {
+      await controlPlane.completeRun(config, claim, {
         exitCode: null,
         terminalEventSeen: false,
         terminalSuccess: false,
@@ -312,8 +295,8 @@ export const executeClaim = async (
     // `maxRunsPerTask` is the persisted authorization written by `openRun`;
     // this boot gate consumes that verdict and must not recompute a Task budget.
     if (claim.run.runNumber > claim.run.maxRunsPerTask) {
-      const { salvage: _salvage, ...finishedCleanup } = await cleanup(config, claim, workspace, false);
-      await completeRun(config, claim, {
+      const { salvage: _salvage, ...finishedCleanup } = await cleanup(config, claim, workspace, false, false, controlPlane);
+      await controlPlane.completeRun(config, claim, {
         exitCode: null,
         terminalEventSeen: false,
         terminalSuccess: false,
@@ -335,7 +318,7 @@ export const executeClaim = async (
 
     const provisionStartedAt = new Date();
     heartbeatTimer = setInterval(() => {
-      void sendHeartbeat(config, claim, {
+      void controlPlane.heartbeat(config, claim, {
         processAlive: true,
         lastProgressEventAt: provisionStartedAt,
         inFlightTool: {
@@ -345,11 +328,13 @@ export const executeClaim = async (
           lastProgressAt: provisionStartedAt.toISOString(),
         },
       }).then(async (result) => {
-        if (result.cancellation) await acceptCancellation(result.cancellation);
+        const authority = controlPlane.authorityAfterHeartbeat(result);
+        if (!authority.held && authority.reason === "cancelled") await acceptCancellation(authority.request);
         else leaseRenewedAt = Date.now();
       }).catch((error: unknown) => {
-        if (isFencingError(error)) {
-          waitingInbox = (error as { code?: string }).code === "WAITING_INBOX";
+        const authority = controlPlane.authorityFor(error);
+        if (!authority.held) {
+          waitingInbox = authority.reason === "waiting-inbox";
           fencingRejected = true;
         }
         else console.error("Provisioning heartbeat failed", error);
@@ -358,8 +343,10 @@ export const executeClaim = async (
     workspace = claim.resume ? await reuseWorkspace(config, claim) : await provisionWorkspace(config, claim);
     const prompt = buildPrompt(claim);
     scratch = await provisionAgentScratch(config, claim.session.id);
-    retainSessionConfig = runnerUsesSessionConfig(claim.runner);
-    await (dependencies.provisionSessionConfig ?? provisionSessionConfig)(config, claim.runner, scratch, { reuse: claim.resume !== null });
+    sessionConfigLease = openSessionConfig(config, claim, scratch, dependencies);
+    await (dependencies.provisionSessionConfig ?? provisionSessionConfig)(config, claim.runner, scratch, {
+      reuse: claim.resume !== null,
+    });
     const env = buildChildEnvironment(config, claim, scratch, workspace.path);
     const preflight = await adapter.preflight({ config, runner: claim.runner, model: claim.run.model, env });
     if (fencingRejected) {
@@ -369,9 +356,9 @@ export const executeClaim = async (
         await cancellationPromise;
         return;
       }
-      const cleaned = await cleanup(config, claim, workspace, false);
+      const cleaned = await cleanup(config, claim, workspace, false, false, controlPlane);
       const { salvage: _salvage, ...cleanupOutcome } = cleaned;
-      await recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((error: unknown) => {
+      await controlPlane.recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((error: unknown) => {
         console.error(`Unable to record lease-independent cleanup outcome: ${errorMessage(error)}`);
       });
       return;
@@ -381,9 +368,9 @@ export const executeClaim = async (
       const evidence = preflightEvidence(preflight.error ?? "Preflight failed");
       const classified = adapter.classifyError(evidence);
       const worktreeReport = await worktreeContainmentReport();
-      const { salvage: _salvage, ...finishedCleanup } = await cleanup(config, claim, workspace, config.failedWorkspaceRetention > 0);
-      const retainedPath = await retainedSessionConfigPath(claim.runner, scratch);
-      await completeRun(config, claim, {
+      const { salvage: _salvage, ...finishedCleanup } = await cleanup(config, claim, workspace, config.failedWorkspaceRetention > 0, false, controlPlane);
+      const retainedPath = await sessionConfigLease.retainedPath();
+      await controlPlane.completeRun(config, claim, {
         ...evidence,
         failureClass: classified.failureClass,
         failureReason: appendRetainedSessionConfig(preflight.error ?? "Preflight failed", retainedPath),
@@ -431,7 +418,7 @@ export const executeClaim = async (
     // invocation actually handed to the provider.
     const dispatchedPrompt = claim.resume?.input ?? prompt;
     const manifest = manifestFor(spec, dispatchedPrompt);
-    await startRun(config, claim, {
+    await controlPlane.startRun(config, claim, {
       adapterVersion: ADAPTER_VERSION,
       cliVersion: preflight.cliVersion ?? "unknown",
       authMode: preflight.authMode,
@@ -471,16 +458,17 @@ export const executeClaim = async (
           await adapter.kill(heartbeatHandle, budgetReason);
         }
         try {
-          const result = await sendHeartbeat(config, claim, {
+          const result = await controlPlane.heartbeat(config, claim, {
             processAlive: snapshot.processAlive,
             lastProgressEventAt: snapshot.lastProgressEventAt,
             inFlightTool: serializeTool(snapshot.inFlightTool),
           });
-          if (result.cancellation) await acceptCancellation(result.cancellation);
+          const authority = controlPlane.authorityAfterHeartbeat(result);
+          if (!authority.held && authority.reason === "cancelled") await acceptCancellation(authority.request);
           else if (snapshot.processAlive) leaseRenewedAt = Date.now();
         } catch (error: unknown) {
           await noteFencingError(error);
-          if (!isFencingError(error)) console.error("Run heartbeat failed", error);
+          if (controlPlane.authorityFor(error).held) console.error("Run heartbeat failed", error);
         }
         // Event delivery is deliberately detached from the heartbeat attempt:
         // a failed or slow append must not occupy heartbeatBusy or suppress the
@@ -488,7 +476,7 @@ export const executeClaim = async (
         if (!fencingRejected) void flushEvents().catch(observeEventFlush);
       })().catch(async (error: unknown) => {
         await noteFencingError(error);
-        if (!isFencingError(error)) console.error("Run heartbeat failed", error);
+        if (controlPlane.authorityFor(error).held) console.error("Run heartbeat failed", error);
       }).finally(() => { heartbeatBusy = false; });
     }, config.heartbeatIntervalMs);
 
@@ -498,9 +486,9 @@ export const executeClaim = async (
     if (adapterExecutionSucceeded(evidence)
       && claim.task.templateStep?.outputKind
       && !fencingRejected) {
-      let outputStatus: Awaited<ReturnType<typeof readSessionTaskOutputStatus>> = null;
+      let outputStatus: Awaited<ReturnType<ControlPlane["readSessionTaskOutputStatus"]>> = null;
       try {
-        outputStatus = await readSessionTaskOutputStatus(config, claim);
+        outputStatus = await controlPlane.readSessionTaskOutputStatus(config, claim);
       } catch (error: unknown) {
         sink({
           source: "RUNNER",
@@ -527,7 +515,7 @@ export const executeClaim = async (
           const remediationEvidence = await handle.exit;
           let remediated = false;
           try {
-            remediated = (await readSessionTaskOutputStatus(config, claim))?.outputPersisted === true;
+            remediated = (await controlPlane.readSessionTaskOutputStatus(config, claim))?.outputPersisted === true;
           } catch (error: unknown) {
             sink({
               source: "RUNNER",
@@ -569,7 +557,11 @@ export const executeClaim = async (
     // renews the lease across it, refuses to let the phase outlive the lease,
     // and — the part a bare heartbeat loop would miss — reports when the
     // control plane has revoked this runner's authority.
-    lease = await openDeliveryLease(config, claim, leaseRenewedAt);
+    lease = await openDeliveryLease(config, claim, leaseRenewedAt, {
+      send: controlPlane.heartbeat,
+      authorityFor: controlPlane.authorityFor,
+      authorityAfterHeartbeat: controlPlane.authorityAfterHeartbeat,
+    });
     const adoptLeaseVerdict = (openLease: DeliveryLease): void => {
       if (!openLease.rejected) return;
       fencingRejected = true;
@@ -587,9 +579,9 @@ export const executeClaim = async (
         return;
       }
       if (waitingInbox) return;
-      const cleaned = await cleanup(config, claim, workspace, false);
+      const cleaned = await cleanup(config, claim, workspace, false, false, controlPlane);
       const { salvage: _salvage, ...cleanupOutcome } = cleaned;
-      await recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((error: unknown) => {
+      await controlPlane.recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((error: unknown) => {
         console.error(`Unable to record lease-independent cleanup outcome: ${errorMessage(error)}`);
       });
       return;
@@ -598,7 +590,7 @@ export const executeClaim = async (
     let delivery: Awaited<ReturnType<typeof deliverWorkspace>> | null = null;
     let gitResult = { branch: workspace.branch, baseSha: workspace.baseSha, headSha: workspace.baseSha };
     try { gitResult = await captureWorkspaceResult(config, workspace); } catch (error: unknown) {
-      await appendActivity(config, claim, `Unable to snapshot git result: ${errorMessage(error)}`, { stream: "runner" });
+      await controlPlane.appendActivity(config, claim, `Unable to snapshot git result: ${errorMessage(error)}`, { stream: "runner" });
     }
     // Bound outside the closures below: `workspace` is nullable at the top of
     // this function, and the narrowing does not survive into a callback.
@@ -619,7 +611,7 @@ export const executeClaim = async (
           claim,
           delivered,
           undefined,
-          (branch) => recordPublishedBranch(config, claim, branch),
+          (branch) => controlPlane.recordPublishedBranch(config, claim, branch),
           retryOptions,
         ));
     }
@@ -637,32 +629,16 @@ export const executeClaim = async (
       // branch is already durable even though the run must fail, so salvaging it
       // would publish a second ref and replace the primary delivery evidence.
       succeeded || Boolean(workspace.pinnedBaseSha) || Boolean(primaryDelivery?.pushedBranch),
+      controlPlane,
     );
     if (!succeeded && cleaned.salvage) {
       delivery = cleaned.salvage;
       if (cleaned.salvage.headSha) gitResult = { ...gitResult, headSha: cleaned.salvage.headSha };
-      await appendActivity(config, claim,
+      await controlPlane.appendActivity(config, claim,
         cleaned.salvage.deliveryInstructions ?? cleaned.salvage.pushError ?? "WIP salvage attempted",
         { stream: "runner" }).catch(() => undefined);
     }
-    retainSessionConfig = !succeeded;
-    let scratchCleanupFailure: string | null = null;
-    if (scratch) {
-      try {
-        await (dependencies.cleanupAgentScratch ?? cleanupAgentScratch)(config, scratch, { retainConfigRoot: retainSessionConfig });
-        sessionConfigRemoved = runnerUsesSessionConfig(claim.runner) && !retainSessionConfig;
-      } catch (error: unknown) {
-        scratchCleanupFailure = errorMessage(error);
-        retainSessionConfig = true;
-        if (runnerUsesSessionConfig(claim.runner) && !await sessionConfigRootExists(scratch)) {
-          try {
-            await (dependencies.provisionSessionConfig ?? provisionSessionConfig)(config, claim.runner, scratch);
-          } catch (restoreError: unknown) {
-            scratchCleanupFailure = `${scratchCleanupFailure}; unable to restore session CLI config: ${errorMessage(restoreError)}`;
-          }
-        }
-      }
-    }
+    const sessionDisposal = await sessionConfigLease.settle(succeeded ? "succeeded" : "failed");
     const { salvage: _salvage, ...finishedCleanup } = cleaned;
     const classified = succeeded ? null : primaryDelivery?.failureClass
       ? { failureClass: primaryDelivery.failureClass, retryable: false }
@@ -672,11 +648,11 @@ export const executeClaim = async (
     // salvage result, because it names the ref that actually became durable.
     const { failure: deliveryFailure } = primaryDelivery ?? {};
     const { failure: _deliveryError, ...deliveryPayload } = delivery ?? { pushStatus: "NOT_REQUESTED" as const };
-    const retainedPath = await retainedSessionConfigPath(claim.runner, scratch);
+    const retainedPath = sessionDisposal.retainedPath;
     const cleanupFailureReason = [
       finishedCleanup.cleanupFailureReason,
-      scratchCleanupFailure
-        ? appendRetainedSessionConfig(`Session CLI config cleanup failed: ${scratchCleanupFailure}`, retainedPath)
+      sessionDisposal.cleanupFailureReason
+        ? appendRetainedSessionConfig(`Session CLI config cleanup failed: ${sessionDisposal.cleanupFailureReason}`, retainedPath)
         : null,
     ].filter((reason): reason is string => reason !== undefined && reason !== null).join("; ");
     const completionCleanup = cleanupFailureReason
@@ -687,7 +663,7 @@ export const executeClaim = async (
     // one heartbeat interval old — half the lease — and the completion call is
     // itself bounded by RUNNER_API_TIMEOUT_MS, so it cannot outlive that.
     lease.close();
-    await completeRun(config, claim, {
+    await controlPlane.completeRun(config, claim, {
       exitCode: evidence.exitCode,
       signal: evidence.signal,
       terminalEventSeen: evidence.terminalEventSeen,
@@ -724,11 +700,12 @@ export const executeClaim = async (
   } catch (error: unknown) {
     closeProviderLaunch();
     if (heartbeatTimer) clearInterval(heartbeatTimer);
-    if ((error as { status?: number; code?: string }).status === 409 && (error as { code?: string }).code === "WAITING_INBOX") {
-      waitingInbox = true;
+    const authority = controlPlane.authorityFor(error);
+    if (!authority.held) {
+      waitingInbox = authority.reason === "waiting-inbox";
       fencingRejected = true;
-      if (handle) await adapter.kill(handle, "waiting for Inbox reply").catch(() => undefined);
-      return;
+      if (handle) await adapter.kill(handle, waitingInbox ? "waiting for Inbox reply" : "fencing token rejected").catch(() => undefined);
+      if (waitingInbox) return;
     }
     const message = errorMessage(error);
     if (handle) await adapter.kill(handle, RUNNER_EXCEPTION_REASON).catch(() => undefined);
@@ -739,9 +716,9 @@ export const executeClaim = async (
       }
       if (waitingInbox) return;
       if (workspace) {
-        const cleaned = await cleanup(config, claim, workspace, false);
+        const cleaned = await cleanup(config, claim, workspace, false, false, controlPlane);
         const { salvage: _salvage, ...cleanupOutcome } = cleaned;
-        await recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((reportError: unknown) => {
+        await controlPlane.recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((reportError: unknown) => {
           console.error(`Unable to record lease-independent cleanup outcome: ${errorMessage(reportError)}`);
         });
       }
@@ -750,36 +727,18 @@ export const executeClaim = async (
     const evidence = preflightEvidence(message);
     const classified = adapter.classifyError(evidence);
     const worktreeReport = await worktreeContainmentReport();
-    const cleaned = await cleanup(config, claim, workspace, config.failedWorkspaceRetention > 0);
+    const cleaned = await cleanup(config, claim, workspace, config.failedWorkspaceRetention > 0, false, controlPlane);
     const { salvage, ...finishedCleanup } = cleaned;
-    let restorationFailure: string | null = null;
-    if (runnerUsesSessionConfig(claim.runner) && scratch && sessionConfigRemoved) {
-      try {
-        await (dependencies.provisionSessionConfig ?? provisionSessionConfig)(config, claim.runner, scratch);
-        sessionConfigRemoved = false;
-        retainSessionConfig = true;
-      } catch (restoreError: unknown) {
-        restorationFailure = errorMessage(restoreError);
-      }
+    const sessionDisposal = sessionConfigLease && scratch
+      ? await sessionConfigLease.settle("failed")
+      : { retainedPath: null, cleanupFailureReason: null };
+    if (sessionDisposal.cleanupFailureReason === null) scratch = null;
+    let failureReason = appendRetainedSessionConfig(message, sessionDisposal.retainedPath);
+    if (sessionDisposal.cleanupFailureReason) {
+      failureReason = `${failureReason}; scratch cleanup failed: ${sessionDisposal.cleanupFailureReason}`;
     }
-    let scratchCleanupFailure: string | null = null;
-    const retainedPath = await retainedSessionConfigPath(claim.runner, scratch);
-    if (scratch) {
-      try {
-        // An exception is a failed run, so the session CLI config must remain
-        // available for diagnosis or resume. Claude has no provisioned config root, and
-        // cleanupAgentScratch safely removes its absent path.
-        await (dependencies.cleanupAgentScratch ?? cleanupAgentScratch)(config, scratch, { retainConfigRoot: runnerUsesSessionConfig(claim.runner) });
-        scratch = null;
-      } catch (cleanupError: unknown) {
-        scratchCleanupFailure = errorMessage(cleanupError);
-      }
-    }
-    let failureReason = appendRetainedSessionConfig(message, retainedPath);
-    if (restorationFailure) failureReason = `${failureReason}; unable to restore session CLI config after completion failure: ${restorationFailure}`;
-    if (scratchCleanupFailure) failureReason = `${failureReason}; scratch cleanup failed: ${scratchCleanupFailure}`;
-    await appendActivity(config, claim, message, { stream: "stderr" }).catch(() => undefined);
-    await completeRun(config, claim, {
+    await controlPlane.appendActivity(config, claim, message, { stream: "stderr" }).catch(() => undefined);
+    await controlPlane.completeRun(config, claim, {
       exitCode: evidence.exitCode,
       signal: null,
       terminalEventSeen: false,
@@ -799,9 +758,9 @@ export const executeClaim = async (
       ...(salvage ?? {}),
       ...worktreeReport,
       ...finishedCleanup,
-      ...(scratchCleanupFailure ? {
+      ...(sessionDisposal.cleanupFailureReason ? {
         cleanupStatus: "FAILED" as const,
-        cleanupFailureReason: [finishedCleanup.cleanupFailureReason, scratchCleanupFailure].filter(Boolean).join("; "),
+        cleanupFailureReason: [finishedCleanup.cleanupFailureReason, sessionDisposal.cleanupFailureReason].filter(Boolean).join("; "),
       } : {}),
     });
   } finally {
@@ -811,17 +770,28 @@ export const executeClaim = async (
     // Throwaway by construction, so losing it costs nothing and leaving it
     // behind would leak a directory per run.
     if (scratch) {
-      await (dependencies.cleanupAgentScratch ?? cleanupAgentScratch)(config, scratch, { retainConfigRoot: retainSessionConfig })
-        .catch((error: unknown) => console.error(`Agent scratch cleanup failed${runnerUsesSessionConfig(claim.runner) ? `; session config ${scratch?.configRoot} retained or may require manual recovery` : ""}`, error));
+      if (sessionConfigLease) {
+        const disposal = await sessionConfigLease.settle("failed");
+        if (disposal.cleanupFailureReason) {
+          console.error(`Agent scratch cleanup failed${disposal.retainedPath ? `; session config retained at ${disposal.retainedPath}` : ""}: ${disposal.cleanupFailureReason}`);
+        }
+      } else {
+        await (dependencies.cleanupAgentScratch ?? cleanupAgentScratch)(config, scratch, {
+          retainConfigRoot: RUNNER_DEFINITIONS[claim.runner].isolatesSessionConfig,
+        }).catch((cleanupError: unknown) => console.error("Agent scratch cleanup failed", cleanupError));
+      }
     }
   }
 };
 
-export const pollForTask = async (config: RunnerConfig): Promise<boolean> => {
-  const claim = await claimTask(config);
+export const pollForTask = async (
+  config: RunnerConfig,
+  controlPlane: ControlPlane = defaultControlPlane,
+): Promise<boolean> => {
+  const claim = await controlPlane.claim(config);
   if (!claim) return false;
   console.log(`Claimed run ${claim.run.id} for task ${claim.task.id} via ${claim.runner.toLowerCase()}`);
-  await executeClaim(config, claim);
+  await executeClaim(config, claim, { controlPlane });
   return true;
 };
 
@@ -832,6 +802,7 @@ export type StartupReportRetryOptions = {
   wait?: (attempt: number) => Promise<void>;
   onRetry?: (runner: RunnerKind, attempt: number, attempts: number) => void;
   onAvailability?: (availability: CliAvailability) => void;
+  controlPlane?: ControlPlane;
 };
 
 const waitBeforeStartupReportRetry = async (attempt: number): Promise<void> => {
@@ -842,16 +813,12 @@ const waitBeforeStartupReportRetry = async (attempt: number): Promise<void> => {
   await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
 };
 
-const startupApiMayBecomeReady = (error: unknown): boolean => {
-  const status = (error as { status?: unknown }).status;
-  return status === undefined || (typeof status === "number" && status >= 500);
-};
-
 const reportStartupStateWithRetry = async (
   runner: RunnerKind,
   send: () => Promise<void>,
   options: StartupReportRetryOptions,
 ): Promise<void> => {
+  const controlPlane = options.controlPlane ?? defaultControlPlane;
   const attempts = options.attempts ?? STARTUP_REPORT_ATTEMPTS;
   if (!Number.isSafeInteger(attempts) || attempts < 1) throw new Error("startup report attempts must be a positive integer");
   const wait = options.wait ?? waitBeforeStartupReportRetry;
@@ -864,7 +831,7 @@ const reportStartupStateWithRetry = async (
       await send();
       return;
     } catch (error: unknown) {
-      if (attempt >= attempts || !startupApiMayBecomeReady(error)) throw error;
+      if (attempt >= attempts || !controlPlane.retriableStartupError(error)) throw error;
       onRetry(runner, attempt, attempts);
       await wait(attempt);
     }
@@ -874,10 +841,10 @@ const reportStartupStateWithRetry = async (
 const reportPreflightWithRetry = async (
   config: RunnerConfig,
   runner: RunnerKind,
-  result: Parameters<typeof reportPreflight>[2],
+  result: Parameters<ControlPlane["reportPreflight"]>[2],
   options: StartupReportRetryOptions,
 ): Promise<void> => reportStartupStateWithRetry(
-  runner, () => reportPreflight(config, runner, result), options,
+  runner, () => (options.controlPlane ?? defaultControlPlane).reportPreflight(config, runner, result), options,
 );
 
 const reportAvailabilityWithRetry = async (
@@ -886,7 +853,7 @@ const reportAvailabilityWithRetry = async (
   options: StartupReportRetryOptions,
 ): Promise<void> => reportStartupStateWithRetry(
   availability.runner,
-  async () => { await reportCliAvailability(config, availability); },
+  async () => { await (options.controlPlane ?? defaultControlPlane).reportCliAvailability(config, availability); },
   options,
 );
 
@@ -923,6 +890,7 @@ export const runStartupPreflight = async (
 export type AvailabilityHeartbeatOptions = {
   onReportError?: (availability: CliAvailability, error: unknown) => void;
   onPreflightError?: (availability: CliAvailability, error: unknown) => void;
+  controlPlane?: ControlPlane;
 };
 
 const runBackendPreflight = async (
@@ -930,9 +898,8 @@ const runBackendPreflight = async (
   runner: RunnerKind,
   env = workspaceEnvironment(config),
 ) => {
-  const model = runner === "PI" ? "openai-codex/gpt-5.6-luna"
-    : runner === "CODEX" ? CODEX_STARTER_MODEL : runner.toLowerCase();
-  return adapters[runner].preflight({ config, runner, model, env });
+  const definition = RUNNER_DEFINITIONS[runner];
+  return definition.adapter.preflight({ config, runner, model: definition.startupPreflightModel, env });
 };
 
 /** One cheap daemon heartbeat. Every backend is attempted independently so a
@@ -941,6 +908,7 @@ export const reportCliAvailabilityHeartbeat = async (
   config: RunnerConfig,
   options: AvailabilityHeartbeatOptions = {},
 ): Promise<void> => {
+  const controlPlane = options.controlPlane ?? defaultControlPlane;
   const availability = await probeSupportedCliAvailability(config);
   const onReportError = options.onReportError ?? ((probe: CliAvailability, error: unknown) => {
     console.error(`Failed to report ${probe.runner.toLowerCase()} runner CLI availability`, error);
@@ -951,14 +919,14 @@ export const reportCliAvailabilityHeartbeat = async (
   for (const runner of SUPPORTED_RUNNERS) {
     let revalidatePreflight = false;
     try {
-      ({ revalidatePreflight } = await reportCliAvailability(config, availability[runner]));
+      ({ revalidatePreflight } = await controlPlane.reportCliAvailability(config, availability[runner]));
     } catch (error: unknown) {
       onReportError(availability[runner], error);
       continue;
     }
     if (revalidatePreflight && availability[runner].available) {
       try {
-        await reportPreflight(config, runner, await runBackendPreflight(config, runner));
+        await controlPlane.reportPreflight(config, runner, await runBackendPreflight(config, runner));
       } catch (error: unknown) {
         onPreflightError(availability[runner], error);
       }

--- a/packages/runner/src/session-config-lease.test.ts
+++ b/packages/runner/src/session-config-lease.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { RunnerConfig } from "./config.js";
+import { openSessionConfig } from "./session-config-lease.js";
+import type { AgentScratch } from "./workspace.js";
+
+const config = { runAsPrefix: [] } as unknown as RunnerConfig;
+
+const scratch: AgentScratch = {
+  base: "/scratch/base",
+  workspaceRoot: "/scratch/workspaces",
+  stateDir: "/scratch/control-plane",
+  configRoot: "/sessions/session-1/config",
+};
+
+test("cleanup failure restores an isolated config root and reports a structured retained disposal", async () => {
+  let rootExists = true;
+  let provisions = 0;
+  let cleanups = 0;
+  const lease = openSessionConfig(config, { runner: "CODEX", resume: null }, scratch, {
+    sessionConfigRootExists: async () => rootExists,
+    provisionSessionConfig: async () => {
+      provisions += 1;
+      rootExists = true;
+    },
+    cleanupAgentScratch: async (_config, _scratch, options) => {
+      cleanups += 1;
+      assert.equal(options?.retainConfigRoot, false);
+      rootExists = false;
+      throw new Error("cleanup refused after removing config root");
+    },
+  });
+
+  const disposal = await lease.settle("succeeded");
+
+  assert.equal(lease.isolated, true);
+  assert.equal(cleanups, 1);
+  assert.equal(provisions, 1);
+  assert.equal(disposal.retainedPath, scratch.configRoot);
+  assert.equal(disposal.cleanupFailureReason, "cleanup refused after removing config root");
+});
+
+test("a failed terminal write re-provisions a config root removed by prior success cleanup", async () => {
+  let rootExists = true;
+  let provisions = 0;
+  const retained: boolean[] = [];
+  const lease = openSessionConfig(config, { runner: "PI", resume: null }, scratch, {
+    sessionConfigRootExists: async () => rootExists,
+    provisionSessionConfig: async () => {
+      provisions += 1;
+      rootExists = true;
+    },
+    cleanupAgentScratch: async (_config, _scratch, options) => {
+      retained.push(options?.retainConfigRoot === true);
+      if (!options?.retainConfigRoot) rootExists = false;
+    },
+  });
+
+  assert.deepEqual(await lease.settle("succeeded"), {
+    retainedPath: null,
+    cleanupFailureReason: null,
+  });
+  assert.deepEqual(await lease.settle("failed"), {
+    retainedPath: scratch.configRoot,
+    cleanupFailureReason: null,
+  });
+  assert.equal(provisions, 1);
+  assert.deepEqual(retained, [false, true]);
+});

--- a/packages/runner/src/session-config-lease.ts
+++ b/packages/runner/src/session-config-lease.ts
@@ -1,0 +1,73 @@
+import { RUNNER_DEFINITIONS } from "./adapters.js";
+import type { ClaimedTask } from "./api.js";
+import type { RunnerConfig } from "./config.js";
+import {
+  cleanupAgentScratch,
+  provisionSessionConfig,
+  sessionConfigRootExists,
+  type AgentScratch,
+} from "./workspace.js";
+
+export type SessionConfigDisposal = {
+  retainedPath: string | null;
+  cleanupFailureReason: string | null;
+};
+
+export type SessionConfigLease = {
+  readonly isolated: boolean;
+  retainedPath(): Promise<string | null>;
+  settle(outcome: "succeeded" | "failed"): Promise<SessionConfigDisposal>;
+};
+
+export type SessionConfigLeaseDependencies = {
+  provisionSessionConfig?: typeof provisionSessionConfig;
+  cleanupAgentScratch?: typeof cleanupAgentScratch;
+  sessionConfigRootExists?: typeof sessionConfigRootExists;
+};
+
+const errorMessage = (error: unknown): string => error instanceof Error ? error.message : String(error);
+
+/**
+ * Owns the lifecycle of one Session's CLI config root. A failed outcome keeps
+ * an isolated root for diagnosis or resume. If scratch cleanup removes or
+ * partially removes that root before failing, the module restores it from the
+ * same adapter before reporting the structured disposal result.
+ */
+export const openSessionConfig = (
+  config: RunnerConfig,
+  claim: Pick<ClaimedTask, "runner" | "resume">,
+  scratch: AgentScratch,
+  dependencies: SessionConfigLeaseDependencies = {},
+): SessionConfigLease => {
+  const isolated = RUNNER_DEFINITIONS[claim.runner].isolatesSessionConfig;
+  const provision = dependencies.provisionSessionConfig ?? provisionSessionConfig;
+  const cleanup = dependencies.cleanupAgentScratch ?? cleanupAgentScratch;
+  const rootExists = dependencies.sessionConfigRootExists ?? sessionConfigRootExists;
+
+  const retainedPath = async (): Promise<string | null> =>
+    isolated && await rootExists(scratch) ? scratch.configRoot : null;
+
+  const restore = async (): Promise<string | null> => {
+    if (!isolated || await rootExists(scratch)) return null;
+    try {
+      await provision(config, claim.runner, scratch);
+      return null;
+    } catch (error: unknown) {
+      return `unable to restore session CLI config: ${errorMessage(error)}`;
+    }
+  };
+
+  return {
+    isolated,
+    retainedPath,
+    settle: async (outcome): Promise<SessionConfigDisposal> => {
+      let cleanupFailureReason = outcome === "failed" ? await restore() : null;
+      try {
+        await cleanup(config, scratch, { retainConfigRoot: isolated && outcome === "failed" });
+      } catch (error: unknown) {
+        cleanupFailureReason = [errorMessage(error), await restore()].filter(Boolean).join("; ");
+      }
+      return { retainedPath: await retainedPath(), cleanupFailureReason };
+    },
+  };
+};

--- a/packages/runner/src/test-control-plane.ts
+++ b/packages/runner/src/test-control-plane.ts
@@ -1,0 +1,227 @@
+import {
+  authorityFor,
+  authorityAfterHeartbeat,
+  ControlPlaneError,
+  retriableStartupError,
+  type ClaimedTask,
+  type Completion,
+  type ControlPlane,
+  type ReclaimResult,
+  type SessionEventPayload,
+  type SessionTaskOutputStatus,
+} from "./api.js";
+import type { RunnerKind } from "./config.js";
+
+type AsyncMethodName = {
+  [K in keyof ControlPlane]: ControlPlane[K] extends (...args: never[]) => Promise<unknown> ? K : never
+}[keyof ControlPlane];
+
+export type ControlPlaneOverrides = Partial<Pick<ControlPlane, AsyncMethodName>>;
+
+export type ControlPlaneDouble = {
+  controlPlane: ControlPlane;
+  completions: Completion[];
+  starts: Array<Record<string, unknown> & { promptHash: string }>;
+  eventBatches: SessionEventPayload[][];
+  activities: Array<{ body: string; metadata: Record<string, unknown> }>;
+  publishedBranches: string[];
+  leaseIndependentCleanups: Array<{ cleanupStatus: string; cleanupFailureReason?: string; workspaceRetained: boolean }>;
+  reclaimReports: ReclaimResult[][];
+  reclaimPublications: string[];
+  preflightReports: Array<{ runner: RunnerKind; result: Parameters<ControlPlane["reportPreflight"]>[2] }>;
+  availabilityReports: Parameters<ControlPlane["reportCliAvailability"]>[1][];
+  heartbeatCount: () => number;
+  outputStatusReadCount: () => number;
+};
+
+/** In-memory adapter for tests that need runner domain outcomes, not HTTP routes. */
+export const createControlPlaneDouble = (
+  overrides: ControlPlaneOverrides = {},
+): ControlPlaneDouble => {
+  const completions: Completion[] = [];
+  const starts: Array<Record<string, unknown> & { promptHash: string }> = [];
+  const eventBatches: SessionEventPayload[][] = [];
+  const activities: Array<{ body: string; metadata: Record<string, unknown> }> = [];
+  const publishedBranches: string[] = [];
+  const leaseIndependentCleanups: Array<{ cleanupStatus: string; cleanupFailureReason?: string; workspaceRetained: boolean }> = [];
+  const reclaimReports: ReclaimResult[][] = [];
+  const reclaimPublications: string[] = [];
+  const preflightReports: ControlPlaneDouble["preflightReports"] = [];
+  const availabilityReports: ControlPlaneDouble["availabilityReports"] = [];
+  let heartbeats = 0;
+  let outputStatusReads = 0;
+
+  const controlPlane: ControlPlane = {
+    claim: async (config) => overrides.claim?.(config) ?? null,
+    startRun: async (config, claim, snapshot) => {
+      starts.push(snapshot);
+      await overrides.startRun?.(config, claim, snapshot);
+    },
+    heartbeat: async (config, claim, state) => {
+      heartbeats += 1;
+      return await overrides.heartbeat?.(config, claim, state) ?? { ok: true, cancellation: null };
+    },
+    appendEvents: async (config, claim, events, providerConversationId) => {
+      eventBatches.push(events);
+      await overrides.appendEvents?.(config, claim, events, providerConversationId);
+    },
+    appendActivity: async (config, claim, body, metadata) => {
+      activities.push({ body, metadata: metadata ?? {} });
+      await overrides.appendActivity?.(config, claim, body, metadata);
+    },
+    completeRun: async (config, claim, completion) => {
+      completions.push(completion);
+      await overrides.completeRun?.(config, claim, completion);
+    },
+    readSessionTaskOutputStatus: async (config, claim) => {
+      outputStatusReads += 1;
+      return await overrides.readSessionTaskOutputStatus?.(config, claim) ?? null;
+    },
+    recordPublishedBranch: async (config, claim, branch) => {
+      publishedBranches.push(branch);
+      await overrides.recordPublishedBranch?.(config, claim, branch);
+    },
+    recordLeaseIndependentCleanup: async (config, claim, cleanup) => {
+      leaseIndependentCleanups.push(cleanup);
+      await overrides.recordLeaseIndependentCleanup?.(config, claim, cleanup);
+    },
+    acknowledgeCancellation: async (config, claim, cancellation, workspace, containment) => {
+      await overrides.acknowledgeCancellation?.(config, claim, cancellation, workspace, containment);
+    },
+    fetchReclaimPlan: async (config, inventory) => overrides.fetchReclaimPlan?.(config, inventory) ?? null,
+    reportReclaimOutcomes: async (config, report) => {
+      reclaimReports.push(report.results);
+      await overrides.reportReclaimOutcomes?.(config, report);
+    },
+    recordReclaimPublication: async (config, body) => {
+      reclaimPublications.push(body.pushedBranch);
+      await overrides.recordReclaimPublication?.(config, body);
+    },
+    reportPreflight: async (config, runner, result) => {
+      preflightReports.push({ runner, result });
+      await overrides.reportPreflight?.(config, runner, result);
+    },
+    reportCliAvailability: async (config, availability) => {
+      availabilityReports.push(availability);
+      return await overrides.reportCliAvailability?.(config, availability) ?? { revalidatePreflight: false };
+    },
+    authorityFor,
+    authorityAfterHeartbeat,
+    retriableStartupError,
+  };
+
+  return {
+    controlPlane,
+    completions,
+    starts,
+    eventBatches,
+    activities,
+    publishedBranches,
+    leaseIndependentCleanups,
+    reclaimReports,
+    reclaimPublications,
+    preflightReports,
+    availabilityReports,
+    heartbeatCount: () => heartbeats,
+    outputStatusReadCount: () => outputStatusReads,
+  };
+};
+
+export const controlPlaneClaim = (claim: ClaimedTask): ControlPlaneOverrides => ({
+  claim: async () => claim,
+});
+
+export type ControlPlaneFetchHandler = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Migration adapter for older runner tests whose scenarios were expressed as
+ * synthetic HTTP responses. The production code still receives a ControlPlane
+ * double; this adapter keeps those fixtures local while newer tests use direct
+ * operation overrides above.
+ */
+export const createRoutedControlPlaneDouble = (
+  handler: ControlPlaneFetchHandler,
+): ControlPlaneDouble => {
+  const request = async <T>(
+    config: Parameters<ControlPlane["completeRun"]>[0],
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<T> => {
+    const response = await handler(`${config.apiUrl}${path}`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    const responseBody = await response.text();
+    if (!response.ok) {
+      let code: string | undefined;
+      try { code = (JSON.parse(responseBody) as { code?: string }).code; } catch { /* non-JSON error */ }
+      throw new ControlPlaneError(response.status, responseBody, code);
+    }
+    return (responseBody.trim() ? JSON.parse(responseBody) : {}) as T;
+  };
+
+  return createControlPlaneDouble({
+    startRun: async (config, claim, snapshot) => {
+      await request(config, `/runner/runs/${claim.run.id}/start`, {
+        runnerId: config.runnerId, fencingToken: claim.fencingToken, ...snapshot,
+      });
+    },
+    heartbeat: async (config, claim, state) => request(config, `/runner/runs/${claim.run.id}/heartbeat`, {
+      runnerId: config.runnerId, fencingToken: claim.fencingToken, ...state,
+    }),
+    appendEvents: async (config, claim, events, providerConversationId) => {
+      await request(config, `/runner/runs/${claim.run.id}/events`, {
+        runnerId: config.runnerId, fencingToken: claim.fencingToken, providerConversationId: providerConversationId ?? null, events,
+      });
+    },
+    appendActivity: async (config, claim, body, metadata) => {
+      await request(config, `/runner/runs/${claim.run.id}/activity`, {
+        fencingToken: claim.fencingToken, actorId: config.runnerId, body, metadata: metadata ?? {},
+      });
+    },
+    completeRun: async (config, claim, completion) => {
+      await request(config, `/runner/runs/${claim.run.id}/complete`, {
+        runnerId: config.runnerId, fencingToken: claim.fencingToken, ...completion,
+      });
+    },
+    readSessionTaskOutputStatus: async (config, claim) => {
+      const payload = await request<{ task: SessionTaskOutputStatus | null }>(
+        config,
+        `/session/runs/${claim.run.id}/status`,
+        {},
+      );
+      return payload.task;
+    },
+    recordPublishedBranch: async (config, claim, pushedBranch) => {
+      await request(config, `/runner/runs/${claim.run.id}/publication`, {
+        runnerId: config.runnerId, fencingToken: claim.fencingToken, pushedBranch,
+      });
+    },
+    recordLeaseIndependentCleanup: async (config, claim, cleanup) => {
+      await request(config, `/runner/runs/${claim.run.id}/cleanup`, {
+        runnerId: config.runnerId, fencingToken: claim.fencingToken, ...cleanup,
+      });
+    },
+    acknowledgeCancellation: async (config, claim, cancellation, workspace, containment) => {
+      await request(config, `/runner/runs/${claim.run.id}/cancel/acknowledge`, {
+        runnerId: config.runnerId,
+        fencingToken: claim.fencingToken,
+        requestId: cancellation.requestId,
+        ...(workspace ? { workspacePath: workspace.path, branch: workspace.branch, baseSha: workspace.baseSha } : {}),
+        ...containment,
+      });
+    },
+    reportPreflight: async (config, runner, result) => {
+      await request(config, "/runner/preflight", { runner, ...result });
+    },
+    reportCliAvailability: async (config, availability) => {
+      const body = await request<{ revalidatePreflight?: boolean }>(config, "/runner/availability", {
+        runnerId: config.runnerId, ...availability,
+      });
+      return { revalidatePreflight: body.revalidatePreflight === true };
+    },
+  });
+};


### PR DESCRIPTION
## 交付物

- 候选 8：把 runner ↔ control plane 交互收进 `ControlPlane` interface；用 typed `ControlPlaneError`、`Authority` 判别联合与 startup retry classifier 取代分散的 status/code cast。
- 候选 8 验收：五个指定测试文件的 39 处 `globalThis.fetch` monkey-patch 全部改为注入 `ControlPlane` double，并新增 Authority 直接单测。
- 候选 10：新增 `SessionConfigLease`，统一 isolated session config 的 retain、cleanup、restore 与 structured disposal；`RunnerDefinition.isolatesSessionConfig` 成为唯一 provider registry 事实。
- 候选 15：新增 `RunnerDefinition.startupPreflightModel`，删除 `runner.ts` provider 三元式和 `adapters.ts` 的 `CODEX_STARTER_MODEL` 转出口；`PreflightSpec.model` 改为 `string | null`。

## 验收结果

- `npm run build -w @agentos/runner`：通过。
- 相关直接测试（ControlPlane、SessionConfigLease、DeliveryLease、reclaim）：30/30 通过。
- `npm run build -w @agentos/web`：通过；该 build 是仓库两个资产测试的显式前置条件。
- `RUNNER_WORKSPACE_ROOT=<fresh-temp> npm test`：通过；runner 307 项为 305 pass / 2 environment skip，其他 workspace 全绿。
- `npm run lint`：通过（Biome 507 files；ESLint 通过）。
- 未改 `*.dbtest.ts`，所以提交前不单跑 `npm run test:db`；exact-head merge gate 覆盖完整 DB suite。

## 替 Leo 做的选择

- 用一个递进 PR 承载 8→10→15：三项共享 `runner.ts` call sites 与 `RUNNER_DEFINITIONS`，拆开会增加冲突而没有独立交付价值。
- 从创建 worktree 时的最新本地 `main` 建分支，而不把共享 checkout 回退到旧 OID：保留并发窗口已交付的 append-only 历史；gate 前 merge 最新 `origin/main`。
- 将 `ControlPlane` 注入延伸到 workspace disposal 与 reclaim：这是消除任务点名的五个文件全部 39 处 global fetch patch 所必需的同一 seam，不是新领域范围。
- transport 层使用 `ControlPlaneError`，caller 只消费 `Authority`：HTTP status/code 仍由 adapter 解码，Run authority 的解释权留在 control plane module。
- 在 session config provision 之前打开 `SessionConfigLease`：这样 provision 中途失败也能走统一 retain/report 回路。
- Claude startup model 设为 `null`，并只在非 null 时上报 `verifiedModel`：Claude preflight 没有执行 model 验证，继续上报假 model 会制造错误证据。
- 旧 runner 场景暂用 test-only routed double 承接既有 HTTP fixture，新规则测试直接注入 operation override：生产路径已完全走 interface，同时避免一次重写大量与本任务无关的场景数据。
- 不新增兼容 export：候选 15 明确要求删除 `adapters.ts` 转出口，现有调用方改为从 owning adapter module 导入。
- merge 冲突保留 main 新增的 remediation containment、cancellation 与 evidence 语义，并让它们接入 `ControlPlane` seam：不能用本分支的旧逻辑覆盖后来已交付的安全强化。

## 合并尾验证

- merge 最新 `main` 后，main 同期新增的 7 个 `run-output` fetch fixture 也改为 operation double，五个验收文件仍为零 monkey-patch。
- integrated runner build：通过。
- 冲突相关测试：59/59 通过。
- integrated `npm run lint`：通过（Biome 513 files；ESLint 通过）。
- exact-head gate：`MERGE GATE: PASS 9a512333913a4349c3e73abc54ca3aa2f45f400a`。