### PR TITLE
refactor(api): centralize step admission

### DIFF
--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -902,6 +902,31 @@ const retryRequest = async (
     // which is what `maxRunsPerTask: 4` already was.
     budgetGrants: 0,
   };
+  const currentTask = {
+    id: "task-1",
+    projectId: "project-1",
+    name: "Retry me",
+    description: "Use current config",
+    assigneeType: "AGENT",
+    assigneeAgentId: assigneeAgent?.id ?? null,
+    repoId: "repo-current",
+    repo: null,
+    templateId: null,
+    templateStepId: currentTemplateStep ? "step-1" : null,
+    maxSessionsPerTask: 4,
+    maxDurationMin: 120,
+    stallTimeoutMin: 10,
+    opensPullRequest: true,
+    chainId: null,
+    chainIndex: null,
+    targetBranch: "main",
+    archivedAt: null,
+    dispatchAfterTaskId: null,
+    dispatchAfter: null,
+    assigneeAgent,
+    templateStep: currentTemplateStep,
+    runs: [last],
+  };
   const database = {
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
       // Retry takes the shared task-row lock before it reads anything else.
@@ -909,38 +934,24 @@ const retryRequest = async (
       agent: { findUnique: async () => lockedAgent(assigneeAgent as Record<string, unknown> | null) },
       task: {
         findUniqueOrThrow: async () => ({ id: "task-1", status: "TODO", archivedAt: null }),
-        findUnique: async () => ({
-          id: "task-1",
-          projectId: "project-1",
-          name: "Retry me",
-          description: "Use current config",
-          assigneeType: "AGENT",
-          assigneeAgentId: assigneeAgent?.id ?? null,
-          repoId: "repo-current",
-          repo: null,
-          templateId: null,
-          templateStepId: currentTemplateStep ? "step-1" : null,
-          maxSessionsPerTask: 4,
-          maxDurationMin: 120,
-          stallTimeoutMin: 10,
-          opensPullRequest: true,
-          chainId: null,
-          chainIndex: null,
-          targetBranch: "main",
-          archivedAt: null,
-          assigneeAgent,
-          templateStep: currentTemplateStep,
-          runs: [last],
-        }),
+        findUnique: async () => currentTask,
+        findMany: async () => [currentTask],
         update: async () => ({}),
       },
       run: {
         count: async () => 0,
+        groupBy: async () => [{
+          taskId: "task-1",
+          status: "FAILED",
+          _count: { _all: 1 },
+          _max: { budgetGrants: 0 },
+        }],
         create: async ({ data }: { data: Record<string, unknown> }) => {
           created = data;
           return { id: "run-2", ...data };
         },
       },
+      agentRepoAccess: { count: async () => 1 },
       taskActivity: { create: async () => ({}) },
     }),
   } as unknown as PrismaClient;

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -15,7 +15,6 @@ import {
   InboxKind,
   InboxSender,
   InboxStatus,
-  lockAgentRepoGrant,
   lockAgentRepoGrantForRevocation,
   lockAgentRow,
   lockChainRows,
@@ -59,7 +58,6 @@ import {
   type CandidateActivity,
   type CardRow,
   type DecisionRow,
-  isMergeReadinessStep,
   mergeRecoveryPhase,
   type MergeRecoveryAttempt,
 } from "@agentos/db";
@@ -98,18 +96,15 @@ import {
 import {
   chainKey,
   chainProgress,
-  chainStartDecisions,
   chainProgressByChain,
   positions,
-  blockingPredecessor,
-  runFactsByTask,
-  taskStartability,
+  readStepAdmission,
+  readStepAdmissions,
   stepName,
 } from "./chain.js";
 import {
   jsonValue,
   normalizeSessionEventValue,
-  runBudgetCeiling,
 } from "./execution.js";
 import { createArchivedRunNoticeScheduler, noteArchivedQueuedRuns, reconcileDatabaseRuns } from "./reconcile.js";
 import {
@@ -2405,49 +2400,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   });
   app.get("/tasks/:taskId/startability", async (context) => {
     const taskId = id.parse(context.req.param("taskId"));
-    const task = await db.task.findUnique({
-      where: { id: taskId },
-      include: {
-        assigneeAgent: { select: { id: true, title: true, archivedAt: true } },
-        repo: { select: { id: true, name: true, defaultBranch: true } },
-        dispatchAfter: { select: { id: true, name: true, status: true } },
-      },
-    });
-    if (!task) return context.json({ error: "Task not found" }, 404);
-    const [grant, budget, activeRuns, prefix] = await Promise.all([
-      task.assigneeAgentId && task.repoId
-        ? db.agentRepoAccess.findFirst({
-          where: { projectId: task.projectId, agentId: task.assigneeAgentId, repoId: task.repoId },
-          select: { agentId: true },
-        })
-        : null,
-      db.run.aggregate({
-        where: { taskId },
-        _count: { _all: true },
-        _max: { budgetGrants: true },
-      }),
-      db.run.count({ where: { taskId, status: { in: ACTIVE_RUN_STATUSES } } }),
-      task.chainId && task.chainIndex !== null
-        ? db.task.findMany({
-          where: {
-            projectId: task.projectId,
-            chainId: task.chainId,
-          },
-          select: { id: true, name: true, status: true, chainIndex: true, chainLayer: true },
-        })
-        : [],
-    ]);
-    const blocker = blockingPredecessor(prefix, taskId);
-    const verdict = taskStartability({
-      ...task,
-      hasRepoGrant: grant !== null,
-    }, {
-      total: budget._count._all,
-      active: activeRuns > 0,
-      budgetGrants: budget._max.budgetGrants,
-    }, task.maxSessionsPerTask, blocker === null);
+    const admission = await db.$transaction((tx) => readStepAdmission(tx, taskId, { locked: false }));
+    if (!admission.task) return refusalJson(context, admission.refusal);
+    const task = admission.task;
     return context.json({
-      ...verdict,
+      ...admission.verdict,
       task: {
         id: task.id,
         name: task.name,
@@ -2471,7 +2428,6 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         id: true,
         title: true,
         archivedAt: true,
-        repoAccess: { where: { projectId: subject.projectId }, select: { repoId: true } },
       } },
       templateStep: {
         select: {
@@ -2517,29 +2473,16 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       dispatchAfter: row.id === firstTask?.id ? dispatchAfter : null,
     }));
 
-    const [runGroups, recoveryRow] = await Promise.all([
-      chainRows.length === 0 ? [] : db.run.groupBy({
-        by: ["taskId", "status"],
-        where: { taskId: { in: chainRows.map((row) => row.id) } },
-        _count: { _all: true },
-        // The grants travel with the count, in the same one query: a step whose
-        // failures were all provisioning failures has been refunded them, and its
-        // Start button must say so.
-        _max: { budgetGrants: true },
-      }),
+    const [admissions, recoveryRow] = await Promise.all([
+      db.$transaction((tx) => readStepAdmissions(tx, chainRows.map((row) => row.id), { locked: false })),
       db.mergeRecoveryAttempt.findFirst({
         where: { integratorTask: { projectId: subject.projectId, chainId: subject.chainId } },
         orderBy: [{ startedAt: "desc" }, { id: "desc" }],
       }),
     ]);
     const mergeRecovery = mergeRecoveryProjection(recoveryRow);
-    const facts = runFactsByTask(runGroups, ACTIVE_RUN_STATUSES);
     const ordinals = positions(chainRows);
     const progress = chainProgress(chainRows);
-    const decisions = chainStartDecisions(chainRows.map((row) => ({
-      ...row,
-      hasRepoGrant: Boolean(row.repoId && row.assigneeAgent?.repoAccess.some((grant) => grant.repoId === row.repoId)),
-    })), facts);
 
     return context.json({
       chainId: subject.chainId,
@@ -2562,9 +2505,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         latestRun: row.runs[0]
           ? { id: row.runs[0].id, status: row.runs[0].status, runNumber: row.runs[0].runNumber }
           : null,
-        startable: decisions.get(row.id)?.startable ?? false,
-        startAction: decisions.get(row.id)?.startAction ?? null,
-        currentExecution: decisions.get(row.id)?.currentExecution ?? false,
+        startable: admissions.get(row.id)?.verdict.startable ?? false,
+        startAction: admissions.get(row.id)?.verdict.startable
+          ? row.status === TaskStatus.BACKLOG ? "recover" : "start"
+          : null,
+        currentExecution: admissions.get(row.id)?.facts.active ?? false,
         blockedOn: row.id === firstTask?.id
           && row.dispatchAfterTaskId !== null
           && dispatchAfter !== null
@@ -2598,45 +2543,14 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const result = await db.$transaction(async (tx) => {
       const locked = await lockTaskMutationRows(tx, taskId);
       if (!locked) return refusal("not-found", "Task not found");
-      const task = await tx.task.findUnique({
-        where: { id: taskId },
-        include: {
-          assigneeAgent: true,
-          // The template name travels with the step because §D-P4's predicate
-          // needs all four facts; a stepIndex and an outputKind alone collide
-          // with any other template that uses the same step index.
-          templateStep: { include: { taskTemplate: { select: { name: true } } } },
-          repo: true,
-          runs: { orderBy: { runNumber: "desc" }, take: 1 },
-        },
-      });
-      if (!task) return refusal("not-found", "Task not found");
-      if (task.chainId && task.chainIndex !== null) {
-        const chainRows = await tx.task.findMany({
-          where: { projectId: task.projectId, chainId: task.chainId },
-          orderBy: [{ chainLayer: "asc" }, { chainIndex: "asc" }, { id: "asc" }],
-          select: { id: true, name: true, status: true, chainIndex: true, chainLayer: true },
-        });
-        const blocker = blockingPredecessor(chainRows.map((row) => ({
-          ...row,
-          projectId: task.projectId,
-          chainId: task.chainId,
-          archivedAt: null,
-          templateStep: null,
-        })), taskId);
-        if (blocker) {
-          return refusal("conflict", `Cannot retry ${task.name}; predecessor ${blocker.name} is not done`);
-        }
+      const admission = await readStepAdmission(tx, taskId, { locked: true });
+      if (!admission.task) return admission.refusal;
+      const task = admission.task;
+      if (admission.blocker) {
+        return refusal("conflict", `Cannot retry ${task.name}; predecessor ${admission.blocker.name} is not done`);
       }
-      const last = task.runs[0];
-      if (!last) return refusal("conflict", "Task has no run to retry");
-      // Checked across ALL of the task's runs with the shared active set, not
-      // the latest run's status alone: the old latest-only enum check missed
-      // PROVISIONING and WAITING_INBOX, so a retry during a clone or a
-      // 7-day Inbox suspension created a second concurrent run writing the
-      // same task and chain branch.
-      const activeRuns = await tx.run.count({ where: { taskId, status: { in: ACTIVE_RUN_STATUSES } } });
-      if (activeRuns > 0) {
+      if (admission.facts.total === 0) return refusal("conflict", "Task has no run to retry");
+      if (admission.facts.active) {
         return refusal("conflict", "Task already has an active run");
       }
       const opened = await openRun(tx, taskId, { kind: "retry", readyAt: now });
@@ -2651,110 +2565,15 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   });
   app.post("/tasks/:taskId/start", async (context) => {
     const taskId = id.parse(context.req.param("taskId"));
-    const identity = await db.task.findUnique({
-      where: { id: taskId }, select: { projectId: true, chainId: true },
-    });
-    if (!identity) return context.json({ error: "Task not found" }, 404);
     try {
       const result = await readCommitted(db, async (tx) => {
         if (!await lockTaskMutationRows(tx, taskId)) {
           return refusal("not-found", "Task not found");
         }
-        const task = await tx.task.findUniqueOrThrow({
-          where: { id: taskId },
-          include: {
-            assigneeAgent: { select: { archivedAt: true } },
-            dispatchAfter: { select: { id: true, name: true, status: true } },
-            templateStep: { include: { taskTemplate: { select: { name: true } } } },
-          },
-        });
-        if (identity.chainId) {
-          const prefix = await tx.task.findMany({
-            where: {
-              projectId: identity.projectId,
-              chainId: identity.chainId,
-            },
-            orderBy: [{ chainLayer: "asc" }, { chainIndex: "asc" }, { id: "asc" }],
-            select: { id: true, name: true, status: true, chainIndex: true, chainLayer: true },
-          });
-          const blocker = blockingPredecessor(prefix.map((row) => ({
-            ...row,
-            projectId: identity.projectId,
-            chainId: identity.chainId,
-            archivedAt: null,
-            templateStep: null,
-          })), taskId);
-          if (blocker) {
-            return refusal("conflict", `Cannot start ${task.name}; predecessor ${blocker.name} is not done`);
-          }
-        }
-        if (task.dispatchAfterTaskId !== null && task.dispatchAfter?.status !== TaskStatus.DONE) {
-          const predecessorName = task.dispatchAfter?.name ?? task.dispatchAfterTaskId;
-          return refusal("conflict", `Cannot start ${task.name}; bound predecessor ${predecessorName} is not done`);
-        }
-        if (task.archivedAt !== null) return refusal("conflict", "Cannot start an archived task");
-        if (task.status === TaskStatus.DONE) return refusal("conflict", "Task is already done");
-        if (task.assigneeType !== AssigneeType.AGENT) {
-          return refusal("conflict", "Human steps cannot be started");
-        }
-        if (isMergeReadinessStep(task.templateStep)) {
-          return refusal("conflict", "Merge readiness is server-owned and cannot be started as a model run");
-        }
-        if (await hasActiveRun(tx, taskId)) {
-          return refusal("conflict", "Task already has an active run");
-        }
-        // A count, not the latest run number: Run is one-to-many and a task at
-        // its ceiling whose last run failed must not look startable.
-        //
-        // Measured against the configured budget *plus the grants on top of it*
-        // rather than the budget alone (issue #113). A run that died
-        // provisioning was refunded onto its own row, and this gate could not
-        // see the refund: a task whose two failures were sub-second clone errors
-        // answered "Run budget exhausted" here while `POST /tasks/:id/retry`,
-        // reading the very same refund one route away, would have queued the
-        // run. Reading the grant rather than the historical `maxRunsPerTask` is
-        // what keeps a budget an operator has just *lowered* in force.
-        const budget = await tx.run.aggregate({
-          where: { taskId },
-          _count: { _all: true },
-          _max: { budgetGrants: true },
-        });
-        const facts = { total: budget._count._all, active: false, budgetGrants: budget._max.budgetGrants };
-        if (facts.total >= runBudgetCeiling(task.maxSessionsPerTask, facts.budgetGrants)) {
-          return refusal("conflict", "Run budget exhausted");
-        }
-        // The specific messages above and below are a reason ladder in front of
-        // the shared predicate, so the operator gets the sentence that names
-        // their problem. `startable` itself is the authority: spec §4.3 defines
-        // the button's enabled state and this guard as one thing, and the route
-        // re-deriving them by hand was how it came to accept gated REVIEW steps
-        // and DOING steps and to answer 500 on a task with no repo.
-        if (task.status !== TaskStatus.TODO && task.status !== TaskStatus.BACKLOG) {
-          return refusal("conflict", "Only Todo and Backlog steps can be started");
-        }
-        if (!task.repoId) {
-          return refusal("invalid-request", "This task has no repository");
-        }
-        if (!task.assigneeAgentId) {
-          return refusal("invalid-request", "This task has no assignee");
-        }
-        const hasRepoGrant = await lockAgentRepoGrant(tx, {
-          projectId: task.projectId,
-          agentId: task.assigneeAgentId,
-          repoId: task.repoId,
-        });
-        if (!hasRepoGrant) {
-          return refusal("invalid-request", "Assignee has no grant for this Repo");
-        }
-        if (!taskStartability({ ...task, hasRepoGrant }, facts, task.maxSessionsPerTask).startable) {
-          // The one remaining `startable` condition with no message of its own
-          // is the archived assignee, and `enqueueTaskRun` already throws an
-          // error that names the agent — a better sentence than anything this
-          // branch could write. Fall through to it; the catch maps it to 409.
-          if (!task.assigneeAgent?.archivedAt) {
-            return refusal("conflict", "This step cannot be started");
-          }
-        }
+        const admission = await readStepAdmission(tx, taskId, { locked: true });
+        if (!admission.task) return admission.refusal;
+        if (admission.refusal) return admission.refusal;
+        const task = admission.task;
         const run = await enqueueTaskRun(tx, taskId);
         const recovering = task.status === TaskStatus.BACKLOG;
         if (recovering) {

--- a/packages/api/src/chain.test.ts
+++ b/packages/api/src/chain.test.ts
@@ -5,10 +5,9 @@ import {
   chainKey,
   chainProgress,
   chainProgressByChain,
-  chainStartDecisions,
+  blockingPredecessor,
   positions,
   runFactsByTask,
-  startable,
   stepName,
   taskStartability,
   type ChainRow,
@@ -138,7 +137,7 @@ const startableRow = (overrides: Partial<StartableRow> = {}): StartableRow => ({
 });
 
 test("a TODO agent step with no runs is startable", () => {
-  assert.equal(startable(startableRow(), { total: 0, active: false }, 3), true);
+  assert.equal(taskStartability(startableRow(), { total: 0, active: false }, 3, true).startable, true);
 });
 
 test("an unresolved dispatch binding blocks the first-step decision", () => {
@@ -149,25 +148,14 @@ test("an unresolved dispatch binding blocks the first-step decision", () => {
   const verdict = taskStartability(rowWithBinding, { total: 0, active: false }, 3, true);
   assert.equal(verdict.startable, false);
   assert.equal(verdict.checklist.predecessorsDone, false);
-  const decision = chainStartDecisions([
-    decisionRow(1, {
-      dispatchAfterTaskId: "predecessor",
-      dispatchAfter: { status: "TODO" },
-    }),
-  ], new Map()).get("step-1")!;
-  assert.equal(decision.startable, false);
-  assert.equal(decision.startAction, null);
 });
 
 test("a resolved dispatch binding restores the ordinary first-step decision", () => {
-  const decision = chainStartDecisions([
-    decisionRow(1, {
-      dispatchAfterTaskId: "predecessor",
-      dispatchAfter: { status: "DONE" },
-    }),
-  ], new Map()).get("step-1")!;
-  assert.equal(decision.startable, true);
-  assert.equal(decision.startAction, "start");
+  const resolved = startableRow({
+    dispatchAfterTaskId: "predecessor",
+    dispatchAfter: { status: "DONE" },
+  });
+  assert.equal(taskStartability(resolved, { total: 0, active: false }, 3, true).startable, true);
 });
 
 test("the exposed checklist and overall verdict come from the shared start predicate", () => {
@@ -200,39 +188,39 @@ test("the exposed checklist and overall verdict come from the shared start predi
 });
 
 test("a BACKLOG agent step is startable — that is what parks it there", () => {
-  assert.equal(startable(startableRow({ status: "BACKLOG" }), { total: 0, active: false }, 3), true);
+  assert.equal(taskStartability(startableRow({ status: "BACKLOG" }), { total: 0, active: false }, 3, true).startable, true);
 });
 
 test("human steps, done steps, and archived steps are not startable", () => {
-  assert.equal(startable(startableRow({ assigneeType: "HUMAN", assigneeAgentId: null }), { total: 0, active: false }, 3), false);
-  assert.equal(startable(startableRow({ status: "DONE" }), { total: 0, active: false }, 3), false);
-  assert.equal(startable(startableRow({ status: "REVIEW" }), { total: 0, active: false }, 3), false);
-  assert.equal(startable(startableRow({ archivedAt: new Date() }), { total: 0, active: false }, 3), false);
+  assert.equal(taskStartability(startableRow({ assigneeType: "HUMAN", assigneeAgentId: null }), { total: 0, active: false }, 3, true).startable, false);
+  assert.equal(taskStartability(startableRow({ status: "DONE" }), { total: 0, active: false }, 3, true).startable, false);
+  assert.equal(taskStartability(startableRow({ status: "REVIEW" }), { total: 0, active: false }, 3, true).startable, false);
+  assert.equal(taskStartability(startableRow({ archivedAt: new Date() }), { total: 0, active: false }, 3, true).startable, false);
 });
 
 test("a step with no agent or no repo is not startable", () => {
-  assert.equal(startable(startableRow({ assigneeAgentId: null }), { total: 0, active: false }, 3), false);
-  assert.equal(startable(startableRow({ repoId: null }), { total: 0, active: false }, 3), false);
+  assert.equal(taskStartability(startableRow({ assigneeAgentId: null }), { total: 0, active: false }, 3, true).startable, false);
+  assert.equal(taskStartability(startableRow({ repoId: null }), { total: 0, active: false }, 3, true).startable, false);
 });
 
 test("a missing repo grant blocks starting", () => {
-  assert.equal(startable(startableRow({ hasRepoGrant: false }), { total: 0, active: false }, 3), false);
+  assert.equal(taskStartability(startableRow({ hasRepoGrant: false }), { total: 0, active: false }, 3, true).startable, false);
 });
 
 test("an archived assignee blocks starting", () => {
-  assert.equal(startable(startableRow({ assigneeAgent: { archivedAt: new Date() } }), { total: 0, active: false }, 3), false);
+  assert.equal(taskStartability(startableRow({ assigneeAgent: { archivedAt: new Date() } }), { total: 0, active: false }, 3, true).startable, false);
 });
 
 test("an active run blocks starting — including a run parked on an Inbox question", () => {
   // `active` is computed from ACTIVE_RUN_STATUSES, which includes WAITING_INBOX:
   // that run resumes the moment the operator answers.
-  assert.equal(startable(startableRow(), { total: 1, active: true }, 3), false);
+  assert.equal(taskStartability(startableRow(), { total: 1, active: true }, 3, true).startable, false);
 });
 
 test("the run budget compares the count of runs, not the latest one", () => {
-  assert.equal(startable(startableRow(), { total: 2, active: false }, 3), true);
-  assert.equal(startable(startableRow(), { total: 3, active: false }, 3), false);
-  assert.equal(startable(startableRow(), { total: 4, active: false }, 3), false);
+  assert.equal(taskStartability(startableRow(), { total: 2, active: false }, 3, true).startable, true);
+  assert.equal(taskStartability(startableRow(), { total: 3, active: false }, 3, true).startable, false);
+  assert.equal(taskStartability(startableRow(), { total: 4, active: false }, 3, true).startable, false);
 });
 
 test("a run refunded as an external failure does not count against the budget", () => {
@@ -240,10 +228,10 @@ test("a run refunded as an external failure does not count against the budget", 
   // refunded. Exactly one attempt of a budget of three has actually been spent,
   // so the step is still startable — and it was not, because this predicate
   // only ever read the task's configured budget.
-  assert.equal(startable(startableRow(), { total: 3, active: false, budgetGrants: 2 }, 3), true);
-  assert.equal(startable(startableRow(), { total: 5, active: false, budgetGrants: 2 }, 3), false);
+  assert.equal(taskStartability(startableRow(), { total: 3, active: false, budgetGrants: 2 }, 3, true).startable, true);
+  assert.equal(taskStartability(startableRow(), { total: 5, active: false, budgetGrants: 2 }, 3, true).startable, false);
   // Omitted entirely — a caller with nothing granted — is the configured budget.
-  assert.equal(startable(startableRow(), { total: 3, active: false }, 3), false);
+  assert.equal(taskStartability(startableRow(), { total: 3, active: false }, 3, true).startable, false);
 });
 
 test("lowering a task's budget bites immediately, and only the grants survive it", () => {
@@ -251,12 +239,12 @@ test("lowering a task's budget bites immediately, and only the grants survive it
   // `maxRunsPerTask`: two ordinary EXECUTE failures leave `maxRunsPerTask: 5`
   // on their rows and grant nothing. After the budget is lowered to 2 those
   // rows must not buy a third attempt.
-  assert.equal(startable(startableRow(), { total: 2, active: false, budgetGrants: 0 }, 2), false);
+  assert.equal(taskStartability(startableRow(), { total: 2, active: false, budgetGrants: 0 }, 2, true).startable, false);
   // A task that really was refunded twice keeps both refunds across the same
   // edit: two runs, none of them the agent's own attempt.
-  assert.equal(startable(startableRow(), { total: 2, active: false, budgetGrants: 2 }, 2), true);
+  assert.equal(taskStartability(startableRow(), { total: 2, active: false, budgetGrants: 2 }, 2, true).startable, true);
   // And raising the budget takes effect just as directly.
-  assert.equal(startable(startableRow(), { total: 3, active: false, budgetGrants: 0 }, 5), true);
+  assert.equal(taskStartability(startableRow(), { total: 3, active: false, budgetGrants: 0 }, 5, true).startable, true);
 });
 
 test("runFactsByTask sums a grouped run query into totals, an active flag and the grants", () => {
@@ -278,70 +266,17 @@ test("runFactsByTask tolerates a grouped query with no grants column", () => {
   assert.deepEqual(facts.get("a"), { total: 2, active: false, budgetGrants: null });
 });
 
-const decisionRow = (index: number, overrides: Partial<ChainRow & StartableRow & { maxSessionsPerTask: number }> = {}) => ({
-  ...row({ id: `step-${index}`, chainIndex: index }),
-  ...startableRow(),
-  maxSessionsPerTask: 3,
-  ...overrides,
-});
+test("blockingPredecessor respects layered siblings and surviving archived rows", () => {
+  const rows = [
+    row({ id: "done", chainIndex: 1, chainLayer: 1, status: "DONE" }),
+    row({ id: "sibling-a", chainIndex: 2, chainLayer: 2 }),
+    row({ id: "sibling-b", chainIndex: 3, chainLayer: 2 }),
+    row({ id: "join", chainIndex: 4, chainLayer: 3 }),
+  ];
+  assert.equal(blockingPredecessor(rows, "sibling-a"), null);
+  assert.equal(blockingPredecessor(rows, "sibling-b"), null);
+  assert.equal(blockingPredecessor(rows, "join")?.id, "sibling-a");
 
-test("chain dependency exposes only the first unfinished TODO or BACKLOG action", () => {
-  const prefix = [1, 2, 3].map((index) => decisionRow(index, { status: "DONE" }));
-  const doing = chainStartDecisions([...prefix, decisionRow(4, { status: "DOING" }), decisionRow(5), decisionRow(6)], new Map());
-  assert.deepEqual([...doing.values()].map((item) => item.startAction), [null, null, null, null, null, null]);
-  assert.equal(doing.get("step-5")!.blockingPredecessor?.name, "Task step-4");
-
-  const todo = chainStartDecisions([...prefix, decisionRow(4), decisionRow(5)], new Map());
-  assert.equal(todo.get("step-4")!.startAction, "start");
-  assert.equal(todo.get("step-5")!.startAction, null);
-
-  const parked = chainStartDecisions([...prefix, decisionRow(4, { status: "BACKLOG" }), decisionRow(5)], new Map());
-  assert.equal(parked.get("step-4")!.startAction, "recover");
-});
-
-test("layered chain siblings are candidates together and do not block one another", () => {
-  const decisions = chainStartDecisions([
-    decisionRow(1, { chainLayer: 1, status: "DONE" }),
-    decisionRow(2, { chainLayer: 2 }),
-    decisionRow(3, { chainLayer: 2 }),
-    decisionRow(4, { chainLayer: 3 }),
-  ], new Map());
-  assert.equal(decisions.get("step-2")!.startAction, "start");
-  assert.equal(decisions.get("step-3")!.startAction, "start");
-  assert.equal(decisions.get("step-2")!.blockingPredecessor, null);
-  assert.equal(decisions.get("step-3")!.blockingPredecessor, null);
-  assert.deepEqual(decisions.get("step-4")!.blockingPredecessor, {
-    id: "step-2", name: "Task step-2",
-  });
-});
-
-test("REVIEW, HUMAN, archive, grant, budget, and active-run facts fail closed", () => {
-  for (const first of [
-    decisionRow(1, { status: "REVIEW" }),
-    decisionRow(1, { assigneeType: "HUMAN", assigneeAgentId: null }),
-    decisionRow(1, { archivedAt: new Date() }),
-    decisionRow(1, { hasRepoGrant: false }),
-  ]) {
-    assert.equal(chainStartDecisions([first, decisionRow(2)], new Map()).get("step-1")!.startAction, null);
-  }
-  assert.equal(chainStartDecisions([decisionRow(1)], new Map([["step-1", { total: 3, active: false }]])).get("step-1")!.startAction, null);
-  // …but the same three runs with two of them refunded still leave an attempt.
-  assert.equal(
-    chainStartDecisions([decisionRow(1)], new Map([["step-1", { total: 3, active: false, budgetGrants: 2 }]])).get("step-1")!.startAction,
-    "start",
-  );
-  const active = chainStartDecisions([decisionRow(1)], new Map([["step-1", { total: 1, active: true }]])).get("step-1")!;
-  assert.equal(active.startAction, null);
-  assert.equal(active.currentExecution, true);
-});
-
-test("deleted predecessors disappear while archived unfinished predecessors still block", () => {
-  const deletedGap = chainStartDecisions([decisionRow(1, { status: "DONE" }), decisionRow(3)], new Map());
-  assert.equal(deletedGap.get("step-3")!.startAction, "start");
-  const archived = chainStartDecisions([
-    decisionRow(1, { status: "DONE" }),
-    decisionRow(2, { status: "BACKLOG", archivedAt: new Date() }),
-    decisionRow(3),
-  ], new Map());
-  assert.equal(archived.get("step-3")!.blockingPredecessor?.id, "step-2");
+  const archived = row({ id: "archived", chainIndex: 2, chainLayer: 2, status: "BACKLOG", archivedAt: new Date() });
+  assert.equal(blockingPredecessor([rows[0]!, archived, rows[3]!], "join")?.id, "archived");
 });

--- a/packages/api/src/chain.ts
+++ b/packages/api/src/chain.ts
@@ -1,6 +1,14 @@
-import { AssigneeType, TaskStatus } from "@agentos/db";
+import {
+  ACTIVE_RUN_STATUSES,
+  AssigneeType,
+  isMergeReadinessStep,
+  lockAgentRepoGrant,
+  Prisma,
+  TaskStatus,
+} from "@agentos/db";
 
 import { runBudgetCeiling } from "./execution.js";
+import type { Refusal } from "./refusal.js";
 
 /**
  * The chain columns every consumer of this module needs, as a plain object.
@@ -21,7 +29,7 @@ export type ChainRow = {
   name: string;
   status: TaskStatus;
   archivedAt: Date | null;
-  templateStep: { name: string } | null;
+  templateStep: { name: string; stepIndex?: number; outputKind?: string } | null;
   /** A bound first task carries the predecessor id. The predecessor relation
    * is fetched only by the chain-detail route when that id is present; making
    * both fields optional keeps legacy board/progress callers unchanged. */
@@ -186,7 +194,7 @@ export const taskStartability = (
   row: StartableRow,
   facts: RunFacts,
   maxSessionsPerTask: number,
-  predecessorsDone = true,
+  predecessorsDone: boolean,
 ): TaskStartability => {
   const bindingResolved = dispatchBindingResolved(row);
   const checklist = {
@@ -207,33 +215,6 @@ export const taskStartability = (
   };
 };
 
-/**
- * May the operator press `Start now` on this step?
- *
- * The single source for both the API guard and the button's enabled state — the
- * web app reads this boolean rather than re-deriving it, so the two cannot
- * disagree. "Active run" is `ACTIVE_RUN_STATUSES`, which includes WAITING_INBOX.
- */
-export const startable = (row: StartableRow, facts: RunFacts, maxSessionsPerTask: number): boolean => {
-  return taskStartability(row, facts, maxSessionsPerTask).startable;
-};
-
-export type ChainDecisionRow = ChainRow & StartableRow & { maxSessionsPerTask: number };
-export type ChainStartAction = "start" | "recover" | null;
-export type ChainStartDecision = {
-  startable: boolean;
-  startAction: ChainStartAction;
-  currentExecution: boolean;
-  blockingPredecessor: { id: string; name: string } | null;
-};
-
-/** The earliest surviving row that still owns chain progress. Deleted rows are
- * absent; archived rows remain dependencies until they are DONE. */
-export const firstUnfinishedStep = <T extends Pick<ChainRow, "chainIndex" | "id" | "status">>(rows: T[]): T | null => (
-  [...rows].sort(byExecutionPosition)
-    .find((item) => item.status !== TaskStatus.DONE) ?? null
-);
-
 /** The first unfinished surviving row before target, or null when the ordered
  * prefix is complete. This is the predecessor named by the 409 response. */
 export const blockingPredecessor = <T extends Pick<ChainRow, "chainIndex" | "id" | "name" | "status"> & { chainLayer?: number | null }>(
@@ -250,32 +231,6 @@ export const blockingPredecessor = <T extends Pick<ChainRow, "chainIndex" | "id"
       ? itemLayer < targetLayer && item.status !== TaskStatus.DONE
       : item.id !== target.id && item.status !== TaskStatus.DONE;
   }) ?? null;
-};
-
-/** One dependency decision for the whole chain. Row-local capability remains
- * `startable`; chain position narrows it to the sole first-unfinished row. */
-export const chainStartDecisions = (
-  rows: ChainDecisionRow[],
-  factsByTask: ReadonlyMap<string, RunFacts>,
-): Map<string, ChainStartDecision> => {
-  const ordered = [...rows].sort(byExecutionPosition);
-  const first = firstUnfinishedStep(ordered);
-  const firstLayer = first ? executionLayer(first) : null;
-  return new Map(ordered.map((row) => {
-    const facts = factsByTask.get(row.id) ?? { total: 0, active: false };
-    // Siblings in one layer are eligible together. A completed sibling remains
-    // historical, while every unfinished sibling in the frontier is a start
-    // candidate; a same-layer sibling is never reported as a predecessor.
-    const isCandidate = firstLayer !== null && executionLayer(row) === firstLayer;
-    const allowed = taskStartability(row, facts, row.maxSessionsPerTask, isCandidate).startable;
-    const predecessor = blockingPredecessor(ordered, row.id);
-    return [row.id, {
-      startable: allowed,
-      startAction: allowed ? row.status === TaskStatus.BACKLOG ? "recover" : "start" : null,
-      currentExecution: facts.active,
-      blockingPredecessor: predecessor ? { id: predecessor.id, name: predecessor.name } : null,
-    }];
-  }));
 };
 
 /** One grouped run query → per-task facts. Constant in task count, which is what
@@ -305,4 +260,194 @@ export const runFactsByTask = (
     });
   }
   return facts;
+};
+
+const admissionTaskInclude = {
+  assigneeAgent: { select: { id: true, name: true, title: true, archivedAt: true } },
+  repo: { select: { id: true, name: true, defaultBranch: true } },
+  dispatchAfter: { select: { id: true, name: true, status: true } },
+  templateStep: {
+    select: {
+      stepIndex: true,
+      outputKind: true,
+      taskTemplate: { select: { name: true } },
+    },
+  },
+} as const satisfies Prisma.TaskInclude;
+
+export type StepAdmissionTask = Prisma.TaskGetPayload<{ include: typeof admissionTaskInclude }>;
+
+export type FoundStepAdmission = {
+  task: StepAdmissionTask;
+  facts: RunFacts;
+  verdict: TaskStartability;
+  blocker: { id: string; name: string } | null;
+  refusal: Refusal | null;
+};
+
+export type StepAdmission =
+  | FoundStepAdmission
+  | {
+    task: null;
+    facts: null;
+    verdict: null;
+    blocker: null;
+    refusal: Refusal;
+  };
+
+type ReadStepAdmissionOptions = { locked: boolean };
+
+const grantKey = (input: { projectId: string; agentId: string; repoId: string }): string => (
+  `${input.projectId}:${input.agentId}:${input.repoId}`
+);
+
+const chainRowsKey = (input: { projectId: string; chainId: string }): string => (
+  `${input.projectId}:${input.chainId}`
+);
+
+const refusalForStepAdmission = (
+  task: StepAdmissionTask,
+  verdict: TaskStartability,
+  blocker: { id: string; name: string } | null,
+): Refusal | null => {
+  if (!verdict.checklist.predecessorsDone) {
+    if (blocker) {
+      return { reason: "conflict", message: `Cannot start ${task.name}; predecessor ${blocker.name} is not done` };
+    }
+    const predecessorName = task.dispatchAfter?.name ?? task.dispatchAfterTaskId;
+    return {
+      reason: "conflict",
+      message: `Cannot start ${task.name}; bound predecessor ${predecessorName ?? "unknown"} is not done`,
+    };
+  }
+  if (task.archivedAt !== null) return { reason: "conflict", message: "Cannot start an archived task" };
+  if (task.status === TaskStatus.DONE) return { reason: "conflict", message: "Task is already done" };
+  if (task.assigneeType !== AssigneeType.AGENT) {
+    return { reason: "conflict", message: "Human steps cannot be started" };
+  }
+  if (isMergeReadinessStep(task.templateStep)) {
+    return { reason: "conflict", message: "Merge readiness is server-owned and cannot be started as a model run" };
+  }
+  if (!verdict.checklist.noActiveRun) {
+    return { reason: "conflict", message: "Task already has an active run" };
+  }
+  if (!verdict.checklist.budgetRemaining) return { reason: "conflict", message: "Run budget exhausted" };
+  if (task.status !== TaskStatus.TODO && task.status !== TaskStatus.BACKLOG) {
+    return { reason: "conflict", message: "Only Todo and Backlog steps can be started" };
+  }
+  if (!verdict.checklist.repoBound) return { reason: "invalid-request", message: "This task has no repository" };
+  if (!verdict.checklist.agentAssignee) return { reason: "invalid-request", message: "This task has no assignee" };
+  if (!verdict.checklist.repoAccessGrant) {
+    return { reason: "invalid-request", message: "Assignee has no grant for this Repo" };
+  }
+  if (task.assigneeAgent?.archivedAt) {
+    return {
+      reason: "archived-assignee",
+      message: `Task ${task.name} assignee ${task.assigneeAgent.name} is archived; unarchive the agent to queue this step`,
+    };
+  }
+  if (!verdict.startable) return { reason: "conflict", message: "This step cannot be started" };
+  return null;
+};
+
+/**
+ * Reads every fact that decides whether a Step may start and names the first
+ * refusal from the same checklist. Mutation callers hold the Task/Chain mutex
+ * before requesting `locked`; that mode also holds the exact Repo grant through
+ * Run creation, while read callers use an ordinary grant read.
+ */
+export const readStepAdmissions = async (
+  tx: Prisma.TransactionClient,
+  taskIds: string[],
+  options: ReadStepAdmissionOptions,
+): Promise<Map<string, FoundStepAdmission>> => {
+  const ids = [...new Set(taskIds)];
+  if (ids.length === 0) return new Map();
+  if (options.locked && ids.length !== 1) {
+    throw new Error("Locked Step admission reads exactly one Step");
+  }
+  const tasks = await tx.task.findMany({ where: { id: { in: ids } }, include: admissionTaskInclude });
+  const grantInputs = tasks.flatMap((task) => (
+    task.assigneeAgentId !== null && task.repoId !== null
+      ? [{ projectId: task.projectId, agentId: task.assigneeAgentId, repoId: task.repoId }]
+      : []
+  ));
+  const chainInputs = [...new Map(tasks.flatMap((task) => (
+    task.chainId !== null && task.chainIndex !== null
+      ? [[chainRowsKey({ projectId: task.projectId, chainId: task.chainId }), {
+        projectId: task.projectId,
+        chainId: task.chainId,
+      }] as const]
+      : []
+  ))).values()];
+  const [runGroups, chainRows, grantRows] = await Promise.all([
+    tx.run.groupBy({
+      by: ["taskId", "status"],
+      where: { taskId: { in: ids } },
+      _count: { _all: true },
+      _max: { budgetGrants: true },
+    }),
+    chainInputs.length > 0
+      ? tx.task.findMany({
+        where: { OR: chainInputs },
+        select: { id: true, projectId: true, chainId: true, name: true, status: true, chainIndex: true, chainLayer: true },
+      })
+      : [],
+    grantInputs.length === 0
+      ? []
+      : options.locked
+        ? Promise.all(grantInputs.map(async (input) => (
+          await lockAgentRepoGrant(tx, input) ? input : null
+        ))).then((rows) => rows.filter((row): row is (typeof grantInputs)[number] => row !== null))
+        : tx.agentRepoAccess.findMany({
+          where: { OR: grantInputs },
+          select: { projectId: true, agentId: true, repoId: true },
+        }),
+  ]);
+  const factsByTask = runFactsByTask(runGroups, ACTIVE_RUN_STATUSES);
+  const granted = new Set(grantRows.map(grantKey));
+  const rowsByChain = new Map<string, Array<(typeof chainRows)[number]>>();
+  for (const row of chainRows) {
+    if (row.chainId === null) continue;
+    const key = chainRowsKey({ projectId: row.projectId, chainId: row.chainId });
+    const rows = rowsByChain.get(key);
+    if (rows) rows.push(row); else rowsByChain.set(key, [row]);
+  }
+  return new Map(tasks.map((task): [string, FoundStepAdmission] => {
+    const facts = factsByTask.get(task.id) ?? { total: 0, active: false, budgetGrants: null };
+    const hasRepoGrant = task.assigneeAgentId !== null && task.repoId !== null
+      && granted.has(grantKey({ projectId: task.projectId, agentId: task.assigneeAgentId, repoId: task.repoId }));
+    const chain = task.chainId !== null && task.chainIndex !== null
+      ? rowsByChain.get(chainRowsKey({ projectId: task.projectId, chainId: task.chainId })) ?? []
+      : [];
+    const blocker = blockingPredecessor(chain, task.id);
+    const baseVerdict = taskStartability(
+      { ...task, hasRepoGrant },
+      facts,
+      task.maxSessionsPerTask,
+      blocker === null,
+    );
+    const refused = refusalForStepAdmission(task, baseVerdict, blocker);
+    return [task.id, {
+      task,
+      facts,
+      verdict: { ...baseVerdict, startable: baseVerdict.startable && refused === null },
+      blocker: blocker ? { id: blocker.id, name: blocker.name } : null,
+      refusal: refused,
+    }];
+  }));
+};
+
+export const readStepAdmission = async (
+  tx: Prisma.TransactionClient,
+  taskId: string,
+  options: ReadStepAdmissionOptions,
+): Promise<StepAdmission> => (
+  await readStepAdmissions(tx, [taskId], options)
+).get(taskId) ?? {
+  task: null,
+  facts: null,
+  verdict: null,
+  blocker: null,
+  refusal: { reason: "not-found", message: "Task not found" },
 };

--- a/packages/api/src/task-patch.ts
+++ b/packages/api/src/task-patch.ts
@@ -239,13 +239,7 @@ export const patchTask = async (
               orderBy: [{ chainLayer: "asc" }, { chainIndex: "asc" }, { id: "asc" }],
               select: { id: true, name: true, status: true, chainIndex: true, chainLayer: true },
             });
-            const blocker = blockingPredecessor(chainRows.map((row) => ({
-              ...row,
-              projectId: locked.projectId,
-              chainId: locked.chainId,
-              archivedAt: null,
-              templateStep: null,
-            })), taskId);
+            const blocker = blockingPredecessor(chainRows, taskId);
             if (blocker) {
               return refuse(`Cannot complete ${before.name}; predecessor ${blocker.name} is not done`);
             }

--- a/packages/api/src/tasks.dbtest.ts
+++ b/packages/api/src/tasks.dbtest.ts
@@ -213,6 +213,97 @@ test("startability endpoint exposes the shared checklist and dependency verdict"
   assert.equal(blocked.body.checklist.predecessorsDone, false);
 });
 
+test("every false admission checklist fact drives the matching start refusal", async () => {
+  type SeededTask = Awaited<ReturnType<typeof seedTask>>;
+  type ChecklistKey = "repoBound" | "agentAssignee" | "repoAccessGrant" | "budgetRemaining" | "noActiveRun" | "predecessorsDone";
+  const cases: Array<{
+    key: ChecklistKey;
+    arrange: (context: SeededTask) => Promise<void>;
+    status: number;
+    error: RegExp;
+  }> = [
+    {
+      key: "repoBound",
+      arrange: async (context) => { await db.task.update({ where: { id: context.task.id }, data: { repoId: null } }); },
+      status: 400,
+      error: /no repository/u,
+    },
+    {
+      key: "agentAssignee",
+      arrange: async (context) => { await db.task.update({ where: { id: context.task.id }, data: { assigneeAgentId: null } }); },
+      status: 400,
+      error: /no assignee/u,
+    },
+    {
+      key: "repoAccessGrant",
+      arrange: async (context) => {
+        await db.agentRepoAccess.delete({ where: { agentId_repoId: { agentId: context.agent.id, repoId: context.repo.id } } });
+      },
+      status: 400,
+      error: /no grant/u,
+    },
+    {
+      key: "budgetRemaining",
+      arrange: async (context) => {
+        await db.task.update({ where: { id: context.task.id }, data: { maxSessionsPerTask: 1 } });
+        await seedRun(context, 1, "FAILED");
+      },
+      status: 409,
+      error: /budget exhausted/u,
+    },
+    {
+      key: "noActiveRun",
+      arrange: async (context) => { await seedRun(context, 1, "WAITING_INBOX"); },
+      status: 409,
+      error: /active run/u,
+    },
+    {
+      key: "predecessorsDone",
+      arrange: async (context) => {
+        const chainId = `admission-predecessor-${Date.now()}-${context.task.id}`;
+        await db.task.create({ data: {
+          projectId: context.project.id,
+          name: "Admission blocker",
+          description: "work",
+          status: "TODO",
+          chainId,
+          chainIndex: 0,
+          chainLayer: 0,
+        } });
+        await db.task.update({
+          where: { id: context.task.id },
+          data: { chainId, chainIndex: 1, chainLayer: 1 },
+        });
+      },
+      status: 409,
+      error: /predecessor Admission blocker is not done/u,
+    },
+  ];
+
+  for (const item of cases) {
+    const context = await seedTask(`admission-${item.key}`);
+    await item.arrange(context);
+    const beforeRuns = await db.run.count({ where: { taskId: context.task.id } });
+    const read = await call("GET", `/tasks/${context.task.id}/startability`);
+    assert.equal(read.status, 200, item.key);
+    assert.equal(read.body.startable, false, item.key);
+    assert.equal(read.body.checklist[item.key], false, item.key);
+
+    const write = await call("POST", `/tasks/${context.task.id}/start`);
+    assert.equal(write.status, item.status, item.key);
+    assert.match(write.body.error, item.error, item.key);
+    assert.equal(await db.run.count({ where: { taskId: context.task.id } }), beforeRuns, item.key);
+  }
+});
+
+test("startability and start accept the same admission snapshot", async () => {
+  const context = await seedTask("admission-consistency");
+  const read = await call("GET", `/tasks/${context.task.id}/startability`);
+  assert.equal(read.status, 200);
+  assert.equal(read.body.startable, true);
+  assert.equal((await call("POST", `/tasks/${context.task.id}/start`)).status, 201);
+});
+
 test("unfinished chain predecessor blocks every future start with zero side effects", async () => {
   const chainId = `safe-chain-${Date.now()}`;
   const context = await seedTask("chain-block", { chainId, chainIndex: 0, name: "Step 1", status: "DONE" });


### PR DESCRIPTION
## 交付物

- 新增 `readStepAdmission(tx, taskId, { locked })`，统一读取 Task、Chain、Run、repo grant facts，并输出 checklist、blocker 与 refusal。
- GET startability、GET chain、POST start、POST retry 复用同一 admission module；chain 使用 batch companion 避免 N+1。
- 删除 `startable` dead export，并将 `predecessorsDone` 改为 required input。
- 增加六项 checklist 的 GET/POST 一致性 dbtest 与成功路径 dbtest。

## 验收结果

- `npm run lint`：PASS；整合最新 main 后复跑仍 PASS
- `npm test`：PASS
- `npm run test:db -w @agentos/api -- src/tasks.dbtest.ts`：66/66 PASS
- `npm run test:db -w @agentos/api -- src/chain.dbtest.ts`：45/45 PASS
- 整合后 API tests：562 项，561 PASS、1 SKIP、0 FAIL
- exact-head full merge gate（包含完整 `npm run test:db`）：`MERGE GATE: PASS 4e5686ef49dbe0f5200e313d680b52427c6adb05`

## 代 Leo 作出的选择

- 以建 worktree 时的实际 `main`（`3dd37d3`）而不是任务单记录的旧快照 `7fd6fc5` 为起点：避免丢失已合入的并发工作，同时保持 append-only。
- 为 GET chain 增加内部 batch companion `readStepAdmissions`：它与单项 interface 共享事实与判定逻辑，并保持固定查询数，避免 N+1。
- retry 复用 admission 的 facts 与 blocker，但保留 `openRun` 的 retry-specific refusal：start 与 retry 的状态契约不同，不能把 start-only refusal 错套给 retry。
- 将 server-owned readiness 与 archived Agent 纳入 admission refusal：保证任何真实拒绝都与 `startable: false` 一致。
- 删除随 route 迁移后仅剩测试引用的 `chainStartDecisions`：不保留无生产 caller 的旧 decision path。
- GET startability 在 transaction 中读取：让一组 admission facts 在同一数据库视图内形成 verdict。
- 用普通 merge 整合并发 main 到 `4e5686e`，再 gate 并 fast-forward main：遵守 published history append-only 与 exact-head 交付约束。