### PR TITLE
refactor(api): centralize merge lease disposition

### DIFF
--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -781,7 +781,7 @@ test("completion refunds an external failure but refuses an automatic retry for 
         }),
         findUniqueOrThrow: async () => run.task,
       },
-      taskActivity: { create: async () => ({}) },
+      taskActivity: { findMany: async () => [], create: async () => ({}) },
       runnerBackendState: { upsert: async () => ({ consecutiveAuthFailures: 0 }), update: async () => ({}) },
       inboxMessage: { create: async ({ data }: { data: Record<string, unknown> }) => { inbox.push(data); return {}; } },
     };
@@ -811,7 +811,6 @@ test("completion refunds an external failure but refuses an automatic retry for 
       succeeded: false,
       retryCreated: false,
       failureClass: "TRANSIENT_PROVIDER",
-      releaseMergeLeaseTask: null,
     });
     });
   } finally {
@@ -852,7 +851,7 @@ test("startup reconciliation spares a run whose runner is still heartbeating", a
         findUnique: async () => null,
         findUniqueOrThrow: async () => ({ id: "task-2", archivedAt: null }),
       },
-      taskActivity: { create: async () => ({}) },
+      taskActivity: { findMany: async () => [], create: async () => ({}) },
       inboxMessage: { create: async () => ({}) },
     }),
   } as unknown as PrismaClient;
@@ -1579,7 +1578,7 @@ test("claim query filters archived agents before take so active work cannot star
         },
         update: async () => ({}),
       },
-      taskActivity: { create: async () => ({}) },
+      taskActivity: { findMany: async () => [], create: async () => ({}) },
       taskStepOutput: { findMany: async () => [{
         kind: "spec", body: completePriorOutput,
         task: { name: "Approved specification", chainIndex: 0 },
@@ -1617,6 +1616,7 @@ test("claim polling throttles the archived-run audit sweep per API process", asy
       $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
         $queryRaw: async () => [{ granted: true }],
         run: { findMany: async () => [] },
+        taskActivity: { findMany: async () => [] },
       }),
     } as unknown as PrismaClient;
     const app = createApp(database);
@@ -1716,6 +1716,7 @@ test("successful completion commits output and parks an archived chain successor
           },
         },
         taskActivity: {
+          findMany: async () => [],
           create: async ({ data }: { data: Record<string, unknown> }) => {
             if (data.taskId === successor.id) successorActivity = data;
             return {};

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -84,7 +84,7 @@ import {
 } from "./canonical-task-output.js";
 import { LOOPBACK_BROWSER_ORIGINS, originMayReachHandlers } from "./local-origin.js";
 import {
-  mergeTailLeaseChainId,
+  settleLease,
   releaseMergeLease,
   type ReleaseMergeLease,
 } from "./merge-lease.js";
@@ -1025,7 +1025,8 @@ const settleCancellation = async (
   // until a machine steals it 45 minutes later. Release it instead.
   return {
     runId: run.id, taskId: run.taskId, status: RunStatus.CANCELLED, cancellationState: "acknowledged",
-    requestId: input.requestId, releaseMergeLeaseTask: await mergeTailLeaseChainId(tx, run.taskId),
+    requestId: input.requestId,
+    releaseMergeLeaseTask: (await settleLease(tx, { taskId: run.taskId, outcome: "stop" })).leaseToRelease,
   };
 };
 
@@ -4028,9 +4029,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       runId,
       body,
       claimantClass: principal.kind === "merge-executor" ? "merge-executor" : "runner",
-    });
+    }, releaseChainLease);
     if ("message" in result) return refusalJson(context, result);
-    await releaseChainLease(result.releaseMergeLeaseTask);
     await options.ownership.assertHeld();
     // Nothing is deleted here, or anywhere else in this process. The runner
     // removed its own workspace before it called /complete and reported the

--- a/packages/api/src/merge-lease-cancel-release.dbtest.ts
+++ b/packages/api/src/merge-lease-cancel-release.dbtest.ts
@@ -282,3 +282,33 @@ test("a lost ordinary step with no attempts left never touches the lease", async
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: run.id } })).status, RunStatus.LOST);
   assert.deepEqual(releasedChainLeases, []);
 });
+
+test("a stranded queued handoff releases once and records settlement after release", async () => {
+  const now = new Date();
+  const chain = await seedChain();
+  const run = await seedRun(chain, { status: RunStatus.QUEUED });
+  await db.taskActivity.create({ data: {
+    taskId: chain.task.id,
+    actorType: "control-plane",
+    body: `Chain Lease handed to queued Run ${run.id}`,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "pending",
+      chainId: chain.chainId,
+      toRunId: run.id,
+      handedOffAt: new Date(now.getTime() - 120_000).toISOString(),
+    },
+  } });
+
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 1);
+  assert.deepEqual(releasedChainLeases, [chain.chainId]);
+  const settled = await db.taskActivity.findFirstOrThrow({
+    where: { taskId: chain.task.id, metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.leaseHandoff } },
+    orderBy: { createdAt: "desc" },
+  });
+  assert.equal((settled.metadata as Record<string, unknown>).state, "released");
+
+  assert.equal(await reconcileDatabaseRuns(db, new Date(now.getTime() + 1_000), collectRelease), 0);
+  assert.deepEqual(releasedChainLeases, [chain.chainId]);
+});

--- a/packages/api/src/merge-lease.test.ts
+++ b/packages/api/src/merge-lease.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { Prisma } from "@agentos/db";
+
 import {
+  commitWithLeaseDisposition,
+  leaseHandoffsWithoutConsumer,
+  leaseHolderFor,
+  settleLease,
   withMergeLease,
   type MergeLeaseAcquirer,
   type MergeLeaseRelease,
@@ -15,11 +21,112 @@ const released: MergeLeaseRelease = {
   sha: "abc",
 };
 
+const holderTx = (input: {
+  task: { chainId: string | null; templateStep: { stepIndex: number; outputKind: string; taskTemplate: { name: string } } };
+  markers?: unknown[];
+  regressionChainId?: string | null;
+}): Prisma.TransactionClient => ({
+  task: {
+    findUnique: async ({ where }: { where: { id: string } }) => where.id === "task-1"
+      ? input.task
+      : { chainId: input.regressionChainId ?? null },
+  },
+  taskActivity: {
+    findMany: async () => input.markers ?? [],
+  },
+} as unknown as Prisma.TransactionClient);
+
+test("leaseHolderFor owns every merge-tail Task shape, including a failed auxiliary", async () => {
+  const cases = [
+    {
+      name: "mechanical",
+      tx: holderTx({ task: { chainId: "chain-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } }),
+      expected: { chainId: "chain-1", taskId: "task-1", role: "mechanical" },
+    },
+    {
+      name: "regression",
+      tx: holderTx({ task: { chainId: "chain-2", templateStep: { stepIndex: 5, outputKind: "regression-verification-v2", taskTemplate: { name: "direct-engineer-workflow" } } } }),
+      expected: { chainId: "chain-2", taskId: "task-1", role: "regression" },
+    },
+    {
+      name: "failed auxiliary reads its repair marker without success gating",
+      tx: holderTx({
+        task: { chainId: null, templateStep: { stepIndex: 0, outputKind: "result", taskTemplate: { name: "repair" } } },
+        markers: [{ metadata: { kind: "mergeTail.repairAttempt", schemaVersion: 1, regressionTaskId: "regression-1" } }],
+        regressionChainId: "chain-3",
+      }),
+      expected: { chainId: "chain-3", taskId: "task-1", role: "auxiliary" },
+    },
+    {
+      name: "ordinary agent Task",
+      tx: holderTx({ task: { chainId: "chain-4", templateStep: { stepIndex: 2, outputKind: "implementation", taskTemplate: { name: "direct-engineer-workflow" } } } }),
+      expected: null,
+    },
+  ] as const;
+
+  for (const entry of cases) {
+    assert.deepEqual(await leaseHolderFor(entry.tx, "task-1"), entry.expected, entry.name);
+  }
+});
+
+test("settleLease maps continuation and stop outcomes through the holder record", async () => {
+  const tx = holderTx({ task: { chainId: "chain-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } });
+  assert.deepEqual(await settleLease(tx, { taskId: "task-1", outcome: "continue" }), {
+    disposition: "retain",
+    leaseToRelease: null,
+  });
+  assert.deepEqual(await settleLease(tx, { taskId: "task-1", outcome: "stop" }), {
+    disposition: "release",
+    leaseToRelease: "chain-1",
+  });
+});
+
+test("leaseHandoffsWithoutConsumer returns only stale Runs that never claimed", async () => {
+  const now = new Date("2026-08-27T12:02:00.000Z");
+  const tx = {
+    taskActivity: { findMany: async () => [
+      { taskId: "task-stale", metadata: { state: "pending", chainId: "chain-stale", toRunId: "run-stale", handedOffAt: "2026-08-27T12:00:00.000Z" } },
+      { taskId: "task-active", metadata: { state: "pending", chainId: "chain-active", toRunId: "run-active", handedOffAt: "2026-08-27T12:01:30.000Z" } },
+      { taskId: "task-done", metadata: { state: "released", chainId: "chain-done", toRunId: "run-done" } },
+      { taskId: "task-done", metadata: { state: "pending", chainId: "chain-done", toRunId: "run-done" } },
+    ] },
+    run: { findMany: async () => [{ id: "run-stale" }] },
+  } as unknown as Prisma.TransactionClient;
+
+  assert.deepEqual(await leaseHandoffsWithoutConsumer(tx, now), [
+    { chainId: "chain-stale", toRunId: "run-stale", taskId: "task-stale" },
+  ]);
+});
+
+test("commitWithLeaseDisposition releases only after the transaction commits", async () => {
+  const events: string[] = [];
+  const db = {
+    $transaction: async (fn: (tx: Prisma.TransactionClient) => Promise<unknown>) => {
+      const result = await fn({} as Prisma.TransactionClient);
+      events.push("commit");
+      return result;
+    },
+  } as unknown as Parameters<typeof commitWithLeaseDisposition>[0];
+
+  const value = await commitWithLeaseDisposition(db, async () => {
+    events.push("transaction");
+    return {
+      value: 42,
+      lease: { disposition: "release", leaseToRelease: "chain-1" },
+    };
+  }, async (chainId) => {
+    events.push(`release:${chainId}`);
+  });
+
+  assert.equal(value, 42);
+  assert.deepEqual(events, ["transaction", "commit", "release:chain-1"]);
+});
+
 test("a completed callback releases the merge Lease", async () => {
   const acquiredFor: string[] = [];
   const releasedFor: string[] = [];
   const result = await withMergeLease("chain-1", async () => ({
-    disposition: "release",
+    disposition: { kind: "release" },
     value: 42,
   }), {
     acquire: async (chainId) => {
@@ -40,7 +147,7 @@ test("a completed callback releases the merge Lease", async () => {
 test("retain hands the merge Lease to the downstream consumer", async () => {
   let releaseCalled = false;
   const result = await withMergeLease("chain-2", async () => ({
-    disposition: "retain",
+    disposition: { kind: "retain", handoffRunId: "run-2" },
     value: "authorized",
   }), {
     acquire: acquired,
@@ -76,7 +183,7 @@ test("a contended merge Lease does not run the callback", async () => {
   let releaseCalled = false;
   const result = await withMergeLease("chain-4", async () => {
     callbackCalled = true;
-    return { disposition: "release", value: null };
+    return { disposition: { kind: "release" }, value: null };
   }, {
     acquire: async () => ({ outcome: "contended" }),
     release: async () => {
@@ -94,7 +201,7 @@ test("the module reports a release anomaly itself", async (t) => {
   const said: string[] = [];
   t.mock.method(console, "error", (...args: unknown[]) => { said.push(args.map(String).join(" ")); });
 
-  await withMergeLease("chain-5", async () => ({ disposition: "release", value: null }), {
+  await withMergeLease("chain-5", async () => ({ disposition: { kind: "release" }, value: null }), {
     acquire: acquired,
     release: async () => ({ outcome: "skipped", heldFor: "chain-42" }),
   });
@@ -109,7 +216,7 @@ test("a rejected release adapter is reported as unreachable", async (t) => {
   t.mock.method(console, "error", (...args: unknown[]) => { said.push(args.map(String).join(" ")); });
   const releaser: MergeLeaseReleaser = async () => { throw new Error("spawn bash ENOENT"); };
 
-  await withMergeLease("chain-6", async () => ({ disposition: "release", value: null }), {
+  await withMergeLease("chain-6", async () => ({ disposition: { kind: "release" }, value: null }), {
     acquire: acquired,
     release: releaser,
   });
@@ -120,7 +227,7 @@ test("a rejected release adapter is reported as unreachable", async (t) => {
 });
 
 test("a Task without a Chain runs without either Lease adapter", async () => {
-  const result = await withMergeLease(null, async () => ({ disposition: "release", value: "unleased" }), {
+  const result = await withMergeLease(null, async () => ({ disposition: { kind: "release" }, value: "unleased" }), {
     acquire: async () => { throw new Error("the acquirer must not be called"); },
     release: async () => { throw new Error("the releaser must not be called"); },
   });

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -6,8 +6,11 @@ import {
   executionModeFor,
   isRegressionVerificationOutputKind,
   latestMarker,
+  MERGE_TAIL_KIND,
   readMarkers,
+  RunStatus,
   type Prisma,
+  type PrismaClient,
 } from "@agentos/db";
 
 const execFileAsync = promisify(execFile);
@@ -134,10 +137,16 @@ const reportMergeLeaseAnomaly = (chainId: string, release: MergeLeaseRelease): v
  * window the completion path reads because it is the same question, which is
  * why the window no longer needs restating here.
  */
-export const mergeTailLeaseChainId = async (
+export type LeaseHolder = {
+  chainId: string;
+  taskId: string;
+  role: "mechanical" | "regression" | "auxiliary";
+};
+
+export const leaseHolderFor = async (
   tx: Prisma.TransactionClient,
   taskId: string | null,
-): Promise<string | null> => {
+): Promise<LeaseHolder | null> => {
   if (!taskId) return null;
   const task = await tx.task.findUnique({
     where: { id: taskId },
@@ -151,19 +160,141 @@ export const mergeTailLeaseChainId = async (
     },
   });
   if (!task) return null;
+  const directRole = executionModeFor(task.templateStep) === "mechanical"
+    ? "mechanical" as const
+    : isRegressionVerificationOutputKind(task.templateStep?.outputKind)
+      ? "regression" as const
+      : null;
+  if (directRole) return task.chainId ? { chainId: task.chainId, taskId, role: directRole } : null;
   const markers = await readMarkers(tx, taskId);
   const auxiliaryRegressionTaskId = latestMarker(markers, "repairAttempt")?.regressionTaskId ?? null;
-  const tail = executionModeFor(task.templateStep) === "mechanical"
-    || isRegressionVerificationOutputKind(task.templateStep?.outputKind)
-    || auxiliaryRegressionTaskId !== null;
-  if (!tail) return null;
-  if (task.chainId) return task.chainId;
   if (!auxiliaryRegressionTaskId) return null;
   const regression = await tx.task.findUnique({
     where: { id: auxiliaryRegressionTaskId },
     select: { chainId: true },
   });
-  return regression?.chainId ?? null;
+  return regression?.chainId
+    ? { chainId: regression.chainId, taskId, role: "auxiliary" }
+    : null;
+};
+
+export type LeaseSettlementOutcome = "continue" | "stop";
+export type LeaseSettlement = {
+  disposition: "retain" | "release";
+  leaseToRelease: string | null;
+};
+
+/** Decide the Lease disposition from one terminal-control outcome. */
+export const settleLease = async (
+  tx: Prisma.TransactionClient,
+  input: { taskId: string | null; outcome: LeaseSettlementOutcome },
+): Promise<LeaseSettlement> => {
+  if (input.outcome === "continue") return { disposition: "retain", leaseToRelease: null };
+  const holder = await leaseHolderFor(tx, input.taskId);
+  return { disposition: "release", leaseToRelease: holder?.chainId ?? null };
+};
+
+const LEASE_HANDOFF_GRACE_MS = 60_000;
+
+/** Persist the queued Run that must consume a retained Chain Lease. */
+export const noteLeaseHandoff = async (
+  tx: Prisma.TransactionClient,
+  input: { chainId: string; toRunId: string; at: Date },
+): Promise<void> => {
+  const run = await tx.run.findUnique({ where: { id: input.toRunId }, select: { taskId: true } });
+  if (!run?.taskId) throw new Error(`Lease handoff target Run ${input.toRunId} has no Task`);
+  await tx.taskActivity.create({ data: {
+    taskId: run.taskId,
+    actorType: "control-plane",
+    body: `Chain Lease handed to queued Run ${input.toRunId}`,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "pending",
+      chainId: input.chainId,
+      toRunId: input.toRunId,
+      handedOffAt: input.at.toISOString(),
+    },
+  } });
+};
+
+/** Find retained handoffs whose queued Run never became a Lease consumer. */
+export const leaseHandoffsWithoutConsumer = async (
+  tx: Prisma.TransactionClient,
+  now: Date,
+): Promise<Array<{ chainId: string; toRunId: string; taskId: string }>> => {
+  const rows = await tx.taskActivity.findMany({
+    where: {
+      metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.leaseHandoff },
+    },
+    select: { taskId: true, metadata: true },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+  });
+  const pending = new Map<string, { chainId: string; toRunId: string; taskId: string }>();
+  const settled = new Set<string>();
+  for (const row of rows) {
+    const raw = row.metadata;
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+    const metadata = raw as Record<string, unknown>;
+    if (typeof metadata.toRunId !== "string") continue;
+    if (metadata.state === "released") {
+      settled.add(metadata.toRunId);
+      continue;
+    }
+    const handedOffAt = typeof metadata.handedOffAt === "string" ? Date.parse(metadata.handedOffAt) : Number.NaN;
+    if (metadata.state === "pending" && typeof metadata.chainId === "string"
+      && Number.isFinite(handedOffAt) && handedOffAt < now.getTime() - LEASE_HANDOFF_GRACE_MS
+      && !settled.has(metadata.toRunId) && !pending.has(metadata.toRunId)) {
+      pending.set(metadata.toRunId, { chainId: metadata.chainId, toRunId: metadata.toRunId, taskId: row.taskId });
+    }
+  }
+  if (pending.size === 0) return [];
+  const queued = await tx.run.findMany({
+    where: { id: { in: [...pending.keys()] }, status: RunStatus.QUEUED, claimedAt: null, startedAt: null },
+    select: { id: true },
+  });
+  return queued.flatMap((run) => {
+    const handoff = pending.get(run.id);
+    return handoff ? [handoff] : [];
+  });
+};
+
+/** Record a completed orphan-handoff release after the external release attempt. */
+export const noteLeaseHandoffReleased = async (
+  tx: Prisma.TransactionClient,
+  input: { chainId: string; toRunId: string; taskId: string; at: Date },
+): Promise<void> => {
+  await tx.taskActivity.create({ data: {
+    taskId: input.taskId,
+    actorType: "control-plane",
+    body: `Queued Run ${input.toRunId} did not consume its Chain Lease handoff`,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "released",
+      chainId: input.chainId,
+      toRunId: input.toRunId,
+      releasedAt: input.at.toISOString(),
+    },
+  } });
+};
+
+export type TransactionLeaseDisposition<T> = {
+  value: T;
+  lease: LeaseSettlement;
+};
+
+/** Commit database state before carrying out its post-commit Lease release. */
+export const commitWithLeaseDisposition = async <T>(
+  db: PrismaClient,
+  fn: (tx: Prisma.TransactionClient) => Promise<TransactionLeaseDisposition<T> | null>,
+  release: ReleaseMergeLease = releaseMergeLease,
+  options?: { isolationLevel: Prisma.TransactionIsolationLevel },
+): Promise<T | null> => {
+  const committed = await db.$transaction(fn, options);
+  if (committed === null) return null;
+  if (committed.lease.disposition === "release") await release(committed.lease.leaseToRelease);
+  return committed.value;
 };
 
 /**
@@ -213,7 +344,9 @@ const acquireMergeLease: MergeLeaseAcquirer = async (chainId) => {
   }
 };
 
-export type LeaseDisposition = "release" | "retain";
+export type LeaseDisposition =
+  | { kind: "release" }
+  | { kind: "retain"; handoffRunId: string };
 
 export type MergeLeaseDependencies = {
   acquire: MergeLeaseAcquirer;
@@ -251,13 +384,13 @@ export const withMergeLease = async <T>(
     throw new Error(`merge lease acquire is unreachable: ${acquisition.detail}`);
   }
 
-  let disposition: LeaseDisposition = "release";
+  let disposition: LeaseDisposition = { kind: "release" };
   try {
     const result = await fn();
     disposition = result.disposition;
     return { outcome: "ran", value: result.value };
   } finally {
-    if (disposition === "release") {
+    if (disposition.kind === "release") {
       await releaseMergeLeaseWith(dependencies.release, chainId);
     }
   }

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -4,6 +4,7 @@ import {
   AUTHORIZED_MERGE_METHOD,
   MergeRecoveryStatus,
   Prisma,
+  RunStatus,
   TaskStatus,
   activateChainSuccessor,
   activateRecoveryIntegratorSuccessor,
@@ -29,6 +30,7 @@ import {
   type ReadinessInput,
 } from "./readiness-decision.js";
 import {
+  noteLeaseHandoff,
   releaseMergeLease,
   withMergeLease,
   type ReleaseMergeLease,
@@ -508,8 +510,20 @@ const applyReadinessDecision = async (
       const activeSuccessor = current?.status === TaskStatus.DONE
         || (current?.status === TaskStatus.DOING
           && current.failureReason?.startsWith(READINESS_CLAIM_PREFIX));
+      const handoff = activeSuccessor && readiness.chainId
+        ? await db.run.findFirst({
+          where: {
+            task: { chainId: readiness.chainId, chainIndex: { gt: readiness.chainIndex ?? -1 } },
+            status: { in: [RunStatus.QUEUED, RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING] },
+          },
+          select: { id: true },
+          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+        })
+        : null;
       return {
-        disposition: activeSuccessor ? "retain" as const : "release" as const,
+        disposition: handoff
+          ? { kind: "retain" as const, handoffRunId: handoff.id }
+          : { kind: "release" as const },
         value: activeSuccessor ? "claim-lost-active" as const : "claim-lost-inactive" as const,
       };
     }
@@ -530,7 +544,20 @@ const applyReadinessDecision = async (
         const activeSuccessor = current?.status === TaskStatus.DONE
           || (current?.status === TaskStatus.DOING
             && current.failureReason?.startsWith(READINESS_CLAIM_PREFIX));
-        return activeSuccessor ? "claim-lost-active" as const : "claim-lost-inactive" as const;
+        const handoff = activeSuccessor && readiness.chainId
+          ? await tx.run.findFirst({
+            where: {
+              task: { chainId: readiness.chainId, chainIndex: { gt: readiness.chainIndex ?? -1 } },
+              status: { in: [RunStatus.QUEUED, RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING] },
+            },
+            select: { id: true },
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+          })
+          : null;
+        return {
+          kind: activeSuccessor ? "claim-lost-active" as const : "claim-lost-inactive" as const,
+          handoffRunId: handoff?.id ?? null,
+        };
       }
       const binding = `mechanical:${readiness.id}:${randomUUID()}`;
       const payload = {
@@ -594,24 +621,32 @@ const applyReadinessDecision = async (
           recoverySourceStopId: recovery?.sourceStopId ?? null,
         },
       });
-      if (recovery) {
-        await activateRecoveryIntegratorSuccessor(tx, {
+      const activated = recovery
+        ? await activateRecoveryIntegratorSuccessor(tx, {
           readinessTaskId: readiness.id,
           integratorTaskId: recovery.integratorTaskId,
           sourceStopId: recovery.sourceStopId,
           recoveryRunId: recovery.recoveryRunId,
           authorizationActivityId: activity.id,
-        }, read.input.now);
-      } else {
-        await activateChainSuccessor(tx, readiness, {}, read.input.now);
+        }, read.input.now)
+        : await activateChainSuccessor(tx, readiness, {}, read.input.now);
+      const handoff = activated.nextTaskId
+        ? await tx.run.findFirst({
+          where: { taskId: activated.nextTaskId, status: RunStatus.QUEUED },
+          select: { id: true },
+          orderBy: { runNumber: "desc" },
+        })
+        : null;
+      if (handoff && readiness.chainId) {
+        await noteLeaseHandoff(tx, { chainId: readiness.chainId, toRunId: handoff.id, at: read.input.now });
       }
-      return "authorized" as const;
+      return { kind: "authorized" as const, handoffRunId: handoff?.id ?? null };
     });
     return {
-      disposition: authorization === "authorized" || authorization === "claim-lost-active"
-        ? "retain" as const
-        : "release" as const,
-      value: authorization,
+      disposition: authorization.handoffRunId
+        ? { kind: "retain" as const, handoffRunId: authorization.handoffRunId }
+        : { kind: "release" as const },
+      value: authorization.kind,
     };
   });
   if (leased.outcome === "contended") return;

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -443,7 +443,7 @@ test("an unreachable merge lease acquire stops with a durable reason", async () 
   assert.deepEqual(releasedChainLeases, [seeded.readiness.chainId]);
 });
 
-test("a worker that acquired then lost its claim releases unless a successor owns the lease window", async () => {
+test("a worker that acquired then lost its claim releases without a concrete successor Run", async () => {
   const abandoned = await seedReadiness();
   const loseToOperator: MergeLeaseAcquirer = async () => {
     await db.task.update({
@@ -472,7 +472,7 @@ test("a worker that acquired then lost its claim releases unless a successor own
     await readinessTick(db, reader(), new Date(), 5, releaseChainLease, leaseRunner(loseToWorker)),
     { claimed: 1, authorized: 0, requeued: 0, stopped: 0 },
   );
-  assert.deepEqual(releasedChainLeases, []);
+  assert.deepEqual(releasedChainLeases, [succeeded.readiness.chainId]);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: succeeded.readiness.id } })).failureReason, NEWER_CLAIM);
 });
 

--- a/packages/api/src/reconcile.test.ts
+++ b/packages/api/src/reconcile.test.ts
@@ -17,6 +17,9 @@ test("database reconciliation active status query remains limited to three execu
       if (typeof where.status === "object") statuses = where.status.in;
       return [];
     } },
+    $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
+      taskActivity: { findMany: async () => [] },
+    }),
   } as unknown as PrismaClient;
   assert.equal(await reconcileDatabaseRuns(database), 0);
   assert.deepEqual(statuses, [RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING]);
@@ -131,7 +134,7 @@ test("database reconciliation times out expired Inbox waits and makes retained w
       session: { updateMany: async ({ data }: { data: Record<string, unknown> }) => { writes.push({ target: "session", data }); return { count: 1 }; } },
       inboxMessage: { updateMany: async ({ data }: { data: Record<string, unknown> }) => { writes.push({ target: "message", data }); return { count: 1 }; } },
       task: { update: async ({ data }: { data: Record<string, unknown> }) => { writes.push({ target: "task", data }); return {}; } },
-      taskActivity: { create: async () => ({}) },
+      taskActivity: { findMany: async () => [], create: async () => ({}) },
     }),
   } as unknown as PrismaClient;
   assert.equal(await reconcileDatabaseRuns(database, now), 1);
@@ -156,6 +159,9 @@ test("startup reconciliation does not fail when archived notice persistence fail
     inboxMessage: { findMany: async () => [], updateMany: async () => ({ count: 0 }) },
     taskActivity: { findMany: async () => [] },
     taskTemplate: { findMany: async () => [] },
+    $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
+      taskActivity: { findMany: async () => [] },
+    }),
   } as unknown as PrismaClient;
   const originalError = console.error;
   let logged = "";

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -11,7 +11,13 @@ import {
   type PrismaClient,
 } from "@agentos/db";
 
-import { mergeTailLeaseChainId, releaseMergeLease, type ReleaseMergeLease } from "./merge-lease.js";
+import {
+  leaseHandoffsWithoutConsumer,
+  noteLeaseHandoffReleased,
+  releaseMergeLease,
+  settleLease,
+  type ReleaseMergeLease,
+} from "./merge-lease.js";
 import { openReclaimIntentCount } from "./workspace-reclaim.js";
 
 const activeStatuses = [RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING] as const;
@@ -132,8 +138,11 @@ export const reconcileDatabaseRuns = async (
   const orphans = candidates.filter((run) => run.cancelRequestedAt !== null || !(
     run.heartbeatAt && now.getTime() - run.heartbeatAt.getTime() < run.stallTimeoutMin * 60_000
   ));
-  if (orphans.length === 0 && expiredInboxRuns.length === 0) return 0;
-  const strandedChainLeases = await db.$transaction(async (tx) => {
+  const reconciliation = await db.$transaction(async (tx) => {
+    const strandedHandoffs = await leaseHandoffsWithoutConsumer(tx, now);
+    if (orphans.length === 0 && expiredInboxRuns.length === 0 && strandedHandoffs.length === 0) {
+      return { strandedChainLeases: [] as string[], strandedHandoffs, count: 0 };
+    }
     // Chains whose tail run this sweep terminalizes without a successor. Held
     // until the sweep commits, because a lease released against a transaction
     // that then rolls back would free a window the chain still owns.
@@ -216,8 +225,8 @@ export const reconcileDatabaseRuns = async (
             },
           } });
         }
-        const cancelledChainId = await mergeTailLeaseChainId(tx, run.taskId);
-        if (cancelledChainId) stranded.add(cancelledChainId);
+        const lease = await settleLease(tx, { taskId: run.taskId, outcome: "stop" });
+        if (lease.leaseToRelease) stranded.add(lease.leaseToRelease);
         continue;
       }
       // Losing a lease is an external failure: it buys an attempt, never spends one.
@@ -272,8 +281,8 @@ export const reconcileDatabaseRuns = async (
             data: { taskId: run.taskId, actorType: "control-plane", body: `Run ${run.runNumber} lost; retry ${opened.run.runNumber} queued` },
           });
         } else {
-          const lostChainId = await mergeTailLeaseChainId(tx, run.taskId);
-          if (lostChainId) stranded.add(lostChainId);
+          const lease = await settleLease(tx, { taskId: run.taskId, outcome: "stop" });
+          if (lease.leaseToRelease) stranded.add(lease.leaseToRelease);
           await tx.task.update({
             where: { id: run.taskId },
             data: { status: TaskStatus.REVIEW, failureReason: `Lease-loss retry refused: ${opened.refusal.message}` },
@@ -293,8 +302,8 @@ export const reconcileDatabaseRuns = async (
       } else {
         // Budget exhausted: no retry follows, so this lost run is the chain's
         // last word and its lease has no successor to hand itself to.
-        const lostChainId = await mergeTailLeaseChainId(tx, run.taskId);
-        if (lostChainId) stranded.add(lostChainId);
+        const lease = await settleLease(tx, { taskId: run.taskId, outcome: "stop" });
+        if (lease.leaseToRelease) stranded.add(lease.leaseToRelease);
         await tx.task.update({
           where: { id: run.taskId },
           data: { status: TaskStatus.REVIEW, failureReason: `Maximum ${budgetCeiling} runs reached after lease loss` },
@@ -349,10 +358,24 @@ export const reconcileDatabaseRuns = async (
         });
       }
     }
-    return [...stranded];
+    for (const handoff of strandedHandoffs) {
+      stranded.add(handoff.chainId);
+    }
+    return {
+      strandedChainLeases: [...stranded],
+      strandedHandoffs,
+      count: orphans.length + expiredInboxRuns.length + strandedHandoffs.length,
+    };
   });
-  for (const chainId of strandedChainLeases) await releaseChainLease(chainId);
-  return orphans.length + expiredInboxRuns.length;
+  for (const chainId of reconciliation.strandedChainLeases) await releaseChainLease(chainId);
+  if (reconciliation.strandedHandoffs.length > 0) {
+    await db.$transaction(async (tx) => {
+      for (const handoff of reconciliation.strandedHandoffs) {
+        await noteLeaseHandoffReleased(tx, { ...handoff, at: now });
+      }
+    });
+  }
+  return reconciliation.count;
 };
 
 /**

--- a/packages/api/src/run-completion.dbtest.ts
+++ b/packages/api/src/run-completion.dbtest.ts
@@ -126,7 +126,6 @@ test("an accepted completion returns what it did rather than a response", async 
     succeeded: true,
     retryCreated: false,
     failureClass: null,
-    releaseMergeLeaseTask: null,
   });
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: run.id } })).status, RunStatus.SUCCEEDED);
 });

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -58,6 +58,12 @@ import {
   openMergeTailStopNotice,
 } from "./merge-tail-actions.js";
 import { explainFenceRefusal, fenceRefusalResponse, fencedRunWhere, type RunFence } from "./run-fence.js";
+import {
+  commitWithLeaseDisposition,
+  settleLease,
+  type LeaseSettlementOutcome,
+  type ReleaseMergeLease,
+} from "./merge-lease.js";
 import type { Refusal } from "./refusal.js";
 import { lockTask, lockTaskMutationRows } from "./task-write.js";
 
@@ -184,7 +190,6 @@ export type RunCompletion = {
   succeeded: boolean;
   retryCreated: boolean;
   failureClass: FailureClass | null;
-  releaseMergeLeaseTask: string | null;
 };
 
 /** Why a completion wrote nothing. Three distinct answers the route used to
@@ -213,6 +218,7 @@ export type CompleteRunInput = {
 export const completeRun = async (
   db: PrismaClient,
   { runId, body, claimantClass }: CompleteRunInput,
+  releaseMergeLease?: ReleaseMergeLease,
 ): Promise<RunCompletion | CompleteRunRefusal> => {
   const now = new Date();
   const fence: RunFence = { runId, runnerId: body.runnerId, fencingToken: body.fencingToken, at: now };
@@ -234,7 +240,7 @@ export const completeRun = async (
     );
     if (refusal) return { reason: "forbidden", message: refusal };
   }
-  const result = await db.$transaction(async (tx) => {
+  const result = await commitWithLeaseDisposition(db, async (tx) => {
     // Run owns fencing, cancellation, and terminalization. Take that mutex
     // before Task so completion, cancellation, and canonical output writes
     // cannot deadlock by entering the same two rows in opposite orders.
@@ -404,8 +410,7 @@ export const completeRun = async (
     // row: a task's budget being edited mid-run must not retroactively refuse
     // an attempt already authorized.
     const budgetGrants = run.budgetGrants + refunded;
-    const tailLeaseChainId = run.task?.chainId ?? repairRegression?.chainId ?? null;
-    let releaseMergeLeaseTask: string | null = null;
+    let leaseOutcome: LeaseSettlementOutcome = "continue";
     // Completion always mutates its Task, including terminal non-retryable
     // failures. Run is already locked above; acquire the Task/chain mutex now
     // for every outcome rather than only the branches that may retry or
@@ -517,7 +522,7 @@ export const completeRun = async (
     if (!succeeded && !retryCreated && (mechanical
       || isRegressionVerificationOutputKind(run.task?.templateStep?.outputKind)
       || mergeTailAuxiliary)) {
-      releaseMergeLeaseTask = tailLeaseChainId;
+      leaseOutcome = "stop";
     }
     if (run.taskId) {
       const budgetExhausted = !succeeded && retryable && !retryCreated && !retryRefusal;
@@ -548,7 +553,7 @@ export const completeRun = async (
       // may touch it, because a synthesized body would read as a merge that
       // never happened.
       if (succeeded && mechanical && run.task) {
-        releaseMergeLeaseTask = tailLeaseChainId;
+        leaseOutcome = "stop";
         const persisted = await tx.taskStepOutput.findUnique({
           where: { taskId: run.taskId }, select: { kind: true, body: true },
         });
@@ -622,7 +627,7 @@ export const completeRun = async (
             },
           } });
           if (isRegressionVerificationOutputKind(run.task.templateStep?.outputKind)) {
-            releaseMergeLeaseTask = tailLeaseChainId;
+            leaseOutcome = "stop";
           }
         }
         canonicalOutputFailure = outputRefusal;
@@ -649,7 +654,7 @@ export const completeRun = async (
           if (result === "advance") {
             await advanceTemplateTask(tx, run.taskId, run.id, process.env.FEISHU_DEFAULT_CHAT_ID ?? null, now, completionTaskStatus);
           } else {
-            releaseMergeLeaseTask = tailLeaseChainId;
+            leaseOutcome = "stop";
           }
         } else {
           await advanceTemplateTask(tx, run.taskId, run.id, process.env.FEISHU_DEFAULT_CHAT_ID ?? null, now, completionTaskStatus);
@@ -728,7 +733,7 @@ export const completeRun = async (
         }
         if (repairUnable) {
           // The failed repair owns the stop; never activate its follow-up.
-          releaseMergeLeaseTask = tailLeaseChainId;
+          leaseOutcome = "stop";
         } else if (run.task.approvalGate) {
           const claimed = await tx.task.updateMany({
             where: { id: run.taskId, status: completionTaskStatus! },
@@ -831,11 +836,15 @@ export const completeRun = async (
         update: { consecutiveAuthFailures: 0 },
       });
     }
-    return { taskId: run.taskId, succeeded, retryCreated, failureClass, releaseMergeLeaseTask };
+    const lease = await settleLease(tx, { taskId: run.taskId, outcome: leaseOutcome });
+    return {
+      value: { taskId: run.taskId, succeeded, retryCreated, failureClass },
+      lease,
+    };
   // ReadCommitted lets successor CAS losers observe count=0 instead of
   // surfacing a serialization failure to runners. Every task status write
   // above has its own status CAS so concurrent operator decisions win.
-  }, { isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted });
+  }, releaseMergeLease, { isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted });
   // Why the transaction refused, answered here rather than by the caller: a
   // caller that had to re-query the run to tell "suspended for Inbox" from
   // "stale fence" would be re-deriving a distinction this action already made.

--- a/packages/api/src/runners.test.ts
+++ b/packages/api/src/runners.test.ts
@@ -103,7 +103,7 @@ const makeDatabase = (
       },
       update: async () => ({}),
     },
-    taskActivity: { create: async () => ({}) },
+    taskActivity: { findMany: async () => [], create: async () => ({}) },
     taskStepOutput: { findMany: async () => [] },
   };
   return {

--- a/packages/db/src/merge-tail-markers.test.ts
+++ b/packages/db/src/merge-tail-markers.test.ts
@@ -176,16 +176,6 @@ test("completion-path sites read the recent-state window (app.ts success and fai
   assert.equal(latestMarker(markers, "repairAttempt")?.regressionTaskId, "reg-1");
 });
 
-test("mergeTailLeaseChainId reads the same window as the completion path (merge-lease.ts)", async () => {
-  const { tx, reads } = recordingTx([
-    marker("repairAttempt", { repairKind: "gate-fix", regressionTaskId: "reg-9" }),
-  ]);
-  const markers = await readMarkers(tx, "repair-task");
-
-  assert.equal(reads[0]!.take, MERGE_TAIL_MARKER_SCAN);
-  assert.equal(latestMarker(markers, "repairAttempt")?.regressionTaskId, "reg-9");
-});
-
 test("alreadyAttempted sees an attempt buried past the recent-state window (app.ts:639)", async () => {
   const rows = [
     ...Array.from({ length: 25 }, () => marker("regression", {})),

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -22,6 +22,7 @@ export const LEGACY_PRE_ADJUDICATION_DIRECT_MERGE_READINESS_STEP_INDEX = 7;
 export const LEGACY_PRE_ADJUDICATION_MERGE_READINESS_STEP_INDEX = 12;
 export const MERGE_TAIL_KIND = {
   baseDriftRecovery: "mergeTail.baseDriftRecovery",
+  leaseHandoff: "mergeTail.leaseHandoff",
   regression: "mergeTail.regression",
   repairAttempt: "mergeTail.repairAttempt",
   repairResult: "mergeTail.repairResult",


### PR DESCRIPTION
## 交付物

- 用 `LeaseHolder`、`leaseHolderFor` 与 `settleLease` 统一 mechanical、Regression、auxiliary 的 Chain Lease 归属和 release/retain 判定。
- 把 `withMergeLease` 的 retain 收紧为显式 `handoffRunId`，授权事务内记录 queued Run handoff；startup reconciliation 清扫从未 active 的 stranded handoff。
- 用 `commitWithLeaseDisposition` 保证数据库 commit 后才 release；handoff settlement 也在外部 release 尝试后记录，避免 crash window 提前封死重试。
- 修复 M6：删除未调用实现的假测试，改为 step shape × marker state 的表驱动测试，并覆盖 failed auxiliary。
- 本段与既有卡 `cmtazglzl0082mp9hfot76q0x`（记录持锁时长）合并立案，不另立案。

## 验收

- `npm run lint`：PASS
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm test`：PASS
- scratch PostgreSQL 下 `npm run test:db -w @agentos/api -- src/merge-tail-readiness.dbtest.ts src/merge-lease-cancel-release.dbtest.ts src/run-completion.dbtest.ts`：30/30 PASS
- stranded handoff 单文件复验：9/9 PASS
- 未修改 `readReadiness` / `readiness-decision.ts`；ADR-0001 R1 顺序保持不变。

## 代 Leo 做的选择

- 选择从创建 worktree 时实际 `main` 的 `3dd37d3` 开始，而不是回退到任务记录中的 `7fd6fc5`：共享仓库已前进，回退会丢失已交付提交且违反 append-only。
- 选择复用 `TaskActivity` append-only marker 记录 handoff，不新增 schema：仓库已有 merge-tail marker seam，足以提供 durability 与可审计性。
- 选择 60 秒作为 pending handoff grace：与现有 control-plane tick/Lease 时间尺度一致，既给正常 claim 留余量，也不把 main 锁到人工超时。
- 选择 failed auxiliary 仅凭 `repairAttempt` marker 归属 Regression Chain Lease，不再以成功输出作门槛：失败正是必须 release 的终态。
- 选择只有具体 active/queued successor Run 才允许 retain；单有更新的 readiness claim 仍 release：新的 interface 要求可追踪 consumer，避免无主 Lease。
- 选择先执行外部 release、再写 released marker：若进程在两步之间退出，下次 sweep 可安全重试；相反顺序会永久跳过未完成 release。

- 选择在两次 10-lane gate 分别暴露两个不同 runner timing flake、且单测复验通过后，使用 gate 支持的 AGENTOS_GATE_HOST_SHARE=2 档位重跑同一 exact head：减少 host saturation，不改变代码、测试集合或 PASS 标准。
- exact-head merge gate：MERGE GATE: PASS 47e1107c0151037da89ebf96998ae4afbdb8bf15。
