### PR TITLE
fix(db): relax canonical sync timeout

### DIFF
--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -558,7 +558,7 @@ const main = async (): Promise<void> => {
         updatedSteps,
         updatedRoles,
       };
-    }, { timeout: 30_000 });
+    }, { timeout: 120_000 });
     const updated = result.createdCanonicalTemplates + result.createdAgents + result.createdAgentRepoGrants + result.adoptedAssignees + result.adoptedStepBases
       + result.adoptedPriorOutputDeclarations
       + result.renamedSteps + result.migratedTasks + result.adoptedAgentDefaults + Object.values(result.updatedSteps)


### PR DESCRIPTION
## Summary

- keep canonical prompt sync bounded while allowing transient production contention
- raise the interactive transaction timeout from 30 seconds to 120 seconds

## Verification

- node --test scripts/deploy/quiet-window-deploy.test.mjs
- node --import tsx --test --test-concurrency=1 packages/db/src/canonical-prompt-sync.dbtest.ts
- npm run build -w @agentos/db