### PR TITLE
refactor(db): centralize canonical template installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "db:drift-check": "npm run db:drift-check -w @agentos/db",
     "db:seed": "npm run db:seed -w @agentos/db",
     "db:sync-canonical-prompts": "npm run db:sync-canonical-prompts -w @agentos/db",
+    "db:template-digest": "npm run db:template-digest -w @agentos/db",
     "db:verify-agent-template": "npm run db:verify-agent-template -w @agentos/db",
     "db:validate": "npm run db:validate -w @agentos/db",
     "db:preflight-goal-execution": "npm run db:preflight-goal-execution -w @agentos/db",

--- a/packages/api/src/prior-outputs-upgrade.dbtest.ts
+++ b/packages/api/src/prior-outputs-upgrade.dbtest.ts
@@ -118,7 +118,7 @@ test("the whitelist migration preserves legacy claims and canonical sync adopts 
               "baseFromStepIndex", "layer"
             ) VALUES ($1, $2, $3, $4, $5, $6::"AssigneeType", $7, $8, $9, $10::jsonb, $11, $12, $13, $14)`,
             `${templateId}-step-${step.stepIndex}`, templateId,
-            step.agentName ? agentIds.get(step.agentName) : null, step.stepIndex, `Step ${step.stepIndex}`,
+            step.agentName ? agentIds.get(step.agentName) : null, step.stepIndex, step.name,
             step.agentName ? "agent" : "human", step.prompt, step.approvalGate,
             step.attachmentsFromPrevious, step.spawnPolicy === null ? null : JSON.stringify(step.spawnPolicy),
             step.outputKind, step.opensPullRequest, step.baseFromStepIndex, step.layer,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -47,6 +47,7 @@
     "db:validate": "dotenv -e ../../.env -- prisma validate",
     "db:seed": "dotenv -e ../../.env -- prisma db seed",
     "db:sync-canonical-prompts": "tsx prisma/sync-canonical-prompts.ts",
+    "db:template-digest": "tsx prisma/template-digest.ts",
     "db:fixture": "dotenv -e ../../.env -- tsx prisma/acceptance-fixture.ts"
   },
   "prisma": {

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -365,6 +365,7 @@ test("the complete template source inventory rejects a missing workflow or non-d
 test("canonical prompt sync can detect every Markdown-owned structural field", async () => {
   const expected = (await loadTemplateStepSources(DIRECT_TEMPLATE_NAME))[0]!;
   const persisted: PersistedTemplateStepStructure = {
+    name: expected.name,
     assigneeAgent: { name: expected.agentName! },
     assigneeType: "AGENT",
     layer: expected.layer,
@@ -378,6 +379,7 @@ test("canonical prompt sync can detect every Markdown-owned structural field", a
   };
   assert.deepEqual(templateStepStructureDifferences(persisted, expected), []);
   const mutations: Array<[string, PersistedTemplateStepStructure]> = [
+    ["name", { ...persisted, name: "Different display name" }],
     ["agent", { ...persisted, assigneeAgent: { name: "different-agent" } }],
     ["assigneeType", { ...persisted, assigneeType: "HUMAN" }],
     ["layer", { ...persisted, layer: expected.layer + 1 }],

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,14 +1,12 @@
-import { AssigneeType, CodexServiceTier, Prisma, PrismaClient, TaskStatus } from "@prisma/client";
+import { AssigneeType, CodexServiceTier, PrismaClient } from "@prisma/client";
 
 import { CANONICAL_AGENT_RUNTIME_TRANSITIONS, DIRECT_TEMPLATE_NAME } from "../src/agent-contract.js";
 import { loadAgentSources } from "../src/agent-sources.js";
 import {
-  legacyTemplateName,
-  matchedLegacyGeneration,
-  TEMPLATE_ROLLOVER_ACTIVE_RUN_STATUSES,
-  templateRolloverBlockerCount,
-  type PersistedTransitionStep,
-} from "../src/canonical-template-transition.js";
+  applyCanonicalInstallation,
+  planCanonicalInstallation,
+  type CanonicalInstallationRow,
+} from "../src/canonical-template-installation.js";
 import {
   INTEGRATOR_AGENT_NAME,
   INTEGRATOR_OUTPUT_KIND,
@@ -18,12 +16,7 @@ import {
   legacyRegressionFirstThirteenStepTemplateName,
   legacyTenStepTemplateName,
 } from "../src/merge-integrator.js";
-import {
-  loadAllTemplateStepSources,
-  templateStepStructureDifferences,
-  type PersistedTemplateStepStructure,
-  type TemplateStepSource,
-} from "../src/template-sources.js";
+import { loadAllTemplateStepSources } from "../src/template-sources.js";
 
 // The loader this seed used to carry moved to `packages/db/src/agent-sources.ts`
 // so that OSS-B0's first-run onboarding can read the same `agents/` contract
@@ -43,38 +36,67 @@ const HISTORICAL_NINE_STEP_CONTRACT = [
   [9, null, AssigneeType.HUMAN, "approval", true],
 ] as const;
 
-/**
- * A row that still carries the canonical name after every registered legacy
- * generation failed to match must be the current source graph, field for
- * field. A half-migrated graph is neither: the step upsert below would
- * silently rewrite it into the current shape, skipping the unfinished-task
- * and webhook guards a registered rollover runs and leaving no legacy row
- * behind. Refuse it the way canonical sync refuses it.
- */
-const assertCurrentCanonicalGraph = (
-  templateName: string,
-  persistedSteps: readonly (PersistedTemplateStepStructure & { stepIndex: number })[],
-  sourceSteps: readonly TemplateStepSource[],
-): void => {
-  if (persistedSteps.length !== sourceSteps.length) {
-    throw new Error(`Canonical template ${templateName} has structural drift: expected ${sourceSteps.length} steps, found ${persistedSteps.length}`);
+type HistoricalSeedTemplate = Readonly<{
+  id: string;
+  steps: readonly {
+    stepIndex: number;
+    assigneeType: AssigneeType;
+    approvalGate: boolean;
+    outputKind: string;
+    assigneeAgent: { name: string } | null;
+  }[];
+}>;
+
+const historicalSeedLegacyName = (
+  templateName: "compound-engineer-workflow" | "direct-engineer-workflow",
+  existing: HistoricalSeedTemplate,
+): string | null => {
+  if (templateName === "direct-engineer-workflow") {
+    return existing.steps.length === 6
+      && existing.steps[5]?.assigneeType === AssigneeType.HUMAN
+      && existing.steps[5]?.outputKind === "approval"
+      ? `${templateName}-legacy-human-6-${existing.id}`
+      : null;
   }
-  const ordered = [...persistedSteps].sort((left, right) => left.stepIndex - right.stepIndex);
-  if (ordered.some((step, index) => step.stepIndex !== index + 1)) {
-    throw new Error(`Canonical template ${templateName} has structural drift: step indexes are not contiguous`);
-  }
-  for (const [index, step] of ordered.entries()) {
-    const differences = templateStepStructureDifferences(step, sourceSteps[index]!);
-    if (differences.length > 0) {
-      throw new Error(`Canonical template ${templateName} has structural drift: step ${step.stepIndex} differs from the canonical source in ${differences.join(", ")}`);
-    }
-  }
+
+  const historicalIntegrator = existing.steps.find((step) => step.stepIndex === 10);
+  const isHistoricalNineStepTemplate = existing.steps.length === HISTORICAL_NINE_STEP_CONTRACT.length
+    && HISTORICAL_NINE_STEP_CONTRACT.every(([stepIndex, agentName, assigneeType, outputKind, approvalGate], index) => {
+      const step = existing.steps[index];
+      return step?.stepIndex === stepIndex
+        && (step.assigneeAgent?.name ?? null) === agentName
+        && step.assigneeType === assigneeType
+        && step.outputKind === outputKind
+        && step.approvalGate === approvalGate;
+    });
+  const isHistoricalTenStepTemplate = existing.steps.length === 10
+    && existing.steps.every((step, index) => step.stepIndex === index + 1)
+    && historicalIntegrator?.outputKind === INTEGRATOR_OUTPUT_KIND
+    && historicalIntegrator.assigneeAgent?.name === INTEGRATOR_AGENT_NAME;
+  const isHistoricalHumanTwelveStepTemplate = existing.steps.length === 12
+    && existing.steps[10]?.assigneeType === AssigneeType.HUMAN
+    && existing.steps[10]?.outputKind === "approval"
+    && existing.steps[11]?.assigneeAgent?.name === INTEGRATOR_AGENT_NAME
+    && existing.steps[11]?.outputKind === INTEGRATOR_OUTPUT_KIND;
+  const isRegressionFirstThirteenStepTemplate = existing.steps.length === 13
+    && existing.steps.every((step, index) => step.stepIndex === index + 1)
+    && existing.steps[9]?.assigneeAgent?.name === "regression-verifier"
+    && existing.steps[9]?.outputKind === "regression-verification"
+    && existing.steps[10]?.assigneeAgent?.name === "librarian"
+    && existing.steps[10]?.outputKind === "documentation"
+    && existing.steps[11]?.outputKind === "merge-authorization"
+    && existing.steps[12]?.assigneeAgent?.name === INTEGRATOR_AGENT_NAME
+    && existing.steps[12]?.outputKind === INTEGRATOR_OUTPUT_KIND;
+
+  if (isHistoricalHumanTwelveStepTemplate) return legacyHumanTwelveStepTemplateName(existing.id);
+  if (isRegressionFirstThirteenStepTemplate) return legacyRegressionFirstThirteenStepTemplateName(existing.id);
+  if (isHistoricalNineStepTemplate) return legacyNineStepTemplateName(existing.id);
+  if (isHistoricalTenStepTemplate) return legacyTenStepTemplateName(existing.id);
+  return null;
 };
 
 const main = async (): Promise<void> => {
   const [sources, templateStepsByName] = await Promise.all([loadAgentSources(), loadAllTemplateStepSources()]);
-  const templateSteps = templateStepsByName.get(INTEGRATOR_TEMPLATE_NAME)!;
-  const directTemplateSteps = templateStepsByName.get(DIRECT_TEMPLATE_NAME)!;
   const project = await prisma.project.upsert({
     where: { slug: "agentos-example" },
     update: {},
@@ -162,225 +184,42 @@ const main = async (): Promise<void> => {
       });
     }
   }
-  const template = await prisma.$transaction(async (tx) => {
-    const existing = await tx.taskTemplate.findUnique({
-      where: { projectId_name: { projectId: project.id, name: INTEGRATOR_TEMPLATE_NAME } },
-      include: { steps: { include: { assigneeAgent: { select: { name: true } } }, orderBy: { stepIndex: "asc" } } },
-    });
-    const legacyCanonicalMarker = existing
-      ? matchedLegacyGeneration(INTEGRATOR_TEMPLATE_NAME, existing.steps as unknown as PersistedTransitionStep[])
-      : null;
-    const legacyCanonical = existing && legacyCanonicalMarker !== null;
-    const historicalIntegrator = existing?.steps.find((step) => step.stepIndex === 10);
-    const isHistoricalNineStepTemplate = existing?.steps.length === HISTORICAL_NINE_STEP_CONTRACT.length
-      && HISTORICAL_NINE_STEP_CONTRACT.every(([stepIndex, agentName, assigneeType, outputKind, approvalGate], index) => {
-        const step = existing.steps[index];
-        return step?.stepIndex === stepIndex
-          && (step.assigneeAgent?.name ?? null) === agentName
-          && step.assigneeType === assigneeType
-          && step.outputKind === outputKind
-          && step.approvalGate === approvalGate;
-      });
-    const isHistoricalTenStepTemplate = existing?.steps.length === 10
-      && existing.steps.every((step, index) => step.stepIndex === index + 1)
-      && historicalIntegrator?.outputKind === INTEGRATOR_OUTPUT_KIND
-      && historicalIntegrator.assigneeAgent?.name === INTEGRATOR_AGENT_NAME;
-    const isHistoricalHumanTwelveStepTemplate = existing?.steps.length === 12
-      && existing.steps[10]?.assigneeType === AssigneeType.HUMAN
-      && existing.steps[10]?.outputKind === "approval"
-      && existing.steps[11]?.assigneeAgent?.name === INTEGRATOR_AGENT_NAME
-      && existing.steps[11]?.outputKind === INTEGRATOR_OUTPUT_KIND;
-    const isRegressionFirstThirteenStepTemplate = existing?.steps.length === 13
-      && existing.steps.every((step, index) => step.stepIndex === index + 1)
-      && existing.steps[9]?.assigneeAgent?.name === "regression-verifier"
-      && existing.steps[9]?.outputKind === "regression-verification"
-      && existing.steps[10]?.assigneeAgent?.name === "librarian"
-      && existing.steps[10]?.outputKind === "documentation"
-      && existing.steps[11]?.outputKind === "merge-authorization"
-      && existing.steps[12]?.assigneeAgent?.name === INTEGRATOR_AGENT_NAME
-      && existing.steps[12]?.outputKind === INTEGRATOR_OUTPUT_KIND;
-    if (existing && (isRegressionFirstThirteenStepTemplate || legacyCanonical)) {
-      const rolloverTasks = await tx.task.findMany({
-        where: { templateId: existing.id, archivedAt: null, status: { not: TaskStatus.DONE } },
-        select: {
-          chainId: true,
-          _count: { select: { runs: { where: { status: { in: [...TEMPLATE_ROLLOVER_ACTIVE_RUN_STATUSES] } } } } },
+  const canonicalNames = [INTEGRATOR_TEMPLATE_NAME, DIRECT_TEMPLATE_NAME] as const;
+  await prisma.$transaction(async (tx) => {
+    const installationRows: CanonicalInstallationRow[] = [];
+    for (const templateName of canonicalNames) {
+      const existing = await tx.taskTemplate.findUnique({
+        where: { projectId_name: { projectId: project.id, name: templateName } },
+        include: {
+          steps: {
+            include: { assigneeAgent: { select: { name: true } } },
+            orderBy: { stepIndex: "asc" },
+          },
         },
       });
-      const blockers = templateRolloverBlockerCount(rolloverTasks.map((task) => ({
-        chainId: task.chainId,
-        activeRunCount: task._count.runs,
-      })));
-      if (blockers > 0) {
-        throw new Error(`${INTEGRATOR_TEMPLATE_NAME} ${existing.id} still has ${blockers} tasks with active Runs or no chain identity; canonical rollover requires active Runs to settle first`);
-      }
-      if (existing.webhookSecretId !== null || existing.webhookRepoId !== null
-        || existing.webhookPayloadMapping !== null || existing.webhookPausedAt !== null
-        || existing.webhookReplayWindowSec !== null) {
-        throw new Error(`${INTEGRATOR_TEMPLATE_NAME} ${existing.id} has webhook configuration; canonical rollover will not move operator-owned trigger state`);
-      }
-    }
-
-    // A historical 9- or 10-row template cannot be rewritten in place: its
-    // in-flight tasks keep foreign keys to rows 6-10, whose meanings changed in
-    // the 12-row routing contract. Preserve the entire template under a
-    // seed-minted legacy identity; then the canonical upsert below creates a
-    // new template for new Runs. Runtime mechanical recognition remains
-    // limited to the marked 10-row shape, because the 9-row shape had no
-    // integrator.
-    const legacyName = existing && legacyCanonicalMarker !== null
-      ? legacyTemplateName(INTEGRATOR_TEMPLATE_NAME, legacyCanonicalMarker, existing.id)
-      : existing && isHistoricalHumanTwelveStepTemplate
-      ? legacyHumanTwelveStepTemplateName(existing.id)
-      : existing && isRegressionFirstThirteenStepTemplate
-      ? legacyRegressionFirstThirteenStepTemplateName(existing.id)
-      : existing && isHistoricalNineStepTemplate
-      ? legacyNineStepTemplateName(existing.id)
-      : existing && isHistoricalTenStepTemplate
-        ? legacyTenStepTemplateName(existing.id)
-        : null;
-    if (existing && legacyName) {
-      const collision = await tx.taskTemplate.findUnique({
-        where: { projectId_name: { projectId: project.id, name: legacyName } },
-        select: { id: true },
-      });
-      if (collision) throw new Error(`Canonical template ${INTEGRATOR_TEMPLATE_NAME} cannot rename to ${legacyName}: target already exists`);
-      await tx.taskTemplate.update({
-        where: { id: existing.id },
-        data: { name: legacyName },
+      if (!existing) continue;
+      installationRows.push({
+        ...existing,
+        name: templateName,
+        steps: existing.steps as unknown as CanonicalInstallationRow["steps"],
+        legacyNameOverride: historicalSeedLegacyName(templateName, existing),
       });
     }
-    if (existing && !legacyName) {
-      assertCurrentCanonicalGraph(INTEGRATOR_TEMPLATE_NAME, existing.steps, templateSteps);
-    }
 
-    return tx.taskTemplate.upsert({
-      where: { projectId_name: { projectId: project.id, name: INTEGRATOR_TEMPLATE_NAME } },
-      update: {
-        description: "Twelve-step Full Assurance workflow with parallel independent code review, operator-free fix adjudication inside the fix step, refreshed exact-head regression verification, mechanical readiness, and mechanical merge execution.",
-        variables: ["branchName"],
-      },
-      create: {
-        projectId: project.id,
-        name: INTEGRATOR_TEMPLATE_NAME,
-        description: "Twelve-step Full Assurance workflow with parallel independent code review, operator-free fix adjudication inside the fix step, refreshed exact-head regression verification, mechanical readiness, and mechanical merge execution.",
-        variables: ["branchName"],
-      },
+    const plan = planCanonicalInstallation(installationRows, templateStepsByName, [project.id]);
+    await applyCanonicalInstallation(
+      tx,
+      plan,
+      templateStepsByName,
+      { synchronizeCurrent: true },
+    );
+    const templates = await tx.taskTemplate.findMany({
+      where: { projectId: project.id, name: { in: [...canonicalNames] } },
     });
-  });
-  const stepNames = [
-    "Write a spec",
-    "Plan",
-    "Plan review",
-    "Revise plan",
-    "Implementation",
-    "Code review (Sol)",
-    "Code review (Opus blind)",
-    "Apply review fixes",
-    "Librarian",
-    "Regression verification",
-    "Merge authorization",
-    "Merge execution",
-  ] as const;
-  for (const step of templateSteps) {
-    const { stepIndex, layer, agentName, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, priorOutputKinds, baseFromStepIndex, spawnPolicy } = step;
-    const name = stepNames[stepIndex - 1];
-    if (!name) throw new Error(`Missing canonical template step name ${stepIndex}`);
-    const assigneeType = agentName === null ? AssigneeType.HUMAN : AssigneeType.AGENT;
-    const assigneeAgentId: string | null = agentName ? (agentByName.get(agentName)?.id ?? null) : null;
-    if (agentName && !assigneeAgentId) throw new Error(`Missing seeded agent ${agentName}`);
-    await prisma.taskTemplateStep.upsert({
-      where: { taskTemplateId_stepIndex: { taskTemplateId: template.id, stepIndex } },
-      update: { name, layer, assigneeAgentId, assigneeType, runner: null, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, priorOutputKinds, baseFromStepIndex, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
-      create: { taskTemplateId: template.id, stepIndex, layer, name, assigneeAgentId, assigneeType, runner: null, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, priorOutputKinds, baseFromStepIndex, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
-    });
-  }
-
-  const historicalDirect = await prisma.taskTemplate.findUnique({
-    where: { projectId_name: { projectId: project.id, name: DIRECT_TEMPLATE_NAME } },
-    include: { steps: { include: { assigneeAgent: { select: { name: true } } }, orderBy: { stepIndex: "asc" } } },
-  });
-  const legacyDirectMarker = historicalDirect
-    ? matchedLegacyGeneration(DIRECT_TEMPLATE_NAME, historicalDirect.steps as unknown as PersistedTransitionStep[])
-    : null;
-  const legacyDirect = historicalDirect && legacyDirectMarker !== null;
-  if (legacyDirect) {
-    const rolloverTasks = await prisma.task.findMany({
-      where: { templateId: historicalDirect.id, archivedAt: null, status: { not: TaskStatus.DONE } },
-      select: {
-        chainId: true,
-        _count: { select: { runs: { where: { status: { in: [...TEMPLATE_ROLLOVER_ACTIVE_RUN_STATUSES] } } } } },
-      },
-    });
-    const blockers = templateRolloverBlockerCount(rolloverTasks.map((task) => ({
-      chainId: task.chainId,
-      activeRunCount: task._count.runs,
-    })));
-    if (blockers > 0) {
-      throw new Error(`${DIRECT_TEMPLATE_NAME} ${historicalDirect.id} still has ${blockers} tasks with active Runs or no chain identity; canonical rollover requires active Runs to settle first`);
+    if (templates.length !== canonicalNames.length) {
+      throw new Error(`Canonical installation produced ${templates.length} of ${canonicalNames.length} templates`);
     }
-    if (historicalDirect.webhookSecretId !== null || historicalDirect.webhookRepoId !== null
-      || historicalDirect.webhookPayloadMapping !== null || historicalDirect.webhookPausedAt !== null
-      || historicalDirect.webhookReplayWindowSec !== null) {
-      throw new Error(`${DIRECT_TEMPLATE_NAME} ${historicalDirect.id} has webhook configuration; canonical rollover will not move operator-owned trigger state`);
-    }
-  }
-  if (legacyDirect) {
-    const legacyName = legacyTemplateName(DIRECT_TEMPLATE_NAME, legacyDirectMarker!, historicalDirect.id);
-    const collision = await prisma.taskTemplate.findUnique({
-      where: { projectId_name: { projectId: project.id, name: legacyName } },
-      select: { id: true },
-    });
-    if (collision) throw new Error(`Canonical template ${DIRECT_TEMPLATE_NAME} cannot rename to ${legacyName}: target already exists`);
-    await prisma.taskTemplate.update({ where: { id: historicalDirect.id }, data: { name: legacyName } });
-  }
-  const isHistoricalHumanSixStepDirectTemplate = historicalDirect?.steps.length === 6
-    && historicalDirect.steps[5]?.assigneeType === AssigneeType.HUMAN
-    && historicalDirect.steps[5]?.outputKind === "approval";
-  if (isHistoricalHumanSixStepDirectTemplate) {
-    await prisma.taskTemplate.update({
-      where: { id: historicalDirect.id },
-      data: { name: `${DIRECT_TEMPLATE_NAME}-legacy-human-6-${historicalDirect.id}` },
-    });
-  }
-  if (historicalDirect && !legacyDirect && !isHistoricalHumanSixStepDirectTemplate) {
-    assertCurrentCanonicalGraph(DIRECT_TEMPLATE_NAME, historicalDirect.steps, directTemplateSteps);
-  }
-  const directTemplate = await prisma.taskTemplate.upsert({
-    where: { projectId_name: { projectId: project.id, name: DIRECT_TEMPLATE_NAME } },
-    update: {
-      description: "Direct-tier workflow: implementation from the task brief, parallel independent code review, operator-free fix adjudication inside the fix step, refreshed exact-head regression verification, mechanical readiness, and mechanical merge execution.",
-      variables: ["branchName"],
-    },
-    create: {
-      projectId: project.id,
-      name: DIRECT_TEMPLATE_NAME,
-      description: "Direct-tier workflow: implementation from the task brief, parallel independent code review, operator-free fix adjudication inside the fix step, refreshed exact-head regression verification, mechanical readiness, and mechanical merge execution.",
-      variables: ["branchName"],
-    },
-  });
-  const directStepNames = [
-    "Implementation",
-    "Code review (Sol)",
-    "Code review (Opus blind)",
-    "Apply review fixes",
-    "Regression verification",
-    "Merge authorization",
-    "Merge execution",
-  ] as const;
-  for (const step of directTemplateSteps) {
-    const { stepIndex, layer, agentName, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, priorOutputKinds, baseFromStepIndex, spawnPolicy } = step;
-    const name = directStepNames[stepIndex - 1];
-    if (!name) throw new Error(`Missing direct template step name ${stepIndex}`);
-    const assigneeType = agentName === null ? AssigneeType.HUMAN : AssigneeType.AGENT;
-    const assigneeAgentId: string | null = agentName ? (agentByName.get(agentName)?.id ?? null) : null;
-    if (agentName && !assigneeAgentId) throw new Error(`Missing seeded agent ${agentName}`);
-    await prisma.taskTemplateStep.upsert({
-      where: { taskTemplateId_stepIndex: { taskTemplateId: directTemplate.id, stepIndex } },
-      update: { name, layer, assigneeAgentId, assigneeType, runner: null, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, priorOutputKinds, baseFromStepIndex, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
-      create: { taskTemplateId: directTemplate.id, stepIndex, layer, name, assigneeAgentId, assigneeType, runner: null, approvalGate, outputKind, prompt, opensPullRequest, attachmentsFromPrevious, priorOutputKinds, baseFromStepIndex, spawnPolicy: spawnPolicy ?? Prisma.JsonNull },
-    });
-  }
+  }, { timeout: 30_000 });
 
   console.log(`Seeded ${project.name} from agents/ with ${sources.roles.length} agents, the twelve-step feature template, and the seven-step direct template.`);
 };

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -3,38 +3,18 @@ import { PrismaClient, Prisma, RunnerPreference, TaskStatus } from "@prisma/clie
 import { CANONICAL_AGENT_RUNTIME_TRANSITIONS, catalogRunnerForModel } from "../src/agent-contract.js";
 import { loadAgentSources, roleSourceStructureDifferences } from "../src/agent-sources.js";
 import {
-  legacyTemplateName,
-  matchedLegacyGeneration,
-  successorPromptDrift,
-  TEMPLATE_ROLLOVER_ACTIVE_RUN_STATUSES,
-  templateRolloverBlockerCount,
-  type PersistedTransitionStep,
-} from "../src/canonical-template-transition.js";
+  applyCanonicalInstallation,
+  planCanonicalInstallation,
+  type CanonicalInstallationRow,
+} from "../src/canonical-template-installation.js";
 import {
   loadAllTemplateStepSources,
   LEGACY_ALL_PRIOR_OUTPUTS,
   templateStepStructureDifferences,
-  type CanonicalTemplateName,
-  type TemplateStepSource,
 } from "../src/template-sources.js";
 
 const REGRESSION_AGENT_NAME = "regression-verifier";
 const REGRESSION_AGENT_SOURCE = "review-coordinator-sol";
-const CANONICAL_TEMPLATE_DESCRIPTIONS = new Map([
-  ["compound-engineer-workflow", "Twelve-step Full Assurance workflow with parallel independent code review, operator-free fix adjudication inside the fix step, refreshed exact-head regression verification, mechanical readiness, and mechanical merge execution."],
-  ["direct-engineer-workflow", "Direct-tier workflow: implementation from the task brief, parallel independent code review, operator-free fix adjudication inside the fix step, refreshed exact-head regression verification, mechanical readiness, and mechanical merge execution."],
-]);
-const CANONICAL_STEP_NAMES = new Map([
-  ["compound-engineer-workflow", [
-    "Write a spec", "Plan", "Plan review", "Revise plan", "Implementation", "Code review (Sol)",
-    "Code review (Opus blind)", "Apply review fixes", "Librarian",
-    "Regression verification", "Merge authorization", "Merge execution",
-  ]],
-  ["direct-engineer-workflow", [
-    "Implementation", "Code review (Sol)", "Code review (Opus blind)",
-    "Apply review fixes", "Regression verification", "Merge authorization", "Merge execution",
-  ]],
-]);
 type AssigneeTransition = { from: readonly string[]; to: string };
 const ASSIGNEE_TRANSITIONS = new Map<string, AssigneeTransition>([
   ["compound-engineer-workflow:10", { from: ["review-coordinator-opus", "review-coordinator-sol"], to: REGRESSION_AGENT_NAME }],
@@ -58,156 +38,15 @@ const runtimeConfigRefusal = (agent: { model: string; runnerPreference: RunnerPr
   return `Model ${agent.model} requires ${expected}, but this Agent stores ${agent.runnerPreference}`;
 };
 
-type CanonicalTransaction = Prisma.TransactionClient;
-type CanonicalSources = Map<CanonicalTemplateName, TemplateStepSource[]>;
-
 const transitionStepInclude = {
   assigneeAgent: { select: { name: true } },
   _count: { select: { tasks: true } },
 } as const;
 
-const readCanonicalTemplateRows = async (tx: CanonicalTransaction, name: string) => tx.taskTemplate.findMany({
+const readCanonicalTemplateRows = async (tx: Prisma.TransactionClient, name: string) => tx.taskTemplate.findMany({
   where: { name },
   include: { steps: { orderBy: { stepIndex: "asc" }, include: transitionStepInclude } },
 });
-
-/**
- * Validate every named row before the transition begins. A row with the old
- * exact shape is the only row eligible for a fixed legacy-v1 rename. A row
- * with the current count is checked in the normal canonical sync loop below,
- * which retains its narrow, named adoption rules for already-reviewed source
- * edits. Any other count or an unrecognized old shape is a structural refusal.
- */
-const preflightCanonicalTemplateRows = async (
-  tx: CanonicalTransaction,
-  templateSources: CanonicalSources,
-): Promise<void> => {
-  for (const [templateName, steps] of templateSources) {
-    const rows = await readCanonicalTemplateRows(tx, templateName);
-    if (rows.length === 0) throw new Error(`Template ${templateName} was not found`);
-    for (const row of rows) {
-      const persistedSteps = row.steps as unknown as PersistedTransitionStep[];
-      const legacyMarker = matchedLegacyGeneration(templateName, persistedSteps);
-      if (legacyMarker !== null) {
-        const legacyName = legacyTemplateName(templateName, legacyMarker, row.id);
-        const existingLegacy = await tx.taskTemplate.findUnique({
-          where: { projectId_name: { projectId: row.projectId, name: legacyName } },
-          select: { id: true },
-        });
-        if (existingLegacy) {
-          throw new Error(`Canonical template ${templateName} on project ${row.projectId} cannot rename to ${legacyName}: target already exists`);
-        }
-        continue;
-      }
-      if (persistedSteps.length !== steps.length) {
-        throw new Error(`Canonical template ${templateName} on project ${row.projectId} has structural drift: expected ${steps.length} steps, found ${persistedSteps.length}`);
-      }
-      const duplicateIndexes = new Set<number>();
-      for (const step of persistedSteps) {
-        if (duplicateIndexes.has(step.stepIndex)) {
-          throw new Error(`Canonical template ${templateName} on project ${row.projectId} has structural drift: duplicate stepIndex ${step.stepIndex}`);
-        }
-        duplicateIndexes.add(step.stepIndex);
-      }
-    }
-  }
-};
-
-const createCanonicalTemplate = async (
-  tx: CanonicalTransaction,
-  projectId: string,
-  templateName: string,
-  steps: readonly TemplateStepSource[],
-): Promise<void> => {
-  const description = CANONICAL_TEMPLATE_DESCRIPTIONS.get(templateName);
-  const stepNames = CANONICAL_STEP_NAMES.get(templateName);
-  if (!description || !stepNames) throw new Error(`No canonical template metadata is defined for ${templateName}`);
-  const template = await tx.taskTemplate.create({
-    data: {
-      projectId,
-      name: templateName,
-      description,
-      variables: ["branchName"],
-    },
-  });
-  for (const step of steps) {
-    const name = stepNames[step.stepIndex - 1];
-    if (!name) throw new Error(`Missing canonical template step name ${templateName}:${step.stepIndex}`);
-    const assigneeAgentId = step.agentName
-      ? (await tx.agent.findFirst({
-        where: { projectId, name: step.agentName, archivedAt: null },
-        select: { id: true },
-      }))?.id ?? null
-      : null;
-    if (step.agentName && !assigneeAgentId) {
-      throw new Error(`Canonical template ${templateName} step ${step.stepIndex} cannot bind ${step.agentName}: active Agent was not found in project ${projectId}`);
-    }
-    await tx.taskTemplateStep.create({
-      data: {
-        taskTemplateId: template.id,
-        stepIndex: step.stepIndex,
-        layer: step.layer,
-        name,
-        assigneeAgentId,
-        assigneeType: step.agentName === null ? "HUMAN" : "AGENT",
-        runner: null,
-        approvalGate: step.approvalGate,
-        outputKind: step.outputKind,
-        prompt: step.prompt,
-        opensPullRequest: step.opensPullRequest,
-        attachmentsFromPrevious: step.attachmentsFromPrevious,
-        priorOutputKinds: step.priorOutputKinds,
-        baseFromStepIndex: step.baseFromStepIndex,
-        spawnPolicy: step.spawnPolicy ?? Prisma.JsonNull,
-      },
-    });
-  }
-};
-
-const transitionCanonicalTemplateRows = async (
-  tx: CanonicalTransaction,
-  templateSources: Awaited<ReturnType<typeof loadAllTemplateStepSources>>,
-): Promise<number> => {
-  let created = 0;
-  for (const [templateName, steps] of templateSources) {
-    const rows = await readCanonicalTemplateRows(tx, templateName);
-    for (const row of rows) {
-      const persistedSteps = row.steps as unknown as PersistedTransitionStep[];
-      const legacyMarker = matchedLegacyGeneration(templateName, persistedSteps);
-      if (legacyMarker === null) continue;
-      // The registration names both ends of the transition. Renaming a row on
-      // the strength of the outgoing digest alone would let prompts edited
-      // after the entry was written ride in on its authority, so the source has
-      // to be the successor this rollover was registered to install.
-      const drift = successorPromptDrift(templateName, legacyMarker, steps);
-      if (drift) throw new Error(drift);
-      const rolloverTasks = await tx.task.findMany({
-        where: { templateId: row.id, archivedAt: null, status: { not: TaskStatus.DONE } },
-        select: {
-          chainId: true,
-          _count: { select: { runs: { where: { status: { in: [...TEMPLATE_ROLLOVER_ACTIVE_RUN_STATUSES] } } } } },
-        },
-      });
-      const blockers = templateRolloverBlockerCount(rolloverTasks.map((task) => ({
-        chainId: task.chainId,
-        activeRunCount: task._count.runs,
-      })));
-      if (blockers > 0) {
-        throw new Error(`${templateName} ${row.id} still has ${blockers} tasks with active Runs or no chain identity; canonical rollover requires active Runs to settle first`);
-      }
-      if (row.webhookSecretId !== null || row.webhookRepoId !== null
-        || row.webhookPayloadMapping !== null || row.webhookPausedAt !== null
-        || row.webhookReplayWindowSec !== null) {
-        throw new Error(`${templateName} ${row.id} has webhook configuration; canonical rollover will not move operator-owned trigger state`);
-      }
-      const legacyName = legacyTemplateName(templateName, legacyMarker, row.id);
-      await tx.taskTemplate.update({ where: { id: row.id }, data: { name: legacyName } });
-      await createCanonicalTemplate(tx, row.projectId, templateName, steps);
-      created += 1;
-    }
-  }
-  return created;
-};
 
 // Every canonical template, every step of each, and every role under agents/
 // is synced. Omitting any source here would let a prompt edit silently miss
@@ -225,7 +64,17 @@ const main = async (): Promise<void> => {
         select: { id: true },
       });
       if (!canonicalProject) throw new Error("Canonical project agentos-example was not found");
-      await preflightCanonicalTemplateRows(tx, templateSources);
+      const installationRows: CanonicalInstallationRow[] = [];
+      for (const templateName of templateSources.keys()) {
+        const rows = await readCanonicalTemplateRows(tx, templateName);
+        if (rows.length === 0) throw new Error(`Template ${templateName} was not found`);
+        installationRows.push(...rows.map((row) => ({
+          ...row,
+          name: templateName,
+          steps: row.steps as unknown as CanonicalInstallationRow["steps"],
+        })));
+      }
+      const installationPlan = planCanonicalInstallation(installationRows, templateSources);
       let createdAgents = 0;
       let createdAgentRepoGrants = 0;
       const regressionRole = rolesByName.get(REGRESSION_AGENT_NAME);
@@ -270,7 +119,7 @@ const main = async (): Promise<void> => {
         }
         createdAgents = 1;
       }
-      const createdCanonicalTemplates = await transitionCanonicalTemplateRows(tx, templateSources);
+      const createdCanonicalTemplates = (await applyCanonicalInstallation(tx, installationPlan, templateSources)).created;
       const updatedSteps: Record<string, Record<number, number>> = {};
       let adoptedAssignees = 0;
       let adoptedStepBases = 0;

--- a/packages/db/prisma/template-digest.ts
+++ b/packages/db/prisma/template-digest.ts
@@ -1,0 +1,10 @@
+import { templatePromptGenerationDigest } from "../src/canonical-template-transition.js";
+import { loadAllTemplateStepSources } from "../src/template-sources.js";
+
+const sources = await loadAllTemplateStepSources();
+const digests = Object.fromEntries([...sources].map(([name, steps]) => [
+  name,
+  templatePromptGenerationDigest(steps),
+]));
+
+console.log(JSON.stringify(digests, null, 2));

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -574,7 +574,7 @@ test("sync refuses a seven-step canonical shape with structural drift before mut
   const beforeLegacyCount = await prisma.taskTemplate.count({ where: { projectId: project.id, name: { startsWith: "direct-engineer-workflow-legacy" } } });
   const refused = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
   assert.notEqual(refused.status, 0, refused.output);
-  assert.match(refused.output, /direct-engineer-workflow step 7 .* differs from canonical Markdown structure/u);
+  assert.match(refused.output, /direct-engineer-workflow has structural drift: step 7 differs from the canonical source in outputKind/u);
   assert.equal(await prisma.taskTemplate.count({ where: { projectId: project.id, name: { startsWith: "direct-engineer-workflow-legacy" } } }), beforeLegacyCount);
   assert.equal((await prisma.taskTemplateStep.findUniqueOrThrow({ where: { id: step.id } })).outputKind, "drifted-output");
 });

--- a/packages/db/src/canonical-template-installation.test.ts
+++ b/packages/db/src/canonical-template-installation.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  planCanonicalInstallation,
+  type CanonicalInstallationRow,
+  type CanonicalInstallationSources,
+} from "./canonical-template-installation.js";
+import {
+  LEGACY_TEMPLATE_GENERATIONS,
+  type LegacyTemplateGeneration,
+  type PersistedTransitionStep,
+} from "./canonical-template-transition.js";
+import { loadTemplateStepSources, type TemplateStepSource } from "./template-sources.js";
+
+const asPersisted = (steps: readonly TemplateStepSource[]): PersistedTransitionStep[] => steps.map((step) => ({
+  id: `step-${String(step.stepIndex)}`,
+  taskTemplateId: "template",
+  stepIndex: step.stepIndex,
+  name: step.name,
+  assigneeAgent: step.agentName === null ? null : { name: step.agentName },
+  assigneeType: step.agentName === null ? "HUMAN" : "AGENT",
+  layer: step.layer,
+  approvalGate: step.approvalGate,
+  outputKind: step.outputKind,
+  attachmentsFromPrevious: step.attachmentsFromPrevious,
+  priorOutputKinds: step.priorOutputKinds,
+  opensPullRequest: step.opensPullRequest,
+  baseFromStepIndex: step.baseFromStepIndex,
+  spawnPolicy: step.spawnPolicy as PersistedTransitionStep["spawnPolicy"],
+  prompt: step.prompt,
+}));
+
+const generationAsPersisted = (generation: LegacyTemplateGeneration): PersistedTransitionStep[] => (
+  generation.shape.map((step, index) => ({
+    id: `legacy-step-${String(index + 1)}`,
+    taskTemplateId: "template",
+    stepIndex: index + 1,
+    name: step.name,
+    assigneeAgent: step.agentName === null ? null : { name: step.agentName },
+    assigneeType: step.assigneeType,
+    layer: step.layer,
+    approvalGate: step.approvalGate,
+    outputKind: step.outputKind,
+    attachmentsFromPrevious: step.attachmentsFromPrevious,
+    priorOutputKinds: [],
+    opensPullRequest: step.opensPullRequest,
+    baseFromStepIndex: step.baseFromStepIndex,
+    spawnPolicy: step.spawnPolicy,
+    prompt: `retired prompt ${String(index + 1)}`,
+  }))
+);
+
+const row = (steps: readonly PersistedTransitionStep[]): CanonicalInstallationRow => ({
+  id: "template",
+  projectId: "project",
+  name: "direct-engineer-workflow",
+  steps,
+});
+
+test("installation planning decides successor drift, half migrations, and spawnPolicy without a database", async () => {
+  const loaded = await loadTemplateStepSources("direct-engineer-workflow");
+  const sources = (steps: readonly TemplateStepSource[]): CanonicalInstallationSources => new Map([
+    ["direct-engineer-workflow", steps],
+  ]);
+  const generation = LEGACY_TEMPLATE_GENERATIONS["direct-engineer-workflow"]
+    .find((candidate) => candidate.marker === "pre-adjudication")!;
+  const mutableGeneration = generation as LegacyTemplateGeneration & { successorPromptDigest?: string };
+  const originalSuccessorDigest = mutableGeneration.successorPromptDigest;
+
+  const halfMigrated = asPersisted(loaded);
+  halfMigrated[0] = { ...halfMigrated[0]!, approvalGate: !halfMigrated[0]!.approvalGate };
+  const spawnPolicy = { mode: "parallel", limit: 2 };
+  const sourceWithSpawnPolicy = loaded.map((step, index) => index === 0 ? { ...step, spawnPolicy } : step);
+
+  try {
+    mutableGeneration.successorPromptDigest = "0".repeat(64);
+    const cases = [
+      {
+        name: "registered row whose source is not its pinned successor",
+        plan: planCanonicalInstallation([row(generationAsPersisted(generation))], sources(loaded)),
+        kind: "refused",
+        reason: /registered to install prompt generation/u,
+      },
+      {
+        name: "half-migrated current row",
+        plan: planCanonicalInstallation([row(halfMigrated)], sources(loaded)),
+        kind: "refused",
+        reason: /structural drift: step 1/u,
+      },
+      {
+        name: "current row with a named spawnPolicy",
+        plan: planCanonicalInstallation([row(asPersisted(sourceWithSpawnPolicy))], sources(sourceWithSpawnPolicy)),
+        kind: "current",
+      },
+    ] as const;
+
+    for (const candidate of cases) {
+      assert.equal(candidate.plan.length, 1, candidate.name);
+      const action = candidate.plan[0]!;
+      assert.equal(action.kind, candidate.kind, candidate.name);
+      if (action.kind === "refused" && "reason" in candidate) assert.match(action.reason, candidate.reason, candidate.name);
+    }
+  } finally {
+    if (originalSuccessorDigest === undefined) delete mutableGeneration.successorPromptDigest;
+    else mutableGeneration.successorPromptDigest = originalSuccessorDigest;
+  }
+});

--- a/packages/db/src/canonical-template-installation.ts
+++ b/packages/db/src/canonical-template-installation.ts
@@ -1,0 +1,265 @@
+import { AssigneeType, Prisma, RunStatus, TaskStatus } from "@prisma/client";
+
+import {
+  legacyTemplateName,
+  LEGACY_TEMPLATE_GENERATIONS,
+  matchedLegacyGeneration,
+  successorPromptDrift,
+  templateRolloverBlockerCount,
+  type PersistedTransitionStep,
+} from "./canonical-template-transition.js";
+import {
+  LEGACY_ALL_PRIOR_OUTPUTS,
+  canonicalTemplateSourceSpec,
+  templateStepStructureDifferences,
+  type CanonicalTemplateName,
+  type TemplateStepSource,
+} from "./template-sources.js";
+
+export type CanonicalInstallationRow = Readonly<{
+  id: string;
+  projectId: string;
+  name: CanonicalTemplateName;
+  steps: readonly PersistedTransitionStep[];
+  /** Seed-only adapter for predecessor graphs that predate the closed registry. */
+  legacyNameOverride?: string;
+}>;
+
+export type CanonicalInstallationAction =
+  | Readonly<{ kind: "current"; templateName: CanonicalTemplateName; projectId: string; rowId: string }>
+  | Readonly<{ kind: "create"; templateName: CanonicalTemplateName; projectId: string }>
+  | Readonly<{
+    kind: "rollover";
+    templateName: CanonicalTemplateName;
+    projectId: string;
+    rowId: string;
+    marker: string;
+    legacyName: string;
+    successorVerified: boolean;
+  }>
+  | Readonly<{
+    kind: "refused";
+    templateName: CanonicalTemplateName;
+    projectId: string;
+    rowId: string | null;
+    reason: string;
+  }>;
+
+export type CanonicalInstallationPlan = readonly CanonicalInstallationAction[];
+export type CanonicalInstallationSources = ReadonlyMap<CanonicalTemplateName, readonly TemplateStepSource[]>;
+
+const adoptionDifferenceAllowed = (
+  templateName: CanonicalTemplateName,
+  actual: PersistedTransitionStep,
+  source: TemplateStepSource,
+  difference: string,
+): boolean => {
+  if (difference === "name") return actual.name === "Merge readiness" && source.name === "Merge authorization";
+  if (difference === "priorOutputKinds") {
+    return actual.priorOutputKinds.length === 1 && actual.priorOutputKinds[0] === LEGACY_ALL_PRIOR_OUTPUTS;
+  }
+  if (difference === "agent") {
+    const from = actual.assigneeAgent?.name;
+    return source.agentName === "regression-verifier"
+      && (from === "review-coordinator-opus" || from === "review-coordinator-sol");
+  }
+  if (difference === "baseFromStepIndex") {
+    return actual.baseFromStepIndex === null
+      && ((templateName === "compound-engineer-workflow" && actual.stepIndex === 6 && source.baseFromStepIndex === 5)
+        || (templateName === "direct-engineer-workflow" && actual.stepIndex === 2 && source.baseFromStepIndex === 1));
+  }
+  return false;
+};
+
+const currentGraphRefusal = (
+  templateName: CanonicalTemplateName,
+  steps: readonly PersistedTransitionStep[],
+  sources: readonly TemplateStepSource[],
+): string | null => {
+  if (steps.length !== sources.length) {
+    return `Canonical template ${templateName} has structural drift: expected ${sources.length} steps, found ${steps.length}`;
+  }
+  const ordered = [...steps].sort((left, right) => left.stepIndex - right.stepIndex);
+  if (ordered.some((step, index) => step.stepIndex !== index + 1)) {
+    return `Canonical template ${templateName} has structural drift: step indexes are not contiguous`;
+  }
+  for (const [index, step] of ordered.entries()) {
+    const source = sources[index]!;
+    const differences = templateStepStructureDifferences(step, source)
+      .filter((difference) => !adoptionDifferenceAllowed(templateName, step, source, difference));
+    if (differences.length > 0) {
+      return `Canonical template ${templateName} has structural drift: step ${step.stepIndex} differs from the canonical source in ${differences.join(", ")}`;
+    }
+  }
+  return null;
+};
+
+/**
+ * Decide the complete canonical template installation before any row changes.
+ * Drivers supply database snapshots and source graphs; the plan is pure and
+ * makes refusal, adoption, and registered rollover mutually exclusive.
+ */
+export const planCanonicalInstallation = (
+  rows: readonly CanonicalInstallationRow[],
+  sources: CanonicalInstallationSources,
+  requiredProjectIds: readonly string[] = [],
+): CanonicalInstallationPlan => {
+  const plan: CanonicalInstallationAction[] = [];
+  for (const [templateName, sourceSteps] of sources) {
+    const matchingRows = rows.filter((row) => row.name === templateName);
+    for (const projectId of requiredProjectIds) {
+      if (!matchingRows.some((row) => row.projectId === projectId)) {
+        plan.push({ kind: "create", templateName, projectId });
+      }
+    }
+    for (const row of matchingRows) {
+      const marker = matchedLegacyGeneration(templateName, row.steps);
+      if (marker !== null) {
+        const generation = LEGACY_TEMPLATE_GENERATIONS[templateName]
+          .find((candidate) => candidate.marker === marker)!;
+        const drift = successorPromptDrift(templateName, marker, sourceSteps);
+        plan.push(drift === null
+          ? {
+            kind: "rollover",
+            templateName,
+            projectId: row.projectId,
+            rowId: row.id,
+            marker,
+            legacyName: legacyTemplateName(templateName, marker, row.id),
+            successorVerified: generation.successorPromptDigest !== undefined,
+          }
+          : { kind: "refused", templateName, projectId: row.projectId, rowId: row.id, reason: drift });
+        continue;
+      }
+      if (row.legacyNameOverride) {
+        plan.push({
+          kind: "rollover",
+          templateName,
+          projectId: row.projectId,
+          rowId: row.id,
+          marker: "pre-registry-seed",
+          legacyName: row.legacyNameOverride,
+          successorVerified: false,
+        });
+        continue;
+      }
+      const refusal = currentGraphRefusal(templateName, row.steps, sourceSteps);
+      plan.push(refusal === null
+        ? { kind: "current", templateName, projectId: row.projectId, rowId: row.id }
+        : { kind: "refused", templateName, projectId: row.projectId, rowId: row.id, reason: refusal });
+    }
+  }
+  return plan;
+};
+
+const writeCanonicalTemplate = async (
+  tx: Prisma.TransactionClient,
+  projectId: string,
+  templateName: CanonicalTemplateName,
+  steps: readonly TemplateStepSource[],
+  currentRowId: string | null = null,
+): Promise<void> => {
+  const metadata = canonicalTemplateSourceSpec(templateName);
+  const template = currentRowId === null
+    ? await tx.taskTemplate.create({
+      data: { projectId, name: templateName, description: metadata.description, variables: ["branchName"] },
+    })
+    : await tx.taskTemplate.update({
+      where: { id: currentRowId },
+      data: { description: metadata.description, variables: ["branchName"] },
+    });
+  for (const step of steps) {
+    const assigneeAgentId = step.agentName === null
+      ? null
+      : (await tx.agent.findFirst({
+        where: { projectId, name: step.agentName, archivedAt: null },
+        select: { id: true },
+      }))?.id ?? null;
+    if (step.agentName !== null && assigneeAgentId === null) {
+      throw new Error(`Canonical template ${templateName} step ${step.stepIndex} cannot bind ${step.agentName}: active Agent was not found in project ${projectId}`);
+    }
+    const data = {
+      layer: step.layer,
+      name: step.name,
+      assigneeAgentId,
+      assigneeType: step.agentName === null ? AssigneeType.HUMAN : AssigneeType.AGENT,
+      runner: null,
+      approvalGate: step.approvalGate,
+      outputKind: step.outputKind,
+      prompt: step.prompt,
+      opensPullRequest: step.opensPullRequest,
+      attachmentsFromPrevious: step.attachmentsFromPrevious,
+      priorOutputKinds: step.priorOutputKinds,
+      baseFromStepIndex: step.baseFromStepIndex,
+      spawnPolicy: step.spawnPolicy ?? Prisma.JsonNull,
+    } as const;
+    await tx.taskTemplateStep.upsert({
+      where: { taskTemplateId_stepIndex: { taskTemplateId: template.id, stepIndex: step.stepIndex } },
+      update: data,
+      create: { taskTemplateId: template.id, stepIndex: step.stepIndex, ...data },
+    });
+  }
+};
+
+/** Apply one precomputed plan inside the caller's transaction. */
+export const applyCanonicalInstallation = async (
+  tx: Prisma.TransactionClient,
+  plan: CanonicalInstallationPlan,
+  sources: CanonicalInstallationSources,
+  options: Readonly<{ synchronizeCurrent?: boolean }> = {},
+): Promise<{ created: number }> => {
+  const refusal = plan.find((action) => action.kind === "refused");
+  if (refusal?.kind === "refused") throw new Error(refusal.reason);
+
+  let created = 0;
+  for (const action of plan) {
+    if (action.kind === "refused") continue;
+    const sourceSteps = sources.get(action.templateName);
+    if (!sourceSteps) throw new Error(`No canonical source is loaded for ${action.templateName}`);
+    if (action.kind === "current") {
+      if (options.synchronizeCurrent) {
+        await writeCanonicalTemplate(tx, action.projectId, action.templateName, sourceSteps, action.rowId);
+      }
+      continue;
+    }
+    if (action.kind === "rollover") {
+      const tasks = await tx.task.findMany({
+        where: { templateId: action.rowId, archivedAt: null, status: { not: TaskStatus.DONE } },
+        select: {
+          chainId: true,
+          _count: { select: { runs: { where: { status: { in: [
+            RunStatus.QUEUED,
+            RunStatus.CLAIMED,
+            RunStatus.PROVISIONING,
+            RunStatus.RUNNING,
+            RunStatus.WAITING_INBOX,
+          ] } } } } },
+        },
+      });
+      const blockers = templateRolloverBlockerCount(tasks.map((task) => ({
+        chainId: task.chainId,
+        activeRunCount: task._count.runs,
+      })));
+      if (blockers > 0) {
+        throw new Error(`${action.templateName} ${action.rowId} still has ${blockers} tasks with active Runs or no chain identity; canonical rollover requires active Runs to settle first`);
+      }
+      const row = await tx.taskTemplate.findUniqueOrThrow({ where: { id: action.rowId } });
+      if (row.webhookSecretId !== null || row.webhookRepoId !== null
+        || row.webhookPayloadMapping !== null || row.webhookPausedAt !== null
+        || row.webhookReplayWindowSec !== null) {
+        throw new Error(`${action.templateName} ${action.rowId} has webhook configuration; canonical rollover will not move operator-owned trigger state`);
+      }
+      const collision = await tx.taskTemplate.findUnique({
+        where: { projectId_name: { projectId: action.projectId, name: action.legacyName } },
+        select: { id: true },
+      });
+      if (collision) {
+        throw new Error(`Canonical template ${action.templateName} on project ${action.projectId} cannot rename to ${action.legacyName}: target already exists`);
+      }
+      await tx.taskTemplate.update({ where: { id: action.rowId }, data: { name: action.legacyName } });
+    }
+    await writeCanonicalTemplate(tx, action.projectId, action.templateName, sourceSteps);
+    created += 1;
+  }
+  return { created };
+};

--- a/packages/db/src/canonical-template-transition.test.ts
+++ b/packages/db/src/canonical-template-transition.test.ts
@@ -37,7 +37,7 @@ const asPersisted = (steps: readonly TemplateStepSource[]): PersistedTransitionS
     id: `step-${String(step.stepIndex)}`,
     taskTemplateId: "template",
     stepIndex: step.stepIndex,
-    name: step.outputKind,
+    name: step.name,
     assigneeAgent: step.agentName === null ? null : { name: step.agentName },
     assigneeType: step.agentName === null ? "HUMAN" : "AGENT",
     layer: step.layer,
@@ -77,10 +77,10 @@ test("every registered compound generation derives its repair Step ordinals", ()
   for (const generation of LEGACY_TEMPLATE_GENERATIONS["compound-engineer-workflow"]) {
     const ordinals = canonicalStepOrdinals("compound-engineer-workflow", generation.marker);
     assert.ok(ordinals, generation.marker);
-    assert.equal(ordinals.documentation, generation.shape.findIndex((tuple) => tuple[3] === "documentation") + 1);
+    assert.equal(ordinals.documentation, generation.shape.findIndex((step) => step.outputKind === "documentation") + 1);
     assert.equal(
       ordinals.regression,
-      generation.shape.findIndex((tuple) => tuple[3].startsWith("regression-verification")) + 1,
+      generation.shape.findIndex((step) => step.outputKind.startsWith("regression-verification")) + 1,
     );
   }
   assert.deepEqual(
@@ -110,9 +110,20 @@ test("a prompt generation is decided by step index and text, not by array order"
 test("a structure-identical generation is decided by its prompt digest alone", () => {
   // The predicate, exercised directly on a synthetic pair: same shape, one
   // registered prompt generation. This is the case a shape can never express.
-  const shape = [["senior-dev", "AGENT", false, "implementation", false, true, null, 1]] as const;
+  const shape = [{
+    name: "Implementation",
+    agentName: "senior-dev",
+    assigneeType: "AGENT",
+    approvalGate: false,
+    outputKind: "implementation",
+    attachmentsFromPrevious: false,
+    opensPullRequest: true,
+    baseFromStepIndex: null,
+    layer: 1,
+    spawnPolicy: null,
+  }] as const;
   const stepsWith = (prompt: string): PersistedTransitionStep[] => [{
-    id: "step-1", taskTemplateId: "template", stepIndex: 1, name: "implementation",
+    id: "step-1", taskTemplateId: "template", stepIndex: 1, name: "Implementation",
     assigneeAgent: { name: "senior-dev" }, assigneeType: "AGENT", layer: 1,
     approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false,
     priorOutputKinds: [],

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -1,19 +1,22 @@
 import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 
 import { AssigneeType, Prisma, RunStatus } from "@prisma/client";
 
 import { stepRole, type StepRole } from "./step-role.js";
 
-export type LegacyStepTuple = readonly [
-  string,
-  AssigneeType,
-  boolean,
-  string,
-  boolean,
-  boolean,
-  number | null,
-  number,
-];
+export type LegacyStepRecord = Readonly<{
+  name: string;
+  agentName: string | null;
+  assigneeType: AssigneeType;
+  approvalGate: boolean;
+  outputKind: string;
+  attachmentsFromPrevious: boolean;
+  opensPullRequest: boolean;
+  baseFromStepIndex: number | null;
+  layer: number;
+  spawnPolicy: Prisma.JsonValue;
+}>;
 
 /**
  * Every retired canonical graph, keyed by the marker its renamed rows carry.
@@ -38,7 +41,7 @@ export type LegacyStepTuple = readonly [
  */
 export type LegacyTemplateGeneration = Readonly<{
   marker: string;
-  shape: readonly LegacyStepTuple[];
+  shape: readonly LegacyStepRecord[];
   /**
    * The prompt generation this entry retires, as a digest over its ordered step
    * prompts, or absent when the structure alone identifies it.
@@ -79,26 +82,26 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-narrow-regression-lease",
       shape: [
-        ["senior-dev-luna", AssigneeType.AGENT, false, "implementation", false, true, null, 1],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 1, 2],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 1, 2],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 3],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification", true, false, null, 4],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 5],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 6],
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
       ],
     },
     {
       marker: "pre-adjudication",
       shape: [
-        ["senior-dev-luna", AssigneeType.AGENT, false, "implementation", false, true, null, 1],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 1, 2],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 1, 2],
-        ["review-adjudicator-opus", AssigneeType.AGENT, false, "must-fix", true, false, 1, 3],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 4],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification", true, false, null, 5],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 6],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 7],
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Opus adjudication", agentName: "review-adjudicator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "must-fix", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 3, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
       ],
     },
     {
@@ -108,13 +111,13 @@ const legacyTemplateGenerations = {
       promptDigest: "1b2447559a77e28added3509a6f6b17bce8a8cd7db9113bdaaa17d581d874165",
       successorPromptDigest: "3b50afcdd5aef2d0f06b00b7644cc67fac3ffbd29414e44564dc6aeb9757580d",
       shape: [
-        ["senior-dev-luna", AssigneeType.AGENT, false, "implementation", false, true, null, 1],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 1, 2],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 1, 2],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 3],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification-v2", true, false, null, 4],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 5],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 6],
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
       ],
     },
     {
@@ -122,13 +125,13 @@ const legacyTemplateGenerations = {
       promptDigest: "c1a9ec1f8e783c3c814c0d0f5f4a9b91d5759b9dc39473dc200447aeb96677c5",
       successorPromptDigest: "3b50afcdd5aef2d0f06b00b7644cc67fac3ffbd29414e44564dc6aeb9757580d",
       shape: [
-        ["senior-dev-luna", AssigneeType.AGENT, false, "implementation", false, true, null, 1],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 1, 2],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 1, 2],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 3],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification-v2", true, false, null, 4],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 5],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 6],
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
       ],
     },
     {
@@ -138,13 +141,13 @@ const legacyTemplateGenerations = {
       promptDigest: "a760a6ca04bc047b47831fc4a4064cf2157487142f32a480223d6b5d8187c4a1",
       successorPromptDigest: "3b50afcdd5aef2d0f06b00b7644cc67fac3ffbd29414e44564dc6aeb9757580d",
       shape: [
-        ["senior-dev-luna", AssigneeType.AGENT, false, "implementation", false, true, null, 1],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 1, 2],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 1, 2],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 3],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification-v2", true, false, null, 4],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 5],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 6],
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
       ],
     },
   ],
@@ -152,53 +155,53 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-narrow-regression-lease",
       shape: [
-        ["spec", AssigneeType.AGENT, false, "spec", false, false, null, 1],
-        ["plan", AssigneeType.AGENT, false, "plan", true, false, null, 2],
-        ["review-coordinator", AssigneeType.AGENT, false, "plan-review", true, false, null, 3],
-        ["plan-reviser", AssigneeType.AGENT, false, "revised-plan", true, false, null, 4],
-        ["implementation-plan-executioner", AssigneeType.AGENT, false, "implementation", true, true, null, 5],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 5, 6],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 5, 6],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 7],
-        ["librarian", AssigneeType.AGENT, false, "documentation", true, false, null, 8],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification", true, false, null, 9],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 10],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 11],
+        { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+        { name: "Librarian", agentName: "librarian", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "documentation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 8, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 9, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 10, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
       ],
     },
     {
       marker: "pre-adjudication",
       shape: [
-        ["spec", AssigneeType.AGENT, true, "spec", false, false, null, 1],
-        ["plan", AssigneeType.AGENT, false, "plan", true, false, null, 2],
-        ["review-coordinator", AssigneeType.AGENT, false, "plan-review", true, false, null, 3],
-        ["plan-reviser", AssigneeType.AGENT, true, "revised-plan", true, false, null, 4],
-        ["implementation-plan-executioner", AssigneeType.AGENT, false, "implementation", true, true, null, 5],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 5, 6],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 5, 6],
-        ["review-adjudicator-opus", AssigneeType.AGENT, false, "must-fix", true, false, 5, 7],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 8],
-        ["librarian", AssigneeType.AGENT, false, "documentation", true, false, null, 9],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification", true, false, null, 10],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 11],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 12],
+        { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: true, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: true, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Opus adjudication", agentName: "review-adjudicator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "must-fix", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 7, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 8, spawnPolicy: null },
+        { name: "Librarian", agentName: "librarian", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "documentation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 9, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 10, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 12, spawnPolicy: null },
       ],
     },
     {
       marker: "pre-zero-gate",
       shape: [
-        ["spec", AssigneeType.AGENT, true, "spec", false, false, null, 1],
-        ["plan", AssigneeType.AGENT, false, "plan", true, false, null, 2],
-        ["review-coordinator", AssigneeType.AGENT, false, "plan-review", true, false, null, 3],
-        ["plan-reviser", AssigneeType.AGENT, true, "revised-plan", true, false, null, 4],
-        ["implementation-plan-executioner", AssigneeType.AGENT, false, "implementation", true, true, null, 5],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 5, 6],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 5, 6],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 7],
-        ["librarian", AssigneeType.AGENT, false, "documentation", true, false, null, 8],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification", true, false, null, 9],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 10],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 11],
+        { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: true, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: true, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+        { name: "Librarian", agentName: "librarian", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "documentation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 8, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 9, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 10, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
       ],
     },
     {
@@ -208,18 +211,18 @@ const legacyTemplateGenerations = {
       promptDigest: "a9994d131d1cf2667c6d61cc7161f5653cf9903a6aae77ed55c18b1db6fb3cf2",
       successorPromptDigest: "f7635395085052a8f613a65a7e7c11f1389abd950fa624409eb52cac3133fa14",
       shape: [
-        ["spec", AssigneeType.AGENT, false, "spec", false, false, null, 1],
-        ["plan", AssigneeType.AGENT, false, "plan", true, false, null, 2],
-        ["review-coordinator", AssigneeType.AGENT, false, "plan-review", true, false, null, 3],
-        ["plan-reviser", AssigneeType.AGENT, false, "revised-plan", true, false, null, 4],
-        ["implementation-plan-executioner", AssigneeType.AGENT, false, "implementation", true, true, null, 5],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 5, 6],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 5, 6],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 7],
-        ["librarian", AssigneeType.AGENT, false, "documentation", true, false, null, 8],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification-v2", true, false, null, 9],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 10],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 11],
+        { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+        { name: "Librarian", agentName: "librarian", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "documentation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 8, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 9, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 10, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
       ],
     },
     {
@@ -229,18 +232,18 @@ const legacyTemplateGenerations = {
       promptDigest: "74fe9add0789494efce82d477ea472ce2a16132fe105e6f12c87223c18dbabf8",
       successorPromptDigest: "79845a3badc75200d30ac22cb4fb10c6efa38308c31156e7b15f4c8475e9f7ff",
       shape: [
-        ["spec", AssigneeType.AGENT, false, "spec", false, false, null, 1],
-        ["plan", AssigneeType.AGENT, false, "plan", true, false, null, 2],
-        ["review-coordinator", AssigneeType.AGENT, false, "plan-review", true, false, null, 3],
-        ["plan-reviser", AssigneeType.AGENT, false, "revised-plan", true, false, null, 4],
-        ["implementation-plan-executioner", AssigneeType.AGENT, false, "implementation", true, true, null, 5],
-        ["review-coordinator-sol", AssigneeType.AGENT, false, "sol-findings", true, false, 5, 6],
-        ["review-coordinator-opus", AssigneeType.AGENT, false, "blind-findings", false, false, 5, 6],
-        ["senior-dev", AssigneeType.AGENT, false, "fixed-implementation", true, false, null, 7],
-        ["librarian", AssigneeType.AGENT, false, "documentation", true, false, null, 8],
-        ["regression-verifier", AssigneeType.AGENT, false, "regression-verification-v2", true, false, null, 9],
-        ["review-coordinator", AssigneeType.AGENT, false, "merge-authorization", true, false, null, 10],
-        ["merge-integrator", AssigneeType.AGENT, false, "merge-result", true, false, null, 11],
+        { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+        { name: "Librarian", agentName: "librarian", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "documentation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 8, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 9, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 10, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
       ],
     },
   ],
@@ -302,9 +305,9 @@ export const canonicalStepOrdinals = (
   }
 
   const ordinals: Partial<Record<StepRole, number>> = {};
-  for (const [index, tuple] of registered.shape.entries()) {
-    const role = stepRole({ outputKind: tuple[3] });
-    if (role === null) throw new Error(`Registered ${canonicalName} generation ${registered.marker} has unknown outputKind ${tuple[3]}`);
+  for (const [index, step] of registered.shape.entries()) {
+    const role = stepRole({ outputKind: step.outputKind });
+    if (role === null) throw new Error(`Registered ${canonicalName} generation ${registered.marker} has unknown outputKind ${step.outputKind}`);
     if (ordinals[role] !== undefined) throw new Error(`Registered ${canonicalName} generation ${registered.marker} repeats Step role ${role}`);
     ordinals[role] = index + 1;
   }
@@ -389,22 +392,23 @@ export type PersistedTransitionStep = {
 
 const shapeMatches = (
   steps: readonly PersistedTransitionStep[],
-  expected: readonly LegacyStepTuple[],
+  expected: readonly LegacyStepRecord[],
 ): boolean => {
   if (steps.length !== expected.length) return false;
   const ordered = [...steps].sort((left, right) => left.stepIndex - right.stepIndex);
   if (ordered.some((step, index) => step.stepIndex !== index + 1)) return false;
   for (const [index, step] of ordered.entries()) {
-    const [agentName, assigneeType, approvalGate, outputKind, attachmentsFromPrevious, opensPullRequest, baseFromStepIndex, layer] = expected[index]!;
-    if ((step.assigneeAgent?.name ?? null) !== agentName
-      || step.assigneeType !== assigneeType
-      || step.approvalGate !== approvalGate
-      || step.outputKind !== outputKind
-      || step.attachmentsFromPrevious !== attachmentsFromPrevious
-      || step.opensPullRequest !== opensPullRequest
-      || step.baseFromStepIndex !== baseFromStepIndex
-      || step.layer !== layer
-      || step.spawnPolicy !== null) {
+    const expectedStep = expected[index]!;
+    if (step.name !== expectedStep.name
+      || (step.assigneeAgent?.name ?? null) !== expectedStep.agentName
+      || step.assigneeType !== expectedStep.assigneeType
+      || step.approvalGate !== expectedStep.approvalGate
+      || step.outputKind !== expectedStep.outputKind
+      || step.attachmentsFromPrevious !== expectedStep.attachmentsFromPrevious
+      || step.opensPullRequest !== expectedStep.opensPullRequest
+      || step.baseFromStepIndex !== expectedStep.baseFromStepIndex
+      || step.layer !== expectedStep.layer
+      || !isDeepStrictEqual(step.spawnPolicy, expectedStep.spawnPolicy)) {
       return false;
     }
   }

--- a/packages/db/src/seed-canonical-drift.dbtest.ts
+++ b/packages/db/src/seed-canonical-drift.dbtest.ts
@@ -66,6 +66,34 @@ after(async () => {
   }
 });
 
+test("seed rolls a registered canonical generation over inside its installation transaction", async () => {
+  const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
+  const outgoing = await prisma.taskTemplate.findUniqueOrThrow({
+    where: { projectId_name: { projectId: project.id, name: "direct-engineer-workflow" } },
+  });
+  await prisma.taskTemplateStep.updateMany({
+    where: { taskTemplateId: outgoing.id, outputKind: "regression-verification-v2" },
+    data: { outputKind: "regression-verification" },
+  });
+
+  const rolled = seed();
+  assert.equal(rolled.status, 0, rolled.output);
+
+  const legacyName = `direct-engineer-workflow-legacy-pre-narrow-regression-lease-${outgoing.id}`;
+  const legacy = await prisma.taskTemplate.findUniqueOrThrow({
+    where: { projectId_name: { projectId: project.id, name: legacyName } },
+  });
+  const current = await prisma.taskTemplate.findUniqueOrThrow({
+    where: { projectId_name: { projectId: project.id, name: "direct-engineer-workflow" } },
+  });
+  assert.equal(legacy.id, outgoing.id);
+  assert.notEqual(current.id, outgoing.id);
+  assert.equal(await prisma.taskTemplateStep.count({
+    where: { taskTemplateId: current.id, outputKind: "regression-verification-v2" },
+  }), 1);
+  await prisma.taskTemplate.delete({ where: { id: legacy.id } });
+});
+
 /**
  * A half-migrated graph — the zero-gate transition applied to step 1 but not
  * to step 4 — has the current step count and contiguous indexes, yet it is no

--- a/packages/db/src/step-role.test.ts
+++ b/packages/db/src/step-role.test.ts
@@ -37,8 +37,8 @@ for (const [templateName, generations] of Object.entries(LEGACY_TEMPLATE_GENERAT
   for (const generation of generations) {
     test(`${templateName} ${generation.marker} exposes every registered Step role`, () => {
       const persistedName = legacyTemplateName(templateName, generation.marker, "template-row");
-      for (const tuple of generation.shape) {
-        const outputKind = tuple[3];
+      for (const step of generation.shape) {
+        const { outputKind } = step;
         assert.equal(stepRole({ outputKind, taskTemplateName: persistedName }), EXPECTED_ROLES[outputKind]);
         assert.equal(stepGeneration({ outputKind, taskTemplateName: persistedName }), generation.marker);
       }

--- a/packages/db/src/template-sources.test.ts
+++ b/packages/db/src/template-sources.test.ts
@@ -249,6 +249,7 @@ test("parallel nodes share one non-null base and never open a pull request", asy
 test("layer is a structural field in canonical prompt drift comparison", async () => {
   const expected = (await loadTemplateStepSources(DIRECT_TEMPLATE_NAME))[1]!;
   const persisted: PersistedTemplateStepStructure = {
+    name: expected.name,
     assigneeAgent: { name: expected.agentName! },
     assigneeType: "AGENT",
     layer: expected.layer,

--- a/packages/db/src/template-sources.ts
+++ b/packages/db/src/template-sources.ts
@@ -15,16 +15,32 @@ export const LEGACY_ALL_PRIOR_OUTPUTS = "__legacy_all_prior_outputs__";
 export const CANONICAL_TEMPLATE_SOURCE_SPECS = [
   {
     name: INTEGRATOR_TEMPLATE_NAME,
+    description: "Twelve-step Full Assurance workflow with parallel independent code review, operator-free fix adjudication inside the fix step, refreshed exact-head regression verification, mechanical readiness, and mechanical merge execution.",
     stepCount: 12,
     layers: [1, 2, 3, 4, 5, 6, 6, 7, 8, 9, 10, 11],
+    stepNames: [
+      "Write a spec", "Plan", "Plan review", "Revise plan", "Implementation", "Code review (Sol)",
+      "Code review (Opus blind)", "Apply review fixes", "Librarian",
+      "Regression verification", "Merge authorization", "Merge execution",
+    ],
   },
   {
     name: DIRECT_TEMPLATE_NAME,
+    description: "Direct-tier workflow: implementation from the task brief, parallel independent code review, operator-free fix adjudication inside the fix step, refreshed exact-head regression verification, mechanical readiness, and mechanical merge execution.",
     stepCount: 7,
     layers: [1, 2, 2, 3, 4, 5, 6],
+    stepNames: [
+      "Implementation", "Code review (Sol)", "Code review (Opus blind)",
+      "Apply review fixes", "Regression verification", "Merge authorization", "Merge execution",
+    ],
   },
 ] as const;
 export type CanonicalTemplateName = (typeof CANONICAL_TEMPLATE_SOURCE_SPECS)[number]["name"];
+export const canonicalTemplateSourceSpec = (name: CanonicalTemplateName) => {
+  const spec = CANONICAL_TEMPLATE_SOURCE_SPECS.find((candidate) => candidate.name === name);
+  if (!spec) throw new Error(`Unknown canonical template source ${name}`);
+  return spec;
+};
 const STRUCTURAL_FIELDS = [
   "stepIndex",
   "layer",
@@ -40,6 +56,7 @@ const STRUCTURAL_FIELDS = [
 
 export type TemplateStepSource = {
   stepIndex: number;
+  name: string;
   layer: number;
   agentName: string | null;
   approvalGate: boolean;
@@ -53,6 +70,7 @@ export type TemplateStepSource = {
 };
 
 export type PersistedTemplateStepStructure = {
+  name: string;
   assigneeAgent: { name: string } | null;
   assigneeType: string;
   /**
@@ -76,6 +94,7 @@ export const templateStepStructureDifferences = (
 ): string[] => {
   const expectedAssigneeType = expected.agentName === null ? "HUMAN" : "AGENT";
   const fields = [
+    ["name", actual.name, expected.name],
     ["agent", actual.assigneeAgent?.name ?? null, expected.agentName],
     ["assigneeType", actual.assigneeType, expectedAssigneeType],
     ["layer", actual.layer, expected.layer],
@@ -133,8 +152,7 @@ export const loadTemplateStepSources = async (
   templateName: CanonicalTemplateName = INTEGRATOR_TEMPLATE_NAME,
   sourceRoot: string = templatesRoot,
 ): Promise<TemplateStepSource[]> => {
-  const sourceSpec = CANONICAL_TEMPLATE_SOURCE_SPECS.find((candidate) => candidate.name === templateName);
-  if (!sourceSpec) throw new Error(`Unknown canonical template source ${templateName}`);
+  const sourceSpec = canonicalTemplateSourceSpec(templateName);
   const templateRoot = join(sourceRoot, templateName);
   const files = (await readdir(templateRoot)).sort();
   const steps: TemplateStepSource[] = [];
@@ -156,6 +174,7 @@ export const loadTemplateStepSources = async (
     if (document.body.length === 0) throw new Error(`${filePath} has an empty prompt body`);
     steps.push({
       stepIndex,
+      name: sourceSpec.stepNames[stepIndex - 1]!,
       layer,
       agentName: agent === "null" ? null : agent,
       approvalGate: parseBoolean(requiredFrontmatter(document, "approvalGate", filePath), filePath, "approvalGate"),


### PR DESCRIPTION
## Summary

- add `planCanonicalInstallation` as the pure decision interface and `applyCanonicalInstallation(tx, ...)` as the sole canonical rollover/create writer
- make seed and canonical sync thin adapters over the shared installation module; both templates now install in one seed transaction with successor-pin, blocker, webhook, and collision checks
- replace positional `LegacyStepTuple` data with named records including `name` and `spawnPolicy`, and update lane B identity/ordinal derivation to field access
- centralize template descriptions and step display names in `template-sources.ts`
- expose `npm run db:template-digest`

## Decisions

- Metadata lives once in the canonical source spec instead of being copied into every prompt frontmatter. Template description is template-level data, so duplicating it across step files would add another lockstep obligation; the loader attaches each spec-owned step name to its source record.
- Pre-registry seed migrations remain small seed adapters that only recognize their frozen historical shapes and supply a legacy name. The shared apply path owns every guard and write, so those older migrations also gain all-or-none transaction behavior.
- `applyCanonicalInstallation` accepts `synchronizeCurrent` only for seed. Sync retains its narrower task-reference-aware adoption logic, while rollover/create writes stay unique to the installation module.
- A plan records `successorVerified` only when a registry generation actually pins a successor digest; structural and pre-registry migrations report false.

## Verification

- `npm run lint`
- `npm run build -w @agentos/db`
- targeted DB unit tests: 54 passed
- `npm test -w @agentos/db`: 248/249 on first full run; the sole stale fixture was updated for the new `name` structural field and its targeted rerun passed
- `npm run test:db -w @agentos/db`: 50 passed
- `npm run db:template-digest` produced the registered current digests for both canonical templates