### PR TITLE
refactor(api): unify merge tail stop transitions

### DIFF
--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -26,11 +26,11 @@ import {
 } from "@agentos/db";
 
 import { createGitHubReader, type PullRequestReader, type PullRequestSnapshot } from "./github-read.js";
+import { stopMergeTail } from "./merge-tail-actions.js";
 
 type DbReader = PrismaClient | Prisma.TransactionClient;
 
 const SHA = /^[0-9a-f]{40}$/u;
-const RECOVERY_NOTIFICATION_PREFIX = "merge-base-drift-recovery";
 
 export const baseDriftRecoveryPollIntervalMs = (): number => {
   const raw = Number(process.env.MERGE_BASE_DRIFT_RECOVERY_POLL_INTERVAL_MS);
@@ -245,10 +245,6 @@ const snapshotRefusal = (candidate: RecoveryCandidate, snapshot: PullRequestSnap
   return null;
 };
 
-const notificationBody = (state: "ineligible" | "exhausted", stopId: string, reason: string): string => (
-  `Automatic pre-merge base-drift recovery ${state} for stop ${stopId}: ${reason}. No regression run or re-authorization was created.`
-);
-
 const openAbandonQuestion = async (
   tx: Prisma.TransactionClient,
   integratorTaskId: string,
@@ -282,31 +278,25 @@ const settleIneligibleLocked = async (
   identity?: Partial<RecoveryIdentity>,
 ): Promise<void> => {
   const attempt = await ensureValidationAttemptLocked(tx, integratorTaskId, stopId);
-  await tx.mergeRecoveryAttempt.update({ where: { id: attempt.id }, data: {
-    status: MergeRecoveryStatus.FAILED,
-    failureReason: reason,
-    endedAt: new Date(),
-    ...(identity?.repository ? { repository: identity.repository } : {}),
-    ...(identity?.prNumber ? { prNumber: identity.prNumber } : {}),
-    ...(identity?.targetBranch ? { targetBranch: identity.targetBranch } : {}),
-    ...(identity?.authorizedHeadSha ? { authorizedHeadSha: identity.authorizedHeadSha } : {}),
-    ...(identity?.authorizedBaseSha ? { authorizedBaseSha: identity.authorizedBaseSha } : {}),
-    ...(identity?.observedBaseSha ? { observedBaseSha: identity.observedBaseSha } : {}),
-  } });
-  await writeMarker(tx, integratorTaskId, "baseDriftRecovery", {
-    actorType: "control-plane",
-    body: `Automatic pre-merge base-drift recovery refused: ${reason}`,
-    metadata: { state: "ineligible", ...identity, integratorTaskId, sourceStopId: stopId, reason },
+  await stopMergeTail(tx, {
+    phase: "recovery-validation",
+    aggregateId: attempt.id,
+    integratorTaskId,
+    sourceStopId: stopId,
+    reason,
+    at: new Date(),
+    attempt: attempt.attempt,
+    recoveryData: {
+      ...(identity?.repository ? { repository: identity.repository } : {}),
+      ...(identity?.prNumber ? { prNumber: identity.prNumber } : {}),
+      ...(identity?.targetBranch ? { targetBranch: identity.targetBranch } : {}),
+      ...(identity?.authorizedHeadSha ? { authorizedHeadSha: identity.authorizedHeadSha } : {}),
+      ...(identity?.authorizedBaseSha ? { authorizedBaseSha: identity.authorizedBaseSha } : {}),
+      ...(identity?.observedBaseSha ? { observedBaseSha: identity.observedBaseSha } : {}),
+    },
+    markerMetadata: { ...identity },
   });
-  const dedupeKey = `${RECOVERY_NOTIFICATION_PREFIX}:ineligible:${stopId}`;
-  await tx.inboxMessage.upsert({ where: { dedupeKey }, create: {
-    from: "AGENT", taskId: integratorTaskId, kind: "TEXT",
-    body: notificationBody("ineligible", stopId, reason), dedupeKey,
-  }, update: {} });
   await openAbandonQuestion(tx, integratorTaskId, stopId);
-  await tx.task.update({ where: { id: integratorTaskId }, data: {
-    status: TaskStatus.REVIEW, failureReason: `Automatic base-drift recovery refused: ${reason}`,
-  } });
 };
 
 const settleIneligible = async (
@@ -414,36 +404,30 @@ const queueRecovery = async (
   };
   if (attempts >= MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES) {
     const reason = `automatic recovery limit ${MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES} reached for ${expected.repository}#${expected.prNumber} targeting ${expected.targetBranch}`;
-    await tx.mergeRecoveryAttempt.update({ where: { id: aggregate.id }, data: {
-      status: MergeRecoveryStatus.FAILED,
-      failureReason: reason,
-      endedAt: now,
-      boundSourceRunId: expected.sourceRunId,
-      authorizationActivityId: expected.authorizationActivityId,
-      readinessTaskId: expected.readinessTaskId,
-      regressionTaskId: expected.regressionTaskId,
-      repository: expected.repository,
-      prNumber: expected.prNumber,
-      targetBranch: expected.targetBranch,
-      authorizedHeadSha: expected.authorizedHeadSha,
-      authorizedBaseSha: expected.authorizedBaseSha,
-      observedBaseSha: expected.observedBaseSha,
-      currentBaseSha,
-    } });
-    await writeMarker(tx, expected.integratorTaskId, "baseDriftRecovery", {
-      actorType: "control-plane",
-      body: `Automatic pre-merge base-drift recovery exhausted at attempt ${attempt}`,
-      metadata: { ...common, state: "exhausted", reason },
+    await stopMergeTail(tx, {
+      phase: "recovery-exhausted",
+      aggregateId: aggregate.id,
+      integratorTaskId: expected.integratorTaskId,
+      sourceStopId: expected.stopId,
+      reason,
+      at: now,
+      attempt,
+      recoveryData: {
+        boundSourceRunId: expected.sourceRunId,
+        authorizationActivityId: expected.authorizationActivityId,
+        readinessTaskId: expected.readinessTaskId,
+        regressionTaskId: expected.regressionTaskId,
+        repository: expected.repository,
+        prNumber: expected.prNumber,
+        targetBranch: expected.targetBranch,
+        authorizedHeadSha: expected.authorizedHeadSha,
+        authorizedBaseSha: expected.authorizedBaseSha,
+        observedBaseSha: expected.observedBaseSha,
+        currentBaseSha,
+      },
+      markerMetadata: common,
     });
-    const dedupeKey = `${RECOVERY_NOTIFICATION_PREFIX}:exhausted:${expected.stopId}`;
-    await tx.inboxMessage.upsert({ where: { dedupeKey }, create: {
-      from: "AGENT", taskId: expected.integratorTaskId, kind: "TEXT",
-      body: notificationBody("exhausted", expected.stopId, reason), dedupeKey,
-    }, update: {} });
     await openAbandonQuestion(tx, expected.integratorTaskId, expected.stopId);
-    await tx.task.update({ where: { id: expected.integratorTaskId }, data: {
-      status: TaskStatus.REVIEW, failureReason: reason,
-    } });
     return "exhausted";
   }
 

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 
 import {
   AUTHORIZED_MERGE_METHOD,
@@ -21,7 +21,7 @@ import {
 } from "@agentos/db";
 
 import { lockTaskMutationRows } from "./task-write.js";
-import { openDefenseAuditNotice } from "./merge-tail-actions.js";
+import { openDefenseAuditNotice, stopMergeTail } from "./merge-tail-actions.js";
 import { createGitHubReader, type PullRequestReader } from "./github-read.js";
 import {
   evaluateReadiness,
@@ -132,66 +132,25 @@ const stopReadiness = async (
   },
   releaseChainLease: ReleaseMergeLease,
 ): Promise<boolean> => {
-  const recoveryBody = input.recovery
-    ? `Automatic base-drift recovery ${input.recovery.attempt} stopped at readiness: ${input.reason}`
-    : null;
-  const dedupeKey = input.recovery
-    ? `merge-base-drift-recovery-tail-stop:${input.recovery.sourceStopId}:readiness`
-    : `merge-readiness-stop:${input.readinessTaskId}:${createHash("sha256").update(input.reason).digest("hex")}`;
   const transition = await db.$transaction(async (tx) => {
     await lockTaskMutationRows(tx, input.readinessTaskId);
-    const readiness = await tx.task.findUnique({
-      where: { id: input.readinessTaskId },
-      select: { chainId: true },
-    });
     const held = await tx.task.updateMany({
       where: { id: input.readinessTaskId, status: TaskStatus.DOING, failureReason: input.claimReason },
-      data: { status: TaskStatus.REVIEW, failureReason: input.reason },
+      data: { failureReason: input.claimReason },
     });
-    if (held.count !== 1) return { applied: false as const, chainId: readiness?.chainId ?? null };
-    await tx.task.update({ where: { id: input.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: input.reason } });
-    if (input.recovery) {
-      await tx.mergeRecoveryAttempt.update({ where: { id: input.recovery.aggregateId }, data: {
-        status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
-        failureReason: input.reason,
-        endedAt: new Date(),
-      } });
-      await tx.task.update({
-        where: { id: input.recovery.integratorTaskId },
-        data: { status: TaskStatus.REVIEW, failureReason: recoveryBody },
-      });
-      const metadata = {
-        ...input.recovery,
-        state: "tail-stopped",
-        phase: "readiness",
-        reason: input.reason,
-        dedupeKey,
-      } as Prisma.InputJsonObject;
-      await tx.taskActivity.createMany({ data: [
-        { taskId: input.recovery.integratorTaskId, actorType: "control-plane", body: recoveryBody!, metadata },
-        { taskId: input.regressionTaskId, actorType: "control-plane", body: recoveryBody!, metadata },
-      ] });
-    }
-    await writeMarker(tx, input.regressionTaskId, "readiness", {
-      actorType: "control-plane",
-      body: `Merge readiness stopped at regression: ${input.reason}`,
-      metadata: { state: "stopped", reason: input.reason },
+    if (held.count !== 1) return { applied: false as const, leaseToRelease: null };
+    const stopped = await stopMergeTail(tx, {
+      phase: "readiness",
+      readinessTaskId: input.readinessTaskId,
+      regressionTaskId: input.regressionTaskId,
+      reason: input.reason,
+      recovery: input.recovery,
+      at: new Date(),
     });
-    await tx.inboxMessage.upsert({
-      where: { dedupeKey },
-      create: {
-        from: "AGENT",
-        taskId: input.regressionTaskId,
-        kind: "TEXT",
-        body: recoveryBody ?? `Autonomous merge readiness stopped: ${input.reason}`,
-        dedupeKey,
-      },
-      update: {},
-    });
-    return { applied: true as const, chainId: readiness?.chainId ?? null };
+    return { applied: true as const, leaseToRelease: stopped.leaseToRelease };
   });
   if (!transition.applied) return false;
-  await releaseChainLease(transition.chainId);
+  await releaseChainLease(transition.leaseToRelease);
   return true;
 };
 

--- a/packages/api/src/merge-tail-actions.test.ts
+++ b/packages/api/src/merge-tail-actions.test.ts
@@ -1,12 +1,73 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import type { Prisma } from "@agentos/db";
+import { MergeRecoveryStatus, type Prisma, type RecoveryContext } from "@agentos/db";
 
 import {
   openDefenseAuditNotice,
   openMergeTailStopNotice,
+  stopMergeTail,
+  type StopMergeTailInput,
 } from "./merge-tail-actions.js";
+
+const recoveryContext: RecoveryContext = {
+  aggregateId: "aggregate-1",
+  attempt: 2,
+  sourceStopId: "stop-1",
+  sourceRunId: "source-run-1",
+  authorizationActivityId: "authorization-1",
+  repository: "acme/widgets",
+  prNumber: 42,
+  targetBranch: "main",
+  authorizedHeadSha: "a".repeat(40),
+  authorizedBaseSha: "b".repeat(40),
+  observedBaseSha: "c".repeat(40),
+  currentBaseSha: "d".repeat(40),
+  readinessTaskId: "readiness-1",
+  regressionTaskId: "regression-1",
+  integratorTaskId: "integrator-1",
+  recoveryRunId: "recovery-run-1",
+};
+
+const stopTx = (recoveryStatus: MergeRecoveryStatus) => {
+  const activities: Array<Record<string, any>> = [];
+  const notices: Array<Record<string, any>> = [];
+  const recoveryUpdates: Array<Record<string, any>> = [];
+  const tx = {
+    mergeRecoveryAttempt: {
+      findUnique: async () => ({ status: recoveryStatus }),
+      update: async (args: Record<string, any>) => {
+        recoveryUpdates.push(args);
+        return {};
+      },
+    },
+    task: {
+      findUnique: async () => ({
+        chainId: "chain-1",
+        templateStep: {
+          stepIndex: 5,
+          outputKind: "regression-verification-v2",
+          taskTemplate: { name: "direct-engineer-workflow" },
+        },
+      }),
+      update: async () => ({}),
+      updateMany: async () => ({ count: 1 }),
+    },
+    taskActivity: {
+      create: async ({ data }: { data: Record<string, any> }) => {
+        activities.push(data);
+        return {};
+      },
+    },
+    inboxMessage: {
+      upsert: async (args: Record<string, any>) => {
+        notices.push(args);
+        return {};
+      },
+    },
+  } as unknown as Prisma.TransactionClient;
+  return { tx, activities, notices, recoveryUpdates };
+};
 
 test("openMergeTailStopNotice derives its dedupe key from the task and reason", async () => {
   let upsert: Record<string, unknown> | undefined;
@@ -79,4 +140,121 @@ test("openDefenseAuditNotice records the triggered paths against the readiness t
     },
     update: {},
   });
+});
+
+test("stopMergeTail owns the phase by recovery matrix", async () => {
+  const at = new Date("2026-08-27T12:00:00.000Z");
+  const cases: Array<{
+    name: string;
+    status: MergeRecoveryStatus;
+    input: StopMergeTailInput;
+    markerStates: string[];
+    noticeKey: RegExp;
+    recoveryTarget: MergeRecoveryStatus | null;
+    leaseToRelease: string | null;
+  }> = [
+    {
+      name: "regression without recovery",
+      status: MergeRecoveryStatus.REPAIRING,
+      input: { phase: "regression", regressionTaskId: "regression-1", reason: "bad verdict", at, recovery: null, agentId: "agent-1" },
+      markerStates: ["stopped"],
+      noticeKey: /^merge-tail-stop:regression-1:/u,
+      recoveryTarget: null,
+      leaseToRelease: "chain-1",
+    },
+    {
+      name: "regression during recovery",
+      status: MergeRecoveryStatus.REPAIRING,
+      input: { phase: "regression", regressionTaskId: "regression-1", reason: "bad verdict", at, recovery: recoveryContext, agentId: "agent-1" },
+      markerStates: ["tail-stopped", "tail-stopped"],
+      noticeKey: /:stop-1:regression$/u,
+      recoveryTarget: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
+      leaseToRelease: "chain-1",
+    },
+    {
+      name: "readiness without recovery",
+      status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
+      input: { phase: "readiness", readinessTaskId: "readiness-1", regressionTaskId: "regression-1", reason: "head drift", at, recovery: null },
+      markerStates: ["stopped"],
+      noticeKey: /^merge-readiness-stop:readiness-1:/u,
+      recoveryTarget: null,
+      leaseToRelease: "chain-1",
+    },
+    {
+      name: "readiness during recovery",
+      status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
+      input: { phase: "readiness", readinessTaskId: "readiness-1", regressionTaskId: "regression-1", reason: "head drift", at, recovery: recoveryContext },
+      markerStates: ["tail-stopped", "tail-stopped", "stopped"],
+      noticeKey: /:stop-1:readiness$/u,
+      recoveryTarget: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
+      leaseToRelease: "chain-1",
+    },
+    {
+      name: "recovery validation",
+      status: MergeRecoveryStatus.VALIDATING,
+      input: {
+        phase: "recovery-validation", aggregateId: "aggregate-1", integratorTaskId: "integrator-1",
+        sourceStopId: "stop-1", reason: "identity mismatch", at, attempt: 1,
+        recoveryData: { repository: "acme/widgets" }, markerMetadata: { repository: "acme/widgets" },
+      },
+      markerStates: ["ineligible"],
+      noticeKey: /:ineligible:stop-1$/u,
+      recoveryTarget: MergeRecoveryStatus.FAILED,
+      leaseToRelease: null,
+    },
+    {
+      name: "recovery exhausted",
+      status: MergeRecoveryStatus.VALIDATING,
+      input: {
+        phase: "recovery-exhausted", aggregateId: "aggregate-1", integratorTaskId: "integrator-1",
+        sourceStopId: "stop-1", reason: "attempt limit", at, attempt: 2,
+        recoveryData: { repository: "acme/widgets" }, markerMetadata: { repository: "acme/widgets" },
+      },
+      markerStates: ["exhausted"],
+      noticeKey: /:exhausted:stop-1$/u,
+      recoveryTarget: MergeRecoveryStatus.FAILED,
+      leaseToRelease: null,
+    },
+    {
+      name: "repair",
+      status: MergeRecoveryStatus.REPAIRING,
+      input: {
+        phase: "repair", regressionTaskId: "regression-1", repairTaskId: "repair-1", repairKind: "gate-fix",
+        startHeadSha: "a".repeat(40), targetHeadSha: "b".repeat(40), resolvedHeadSha: null,
+        reason: "repair failed", at, agentId: "agent-1",
+      },
+      markerStates: ["failed"],
+      noticeKey: /^merge-tail-stop:regression-1:/u,
+      recoveryTarget: null,
+      leaseToRelease: "chain-1",
+    },
+  ];
+
+  for (const entry of cases) {
+    const observed = stopTx(entry.status);
+    assert.deepEqual(await stopMergeTail(observed.tx, entry.input), { leaseToRelease: entry.leaseToRelease }, entry.name);
+    assert.deepEqual(
+      observed.activities.map((activity) => (activity.metadata as Record<string, unknown>).state),
+      entry.markerStates,
+      entry.name,
+    );
+    assert.match(String(observed.notices[0]?.where?.dedupeKey), entry.noticeKey, entry.name);
+    assert.equal(observed.recoveryUpdates[0]?.data?.status ?? null, entry.recoveryTarget, entry.name);
+  }
+});
+
+test("stopMergeTail refuses an illegal recovery transition before writing it", async () => {
+  const observed = stopTx(MergeRecoveryStatus.VALIDATING);
+  await assert.rejects(
+    stopMergeTail(observed.tx, {
+      phase: "readiness",
+      readinessTaskId: "readiness-1",
+      regressionTaskId: "regression-1",
+      reason: "cannot skip repair",
+      at: new Date(),
+      recovery: recoveryContext,
+    }),
+    /Illegal merge recovery transition VALIDATING -> BLOCKED_DOWNSTREAM/u,
+  );
+  assert.deepEqual(observed.recoveryUpdates, []);
 });

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import {
   enqueueTaskRun,
   MAX_MERGE_TAIL_REPAIR_ATTEMPTS,
+  mergeRecoveryTransitionAllowed,
   MergeRecoveryStatus,
   parseRegressionVerdict,
   Prisma,
@@ -14,6 +15,7 @@ import {
 } from "@agentos/db";
 
 import { FAILURE_REASON_LIMIT, truncateFailureReason } from "./failure-reason.js";
+import { settleLease } from "./merge-lease.js";
 
 /**
  * The autonomous merge tail's own actions: the base-drift recovery aggregate,
@@ -104,51 +106,225 @@ export const baseDriftRecoveryContext = async (
   return recoveryContext(row);
 };
 
-export const stopBaseDriftRecoveryTail = async (
-  tx: DbTx,
-  context: RecoveryContext,
-  phase: "regression",
-  reason: string,
-): Promise<void> => {
-  const body = `Automatic base-drift recovery ${context.attempt} stopped at ${phase}: ${reason}`;
-  await tx.mergeRecoveryAttempt.update({ where: { id: context.aggregateId }, data: {
-    status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
-    failureReason: reason,
-    endedAt: new Date(),
-  } });
-  await tx.task.updateMany({
-    where: { id: { in: [context.regressionTaskId, context.readinessTaskId, context.integratorTaskId] } },
-    data: { status: TaskStatus.REVIEW, failureReason: body },
-  });
-  const dedupeKey = `merge-base-drift-recovery-tail-stop:${context.sourceStopId}:${phase}`;
-  await tx.inboxMessage.upsert({ where: { dedupeKey }, create: {
-    from: "AGENT", taskId: context.regressionTaskId, kind: "TEXT", body, dedupeKey,
-  }, update: {} });
-  const metadata = { ...context, state: "tail-stopped", phase, reason, dedupeKey };
-  for (const taskId of [context.integratorTaskId, context.regressionTaskId]) {
-    await writeMarker(tx, taskId, "baseDriftRecovery", { actorType: "control-plane", body, metadata });
+type RecoveryStopData = Prisma.MergeRecoveryAttemptUpdateInput;
+
+export type StopMergeTailInput =
+  | {
+    phase: "regression";
+    regressionTaskId: string;
+    reason: string;
+    at: Date;
+    recovery: RecoveryContext | null;
+    agentId: string;
+    sessionId?: string;
   }
+  | {
+    phase: "readiness";
+    readinessTaskId: string;
+    regressionTaskId: string;
+    reason: string;
+    at: Date;
+    recovery: RecoveryContext | null;
+  }
+  | {
+    phase: "recovery-validation" | "recovery-exhausted";
+    aggregateId: string;
+    integratorTaskId: string;
+    sourceStopId: string;
+    reason: string;
+    at: Date;
+    attempt: number;
+    recoveryData: RecoveryStopData;
+    markerMetadata: Record<string, unknown>;
+  }
+  | {
+    phase: "repair";
+    regressionTaskId: string;
+    repairTaskId: string;
+    repairKind: string | null;
+    startHeadSha: string | null;
+    targetHeadSha: string | null;
+    resolvedHeadSha: string | null;
+    reason: string;
+    at: Date;
+    agentId: string;
+    sessionId?: string;
+  };
+
+export type StopMergeTailResult = { leaseToRelease: string | null };
+
+const transitionRecovery = async (
+  tx: DbTx,
+  aggregateId: string,
+  target: MergeRecoveryStatus,
+  data: RecoveryStopData,
+): Promise<void> => {
+  const aggregate = await tx.mergeRecoveryAttempt.findUnique({
+    where: { id: aggregateId },
+    select: { status: true },
+  });
+  if (!aggregate) throw new Error(`Merge recovery aggregate ${aggregateId} is absent`);
+  if (!mergeRecoveryTransitionAllowed(aggregate.status, target)) {
+    throw new Error(`Illegal merge recovery transition ${aggregate.status} -> ${target} for ${aggregateId}`);
+  }
+  await tx.mergeRecoveryAttempt.update({
+    where: { id: aggregateId },
+    data: { ...data, status: target },
+  });
 };
 
-/**
- * Resolves the agent that repairs what this chain's merge tail found: the
- * chain's own fix step assignee, or `senior-dev` when the chain has none.
- */
-export const mergeTailFixAgentName = async (
+const stopNotice = async (
   tx: DbTx,
-  regression: { projectId: string; chainId: string | null; templateId: string | null } | null,
-): Promise<string> => {
-  if (!regression) return "senior-dev";
-  const fixTask = await tx.task.findFirst({
-    where: {
-      projectId: regression.projectId,
-      chainId: regression.chainId,
-      templateId: regression.templateId,
-      templateStep: { outputKind: "fixed-implementation" },
-    },
-    select: { assigneeAgent: { select: { name: true } } },
+  input: { taskId: string; body: string; dedupeKey: string; agentId?: string; sessionId?: string },
+): Promise<void> => {
+  await tx.inboxMessage.upsert({ where: { dedupeKey: input.dedupeKey }, create: {
+    from: "AGENT",
+    ...(input.agentId ? { agentId: input.agentId } : {}),
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    taskId: input.taskId,
+    kind: "TEXT",
+    body: input.body,
+    dedupeKey: input.dedupeKey,
+  }, update: {} });
+};
+
+/** Persist one merge-tail stop and return the Chain Lease its caller may release after commit. */
+export const stopMergeTail = async (
+  tx: DbTx,
+  input: StopMergeTailInput,
+): Promise<StopMergeTailResult> => {
+  if (input.phase === "regression" || input.phase === "readiness") {
+    const recovery = input.recovery;
+    const body = recovery
+      ? `Automatic base-drift recovery ${recovery.attempt} stopped at ${input.phase}: ${input.reason}`
+      : input.phase === "readiness"
+        ? `Autonomous merge readiness stopped: ${input.reason}`
+        : `Autonomous merge tail stopped: ${input.reason}`;
+    if (recovery) {
+      await transitionRecovery(tx, recovery.aggregateId, MergeRecoveryStatus.BLOCKED_DOWNSTREAM, {
+        failureReason: input.reason,
+        endedAt: input.at,
+      });
+      if (input.phase === "regression") {
+        await tx.task.updateMany({
+          where: { id: { in: [recovery.regressionTaskId, recovery.readinessTaskId, recovery.integratorTaskId] } },
+          data: { status: TaskStatus.REVIEW, failureReason: body },
+        });
+      } else {
+        await tx.task.updateMany({
+          where: { id: { in: [input.readinessTaskId, input.regressionTaskId] } },
+          data: { status: TaskStatus.REVIEW, failureReason: input.reason },
+        });
+        await tx.task.update({
+          where: { id: recovery.integratorTaskId },
+          data: { status: TaskStatus.REVIEW, failureReason: body },
+        });
+      }
+      const dedupeKey = `merge-base-drift-recovery-tail-stop:${recovery.sourceStopId}:${input.phase}`;
+      const metadata = { ...recovery, state: "tail-stopped", phase: input.phase, reason: input.reason, dedupeKey };
+      for (const taskId of [recovery.integratorTaskId, recovery.regressionTaskId]) {
+        await writeMarker(tx, taskId, "baseDriftRecovery", { actorType: "control-plane", body, metadata });
+      }
+      await stopNotice(tx, { taskId: input.regressionTaskId, body, dedupeKey });
+    } else if (input.phase === "readiness") {
+      await tx.task.updateMany({
+        where: { id: { in: [input.readinessTaskId, input.regressionTaskId] } },
+        data: { status: TaskStatus.REVIEW, failureReason: input.reason },
+      });
+    } else {
+      await tx.task.update({
+        where: { id: input.regressionTaskId },
+        data: { status: TaskStatus.REVIEW, failureReason: input.reason },
+      });
+    }
+    if (!recovery && input.phase === "regression") {
+      await writeMarker(tx, input.regressionTaskId, "regression", {
+        actorType: "control-plane",
+        body: `Regression did not advance: ${input.reason}`,
+        metadata: { state: "stopped", reason: input.reason },
+      });
+      await openMergeTailStopNotice(tx, {
+        taskId: input.regressionTaskId,
+        agentId: input.agentId,
+        ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+        reason: input.reason,
+      });
+    }
+    if (input.phase === "readiness") {
+      await writeMarker(tx, input.regressionTaskId, "readiness", {
+        actorType: "control-plane",
+        body: `Merge readiness stopped at regression: ${input.reason}`,
+        metadata: { state: "stopped", reason: input.reason },
+      });
+      if (!recovery) {
+        const dedupeKey = `merge-readiness-stop:${input.readinessTaskId}:${createHash("sha256").update(input.reason).digest("hex")}`;
+        await stopNotice(tx, { taskId: input.regressionTaskId, body, dedupeKey });
+      }
+    }
+    const lease = await settleLease(tx, { taskId: input.regressionTaskId, outcome: "stop" });
+    return { leaseToRelease: lease.leaseToRelease };
+  }
+
+  if (input.phase === "repair") {
+    await tx.task.update({
+      where: { id: input.regressionTaskId },
+      data: { status: TaskStatus.REVIEW, failureReason: input.reason },
+    });
+    await writeMarker(tx, input.regressionTaskId, "repairResult", {
+      actorType: "control-plane",
+      body: `Automatic ${input.repairKind} attempt failed: ${input.startHeadSha} -> ${input.resolvedHeadSha ?? "no-delivered-head"}`,
+      metadata: {
+        repairKind: input.repairKind,
+        repairTaskId: input.repairTaskId,
+        startHeadSha: input.startHeadSha,
+        targetHeadSha: input.targetHeadSha,
+        resolvedHeadSha: input.resolvedHeadSha,
+        state: "failed",
+      },
+    });
+    await openMergeTailStopNotice(tx, {
+      taskId: input.regressionTaskId,
+      agentId: input.agentId,
+      ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+      reason: input.reason,
+    });
+    const lease = await settleLease(tx, { taskId: input.regressionTaskId, outcome: "stop" });
+    return { leaseToRelease: lease.leaseToRelease };
+  }
+
+  await transitionRecovery(tx, input.aggregateId, MergeRecoveryStatus.FAILED, {
+    ...input.recoveryData,
+    failureReason: input.reason,
+    endedAt: input.at,
   });
-  return fixTask?.assigneeAgent?.name ?? "senior-dev";
+  const state = input.phase === "recovery-validation" ? "ineligible" : "exhausted";
+  const body = input.phase === "recovery-validation"
+    ? `Automatic pre-merge base-drift recovery refused: ${input.reason}`
+    : `Automatic pre-merge base-drift recovery exhausted at attempt ${input.attempt}`;
+  await writeMarker(tx, input.integratorTaskId, "baseDriftRecovery", {
+    actorType: "control-plane",
+    body,
+    metadata: {
+      state,
+      ...input.markerMetadata,
+      integratorTaskId: input.integratorTaskId,
+      sourceStopId: input.sourceStopId,
+      reason: input.reason,
+    },
+  });
+  const dedupeKey = `merge-base-drift-recovery:${state}:${input.sourceStopId}`;
+  await stopNotice(tx, {
+    taskId: input.integratorTaskId,
+    body: `Automatic pre-merge base-drift recovery ${state} for stop ${input.sourceStopId}: ${input.reason}. No regression run or re-authorization was created.`,
+    dedupeKey,
+  });
+  await tx.task.update({ where: { id: input.integratorTaskId }, data: {
+    status: TaskStatus.REVIEW,
+    failureReason: input.phase === "recovery-validation"
+      ? `Automatic base-drift recovery refused: ${input.reason}`
+      : input.reason,
+  } });
+  return { leaseToRelease: null };
 };
 
 export const createMergeTailRepairTask = async (
@@ -277,17 +453,15 @@ export const handleRegressionCompletion = async (
   const recovery = await baseDriftRecoveryContext(tx, input.task.id, input.run.id);
   const parsed = parseRegressionVerdict(output?.body, output?.kind);
   const stop = async (reason: string): Promise<"handled"> => {
-    if (recovery) {
-      await stopBaseDriftRecoveryTail(tx, recovery, "regression", reason);
-      return "handled";
-    }
-    await tx.task.update({ where: { id: input.task.id }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-    await writeMarker(tx, input.task.id, "regression", {
-      actorType: "control-plane",
-      body: `Regression did not advance: ${reason}`,
-      metadata: { state: "stopped", reason },
+    await stopMergeTail(tx, {
+      phase: "regression",
+      regressionTaskId: input.task.id,
+      reason,
+      at: input.now,
+      recovery,
+      agentId: input.run.agentId,
+      sessionId: input.run.sessionId,
     });
-    await openMergeTailStopNotice(tx, { taskId: input.task.id, agentId: input.run.agentId, sessionId: input.run.sessionId, reason });
     return "handled";
   };
   if (parsed.status === "invalid") return stop(parsed.reason);
@@ -312,11 +486,14 @@ export const handleRegressionCompletion = async (
   }
 
   if (recovery) {
-    await stopBaseDriftRecoveryTail(
-      tx,
+    await stopMergeTail(tx, {
+      phase: "regression",
+      regressionTaskId: input.task.id,
       recovery,
-      "regression",
-      truncateFailureReason(
+      agentId: input.run.agentId,
+      sessionId: input.run.sessionId,
+      at: input.now,
+      reason: truncateFailureReason(
         verdict.outcome === "refresh-conflict"
           ? `refresh conflict at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`
           : verdict.outcome === "review-fail"
@@ -324,7 +501,7 @@ export const handleRegressionCompletion = async (
             : `merge gate FAIL at ${verdict.headSha} against ${verdict.baseHeadSha}: ${verdict.summary}`,
         FAILURE_REASON_LIMIT,
       ),
-    );
+    });
     return "handled";
   }
 

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -56,6 +56,7 @@ import {
 import {
   handleRegressionCompletion,
   openMergeTailStopNotice,
+  stopMergeTail,
 } from "./merge-tail-actions.js";
 import { explainFenceRefusal, fenceRefusalResponse, fencedRunWhere, type RunFence } from "./run-fence.js";
 import {
@@ -530,20 +531,19 @@ export const completeRun = async (
         const failedRepair = latestMarker(tailMarkers, "repairAttempt");
         if (failedRepair?.regressionTaskId) {
           const reason = `${failedRepair.repairKind} repair ${run.taskId} failed without closing the repair at ${failedRepair.headSha}`;
-          await tx.task.update({ where: { id: failedRepair.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-          await writeMarker(tx, failedRepair.regressionTaskId, "repairResult", {
-            actorType: "control-plane",
-            body: `Automatic ${failedRepair.repairKind} attempt failed: ${failedRepair.headSha} -> ${body.headSha ?? "no-delivered-head"}`,
-            metadata: {
-              repairKind: failedRepair.repairKind,
-              repairTaskId: run.taskId,
-              startHeadSha: failedRepair.headSha,
-              targetHeadSha: failedRepair.baseHeadSha,
-              resolvedHeadSha: body.headSha ?? null,
-              state: "failed",
-            },
+          await stopMergeTail(tx, {
+            phase: "repair",
+            regressionTaskId: failedRepair.regressionTaskId,
+            repairTaskId: run.taskId,
+            repairKind: failedRepair.repairKind,
+            startHeadSha: failedRepair.headSha,
+            targetHeadSha: failedRepair.baseHeadSha,
+            resolvedHeadSha: body.headSha ?? null,
+            reason,
+            at: now,
+            agentId: run.agentId,
+            sessionId: run.session.id,
           });
-          await openMergeTailStopNotice(tx, { taskId: failedRepair.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
         }
       }
       // §4.0 outcome branching. The executor's own fenced write is the only


### PR DESCRIPTION
## 交付物

- 新增 `stopMergeTail(tx, input)` discriminated union，统一 regression、readiness、recovery-validation、recovery-exhausted、repair 五个 phase 对应的六个 stop 站点。
- module 统一拥有 Recovery status 迁移校验、Task REVIEW 镜像、marker kind/state、dedupe key、Inbox notice 与 Lease Disposition 返回。
- `mergeRecoveryTransitionAllowed` 成为真实写路径的 guard；非法 Recovery 转换在写入前 fail loudly。
- `stopReadiness` 保留 claim CAS 与 commit 后 release，改为消费 `stopMergeTail` 返回的 `leaseToRelease`；ADR-0001 R1 时序不变。
- M3：删除未使用且与唯一 inline query 重复的 `mergeTailFixAgentName` export。
- `merge-base-drift-worker.ts` 仅改 `settleIneligibleLocked` 与 exhausted 两个 stop 站点，未改 tick 主体。

## 验收

- `npm run lint`：PASS
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm test`：PASS
- scratch PostgreSQL 下 `merge-tail-readiness.dbtest.ts`、`merge-base-drift-recovery.dbtest.ts`、`merge-tail-repair.dbtest.ts`、`run-completion.dbtest.ts`：54/54 PASS
- phase × recovery table-driven unit matrix：覆盖 regression/readiness 有无 Recovery、validation、exhausted、repair，以及非法转换拒绝。
- 未修改 `readReadiness` / `readiness-decision.ts`。

## 代 Leo 做的选择

- 选择把新 interface 放进现有 `merge-tail-actions.ts`，不新建平行 module 文件：该文件已经拥有 merge-tail persistence actions，继续加深同一 module 比新增一层转出口更简单。
- 选择由 `stopMergeTail` 拥有所有重复的持久化转换；readiness claim CAS 与 base-drift abandon question 留在 caller：前者是并发 authority，后者是 phase 特有对话，不属于 stop persistence seam。
- 选择 Recovery 同状态写视为 idempotent，跨越状态机边的写直接抛错：符合现有 `mergeRecoveryTransitionAllowed` 语义，并让已提交 stop 可安全重入。
- 选择只吸收任务单点名的 failed repair stop；resolver invalid/unable 的额外文案分支暂留：本段目标是六个列明站点，扩大到所有 repair outcome 会提前侵入第三段 terminalization。
- 选择删除 M3 dead export、保留当前唯一 inline fix-Agent query：没有第二个 caller，提取 helper 不会增加 depth。
- 选择在本机手工复现误用了低于 24 字符的临时 PostgreSQL 口令后，不改测试基础设施，改由 gate 自带的合规隔离口令重跑同一 exact head：失败来自运行条件，不应污染交付代码。
- exact-head merge gate：`MERGE GATE: PASS 85781e65fb19fcac6e71eed5f6b126e64627fe02`。
