### PR TITLE
refactor(api): centralize run terminalization

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -82,7 +82,6 @@ import {
 } from "./canonical-task-output.js";
 import { LOOPBACK_BROWSER_ORIGINS, originMayReachHandlers } from "./local-origin.js";
 import {
-  settleLease,
   releaseMergeLease,
   type ReleaseMergeLease,
 } from "./merge-lease.js";
@@ -128,6 +127,7 @@ import {
   type RunFence,
   withFencedRun,
 } from "./run-fence.js";
+import { terminalizeRun } from "./run-terminal.js";
 import { InboxRunFenceRefusal, supersedeTaskInboxMessage, suspendForInbox } from "./inbox.js";
 import { createStarterInstallation, onboardingInput, onboardingStatus } from "./onboarding.js";
 import { preflightOnboardingRepository, RepositoryPreflightError } from "./onboarding-preflight.js";
@@ -871,160 +871,6 @@ const sessionWriteInput = z.object({
 const isPublic = (path: string, method: string): boolean =>
   path === "/" || path === "/health" || path === "/version" || method === "OPTIONS"
   || method === "POST" && /^\/hooks\/templates\/[^/]+$/.test(path);
-
-type CancellationSettlement =
-  | Refusal
-  | {
-      runId: string; taskId: string | null; status: RunStatus; cancellationState: "acknowledged";
-      requestId: string; releaseMergeLeaseTask: string | null;
-    };
-
-/** Terminalize one already-recorded cancellation intent. The Run row is the
- * race authority: completion and settlement both update it with mutually
- * exclusive predicates, so whichever commits first is the only terminal
- * writer. No retry or successor is created on this path. */
-const settleCancellation = async (
-  tx: Prisma.TransactionClient,
-  input: {
-    runId: string;
-    requestId: string;
-    now: Date;
-    runnerId?: string;
-    fencingToken?: string;
-    actorId?: string;
-    workspacePath?: string;
-    branch?: string;
-    baseSha?: string;
-    worktreeContainmentViolations?: string[];
-  },
-): Promise<CancellationSettlement> => {
-  await lockRunRow(tx, input.runId);
-  const run = await tx.run.findUnique({
-    where: { id: input.runId },
-    select: {
-      id: true, taskId: true, runNumber: true, status: true, runnerId: true, fencingToken: true,
-      cancelRequestId: true, cancelReason: true, cancelAcknowledgedAt: true,
-      worktreeContainmentViolations: true,
-      session: { select: { id: true, waitingOnMessageId: true } },
-    },
-  });
-  if (!run) return refusal("not-found", "Run not found");
-  if (run.cancelRequestId !== input.requestId) return refusal("conflict", "Cancellation request does not match this Run");
-  if (input.runnerId !== undefined && (run.runnerId !== input.runnerId || run.fencingToken !== input.fencingToken)) {
-    return refusal("conflict", "Cancellation acknowledgement is not owned by this runner");
-  }
-  if (run.status === RunStatus.CANCELLED) {
-    // Reconciliation can settle an expired cancellation before the runner's
-    // final ACK arrives. That ACK is still the only durable account of a
-    // workspace provisioned before /start, so idempotence must backfill its
-    // evidence instead of discarding it.
-    if (input.workspacePath !== undefined) await tx.run.updateMany({
-      where: { id: run.id, workspacePath: null }, data: { workspacePath: input.workspacePath },
-    });
-    if (input.branch !== undefined) await tx.run.updateMany({
-      where: { id: run.id, branch: null }, data: { branch: input.branch },
-    });
-    if (input.baseSha !== undefined) await tx.run.updateMany({
-      where: { id: run.id, baseSha: null }, data: { baseSha: input.baseSha },
-    });
-    if (input.worktreeContainmentViolations?.length && run.worktreeContainmentViolations === null) {
-      await tx.run.update({
-        where: { id: run.id },
-        data: { worktreeContainmentViolations: jsonValue(input.worktreeContainmentViolations) },
-      });
-    }
-    if (!run.cancelAcknowledgedAt && input.runnerId !== undefined) {
-      await tx.run.update({
-        where: { id: run.id },
-        data: { cancelAcknowledgedAt: input.now },
-      });
-      if (run.taskId) await tx.taskActivity.create({ data: {
-        taskId: run.taskId,
-        actorType: "runner",
-        actorId: input.actorId ?? null,
-        body: `Run ${run.runNumber} cancellation cleanup confirmed after terminalization`,
-        metadata: { runId: run.id, requestId: input.requestId, status: RunStatus.CANCELLED },
-      } });
-    } else if (!run.cancelAcknowledgedAt) {
-      return refusal("conflict", "Cancellation cleanup has not been acknowledged by the runner");
-    }
-    // The terminal writer that got here first already released the lease; a
-    // later acknowledgement of the same cancellation has nothing left to free.
-    return {
-      runId: run.id, taskId: run.taskId, status: run.status, cancellationState: "acknowledged",
-      requestId: input.requestId, releaseMergeLeaseTask: null,
-    };
-  }
-  if (run.taskId) await lockTaskMutationRows(tx, run.taskId);
-  const settled = await tx.run.updateMany({
-    where: {
-      id: run.id,
-      cancelRequestId: input.requestId,
-      status: { in: [RunStatus.QUEUED, ...activeRunStatuses] },
-      ...(input.runnerId === undefined ? {} : { runnerId: input.runnerId, fencingToken: input.fencingToken }),
-    },
-    data: {
-      status: RunStatus.CANCELLED,
-      endedAt: input.now,
-      leaseExpiresAt: null,
-      sessionTokenRevokedAt: input.now,
-      cancelAcknowledgedAt: input.now,
-      failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
-      failureReason: run.cancelReason ?? "Cancelled by operator",
-      terminationReason: run.cancelReason ?? "Cancelled by operator",
-      retryable: false,
-      retryAt: null,
-      workspaceRetained: true,
-      ...(input.workspacePath === undefined ? {} : { workspacePath: input.workspacePath }),
-      ...(input.branch === undefined ? {} : { branch: input.branch }),
-      ...(input.baseSha === undefined ? {} : { baseSha: input.baseSha }),
-      ...(input.worktreeContainmentViolations?.length
-        ? { worktreeContainmentViolations: jsonValue(input.worktreeContainmentViolations) }
-        : {}),
-    },
-  });
-  if (settled.count !== 1) return refusal("conflict", `Run is already ${run.status}`);
-  await tx.session.updateMany({
-    where: { runId: run.id },
-    data: {
-      executionStatus: SessionExecutionStatus.CANCELLED,
-      cleanupStatus: CleanupStatus.RETAINED,
-      endedAt: input.now,
-      cleanupEndedAt: input.now,
-      failureReason: run.cancelReason ?? "Cancelled by operator",
-      terminationReason: run.cancelReason ?? "Cancelled by operator",
-    },
-  });
-  if (run.session?.waitingOnMessageId) {
-    await tx.inboxMessage.updateMany({
-      where: { id: run.session.waitingOnMessageId, status: InboxStatus.OPEN },
-      data: { status: InboxStatus.CLOSED },
-    });
-  }
-  if (run.taskId) {
-    const reason = run.cancelReason ?? "Cancelled by operator";
-    await tx.task.updateMany({
-      where: { id: run.taskId, status: { in: [TaskStatus.TODO, TaskStatus.DOING, TaskStatus.REVIEW] } },
-      data: { status: TaskStatus.REVIEW, failureReason: reason },
-    });
-    await tx.taskActivity.create({ data: {
-      taskId: run.taskId,
-      actorType: input.actorId ? "runner" : "control-plane",
-      actorId: input.actorId ?? null,
-      body: `Run ${run.runNumber} cancellation acknowledged; execution authority revoked and evidence retained`,
-      metadata: { runId: run.id, requestId: input.requestId, status: RunStatus.CANCELLED },
-    } });
-  }
-  // Cancellation never creates a retry or a successor, so a cancelled chain-tail
-  // run is the chain's last word: whatever lease it was holding is now stranded
-  // until a machine steals it 45 minutes later. Release it instead.
-  return {
-    runId: run.id, taskId: run.taskId, status: RunStatus.CANCELLED, cancellationState: "acknowledged",
-    requestId: input.requestId,
-    releaseMergeLeaseTask: (await settleLease(tx, { taskId: run.taskId, outcome: "stop" })).leaseToRelease,
-  };
-};
-
 
 /** Locks a whole candidate set in one statement. `ORDER BY "id"` is not
  *  decoration: it is what stops two concurrent Archive All presses from
@@ -3319,23 +3165,29 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/runner/runs/:runId/cancel/acknowledge", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, cancelAcknowledgeInput);
-    const result = await db.$transaction((tx) => settleCancellation(tx, {
+    const result = await db.$transaction((tx) => terminalizeRun(tx, {
       runId,
-      requestId: body.requestId,
-      runnerId: body.runnerId,
-      fencingToken: body.fencingToken,
-      actorId: body.runnerId,
-      now: new Date(),
-      ...(body.workspacePath === undefined ? {} : { workspacePath: body.workspacePath }),
-      ...(body.branch === undefined ? {} : { branch: body.branch }),
-      ...(body.baseSha === undefined ? {} : { baseSha: body.baseSha }),
-      ...(body.worktreeContainmentViolations === undefined
-        ? {}
-        : { worktreeContainmentViolations: body.worktreeContainmentViolations }),
+      at: new Date(),
+      outcome: {
+        kind: "cancelled",
+        requestId: body.requestId,
+        runnerId: body.runnerId,
+        fencingToken: body.fencingToken,
+        actorId: body.runnerId,
+        cleanupConfirmed: true,
+        activity: "acknowledged",
+        ...(body.workspacePath === undefined ? {} : { workspacePath: body.workspacePath }),
+        ...(body.branch === undefined ? {} : { branch: body.branch }),
+        ...(body.baseSha === undefined ? {} : { baseSha: body.baseSha }),
+        ...(body.worktreeContainmentViolations === undefined
+          ? {}
+          : { worktreeContainmentViolations: body.worktreeContainmentViolations }),
+      },
     }));
+    if (result === null) return refusalJson(context, refusal("conflict", "Run changed while cancellation was being acknowledged"));
     if ("message" in result) return refusalJson(context, result);
-    const { releaseMergeLeaseTask, ...settlement } = result;
-    await releaseChainLease(releaseMergeLeaseTask);
+    const { leaseToRelease, ...settlement } = result;
+    await releaseChainLease(leaseToRelease);
     return context.json(settlement);
   });
 
@@ -4037,7 +3889,19 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       // including WAITING_INBOX, requires runner-owned process cleanup or an
       // explicitly unconfirmed terminalization after runner loss.
       if (run.status === RunStatus.QUEUED) {
-        return settleCancellation(tx, { runId: run.id, requestId: body.requestId, now });
+        const terminal = await terminalizeRun(tx, {
+          runId: run.id,
+          at: now,
+          outcome: {
+            kind: "cancelled",
+            requestId: body.requestId,
+            cleanupConfirmed: true,
+            activity: "acknowledged",
+          },
+        });
+        if (terminal === null || "message" in terminal) return terminal;
+        const { leaseToRelease, ...settlement } = terminal;
+        return { ...settlement, releaseMergeLeaseTask: leaseToRelease };
       }
       return {
         runId: run.id,
@@ -4051,6 +3915,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         releaseMergeLeaseTask: null,
       };
     });
+    if (result === null) return refusalJson(context, refusal("conflict", "Run changed while cancellation was being settled"));
     if ("message" in result) return refusalJson(context, result);
     const { releaseMergeLeaseTask, ...cancellation } = result;
     await releaseChainLease(releaseMergeLeaseTask);

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -1,12 +1,8 @@
 import {
-  CleanupStatus,
-  FailureClass,
-  InboxStatus,
   lockTaskRow,
   openRun,
   runBudgetCeiling,
   RunStatus,
-  SessionExecutionStatus,
   TaskStatus,
   type PrismaClient,
 } from "@agentos/db";
@@ -19,6 +15,7 @@ import {
   type ReleaseMergeLease,
 } from "./merge-lease.js";
 import { openReclaimIntentCount } from "./workspace-reclaim.js";
+import { terminalizeRun } from "./run-terminal.js";
 
 const activeStatuses = [RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING] as const;
 const archivedNoticePageSize = 100;
@@ -171,64 +168,24 @@ export const reconcileDatabaseRuns = async (
         },
       });
       if (!current) continue;
+      if (current.cancelRequestId && current.cancelRequestedAt) {
+        const terminal = await terminalizeRun(tx, {
+          runId: run.id,
+          at: now,
+          outcome: {
+            kind: "cancelled",
+            requestId: current.cancelRequestId,
+            cleanupConfirmed: false,
+            activity: "runner-lost",
+          },
+        });
+        if (terminal === null || "message" in terminal) continue;
+        if (terminal.leaseToRelease) stranded.add(terminal.leaseToRelease);
+        continue;
+      }
       // Order PATCH and retry creation through the same Task-row mutex. The
       // task is re-read after this lock before opensPullRequest is snapshotted.
       if (run.taskId) await lockTaskRow(tx, run.taskId);
-      if (current.cancelRequestId && current.cancelRequestedAt) {
-        const reason = current.cancelReason ?? "Cancelled by operator";
-        const cancelled = await tx.run.updateMany({
-          where: {
-            id: run.id,
-            cancelRequestId: current.cancelRequestId,
-            status: { in: [...activeStatuses] },
-            OR: [{ leaseExpiresAt: { lt: now } }, { leaseExpiresAt: null }],
-          },
-          data: {
-            status: RunStatus.CANCELLED,
-            endedAt: now,
-            leaseExpiresAt: null,
-            sessionTokenRevokedAt: now,
-            failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
-            failureReason: reason,
-            retryable: false,
-            retryAt: null,
-            terminationReason: reason,
-            workspaceRetained: true,
-          },
-        });
-        if (cancelled.count !== 1) continue;
-        await tx.session.updateMany({
-          where: { runId: run.id },
-          data: {
-            executionStatus: SessionExecutionStatus.CANCELLED,
-            cleanupStatus: CleanupStatus.RETAINED,
-            endedAt: now,
-            cleanupEndedAt: now,
-            failureReason: reason,
-            terminationReason: reason,
-          },
-        });
-        if (run.taskId) {
-          await tx.task.updateMany({
-            where: { id: run.taskId, status: { in: [TaskStatus.TODO, TaskStatus.DOING, TaskStatus.REVIEW] } },
-            data: { status: TaskStatus.REVIEW, failureReason: reason },
-          });
-          await tx.taskActivity.create({ data: {
-            taskId: run.taskId,
-            actorType: "control-plane",
-            body: `Run ${run.runNumber} cancellation terminalized after runner loss; process cleanup unconfirmed`,
-            metadata: {
-              runId: run.id,
-              requestId: current.cancelRequestId,
-              status: RunStatus.CANCELLED,
-              cleanupConfirmed: false,
-            },
-          } });
-        }
-        const lease = await settleLease(tx, { taskId: run.taskId, outcome: "stop" });
-        if (lease.leaseToRelease) stranded.add(lease.leaseToRelease);
-        continue;
-      }
       // Losing a lease is an external failure: it buys an attempt, never spends one.
       // A lost lease refunds the already-authorized Run; it does not recompute
       // from a task budget that may have changed while the Run was in flight.
@@ -237,35 +194,23 @@ export const reconcileDatabaseRuns = async (
       // gates an operator reaches can still tell it from the configured budget
       // after that budget changes. See `runBudgetCeiling`.
       const budgetGrants = run.budgetGrants + 1;
-      const lost = await tx.run.updateMany({
-        where: {
-          id: run.id,
-          cancelRequestedAt: null,
-          status: { in: [...activeStatuses] },
-          OR: [{ leaseExpiresAt: { lt: now } }, { leaseExpiresAt: null }],
-        },
-        data: {
-          status: RunStatus.LOST,
-          endedAt: now,
-          leaseExpiresAt: null,
-          sessionTokenRevokedAt: now,
-          failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
-          retryable: true,
+      const lost = await terminalizeRun(tx, {
+        runId: run.id,
+        at: now,
+        outcome: {
+          kind: "lost",
+          where: {
+            id: run.id,
+            cancelRequestedAt: null,
+            status: { in: [...activeStatuses] },
+            OR: [{ leaseExpiresAt: { lt: now } }, { leaseExpiresAt: null }],
+          },
+          reason: leaseLossReason,
           maxRunsPerTask: budgetCeiling,
           budgetGrants,
-          failureReason: leaseLossReason,
         },
       });
-      if (lost.count !== 1) continue;
-      await tx.session.updateMany({
-        where: { runId: run.id },
-        data: {
-          executionStatus: SessionExecutionStatus.LOST,
-          cleanupStatus: CleanupStatus.PENDING,
-          endedAt: now,
-          failureReason: leaseLossReason,
-        },
-      });
+      if (lost === null || "message" in lost) continue;
       if (!run.taskId) continue;
       if (run.runNumber < budgetCeiling) {
         const opened = await openRun(tx, run.taskId, {
@@ -319,44 +264,18 @@ export const reconcileDatabaseRuns = async (
       }
     }
     for (const run of expiredInboxRuns) {
-      const expired = await tx.run.updateMany({
-        where: { id: run.id, status: RunStatus.WAITING_INBOX },
-        data: {
-          status: RunStatus.TIMED_OUT,
-          endedAt: now,
-          retryable: false,
-          failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
-          failureReason: "Inbox response window expired",
+      const expired = await terminalizeRun(tx, {
+        runId: run.id,
+        at: now,
+        outcome: {
+          kind: "timed-out",
+          sessionId: run.session?.id ?? null,
+          waitingOnMessageId: run.session?.waitingOnMessageId ?? null,
+          taskId: run.taskId,
+          reason: "Inbox response window expired",
         },
       });
-      if (expired.count !== 1) continue;
-      if (run.session) {
-        await tx.session.updateMany({
-          where: { id: run.session.id, executionStatus: SessionExecutionStatus.WAITING_INBOX },
-          data: {
-            executionStatus: SessionExecutionStatus.TIMED_OUT,
-            cleanupStatus: CleanupStatus.RETAINED,
-            endedAt: now,
-            cleanupEndedAt: now,
-            failureReason: "Inbox response window expired",
-          },
-        });
-      }
-      if (run.session?.waitingOnMessageId) {
-        await tx.inboxMessage.updateMany({
-          where: { id: run.session.waitingOnMessageId, status: InboxStatus.OPEN },
-          data: { status: InboxStatus.CLOSED },
-        });
-      }
-      if (run.taskId) {
-        await tx.task.update({
-          where: { id: run.taskId },
-          data: { status: TaskStatus.REVIEW, failureReason: "Inbox response window expired" },
-        });
-        await tx.taskActivity.create({
-          data: { taskId: run.taskId, actorType: "control-plane", body: "Inbox response window expired; run moved to review" },
-        });
-      }
+      if (expired === null || "message" in expired) continue;
     }
     for (const handoff of strandedHandoffs) {
       stranded.add(handoff.chainId);

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -32,7 +32,6 @@ import {
   recordIntegratorStop,
   runBudgetCeiling,
   RunStatus,
-  SessionExecutionStatus,
   TaskStatus,
   writeMarker,
 } from "@agentos/db";
@@ -59,6 +58,7 @@ import {
   stopMergeTail,
 } from "./merge-tail-actions.js";
 import { explainFenceRefusal, fenceRefusalResponse, fencedRunWhere, type RunFence } from "./run-fence.js";
+import { terminalizeRun } from "./run-terminal.js";
 import {
   commitWithLeaseDisposition,
   settleLease,
@@ -438,16 +438,19 @@ export const completeRun = async (
       : body.terminationReason?.includes("walltime") || body.terminationReason?.includes("stall")
         ? RunStatus.TIMED_OUT
         : RunStatus.FAILED;
-    const closed = await tx.run.updateMany({
-      // The terminal compare-and-set deliberately drops `runnerId`: settlement
-      // races completion on this row and neither may win twice. Same instant
-      // as the read above, which is what `at` on the fence is for.
-      where: fencedRunWhere({ runId, fencingToken: body.fencingToken, at: now }),
-      data: {
+    const terminal = await terminalizeRun(tx, {
+      runId,
+      at: now,
+      outcome: {
+        kind: "completed",
+        // The terminal compare-and-set deliberately drops `runnerId`:
+        // cancellation settlement races completion on this row and neither
+        // may win twice. Same instant as the read above, which is what `at` on
+        // the fence is for.
+        where: fencedRunWhere({ runId, fencingToken: body.fencingToken, at: now }),
         status: terminalStatus,
-        endedAt: now,
-        leaseExpiresAt: null,
-        sessionTokenRevokedAt: now,
+        sessionId: run.session.id,
+        run: {
         failureClass,
         failureReason,
         retryable,
@@ -486,24 +489,18 @@ export const completeRun = async (
           : Prisma.DbNull,
         maxRunsPerTask: budgetCeiling,
         budgetGrants,
-      },
-    });
-    if (closed.count !== 1) return null;
-    await tx.session.update({
-      where: { id: run.session.id },
-      data: {
-        executionStatus: succeeded ? SessionExecutionStatus.SUCCEEDED
-          : terminalStatus === RunStatus.TIMED_OUT ? SessionExecutionStatus.TIMED_OUT : SessionExecutionStatus.FAILED,
+        },
+        session: {
         cleanupStatus: body.cleanupStatus,
         exitCode: body.exitCode,
         signal: body.signal ?? null,
         terminationReason: body.terminationReason ?? null,
-        endedAt: now,
-        cleanupEndedAt: now,
         failureReason,
         cleanupFailureReason: body.cleanupFailureReason ?? null,
+        },
       },
     });
+    if (terminal === null || "message" in terminal) return null;
     let retryCreated = false;
     let retryRefusal: Refusal | null = null;
     if (!succeeded && retryable && run.task && run.runNumber < budgetCeiling) {

--- a/packages/api/src/run-terminal.test.ts
+++ b/packages/api/src/run-terminal.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CleanupStatus, RunStatus } from "@agentos/db";
+
+import { terminalFieldsFor, type TerminalOutcome } from "./run-terminal.js";
+
+const at = new Date("2026-08-27T12:00:00.000Z");
+const reason = "terminal reason";
+
+const cases: Array<{
+  name: string;
+  outcome: TerminalOutcome;
+  run: string[];
+  session: string[];
+}> = [
+  {
+    name: "cancelled",
+    outcome: { kind: "cancelled", requestId: "cancel-1", cleanupConfirmed: true, activity: "acknowledged" },
+    run: [
+      "status", "endedAt", "leaseExpiresAt", "sessionTokenRevokedAt", "cancelAcknowledgedAt",
+      "failureClass", "failureReason", "terminationReason", "retryable", "retryAt", "workspaceRetained",
+    ],
+    session: [
+      "executionStatus", "cleanupStatus", "endedAt", "cleanupEndedAt", "failureReason", "terminationReason",
+    ],
+  },
+  {
+    name: "lost",
+    outcome: { kind: "lost", where: { id: "run-1" }, reason, maxRunsPerTask: 4, budgetGrants: 1 },
+    run: [
+      "status", "endedAt", "leaseExpiresAt", "sessionTokenRevokedAt", "failureClass", "retryable",
+      "maxRunsPerTask", "budgetGrants", "failureReason",
+    ],
+    session: ["executionStatus", "cleanupStatus", "endedAt", "failureReason"],
+  },
+  {
+    name: "timed-out",
+    outcome: { kind: "timed-out", sessionId: "session-1", waitingOnMessageId: "message-1", taskId: "task-1", reason },
+    run: ["status", "endedAt", "retryable", "failureClass", "failureReason"],
+    session: ["executionStatus", "cleanupStatus", "endedAt", "cleanupEndedAt", "failureReason"],
+  },
+  {
+    name: "completed",
+    outcome: {
+      kind: "completed",
+      where: { id: "run-1" },
+      status: RunStatus.SUCCEEDED,
+      run: { retryable: false },
+      sessionId: "session-1",
+      session: { cleanupStatus: CleanupStatus.SUCCEEDED },
+    },
+    run: ["status", "endedAt", "leaseExpiresAt", "sessionTokenRevokedAt", "retryable"],
+    session: ["executionStatus", "endedAt", "cleanupEndedAt", "cleanupStatus"],
+  },
+  {
+    name: "claim-invalidated",
+    outcome: { kind: "claim-invalidated", reason },
+    run: [
+      "status", "endedAt", "leaseExpiresAt", "sessionTokenRevokedAt", "failureClass", "failureReason",
+      "retryable", "maxRunsPerTask", "budgetGrants",
+    ],
+    session: ["executionStatus", "endedAt", "failureReason"],
+  },
+];
+
+for (const row of cases) {
+  test(`${row.name} writes exactly its Run and Session terminal fields`, () => {
+    const fields = terminalFieldsFor(row.outcome, at);
+    assert.deepEqual(Object.keys(fields.run), row.run);
+    assert.deepEqual(Object.keys(fields.session), row.session);
+  });
+}

--- a/packages/api/src/run-terminal.ts
+++ b/packages/api/src/run-terminal.ts
@@ -1,0 +1,371 @@
+import {
+  CleanupStatus,
+  FailureClass,
+  InboxStatus,
+  lockRunRow,
+  Prisma,
+  RunStatus,
+  SessionExecutionStatus,
+  TaskStatus,
+} from "@agentos/db";
+
+import { jsonValue } from "./execution.js";
+import { settleLease } from "./merge-lease.js";
+import type { Refusal } from "./refusal.js";
+import { activeRunStatuses } from "./run-fence.js";
+import { lockTaskMutationRows } from "./task-write.js";
+
+type CancelledOutcome = {
+  kind: "cancelled";
+  requestId: string;
+  runnerId?: string;
+  fencingToken?: string;
+  actorId?: string;
+  cleanupConfirmed: boolean;
+  workspacePath?: string;
+  branch?: string;
+  baseSha?: string;
+  worktreeContainmentViolations?: string[];
+  activity: "acknowledged" | "runner-lost";
+  reason?: string;
+};
+
+type LostOutcome = {
+  kind: "lost";
+  where: Prisma.RunWhereInput;
+  reason: string;
+  maxRunsPerTask: number;
+  budgetGrants: number;
+};
+
+type TimedOutOutcome = {
+  kind: "timed-out";
+  sessionId: string | null;
+  waitingOnMessageId: string | null;
+  taskId: string | null;
+  reason: string;
+};
+
+type CompletedOutcome = {
+  kind: "completed";
+  where: Prisma.RunWhereInput;
+  status: typeof RunStatus.SUCCEEDED | typeof RunStatus.FAILED | typeof RunStatus.TIMED_OUT;
+  run: Omit<Prisma.RunUpdateManyMutationInput, "status" | "endedAt" | "leaseExpiresAt" | "sessionTokenRevokedAt">;
+  sessionId: string;
+  session: Omit<Prisma.SessionUpdateManyMutationInput, "executionStatus" | "endedAt" | "cleanupEndedAt">;
+};
+
+type ClaimInvalidatedOutcome = {
+  kind: "claim-invalidated";
+  reason: string;
+};
+
+export type TerminalOutcome =
+  | CancelledOutcome
+  | LostOutcome
+  | TimedOutOutcome
+  | CompletedOutcome
+  | ClaimInvalidatedOutcome;
+
+export type TerminalResult = {
+  runId: string;
+  taskId: string | null;
+  status: RunStatus;
+  leaseToRelease: string | null;
+  cancellationState?: "acknowledged";
+  requestId?: string;
+};
+
+export type TerminalFieldSet = {
+  run: Prisma.RunUpdateManyMutationInput;
+  session: Prisma.SessionUpdateManyMutationInput;
+};
+
+const refused = (reason: "not-found" | "conflict", message: string): Refusal => ({ reason, message });
+
+/** The terminal field family is derived here once. Callers supply evidence and
+ * policy inputs; they do not assemble partial Run and Session mirrors. */
+export const terminalFieldsFor = (outcome: TerminalOutcome, at: Date): TerminalFieldSet => {
+  switch (outcome.kind) {
+    case "cancelled": {
+      const reason = outcome.reason ?? "Cancelled by operator";
+      return {
+        run: {
+          status: RunStatus.CANCELLED,
+          endedAt: at,
+          leaseExpiresAt: null,
+          sessionTokenRevokedAt: at,
+          ...(outcome.cleanupConfirmed ? { cancelAcknowledgedAt: at } : {}),
+          failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
+          failureReason: reason,
+          terminationReason: reason,
+          retryable: false,
+          retryAt: null,
+          workspaceRetained: true,
+          ...(outcome.workspacePath === undefined ? {} : { workspacePath: outcome.workspacePath }),
+          ...(outcome.branch === undefined ? {} : { branch: outcome.branch }),
+          ...(outcome.baseSha === undefined ? {} : { baseSha: outcome.baseSha }),
+          ...(outcome.worktreeContainmentViolations?.length
+            ? { worktreeContainmentViolations: jsonValue(outcome.worktreeContainmentViolations) }
+            : {}),
+        },
+        session: {
+          executionStatus: SessionExecutionStatus.CANCELLED,
+          cleanupStatus: CleanupStatus.RETAINED,
+          endedAt: at,
+          cleanupEndedAt: at,
+          failureReason: reason,
+          terminationReason: reason,
+        },
+      };
+    }
+    case "lost":
+      return {
+        run: {
+          status: RunStatus.LOST,
+          endedAt: at,
+          leaseExpiresAt: null,
+          sessionTokenRevokedAt: at,
+          failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
+          retryable: true,
+          maxRunsPerTask: outcome.maxRunsPerTask,
+          budgetGrants: outcome.budgetGrants,
+          failureReason: outcome.reason,
+        },
+        session: {
+          executionStatus: SessionExecutionStatus.LOST,
+          cleanupStatus: CleanupStatus.PENDING,
+          endedAt: at,
+          failureReason: outcome.reason,
+        },
+      };
+    case "timed-out":
+      return {
+        run: {
+          status: RunStatus.TIMED_OUT,
+          endedAt: at,
+          retryable: false,
+          failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
+          failureReason: outcome.reason,
+        },
+        session: {
+          executionStatus: SessionExecutionStatus.TIMED_OUT,
+          cleanupStatus: CleanupStatus.RETAINED,
+          endedAt: at,
+          cleanupEndedAt: at,
+          failureReason: outcome.reason,
+        },
+      };
+    case "completed":
+      return {
+        run: {
+          status: outcome.status,
+          endedAt: at,
+          leaseExpiresAt: null,
+          sessionTokenRevokedAt: at,
+          ...outcome.run,
+        },
+        session: {
+          executionStatus: outcome.status === RunStatus.SUCCEEDED
+            ? SessionExecutionStatus.SUCCEEDED
+            : outcome.status === RunStatus.TIMED_OUT
+              ? SessionExecutionStatus.TIMED_OUT
+              : SessionExecutionStatus.FAILED,
+          endedAt: at,
+          cleanupEndedAt: at,
+          ...outcome.session,
+        },
+      };
+    case "claim-invalidated":
+      return {
+        run: {
+          status: RunStatus.CANCELLED,
+          endedAt: at,
+          leaseExpiresAt: null,
+          sessionTokenRevokedAt: at,
+          failureClass: FailureClass.CANCELLED_OR_TIMED_OUT,
+          failureReason: outcome.reason,
+          retryable: true,
+          maxRunsPerTask: { increment: 1 },
+          budgetGrants: { increment: 1 },
+        },
+        session: {
+          executionStatus: SessionExecutionStatus.CANCELLED,
+          endedAt: at,
+          failureReason: outcome.reason,
+        },
+      };
+    default: {
+      const unhandled: never = outcome;
+      return unhandled;
+    }
+  }
+};
+
+const cancelledReason = (cancelReason: string | null): string => cancelReason ?? "Cancelled by operator";
+
+/** Terminalize a Run and its Session as one operation. The outcome union owns
+ * the terminal field matrix; cancellation and Inbox timeout also keep their
+ * Task, Inbox, activity, and Lease mirrors inside this module. */
+export const terminalizeRun = async (
+  tx: Prisma.TransactionClient,
+  input: { runId: string; outcome: TerminalOutcome; at: Date },
+): Promise<TerminalResult | Refusal | null> => {
+  if (input.outcome.kind === "cancelled") {
+    await lockRunRow(tx, input.runId);
+    const run = await tx.run.findUnique({
+      where: { id: input.runId },
+      select: {
+        id: true, taskId: true, runNumber: true, status: true, runnerId: true, fencingToken: true,
+        cancelRequestId: true, cancelReason: true, cancelAcknowledgedAt: true,
+        worktreeContainmentViolations: true,
+        session: { select: { waitingOnMessageId: true } },
+      },
+    });
+    if (!run) return refused("not-found", "Run not found");
+    if (run.cancelRequestId !== input.outcome.requestId) {
+      return refused("conflict", "Cancellation request does not match this Run");
+    }
+    if (input.outcome.runnerId !== undefined
+      && (run.runnerId !== input.outcome.runnerId || run.fencingToken !== input.outcome.fencingToken)) {
+      return refused("conflict", "Cancellation acknowledgement is not owned by this runner");
+    }
+    if (run.status === RunStatus.CANCELLED) {
+      if (input.outcome.workspacePath !== undefined) await tx.run.updateMany({
+        where: { id: run.id, workspacePath: null }, data: { workspacePath: input.outcome.workspacePath },
+      });
+      if (input.outcome.branch !== undefined) await tx.run.updateMany({
+        where: { id: run.id, branch: null }, data: { branch: input.outcome.branch },
+      });
+      if (input.outcome.baseSha !== undefined) await tx.run.updateMany({
+        where: { id: run.id, baseSha: null }, data: { baseSha: input.outcome.baseSha },
+      });
+      if (input.outcome.worktreeContainmentViolations?.length && run.worktreeContainmentViolations === null) {
+        await tx.run.update({
+          where: { id: run.id },
+          data: { worktreeContainmentViolations: jsonValue(input.outcome.worktreeContainmentViolations) },
+        });
+      }
+      if (!run.cancelAcknowledgedAt && input.outcome.cleanupConfirmed) {
+        await tx.run.update({ where: { id: run.id }, data: { cancelAcknowledgedAt: input.at } });
+        if (run.taskId) await tx.taskActivity.create({ data: {
+          taskId: run.taskId,
+          actorType: "runner",
+          actorId: input.outcome.actorId ?? null,
+          body: `Run ${run.runNumber} cancellation cleanup confirmed after terminalization`,
+          metadata: { runId: run.id, requestId: input.outcome.requestId, status: RunStatus.CANCELLED },
+        } });
+      } else if (!run.cancelAcknowledgedAt) {
+        return refused("conflict", "Cancellation cleanup has not been acknowledged by the runner");
+      }
+      return {
+        runId: run.id,
+        taskId: run.taskId,
+        status: run.status,
+        cancellationState: "acknowledged",
+        requestId: input.outcome.requestId,
+        leaseToRelease: null,
+      };
+    }
+    if (run.taskId) await lockTaskMutationRows(tx, run.taskId);
+    const outcome = { ...input.outcome, reason: cancelledReason(run.cancelReason) };
+    const fields = terminalFieldsFor(outcome, input.at);
+    const settled = await tx.run.updateMany({
+      where: {
+        id: run.id,
+        cancelRequestId: input.outcome.requestId,
+        status: { in: [RunStatus.QUEUED, ...activeRunStatuses] },
+        ...(input.outcome.runnerId === undefined
+          ? {}
+          : { runnerId: input.outcome.runnerId, fencingToken: input.outcome.fencingToken }),
+      },
+      data: fields.run,
+    });
+    if (settled.count !== 1) return refused("conflict", `Run is already ${run.status}`);
+    await tx.session.updateMany({ where: { runId: run.id }, data: fields.session });
+    if (run.session?.waitingOnMessageId) {
+      await tx.inboxMessage.updateMany({
+        where: { id: run.session.waitingOnMessageId, status: InboxStatus.OPEN },
+        data: { status: InboxStatus.CLOSED },
+      });
+    }
+    if (run.taskId) {
+      const reason = cancelledReason(run.cancelReason);
+      await tx.task.updateMany({
+        where: { id: run.taskId, status: { in: [TaskStatus.TODO, TaskStatus.DOING, TaskStatus.REVIEW] } },
+        data: { status: TaskStatus.REVIEW, failureReason: reason },
+      });
+      await tx.taskActivity.create({ data: {
+        taskId: run.taskId,
+        actorType: input.outcome.actorId ? "runner" : "control-plane",
+        actorId: input.outcome.actorId ?? null,
+        body: input.outcome.activity === "runner-lost"
+          ? `Run ${run.runNumber} cancellation terminalized after runner loss; process cleanup unconfirmed`
+          : `Run ${run.runNumber} cancellation acknowledged; execution authority revoked and evidence retained`,
+        metadata: input.outcome.activity === "runner-lost"
+          ? {
+              runId: run.id,
+              requestId: input.outcome.requestId,
+              status: RunStatus.CANCELLED,
+              cleanupConfirmed: false,
+            }
+          : { runId: run.id, requestId: input.outcome.requestId, status: RunStatus.CANCELLED },
+      } });
+    }
+    const disposition = await settleLease(tx, { taskId: run.taskId, outcome: "stop" });
+    return {
+      runId: run.id,
+      taskId: run.taskId,
+      status: RunStatus.CANCELLED,
+      cancellationState: "acknowledged",
+      requestId: input.outcome.requestId,
+      leaseToRelease: disposition.leaseToRelease,
+    };
+  }
+
+  const fields = terminalFieldsFor(input.outcome, input.at);
+  const where = input.outcome.kind === "completed" || input.outcome.kind === "lost"
+    ? input.outcome.where
+    : input.outcome.kind === "timed-out"
+      ? { id: input.runId, status: RunStatus.WAITING_INBOX }
+      : { id: input.runId, status: RunStatus.CLAIMED, startedAt: null };
+  const closed = await tx.run.updateMany({ where, data: fields.run });
+  if (closed.count !== 1) return null;
+  const sessionWhere = input.outcome.kind === "completed"
+    ? { id: input.outcome.sessionId }
+    : input.outcome.kind === "timed-out" && input.outcome.sessionId
+      ? { id: input.outcome.sessionId, executionStatus: SessionExecutionStatus.WAITING_INBOX }
+      : { runId: input.runId };
+  if (input.outcome.kind === "completed") {
+    await tx.session.update({ where: sessionWhere, data: fields.session });
+  } else {
+    await tx.session.updateMany({ where: sessionWhere, data: fields.session });
+  }
+
+  if (input.outcome.kind !== "timed-out") {
+    return { runId: input.runId, taskId: null, status: fields.run.status as RunStatus, leaseToRelease: null };
+  }
+  if (input.outcome.waitingOnMessageId) {
+    await tx.inboxMessage.updateMany({
+      where: { id: input.outcome.waitingOnMessageId, status: InboxStatus.OPEN },
+      data: { status: InboxStatus.CLOSED },
+    });
+  }
+  if (input.outcome.taskId) {
+    await tx.task.update({
+      where: { id: input.outcome.taskId },
+      data: { status: TaskStatus.REVIEW, failureReason: input.outcome.reason },
+    });
+    await tx.taskActivity.create({ data: {
+      taskId: input.outcome.taskId,
+      actorType: "control-plane",
+      body: "Inbox response window expired; run moved to review",
+    } });
+  }
+  return {
+    runId: input.runId,
+    taskId: input.outcome.taskId,
+    status: RunStatus.TIMED_OUT,
+    leaseToRelease: null,
+  };
+};


### PR DESCRIPTION
## Deliverables

- Add `run-terminal.ts` with the `terminalizeRun(tx, { runId, outcome, at })` interface and an exhaustive `TerminalOutcome` union for cancelled, lost, timed-out, completed, and claim-invalidated outcomes.
- Centralize the exact Run and Session terminal field families in `terminalFieldsFor`; cancellation additionally owns Task, Inbox, activity, and Lease mirrors.
- Route the five authorized terminal writers in `app.ts`, `reconcile.ts`, and `run-completion.ts` through the new module.
- Delete `settleCancellation` and its local result type from `app.ts`.
- Add a table-driven field-matrix test asserting the exact Run and Session columns for every outcome.

## Acceptance

- `npm run lint`: pass.
- `npm test`: pass.
- API unit focus (`app.test.ts`, `reconcile.test.ts`, `run-terminal.test.ts`): 93/93 pass.
- Relevant database tests (`active-run-cancellation`, `merge-lease-cancel-release`, `run-completion`, `merge-stop-state`, `merge-tail-readiness`, `chain-branch`, `tasks`): 165/165 pass with live PostgreSQL and an isolated `RUNNER_WORKSPACE_ROOT`.
- `settleCancellation` has no remaining definition or call site.
- ADR 0001 R1 is unchanged; this implementation does not alter the mechanical merge order.

## Choices made for Leo

- I treated the conflict matrix as the file-domain authority and did not edit `workspace-reclaim.ts`, even though candidate 4 also names its claim-invalidated writer; the outcome is exhaustive and matrix-tested here, while changing that caller would violate the explicit Lane A allowlist.
- I retained exact-id `Session.update` for completed Runs and use `updateMany` for outcomes whose Session may be absent; completion already guarantees one Session, while reconciliation deliberately tolerates none.
- I kept Inbox timeout Lease disposition null because the existing writer had no Chain Lease settlement obligation; cancellation continues to return the candidate-1 disposition that its caller must release after commit.
- I preserved late cancellation acknowledgement as an evidence backfill, not a second terminal transition, so reconciliation and a delayed runner ACK remain idempotent.
- I merged the then-current `main` (`d3c4a3d`) after acquiring the Lease instead of rebasing; this preserves published history and incorporates Lane K before the exact-head proof.
- Exact-head merge gate: `MERGE GATE: PASS 37ed73d0bc8c72974c6a8187f9430719de35e643`.
