### PR TITLE
refactor(api): isolate base drift recovery decisions

### DIFF
--- a/packages/api/src/base-drift-recovery-decision.test.ts
+++ b/packages/api/src/base-drift-recovery-decision.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  candidateRefusalCodes,
+  recoveryDecision,
+  type CandidateLoad,
+  type RecoveryCandidate,
+  type RecoveryPullRequestFacts,
+} from "./base-drift-recovery-decision.js";
+
+const HEAD = "a".repeat(40);
+const BASE = "b".repeat(40);
+const CURRENT = "c".repeat(40);
+
+const candidate: RecoveryCandidate = {
+  integratorTaskId: "integrator-1",
+  readinessTaskId: "readiness-1",
+  regressionTaskId: "regression-1",
+  sourceRunId: "run-1",
+  stopId: "stop-1",
+  authorizationActivityId: "authorization-1",
+  repository: "acme/widgets",
+  prNumber: 123,
+  targetBranch: "main",
+  authorizedHeadSha: HEAD,
+  authorizedBaseSha: BASE,
+  observedBaseSha: CURRENT,
+};
+
+const snapshot = (overrides: Partial<RecoveryPullRequestFacts> = {}): RecoveryPullRequestFacts => ({
+  repository: candidate.repository,
+  number: candidate.prNumber,
+  state: "OPEN",
+  isDraft: false,
+  merged: false,
+  baseRefName: candidate.targetBranch,
+  baseSha: CURRENT,
+  headRefOid: HEAD,
+  headCommitOid: HEAD,
+  autoMergeRequest: null,
+  mergeQueueEntry: null,
+  ...overrides,
+});
+
+const freshDecision = (overrides: Partial<Parameters<typeof recoveryDecision>[0] & { stage: "fresh" }> = {}) => recoveryDecision({
+  stage: "fresh",
+  candidate,
+  snapshot: snapshot(),
+  comparisonAvailable: true,
+  authorizedAdvance: { status: "ahead", behindBy: 0 },
+  observedAdvance: null,
+  ...overrides,
+});
+
+test("all durable candidate refusal paths decide without a database", () => {
+  assert.equal(candidateRefusalCodes.length, 16);
+  for (const code of candidateRefusalCodes) {
+    const load: CandidateLoad = {
+      kind: "refused",
+      code,
+      stopId: "stop-1",
+      ...(code === "authorization-invalid" ? { detail: "ambiguous" } : {}),
+      ...(code === "target-unresolved" ? { detail: "repository" } : {}),
+    };
+    const decision = recoveryDecision({ stage: "candidate", load });
+    assert.equal(decision.kind, code === "chain-active" ? "retry" : "ineligible", code);
+    assert.notEqual("reason" in decision ? decision.reason : "", "", code);
+  }
+});
+
+test("all fresh pull-request refusal paths decide without a database", () => {
+  const cases: Array<[string, Partial<RecoveryPullRequestFacts>, RegExp]> = [
+    ["identity", { number: 124 }, /identity mismatches/u],
+    ["state", { state: "CLOSED" }, /no longer an unmerged OPEN/u],
+    ["draft", { isDraft: true }, /draft state changed/u],
+    ["foreign merge", { autoMergeRequest: { enabledAt: "now", mergeMethod: "MERGE" } }, /automatic merge machinery/u],
+    ["target", { baseRefName: "release" }, /target ref changed/u],
+    ["head", { headRefOid: "d".repeat(40) }, /head changed/u],
+    ["base", { baseSha: BASE }, /does not prove an advanced SHA/u],
+  ];
+  for (const [label, current, reason] of cases) {
+    const decision = freshDecision({ snapshot: snapshot(current) });
+    assert.equal(decision.kind, "ineligible", label);
+    assert.match(decision.kind === "ineligible" ? decision.reason : "", reason, label);
+  }
+});
+
+test("ancestry refusal, retry, queue, exhaustion, and skip are explicit decisions", () => {
+  assert.equal(freshDecision({ comparisonAvailable: false }).kind, "ineligible");
+  assert.equal(freshDecision({ authorizedAdvance: { status: "diverged", behindBy: 1 } }).kind, "ineligible");
+  assert.equal(freshDecision({
+    candidate: { ...candidate, observedBaseSha: "d".repeat(40) },
+    observedAdvance: { status: "behind", behindBy: 1 },
+  }).kind, "ineligible");
+  assert.deepEqual(freshDecision(), { kind: "queue", candidate, currentBaseSha: CURRENT });
+
+  assert.deepEqual(recoveryDecision({
+    stage: "classification-retry",
+    reason: "reader timeout",
+    validationAttempts: 0,
+    maxAttempts: 2,
+  }), { kind: "retry", reason: "reader timeout", classificationAttempt: 1 });
+  assert.equal(recoveryDecision({
+    stage: "classification-retry",
+    reason: "reader timeout",
+    validationAttempts: 2,
+    maxAttempts: 2,
+  }).kind, "ineligible");
+
+  assert.equal(recoveryDecision({
+    stage: "durable",
+    expected: candidate,
+    load: { kind: "candidate", candidate },
+    aggregateValidating: true,
+    recoveryCount: 2,
+    maxRecoveries: 2,
+    currentBaseSha: CURRENT,
+  }).kind, "exhausted");
+  assert.deepEqual(recoveryDecision({
+    stage: "durable",
+    expected: candidate,
+    load: { kind: "candidate", candidate },
+    aggregateValidating: false,
+    recoveryCount: 0,
+    maxRecoveries: 2,
+    currentBaseSha: CURRENT,
+  }), { kind: "skip" });
+});

--- a/packages/api/src/base-drift-recovery-decision.ts
+++ b/packages/api/src/base-drift-recovery-decision.ts
@@ -1,0 +1,225 @@
+export type RecoveryIdentity = {
+  repository: string;
+  prNumber: number;
+  targetBranch: string;
+  authorizedHeadSha: string;
+  authorizedBaseSha: string;
+  observedBaseSha: string;
+};
+
+export type RecoveryCandidate = RecoveryIdentity & {
+  integratorTaskId: string;
+  readinessTaskId: string;
+  regressionTaskId: string;
+  sourceRunId: string;
+  stopId: string;
+  authorizationActivityId: string;
+};
+
+export const candidateRefusalCodes = [
+  "identity-incomplete",
+  "source-run-unbound",
+  "evidence-invalid",
+  "source-run-mismatch",
+  "chain-active",
+  "output-mismatch",
+  "tail-unresolved",
+  "tail-state-mismatch",
+  "authorization-invalid",
+  "intent-count",
+  "intent-mismatch",
+  "authorized-base-mismatch",
+  "readiness-head-mismatch",
+  "target-unresolved",
+  "target-mismatch",
+  "target-branch-mismatch",
+] as const;
+
+export type CandidateRefusalCode = typeof candidateRefusalCodes[number];
+
+export type CandidateLoad =
+  | { kind: "skip" }
+  | { kind: "refused"; code: CandidateRefusalCode; stopId: string; detail?: string }
+  | { kind: "candidate"; candidate: RecoveryCandidate };
+
+type Comparison = { status: string; behindBy: number };
+
+export type RecoveryPullRequestFacts = {
+  repository: string;
+  number: number;
+  state: string;
+  isDraft: boolean;
+  merged: boolean;
+  baseRefName: string | null;
+  baseSha: string | null;
+  headRefOid: string | null;
+  headCommitOid: string | null;
+  autoMergeRequest: unknown | null;
+  mergeQueueEntry: unknown | null;
+};
+
+export type RecoveryFacts =
+  | { stage: "candidate"; load: CandidateLoad }
+  | { stage: "reader-unavailable" }
+  | { stage: "reader-failure"; reason: string }
+  | {
+      stage: "fresh";
+      candidate: RecoveryCandidate;
+      snapshot: RecoveryPullRequestFacts;
+      comparisonAvailable: boolean;
+      authorizedAdvance: Comparison | null;
+      observedAdvance: Comparison | null;
+    }
+  | {
+      stage: "classification-retry";
+      reason: string;
+      validationAttempts: number;
+      maxAttempts: number;
+    }
+  | {
+      stage: "durable";
+      expected: RecoveryCandidate;
+      load: CandidateLoad;
+      aggregateValidating: boolean;
+      recoveryCount: number;
+      maxRecoveries: number;
+      currentBaseSha: string;
+    };
+
+export type RecoveryDecision =
+  | { kind: "inspect"; candidate: RecoveryCandidate }
+  | { kind: "queue"; candidate: RecoveryCandidate; currentBaseSha: string }
+  | { kind: "retry"; reason: string; classificationAttempt?: number }
+  | { kind: "ineligible"; reason: string }
+  | { kind: "exhausted"; reason: string }
+  | { kind: "skip" };
+
+const refusalReason = (refusal: Extract<CandidateLoad, { kind: "refused" }>): string => {
+  switch (refusal.code) {
+    case "identity-incomplete": return "chain or repository identity is incomplete";
+    case "source-run-unbound": return "stop is not bound to an executor run";
+    case "evidence-invalid": return "base-drift evidence is malformed or is not a SHA-only drift payload";
+    case "source-run-mismatch": return "source executor run identity or terminal state does not match the stop";
+    case "chain-active": return "the chain has an active foreign run while recovery is being classified";
+    case "output-mismatch": return "executor output does not exactly match the recorded source stop";
+    case "tail-unresolved": return "current direct/compound regression and readiness tail cannot be resolved";
+    case "tail-state-mismatch": return "merge tail task state is not the completed-readiness/stopped-executor shape";
+    case "authorization-invalid": return `authorized readiness evidence is ${refusal.detail ?? "missing"}`;
+    case "intent-count": return "source executor run does not have exactly one server-bound merge intent";
+    case "intent-mismatch": return "executor intent does not match the selected authorization";
+    case "authorized-base-mismatch": return "stop evidence does not match the authorized base SHA";
+    case "readiness-head-mismatch": return "readiness output does not match the authorized head SHA";
+    case "target-unresolved": return `pull-request identity is ${refusal.detail ?? "unresolved"}`;
+    case "target-mismatch": return "resolved repository or pull-request identity differs from the authorization";
+    case "target-branch-mismatch": return "authorized target ref differs from the chain target branch";
+  }
+};
+
+const candidateDecision = (load: CandidateLoad): RecoveryDecision => {
+  if (load.kind === "skip") return { kind: "skip" };
+  if (load.kind === "candidate") return { kind: "inspect", candidate: load.candidate };
+  const reason = refusalReason(load);
+  return load.code === "chain-active" ? { kind: "retry", reason } : { kind: "ineligible", reason };
+};
+
+const candidatesMatch = (left: RecoveryCandidate, right: RecoveryCandidate): boolean => {
+  const fields: Array<keyof RecoveryCandidate> = [
+    "integratorTaskId", "readinessTaskId", "regressionTaskId", "sourceRunId", "stopId",
+    "authorizationActivityId", "repository", "prNumber", "targetBranch", "authorizedHeadSha",
+    "authorizedBaseSha", "observedBaseSha",
+  ];
+  return fields.every((field) => left[field] === right[field]);
+};
+
+/**
+ * Owns every base-drift recovery classification rule. The worker reads durable
+ * and remote facts, then applies this result; this module performs no I/O.
+ */
+export const recoveryDecision = (facts: RecoveryFacts): RecoveryDecision => {
+  switch (facts.stage) {
+    case "candidate":
+      return candidateDecision(facts.load);
+    case "reader-unavailable":
+      return { kind: "retry", reason: "server-side GitHub reader is unavailable" };
+    case "reader-failure":
+      return { kind: "retry", reason: facts.reason };
+    case "classification-retry": {
+      const classificationAttempt = facts.validationAttempts + 1;
+      if (classificationAttempt > facts.maxAttempts) {
+        return {
+          kind: "ineligible",
+          reason: `classification retry limit ${facts.maxAttempts} reached after transient failure: ${facts.reason}`,
+        };
+      }
+      return { kind: "retry", reason: facts.reason, classificationAttempt };
+    }
+    case "durable": {
+      if (!facts.aggregateValidating) return { kind: "skip" };
+      const loaded = candidateDecision(facts.load);
+      if (loaded.kind === "skip") {
+        return { kind: "ineligible", reason: "durable chain state changed during fresh recovery verification" };
+      }
+      if (loaded.kind !== "inspect") return loaded;
+      if (!candidatesMatch(loaded.candidate, facts.expected)) {
+        return { kind: "ineligible", reason: "durable chain state changed during fresh recovery verification" };
+      }
+      if (facts.recoveryCount >= facts.maxRecoveries) {
+        return {
+          kind: "exhausted",
+          reason: `automatic recovery limit ${facts.maxRecoveries} reached for ${facts.expected.repository}#${facts.expected.prNumber} targeting ${facts.expected.targetBranch}`,
+        };
+      }
+      return { kind: "queue", candidate: facts.expected, currentBaseSha: facts.currentBaseSha };
+    }
+    case "fresh":
+      break;
+  }
+
+  const { candidate, snapshot } = facts;
+  if (snapshot.repository !== candidate.repository || snapshot.number !== candidate.prNumber) {
+    return { kind: "ineligible", reason: "fresh repository or pull-request identity mismatches the authorization" };
+  }
+  if (snapshot.state !== "OPEN" || snapshot.merged !== false) {
+    return { kind: "ineligible", reason: "pull request is no longer an unmerged OPEN pull request" };
+  }
+  if (snapshot.isDraft !== false) {
+    return { kind: "ineligible", reason: "pull request draft state changed after authorization" };
+  }
+  if (snapshot.autoMergeRequest !== null || snapshot.mergeQueueEntry !== null) {
+    return { kind: "ineligible", reason: "pull request entered foreign automatic merge machinery" };
+  }
+  if (snapshot.baseRefName !== candidate.targetBranch) {
+    return { kind: "ineligible", reason: "target ref changed after authorization" };
+  }
+  if (snapshot.headRefOid !== candidate.authorizedHeadSha || snapshot.headCommitOid !== candidate.authorizedHeadSha) {
+    return { kind: "ineligible", reason: "pull-request head changed after authorization" };
+  }
+  if (!snapshot.baseSha || !/^[0-9a-f]{40}$/u.test(snapshot.baseSha) || snapshot.baseSha === candidate.authorizedBaseSha) {
+    return { kind: "ineligible", reason: "fresh target base does not prove an advanced SHA" };
+  }
+  if (!facts.comparisonAvailable) {
+    return { kind: "ineligible", reason: "server-side ancestry comparison is unavailable" };
+  }
+  if (!facts.authorizedAdvance) {
+    return { kind: "retry", reason: "authorized-base ancestry facts are incomplete" };
+  }
+  if (facts.authorizedAdvance.status !== "ahead" || facts.authorizedAdvance.behindBy !== 0) {
+    return {
+      kind: "ineligible",
+      reason: `target base change is not a forward advancement (${facts.authorizedAdvance.status}, behind_by=${facts.authorizedAdvance.behindBy})`,
+    };
+  }
+  if (candidate.observedBaseSha !== snapshot.baseSha) {
+    if (!facts.observedAdvance) {
+      return { kind: "retry", reason: "executor-observed-base ancestry facts are incomplete" };
+    }
+    if ((facts.observedAdvance.status !== "ahead" && facts.observedAdvance.status !== "identical")
+      || facts.observedAdvance.behindBy !== 0) {
+      return {
+        kind: "ineligible",
+        reason: `current target base does not descend from the executor-observed base (${facts.observedAdvance.status}, behind_by=${facts.observedAdvance.behindBy})`,
+      };
+    }
+  }
+  return { kind: "queue", candidate, currentBaseSha: snapshot.baseSha };
+};

--- a/packages/api/src/base-drift-recovery-decision.ts
+++ b/packages/api/src/base-drift-recovery-decision.ts
@@ -47,9 +47,9 @@ type Comparison = { status: string; behindBy: number };
 export type RecoveryPullRequestFacts = {
   repository: string;
   number: number;
-  state: string;
-  isDraft: boolean;
-  merged: boolean;
+  state: string | null;
+  isDraft: boolean | null;
+  merged: boolean | null;
   baseRefName: string | null;
   baseSha: string | null;
   headRefOid: string | null;

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -237,8 +237,6 @@ test("fresh server-owned readiness authorization alone activates the recovery me
 
 test("recovery holds the full chain mutex before mutation and a concurrent chain writer completes without deadlock or lost recovery", { timeout: 20_000 }, async () => {
   const seeded = await seedStopped("canonical-compound-readiness", "recovery-lock-order");
-  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
-  await recordRecoveryPass(seeded, BASE_2);
 
   let lockObserved!: () => void;
   let releaseRecovery!: () => void;
@@ -269,7 +267,7 @@ test("recovery holds the full chain mutex before mutation and a concurrent chain
   const writerDb = new PrismaClient({ datasources: { db: { url: process.env.TEST_DATABASE_URL! } } });
   const priorToken = process.env.OPERATOR_TOKEN;
   try {
-    const recovery = readinessTick(recoveryDb, reader(snapshot(BASE_2)), new Date(), 5, releaseChainLease, runWithMergeLease);
+    const recovery = baseDriftRecoveryTick(recoveryDb, reader(snapshot(BASE_2)));
     await recoveryHasChain;
     process.env.OPERATOR_TOKEN = OPERATOR;
     const writer = createApp(writerDb).request(`/tasks/${seeded.integratorTask!.id}`, {
@@ -280,15 +278,15 @@ test("recovery holds the full chain mutex before mutation and a concurrent chain
     await new Promise((resolve) => setTimeout(resolve, 50));
     releaseRecovery();
     const [tick, response] = await Promise.all([recovery, writer]);
-    assert.equal(tick.authorized, 1);
+    assert.equal(tick.recovered, 1);
     assert.equal(response.status, 200, await response.text());
   } finally {
     if (priorToken === undefined) delete process.env.OPERATOR_TOKEN;
     else process.env.OPERATOR_TOKEN = priorToken;
     await writerDb.$disconnect();
   }
-  assert.equal(await db.run.count({ where: { taskId: seeded.integratorTask!.id, status: "QUEUED" } }), 1);
-  assert.equal((await db.mergeRecoveryAttempt.findFirstOrThrow({ where: { integratorTaskId: seeded.integratorTask!.id } })).status, "SUCCEEDED");
+  assert.equal(await db.run.count({ where: { taskId: seeded.gateTask.id, status: "QUEUED" } }), 1);
+  assert.equal((await db.mergeRecoveryAttempt.findFirstOrThrow({ where: { integratorTaskId: seeded.integratorTask!.id } })).status, "REPAIRING");
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.integratorTask!.id } })).description, "concurrent writer completed after recovery");
 });
 

--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -11,6 +11,7 @@ import {
   enqueueTaskRun,
   isMergeReadinessStep,
   latestRecordedStop,
+  lockChainRows,
   openStopQuestion,
   parseMergeResult,
   REGRESSION_VERIFICATION_OUTPUT_KINDS,
@@ -26,6 +27,13 @@ import {
 } from "@agentos/db";
 
 import { createGitHubReader, type PullRequestReader, type PullRequestSnapshot } from "./github-read.js";
+import {
+  recoveryDecision,
+  type CandidateLoad,
+  type CandidateRefusalCode,
+  type RecoveryCandidate,
+  type RecoveryIdentity,
+} from "./base-drift-recovery-decision.js";
 import { stopMergeTail } from "./merge-tail-actions.js";
 
 type DbReader = PrismaClient | Prisma.TransactionClient;
@@ -36,28 +44,6 @@ export const baseDriftRecoveryPollIntervalMs = (): number => {
   const raw = Number(process.env.MERGE_BASE_DRIFT_RECOVERY_POLL_INTERVAL_MS);
   return Number.isFinite(raw) && raw >= 250 ? Math.floor(raw) : 2_000;
 };
-
-type RecoveryIdentity = {
-  repository: string;
-  prNumber: number;
-  targetBranch: string;
-  authorizedHeadSha: string;
-  authorizedBaseSha: string;
-  observedBaseSha: string;
-};
-
-type RecoveryCandidate = RecoveryIdentity & {
-  integratorTaskId: string;
-  readinessTaskId: string;
-  regressionTaskId: string;
-  sourceRunId: string;
-  stopId: string;
-  authorizationActivityId: string;
-};
-
-type CandidateLoad =
-  | { ok: true; candidate: RecoveryCandidate }
-  | { ok: false; reason: string; stopId: string; retryable: boolean };
 
 const recoveryAttemptFor = async (
   db: DbReader,
@@ -112,42 +98,62 @@ const parseBaseDriftEvidence = (evidence: string): { observed: string; authorize
   return { observed: record.observed, authorized: record.authorized };
 };
 
-const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<CandidateLoad | null> => {
+/**
+ * Base-drift recovery mutates the three merge-tail Steps together, so it uses
+ * the same ordered, whole-Chain mutex as every other chained-task writer.
+ * Chain identity is immutable after dispatch and can select that mutex before
+ * any mutable state is read.
+ */
+const lockRecoveryChain = async (
+  tx: Prisma.TransactionClient,
+  integratorTaskId: string,
+): Promise<boolean> => {
+  const identity = await tx.task.findUnique({
+    where: { id: integratorTaskId },
+    select: { projectId: true, chainId: true },
+  });
+  const chainId = identity?.chainId;
+  if (!identity || !chainId) return false;
+  const taskIds = await lockChainRows(tx, { projectId: identity.projectId, chainId });
+  return taskIds.includes(integratorTaskId);
+};
+
+const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<CandidateLoad> => {
   const task = await db.task.findUnique({
     where: { id: integratorTaskId },
     include: { templateStep: { include: { taskTemplate: { select: { name: true } } } }, repo: true },
   });
-  if (!task || !taskIsIntegratorStep(task)) return null;
+  if (!task || !taskIsIntegratorStep(task)) return { kind: "skip" };
   const stop = await latestRecordedStop(db as Prisma.TransactionClient, task.id);
-  if (!stop || stop.condition !== "base-drift") return null;
+  if (!stop || stop.condition !== "base-drift") return { kind: "skip" };
   const existingAttempt = await recoveryAttemptFor(db, task.id, stop.stopId);
-  if (existingAttempt && existingAttempt.status !== MergeRecoveryStatus.VALIDATING) return null;
-  const fail = (reason: string, retryable = false): CandidateLoad => ({
-    ok: false, reason, stopId: stop.stopId, retryable,
+  if (existingAttempt && existingAttempt.status !== MergeRecoveryStatus.VALIDATING) return { kind: "skip" };
+  const refuse = (code: CandidateRefusalCode, detail?: string): CandidateLoad => ({
+    kind: "refused", code, stopId: stop.stopId, ...(detail ? { detail } : {}),
   });
-  if (!task.chainId || task.chainIndex === null || !task.repoId || !task.repo) return fail("chain or repository identity is incomplete");
-  if (!stop.sourceRunId) return fail("stop is not bound to an executor run");
+  if (!task.chainId || task.chainIndex === null || !task.repoId || !task.repo) return refuse("identity-incomplete");
+  if (!stop.sourceRunId) return refuse("source-run-unbound");
   const evidence = parseBaseDriftEvidence(stop.evidence);
-  if (!evidence) return fail("base-drift evidence is malformed or is not a SHA-only drift payload");
+  if (!evidence) return refuse("evidence-invalid");
 
   const sourceRun = await db.run.findUnique({
     where: { id: stop.sourceRunId },
     include: { session: { select: { id: true } } },
   });
   if (!sourceRun || sourceRun.taskId !== task.id || sourceRun.status !== "SUCCEEDED" || !sourceRun.session) {
-    return fail("source executor run identity or terminal state does not match the stop");
+    return refuse("source-run-mismatch");
   }
   const active = await db.run.count({
     where: { task: { projectId: task.projectId, chainId: task.chainId }, status: { in: ACTIVE_RUN_STATUSES } },
   });
-  if (active !== 0) return fail("the chain has an active foreign run while recovery is being classified", true);
+  if (active !== 0) return refuse("chain-active");
 
   const output = await db.taskStepOutput.findUnique({ where: { taskId: task.id } });
   const outputResult = parseMergeResult(output);
   if (output?.runId !== sourceRun.id || output?.kind !== INTEGRATOR_OUTPUT_KIND
     || outputResult.outcome !== "stopped" || outputResult.condition !== "base-drift"
     || outputResult.evidence !== stop.evidence) {
-    return fail("executor output does not exactly match the recorded source stop");
+    return refuse("output-mismatch");
   }
 
   const [readiness, regression] = await Promise.all([
@@ -164,10 +170,10 @@ const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<Ca
     }),
   ]);
   if (!readiness || !isMergeReadinessStep(readiness.templateStep) || !regression) {
-    return fail("current direct/compound regression and readiness tail cannot be resolved");
+    return refuse("tail-unresolved");
   }
   if (task.status !== TaskStatus.REVIEW || readiness.status !== TaskStatus.DONE || regression.status !== TaskStatus.DONE) {
-    return fail("merge tail task state is not the completed-readiness/stopped-executor shape");
+    return refuse("tail-state-mismatch");
   }
 
   const activities = await db.taskActivity.findMany({
@@ -185,7 +191,7 @@ const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<Ca
   const selection = selectAuthorization(
     activities as CandidateActivity[], decisions as DecisionRow[], cards as CardRow[], readiness.id,
   );
-  if (!selection.authorization || selection.refusal) return fail(`authorized readiness evidence is ${selection.refusal ?? "missing"}`);
+  if (!selection.authorization || selection.refusal) return refuse("authorization-invalid", selection.refusal ?? "missing");
   const authorization = selection.authorization;
 
   const intentRows = await db.taskActivity.findMany({
@@ -193,28 +199,28 @@ const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<Ca
     orderBy: { createdAt: "asc" }, select: { metadata: true },
   });
   const intents = intentRows.map((row) => asJsonObject(row.metadata)).filter((metadata) => metadata?.sourceRunId === sourceRun.id);
-  if (intents.length !== 1) return fail("source executor run does not have exactly one server-bound merge intent");
+  if (intents.length !== 1) return refuse("intent-count");
   const intent = intents[0]!;
   if (intent.authorizationActivityId !== authorization.activityId
     || intent.prNumber !== authorization.prNumber || intent.headSha !== authorization.headSha) {
-    return fail("executor intent does not match the selected authorization");
+    return refuse("intent-mismatch");
   }
-  if (evidence.authorized !== authorization.baseSha) return fail("stop evidence does not match the authorized base SHA");
-  if (readiness.stepOutput?.commitSha !== authorization.headSha) return fail("readiness output does not match the authorized head SHA");
+  if (evidence.authorized !== authorization.baseSha) return refuse("authorized-base-mismatch");
+  if (readiness.stepOutput?.commitSha !== authorization.headSha) return refuse("readiness-head-mismatch");
 
   const target = await resolveChainTarget(db as Prisma.TransactionClient, task);
-  if (!target.resolved) return fail(`pull-request identity is ${target.unresolvable}`);
+  if (!target.resolved) return refuse("target-unresolved", target.unresolvable);
   if (target.repository !== authorization.repository || target.prNumber !== authorization.prNumber) {
-    return fail("resolved repository or pull-request identity differs from the authorization");
+    return refuse("target-mismatch");
   }
   const firstRun = await db.run.findFirst({
     where: { task: { projectId: task.projectId, chainId: task.chainId, chainIndex: { not: null } } },
     orderBy: [{ task: { chainIndex: "asc" } }, { runNumber: "asc" }], select: { targetBranch: true },
   });
   if (firstRun?.targetBranch !== authorization.baseRef || task.targetBranch !== authorization.baseRef) {
-    return fail("authorized target ref differs from the chain target branch");
+    return refuse("target-branch-mismatch");
   }
-  return { ok: true, candidate: {
+  return { kind: "candidate", candidate: {
     integratorTaskId: task.id,
     readinessTaskId: readiness.id,
     regressionTaskId: regression.id,
@@ -228,21 +234,6 @@ const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<Ca
     authorizedBaseSha: authorization.baseSha,
     observedBaseSha: evidence.observed,
   } };
-};
-
-const snapshotRefusal = (candidate: RecoveryCandidate, snapshot: PullRequestSnapshot): string | null => {
-  if (snapshot.repository !== candidate.repository || snapshot.number !== candidate.prNumber) return "fresh repository or pull-request identity mismatches the authorization";
-  if (snapshot.state !== "OPEN" || snapshot.merged !== false) return "pull request is no longer an unmerged OPEN pull request";
-  if (snapshot.isDraft !== false) return "pull request draft state changed after authorization";
-  if (snapshot.autoMergeRequest !== null || snapshot.mergeQueueEntry !== null) return "pull request entered foreign automatic merge machinery";
-  if (snapshot.baseRefName !== candidate.targetBranch) return "target ref changed after authorization";
-  if (snapshot.headRefOid !== candidate.authorizedHeadSha || snapshot.headCommitOid !== candidate.authorizedHeadSha) {
-    return "pull-request head changed after authorization";
-  }
-  if (!snapshot.baseSha || !SHA.test(snapshot.baseSha) || snapshot.baseSha === candidate.authorizedBaseSha) {
-    return "fresh target base does not prove an advanced SHA";
-  }
-  return null;
 };
 
 const openAbandonQuestion = async (
@@ -306,7 +297,7 @@ const settleIneligible = async (
   reason: string,
   identity?: Partial<RecoveryIdentity>,
 ): Promise<boolean> => db.$transaction(async (tx) => {
-  await tx.$queryRaw`SELECT "id" FROM "Task" WHERE "id" = ${integratorTaskId} FOR UPDATE`;
+  if (!await lockRecoveryChain(tx, integratorTaskId)) return false;
   const currentStop = await latestRecordedStop(tx, integratorTaskId);
   if (currentStop?.stopId !== stopId) return false;
   const existing = await recoveryAttemptFor(tx, integratorTaskId, stopId);
@@ -321,21 +312,30 @@ const recordClassificationRetry = async (
   stopId: string,
   reason: string,
 ): Promise<"retryable" | "ineligible" | "skipped"> => db.$transaction(async (tx) => {
-  await tx.$queryRaw`SELECT "id" FROM "Task" WHERE "id" = ${integratorTaskId} FOR UPDATE`;
+  if (!await lockRecoveryChain(tx, integratorTaskId)) return "skipped";
   const currentStop = await latestRecordedStop(tx, integratorTaskId);
   if (currentStop?.stopId !== stopId) return "skipped";
   const attempt = await ensureValidationAttemptLocked(tx, integratorTaskId, stopId);
   if (attempt.status !== MergeRecoveryStatus.VALIDATING) return "skipped";
-  const classificationAttempt = attempt.validationAttempts + 1;
-  if (classificationAttempt > MAX_BASE_DRIFT_CLASSIFICATION_RETRIES) {
+  const decision = recoveryDecision({
+    stage: "classification-retry",
+    reason,
+    validationAttempts: attempt.validationAttempts,
+    maxAttempts: MAX_BASE_DRIFT_CLASSIFICATION_RETRIES,
+  });
+  if (decision.kind === "ineligible") {
     await settleIneligibleLocked(
       tx,
       integratorTaskId,
       stopId,
-      `classification retry limit ${MAX_BASE_DRIFT_CLASSIFICATION_RETRIES} reached after transient failure: ${reason}`,
+      decision.reason,
     );
     return "ineligible";
   }
+  if (decision.kind !== "retry" || decision.classificationAttempt === undefined) {
+    throw new Error(`Unexpected classification retry decision ${decision.kind}`);
+  }
+  const classificationAttempt = decision.classificationAttempt;
   await tx.mergeRecoveryAttempt.update({
     where: { id: attempt.id },
     data: { validationAttempts: classificationAttempt, failureReason: reason },
@@ -354,24 +354,22 @@ const recordClassificationRetry = async (
   return "retryable";
 });
 
+type QueueRecoveryResult =
+  | { kind: "recovered" }
+  | { kind: "exhausted" }
+  | { kind: "skip" }
+  | { kind: "ineligible"; reason: string }
+  | { kind: "retry"; reason: string };
+
 const queueRecovery = async (
   db: PrismaClient,
   expected: RecoveryCandidate,
   currentBaseSha: string,
   now: Date,
-): Promise<"recovered" | "exhausted" | "skipped" | "ineligible" | "retryable"> => db.$transaction(async (tx) => {
-  await tx.$queryRaw`SELECT "id" FROM "Task" WHERE "id" = ${expected.integratorTaskId} FOR UPDATE`;
+): Promise<QueueRecoveryResult> => db.$transaction(async (tx) => {
+  if (!await lockRecoveryChain(tx, expected.integratorTaskId)) return { kind: "skip" };
   const aggregate = await ensureValidationAttemptLocked(tx, expected.integratorTaskId, expected.stopId, expected);
-  if (aggregate.status !== MergeRecoveryStatus.VALIDATING) return "skipped";
   const loaded = await loadCandidate(tx, expected.integratorTaskId);
-  if (!loaded) return "ineligible";
-  if (!loaded.ok) return loaded.retryable ? "retryable" : "ineligible";
-  const fields: Array<keyof RecoveryCandidate> = [
-    "integratorTaskId", "readinessTaskId", "regressionTaskId", "sourceRunId", "stopId",
-    "authorizationActivityId", "repository", "prNumber", "targetBranch", "authorizedHeadSha",
-    "authorizedBaseSha", "observedBaseSha",
-  ];
-  if (fields.some((field) => loaded.candidate[field] !== expected[field])) return "ineligible";
 
   // A recovery spends an attempt only once it owns a fresh regression Run.
   // Validation refusals remain visible aggregate rows but do not consume the
@@ -385,6 +383,19 @@ const queueRecovery = async (
     targetBranch: expected.targetBranch,
     recoveryRunId: { not: null },
   } });
+  const decision = recoveryDecision({
+    stage: "durable",
+    expected,
+    load: loaded,
+    aggregateValidating: aggregate.status === MergeRecoveryStatus.VALIDATING,
+    recoveryCount: attempts,
+    maxRecoveries: MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES,
+    currentBaseSha,
+  });
+  if (decision.kind === "skip") return { kind: "skip" };
+  if (decision.kind === "retry") return { kind: "retry", reason: decision.reason };
+  if (decision.kind === "ineligible") return { kind: "ineligible", reason: decision.reason };
+  if (decision.kind === "inspect") throw new Error("Durable recovery decision cannot request another remote inspection");
   const attempt = aggregate.attempt;
   const common = {
     sourceStopId: expected.stopId,
@@ -402,14 +413,13 @@ const queueRecovery = async (
     readinessTaskId: expected.readinessTaskId,
     regressionTaskId: expected.regressionTaskId,
   };
-  if (attempts >= MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES) {
-    const reason = `automatic recovery limit ${MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES} reached for ${expected.repository}#${expected.prNumber} targeting ${expected.targetBranch}`;
+  if (decision.kind === "exhausted") {
     await stopMergeTail(tx, {
       phase: "recovery-exhausted",
       aggregateId: aggregate.id,
       integratorTaskId: expected.integratorTaskId,
       sourceStopId: expected.stopId,
-      reason,
+      reason: decision.reason,
       at: now,
       attempt,
       recoveryData: {
@@ -428,7 +438,7 @@ const queueRecovery = async (
       markerMetadata: common,
     });
     await openAbandonQuestion(tx, expected.integratorTaskId, expected.stopId);
-    return "exhausted";
+    return { kind: "exhausted" };
   }
 
   await tx.task.update({ where: { id: expected.regressionTaskId }, data: { status: TaskStatus.TODO, failureReason: null } });
@@ -466,7 +476,7 @@ const queueRecovery = async (
     body: `Automatic base-drift recovery ${attempt} verifies ${expected.authorizedHeadSha} against current base ${currentBaseSha}`,
     metadata,
   });
-  return "recovered";
+  return { kind: "recovered" };
 });
 
 export type BaseDriftRecoveryTickResult = { examined: number; recovered: number; exhausted: number; ineligible: number };
@@ -497,82 +507,97 @@ export const baseDriftRecoveryTick = async (
       cursor = task.id;
       if (result.examined >= limit) break;
       const loaded = await loadCandidate(db, task.id);
-      if (!loaded) continue;
+      const candidateDecision = recoveryDecision({ stage: "candidate", load: loaded });
+      if (candidateDecision.kind === "skip") continue;
       result.examined += 1;
-      if (!loaded.ok) {
-        if (loaded.retryable) {
-          const outcome = await recordClassificationRetry(db, task.id, loaded.stopId, loaded.reason);
+      if (candidateDecision.kind === "retry" || candidateDecision.kind === "ineligible") {
+        if (loaded.kind !== "refused") throw new Error(`Candidate ${task.id} has no refusal binding`);
+        if (candidateDecision.kind === "retry") {
+          const outcome = await recordClassificationRetry(db, task.id, loaded.stopId, candidateDecision.reason);
           if (outcome === "ineligible") result.ineligible += 1;
-        } else if (await settleIneligible(db, task.id, loaded.stopId, loaded.reason)) {
+        } else if (await settleIneligible(db, task.id, loaded.stopId, candidateDecision.reason)) {
           result.ineligible += 1;
         }
         continue;
       }
-      const candidate = loaded.candidate;
+      if (candidateDecision.kind !== "inspect") {
+        throw new Error(`Unexpected candidate recovery decision ${candidateDecision.kind}`);
+      }
+      const candidate = candidateDecision.candidate;
       const validation = await db.$transaction(async (tx) => {
-        await tx.$queryRaw`SELECT "id" FROM "Task" WHERE "id" = ${candidate.integratorTaskId} FOR UPDATE`;
+        if (!await lockRecoveryChain(tx, candidate.integratorTaskId)) return false;
         const attempt = await ensureValidationAttemptLocked(tx, candidate.integratorTaskId, candidate.stopId, candidate);
         return attempt.status === MergeRecoveryStatus.VALIDATING;
       });
       if (!validation) continue;
       if (!reader) {
+        const decision = recoveryDecision({ stage: "reader-unavailable" });
+        if (decision.kind !== "retry") throw new Error(`Unexpected reader decision ${decision.kind}`);
         const outcome = await recordClassificationRetry(
-          db, task.id, candidate.stopId, "server-side GitHub reader is unavailable",
+          db, task.id, candidate.stopId, decision.reason,
         );
         if (outcome === "ineligible") result.ineligible += 1;
         continue;
       }
-    let snapshot: PullRequestSnapshot;
-    let advancementRefusal: string | null = null;
-    try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), 8_000);
+      let snapshot: PullRequestSnapshot;
+      let authorizedAdvance: { status: string; behindBy: number } | null = null;
+      let observedAdvance: { status: string; behindBy: number } | null = null;
       try {
-        snapshot = await reader.readPullRequest(candidate.repository, candidate.prNumber, candidate.targetBranch, controller.signal);
-        if (!reader.compareCommits) {
-          advancementRefusal = "server-side ancestry comparison is unavailable";
-        } else if (!snapshot.baseSha) {
-          advancementRefusal = "fresh target base SHA is unavailable";
-        } else {
-          const advanced = await reader.compareCommits(
-            candidate.repository, candidate.authorizedBaseSha, snapshot.baseSha, controller.signal,
-          );
-          if (advanced.status !== "ahead" || advanced.behindBy !== 0) {
-            advancementRefusal = `target base change is not a forward advancement (${advanced.status}, behind_by=${advanced.behindBy})`;
-          } else if (candidate.observedBaseSha !== snapshot.baseSha) {
-            const sinceStop = await reader.compareCommits(
-              candidate.repository, candidate.observedBaseSha, snapshot.baseSha, controller.signal,
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 8_000);
+        try {
+          snapshot = await reader.readPullRequest(candidate.repository, candidate.prNumber, candidate.targetBranch, controller.signal);
+          if (reader.compareCommits && snapshot.baseSha) {
+            authorizedAdvance = await reader.compareCommits(
+              candidate.repository, candidate.authorizedBaseSha, snapshot.baseSha, controller.signal,
             );
-            if ((sinceStop.status !== "ahead" && sinceStop.status !== "identical") || sinceStop.behindBy !== 0) {
-              advancementRefusal = `current target base does not descend from the executor-observed base (${sinceStop.status}, behind_by=${sinceStop.behindBy})`;
+            if (authorizedAdvance.status === "ahead" && authorizedAdvance.behindBy === 0
+              && candidate.observedBaseSha !== snapshot.baseSha) {
+              observedAdvance = await reader.compareCommits(
+                candidate.repository, candidate.observedBaseSha, snapshot.baseSha, controller.signal,
+              );
             }
           }
+        } finally {
+          clearTimeout(timer);
         }
-      } finally {
-        clearTimeout(timer);
+      } catch (error: unknown) {
+        const decision = recoveryDecision({
+          stage: "reader-failure",
+          reason: `fresh server-side repository read failed (${error instanceof Error ? error.name : "unknown error"})`,
+        });
+        if (decision.kind !== "retry") throw new Error(`Unexpected reader failure decision ${decision.kind}`);
+        const outcome = await recordClassificationRetry(db, task.id, candidate.stopId, decision.reason);
+        if (outcome === "ineligible") result.ineligible += 1;
+        continue;
       }
-    } catch (error: unknown) {
-      const reason = `fresh server-side repository read failed (${error instanceof Error ? error.name : "unknown error"})`;
-      const outcome = await recordClassificationRetry(db, task.id, candidate.stopId, reason);
-      if (outcome === "ineligible") result.ineligible += 1;
-      continue;
-    }
-    const refusal = snapshotRefusal(candidate, snapshot) ?? advancementRefusal;
-    if (refusal) {
-      if (await settleIneligible(db, task.id, candidate.stopId, refusal, candidate)) result.ineligible += 1;
-      continue;
-    }
-    const outcome = await queueRecovery(db, candidate, snapshot.baseSha!, now);
-    if (outcome === "recovered") result.recovered += 1;
-    else if (outcome === "exhausted") result.exhausted += 1;
-    else if (outcome === "ineligible") {
-      if (await settleIneligible(db, task.id, candidate.stopId, "durable chain state changed during fresh recovery verification", candidate)) result.ineligible += 1;
-    } else if (outcome === "retryable") {
-      const retry = await recordClassificationRetry(
-        db, task.id, candidate.stopId, "the chain became temporarily active during durable recovery verification",
-      );
-      if (retry === "ineligible") result.ineligible += 1;
-    }
+      const fresh = recoveryDecision({
+        stage: "fresh",
+        candidate,
+        snapshot,
+        comparisonAvailable: reader.compareCommits !== undefined,
+        authorizedAdvance,
+        observedAdvance,
+      });
+      if (fresh.kind === "ineligible") {
+        if (await settleIneligible(db, task.id, candidate.stopId, fresh.reason, candidate)) result.ineligible += 1;
+        continue;
+      }
+      if (fresh.kind === "retry") {
+        const outcome = await recordClassificationRetry(db, task.id, candidate.stopId, fresh.reason);
+        if (outcome === "ineligible") result.ineligible += 1;
+        continue;
+      }
+      if (fresh.kind !== "queue") throw new Error(`Unexpected fresh recovery decision ${fresh.kind}`);
+      const outcome = await queueRecovery(db, candidate, fresh.currentBaseSha, now);
+      if (outcome.kind === "recovered") result.recovered += 1;
+      else if (outcome.kind === "exhausted") result.exhausted += 1;
+      else if (outcome.kind === "ineligible") {
+        if (await settleIneligible(db, task.id, candidate.stopId, outcome.reason, candidate)) result.ineligible += 1;
+      } else if (outcome.kind === "retry") {
+        const retry = await recordClassificationRetry(db, task.id, candidate.stopId, outcome.reason);
+        if (retry === "ineligible") result.ineligible += 1;
+      }
     }
     if (tasks.length < pageSize) break;
   }


### PR DESCRIPTION
## Summary

- add a pure `recoveryDecision(facts)` seam for candidate, GitHub freshness, retry, durable recheck, exhaustion, queue, and skip outcomes
- route all recovery-validation and recovery-exhausted stop outcomes through the existing `stopMergeTail` entrypoint
- replace four single-row task locks with the canonical ordered whole-Chain `lockChainRows` mutex
- correct the lock-order dbtest so it runs `baseDriftRecoveryTick` under contention instead of testing `readinessTick`

## Decisions

1. I chose the full Chain mutex rather than documenting a special single-row lock. Recovery writes the regression, readiness, and integrator Steps in one transaction, so locking only the integrator row would not protect the actual write set and would preserve a second lock order.
2. I made `recoveryDecision` pure and staged rather than letting it own DB or GitHub reads. This keeps the I/O adapter in the worker, makes the decision interface the no-DB test surface, and centralizes reason text and outcome policy without inventing another remote-reader port.
3. I retained the existing `stopMergeTail` recovery phases for ineligible and exhausted outcomes. The new seam decides; the established merge-tail module applies terminal state, markers, inbox notice, and lease disposition. No additional stop implementation was added.
4. The unit table covers all 16 durable candidate classifications (15 terminal refusals plus the transient active-Chain retry), all 7 fresh pull-request refusals, ancestry refusals, retry limits, queue, exhaustion, and skip. This exceeds the original 21-path evidence set because current `main` has one additional explicit fresh-base refusal.
5. `main` advanced with merge-train documentation while this lane was running. I integrated it with a merge commit, per the append-only/no-rebase rule; it did not overlap the lane L code surface.

## Verification

- `npm run lint`
- `node --import tsx --test packages/api/src/base-drift-recovery-decision.test.ts`
- `npm test -w @agentos/api` (585 tests, 584 pass, 1 skipped)
- `npm run test:db -w @agentos/api -- src/merge-base-drift-recovery.dbtest.ts` (16 pass, disposable PostgreSQL and isolated `RUNNER_WORKSPACE_ROOT`)
