### PR TITLE
chore: remove video provenance references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ dist/
 .DS_Store
 *.log
 packages/db/generated/
-docs/reference/danny-agentos-video/frames/

--- a/README.md
+++ b/README.md
@@ -198,10 +198,6 @@ the authoritative support statement.
 
 ## Credits and license
 
-An independent build inspired by Danny Postma's video *How I Built My Own
-AgentOS on Claude's Agent SDK (So You Can Too)* (2026), written from scratch
-from the ideas in it.
-
 The chain's role and step prompts owe more than inspiration: five skills from
 [mattpocock/skills](https://github.com/mattpocock/skills) supply their working
 text, carried verbatim and wrapped in paragraphs written here for this

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,9 +173,6 @@ AgentOS 是个人项目，不承诺提供支持或响应时间。安全报告请
 
 ## 致谢与许可证
 
-本项目是受 Danny Postma 的视频 *How I Built My Own AgentOS on Claude's Agent
-SDK (So You Can Too)*（2026）启发的独立实现，从视频中的想法出发从零构建。
-
 任务链的角色与步骤提示词欠的不止是启发：其行文主体来自
 [mattpocock/skills](https://github.com/mattpocock/skills) 的五个技能，逐字沿用，
 外面包着为本平台契约另写的段落。上游以 MIT 授权，`Copyright (c) 2026 Matt

--- a/agents/README.md
+++ b/agents/README.md
@@ -2,7 +2,7 @@
 
 Source-of-truth files for canonical agent prompts and initial runtime defaults, the mechanical merge sentinel, and task-template step prompts. The seed script imports these into the `Agent`, join, and `TaskTemplateStep` tables; `packages/db/prisma/seed.ts` is the consumer. Models and runners changed by the operator in the console are persisted runtime overrides and are not replaced by seed or canonical prompt sync. Skills remain an API-managed concept (`Skill` / `AgentSkill`), but no canonical skill is seeded from this directory.
 
-All prompts here are reconstructed from BLUEPRINT.md (itself reconstructed from Danny Postma's talk); none are his verbatim files. The chain prompts with an upstream counterpart in [mattpocock/skills](https://github.com/mattpocock/skills) do carry that text verbatim, wrapped in paragraphs written here for this platform's contracts; the notice is in [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md).
+The chain prompts with an upstream counterpart in [mattpocock/skills](https://github.com/mattpocock/skills) do carry that text verbatim, wrapped in paragraphs written here for this platform's contracts; the notice is in [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md).
 
 ## Layout
 

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 
-/** Thin-line 16px icons in the shape of the reference sidebar set
- *  (design-reference/ui-notes.md §1). */
+/** Thin-line 16px icons used by the sidebar. */
 
 const Svg = ({ children, size = 16 }: { children: ReactNode; size?: number }): ReactNode => (
   <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.3"

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -19,9 +19,7 @@
   --radius-lg: var(--radius); --radius-xl: var(--radius-card); --font-mono: var(--mono);
 }
 
-/* AgentOS web — visual language copied from design-reference/ (Danny Postma's
-   AgentOS): warm-olive near-black, a single yellow accent, mono everywhere.
-   Token names follow design-reference/ui-notes.md §0. */
+/* AgentOS web — warm-olive near-black, a single yellow accent, mono everywhere. */
 
 :root {
   --background:#f6f2e7; --foreground:#252116; --card:#fffdf7; --card-foreground:#252116;

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -188,11 +188,6 @@
       "reason": "internal agent-chain specifications, session identifiers, plans, and review records are operator workflow state rather than product source"
     },
     {
-      "glob": "BLUEPRINT.md",
-      "disposition": "later-release-follow-up",
-      "reason": "private upstream product requirements require a separate publication decision"
-    },
-    {
       "glob": "CLAUDE.md",
       "disposition": "later-release-follow-up",
       "reason": "symlink to AGENTS.md, skipped to avoid divergent copies: the snapshot's file list is what an exporter copies, and an exporter that dereferences it would publish the same instructions twice as two real files that can be edited apart. AGENTS.md is published as the one truth; republishing the link is a decision to make when a snapshot tool can carry a symlink as a symlink."
@@ -211,11 +206,6 @@
       "glob": "deploy/**",
       "disposition": "later-release-follow-up",
       "reason": "host-specific deployment material requires environment and path review"
-    },
-    {
-      "glob": "design-reference/**",
-      "disposition": "later-release-follow-up",
-      "reason": "internal design references and image provenance require separate review"
     },
     {
       "glob": "docs/BACKLOG*.md",
@@ -241,11 +231,6 @@
       "glob": "docs/plans/**",
       "disposition": "later-release-follow-up",
       "reason": "internal plans and generated baseline images require separate review"
-    },
-    {
-      "glob": "docs/reference/**",
-      "disposition": "later-release-follow-up",
-      "reason": "third-party research records and provenance require separate review"
     },
     {
       "glob": "docs/release/private/**",


### PR DESCRIPTION
Remove the Danny Postma video attribution and related design-reference remnants from the public snapshot, while preserving the Matt Pocock third-party license notice.