### PR TITLE
docs: rename the product to Anneal in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 <div align="center">
 
-# AgentOS
+# Anneal
 
 **AI can write code now. Nobody has the capacity to review all of it.**
 
-AgentOS is the part that reviews it: a local control plane for coding agents.
+Anneal is the part that reviews it: a local control plane for coding agents.
 You write the spec. A chain takes it from there — plan, review, implement,
 verify, merge — and every run stays observable and reviewable.
+
+*Annealing is the heat treatment that relieves the internal stresses left in
+worked metal. The defects come out in the process.*
 
 [![status](https://img.shields.io/badge/status-developer%20preview-orange)](#status)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
@@ -15,19 +18,19 @@ verify, merge — and every run stays observable and reviewable.
 
 [Install](#quick-start) · [Docs](#documentation) · [Status](#status) · [简体中文](README.zh-CN.md)
 
-<img src="docs/media/tasks.png" alt="AgentOS task board: template chains in flight, each card showing its step, run status, model and cost" width="880">
+<img src="docs/media/tasks.png" alt="Anneal task board: template chains in flight, each card showing its step, run status, model and cost" width="880">
 
 </div>
 
 ## What it is
 
-AgentOS connects tasks, agents, repository and file grants, isolated run
+Anneal connects tasks, agents, repository and file grants, isolated run
 records, provider event streams, human questions, review gates and git delivery
 into one workflow that runs entirely on your own machine.
 
 It orchestrates the official Codex CLI, Claude Code and Pi that you have
 already installed and signed in to, so the subscription logins those CLIs
-already hold are what it runs on. AgentOS supplies no credential of its own and
+already hold are what it runs on. Anneal supplies no credential of its own and
 resells no subscription. See
 [Authentication and subscriptions](#authentication-and-subscriptions).
 
@@ -75,10 +78,10 @@ can check. Making it checkable is the next preview's job.
 
 ## The twelve-step chain
 
-The Full Assurance template that ships with AgentOS. Every step binds a role,
+The Full Assurance template that ships with Anneal. Every step binds a role,
 and every role carries its own runner, model and reasoning effort.
 
-`Sol` and `Luna` in the table below are not AgentOS names: they are the GPT-5.6
+`Sol` and `Luna` in the table below are not Anneal names: they are the GPT-5.6
 variants the Codex CLI exposes, bound as `gpt-5.6-sol` and `gpt-5.6-luna`.
 
 <details>
@@ -123,10 +126,10 @@ seed.
 > shapes may change between preview releases, and the only upgrade path is a
 > fresh install.
 >
-> **Host execution.** AgentOS launches coding CLIs with non-interactive
+> **Host execution.** Anneal launches coding CLIs with non-interactive
 > permission bypass. By default they run as your macOS user, outside a sandbox,
-> with that user's filesystem and network authority. AgentOS grants constrain
-> AgentOS APIs; they are not host containment. Use a disposable repository and a
+> with that user's filesystem and network authority. Anneal grants constrain
+> Anneal APIs; they are not host containment. Use a disposable repository and a
 > machine you are willing to let an agent modify.
 
 ## Quick start
@@ -137,8 +140,8 @@ Docker Compose, Git, and the official Codex CLI already signed in under the same
 macOS account. Claude Code and Pi are optional.
 
 ```sh
-git clone https://github.com/mosonlab/agentos.git
-cd agentos
+git clone https://github.com/mosonlab/anneal.git
+cd anneal
 git checkout v0.3.0
 npm ci
 npm run setup:local
@@ -162,23 +165,23 @@ recorded in [`docs/release/support-matrix.md`](docs/release/support-matrix.md),
 the authoritative support statement. It describes evidence held in this
 repository, not compatibility promises by the CLI providers.
 
-AgentOS targets macOS on Apple Silicon. Linux is unverified, and Windows is
+Anneal targets macOS on Apple Silicon. Linux is unverified, and Windows is
 unsupported by design: the runner relies on POSIX process-group, path and
 command behavior.
 
 Provider CLIs, accounts, authentication, subscriptions, usage allowances, rate
-limits, models, and provider-side availability remain yours. AgentOS supplies no
+limits, models, and provider-side availability remain yours. Anneal supplies no
 provider credential and no entitlement.
 
 ## Authentication and subscriptions
 
-AgentOS holds no provider credential. It launches the official CLIs you have
+Anneal holds no provider credential. It launches the official CLIs you have
 already installed and signed in to (Codex CLI, Claude Code and Pi), and their
 authentication stays where each CLI keeps it, in that CLI's own configuration.
-AgentOS neither reads it nor forwards it, and there is no AgentOS account, no
+Anneal neither reads it nor forwards it, and there is no Anneal account, no
 API proxy and no key to paste in.
 
-Whatever authentication those CLIs support is therefore what AgentOS runs on: a
+Whatever authentication those CLIs support is therefore what Anneal runs on: a
 ChatGPT subscription login, a Claude Pro/Max login, or each CLI's own API-key
 mode, exactly as you already configured it. Pi carries no account of its own
 either: it authenticates through the Codex login.
@@ -192,7 +195,7 @@ and `Authorization` ([`docs/release/security.md`](docs/release/security.md)).
 
 None of that settles a provider's terms for you. Plan limits,
 rate limits, usage allowances, and whether your plan permits this kind of
-orchestration are between you and the provider. AgentOS grants no entitlement
+orchestration are between you and the provider. Anneal grants no entitlement
 and makes no compatibility promise for a CLI provider.
 
 ## Documentation
@@ -211,7 +214,7 @@ and makes no compatibility promise for a CLI provider.
 
 ## Support
 
-AgentOS is a personal project with no support or response-time commitments. Send
+Anneal is a personal project with no support or response-time commitments. Send
 security reports through the private channel in [`SECURITY.md`](SECURITY.md),
 and see [`docs/release/support-matrix.md`](docs/release/support-matrix.md) for
 the authoritative support statement.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,11 +1,13 @@
 <div align="center">
 
-# AgentOS
+# Anneal
 
 **AI 现在能写代码了，但没人有能力审完它写的东西。**
 
-AgentOS 就是负责审的那一层：面向 coding agent 的本地控制平面。你只写规格，
+Anneal 就是负责审的那一层：面向 coding agent 的本地控制平面。你只写规格，
 剩下的交给一条链——计划、评审、实现、验证、合入，每一次 run 都可观察、可评审。
+
+*退火是消除金属加工后内应力的热处理工序。缺陷在工序里被消掉，而不是留到成品上。*
 
 [![status](https://img.shields.io/badge/status-developer%20preview-orange)](#支持状态)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
@@ -20,11 +22,11 @@ AgentOS 就是负责审的那一层：面向 coding agent 的本地控制平面�
 
 ## 这是什么
 
-AgentOS 把任务、agent、仓库与文件授权、独立的运行记录、provider 事件流、人工
+Anneal 把任务、agent、仓库与文件授权、独立的运行记录、provider 事件流、人工
 提问、评审关卡和 git 交付串成一个工作流，全部跑在你自己的机器上。
 
 它编排的是你已经安装并完成认证的官方 Codex CLI、Claude Code 与 Pi：这些 CLI
-手里已有的订阅登录，就是它运行所依赖的全部认证。AgentOS 自己不提供任何凭据，
+手里已有的订阅登录，就是它运行所依赖的全部认证。Anneal 自己不提供任何凭据，
 也不转售任何订阅，详见[认证与订阅](#认证与订阅)。
 
 ## 它改变了什么
@@ -62,10 +64,10 @@ Mac 上完成。第一个预览版到第三个预览版之间的八天，从里�
 
 ## 十二步任务链
 
-AgentOS 自带的 Full Assurance 模板。每一步绑定一个角色，每个角色自带 runner、
+Anneal 自带的 Full Assurance 模板。每一步绑定一个角色，每个角色自带 runner、
 模型与推理档位。
 
-下表里的 `Sol` 与 `Luna` 不是 AgentOS 造的词，是 Codex CLI 暴露的 GPT-5.6 变体，
+下表里的 `Sol` 与 `Luna` 不是 Anneal 造的词，是 Codex CLI 暴露的 GPT-5.6 变体，
 绑定名为 `gpt-5.6-sol` 与 `gpt-5.6-luna`。
 
 <details>
@@ -107,9 +109,9 @@ AgentOS 自带的 Full Assurance 模板。每一步绑定一个角色，每个�
 > **Developer Preview 3（v0.3.0）。** 接口、配置与已存数据的形状都可能在预览版
 > 之间变动，预览版之间除全新安装外没有升级路径。
 >
-> **裸机执行警告。** AgentOS 会用非交互式 permission bypass 启动 coding CLI。
+> **裸机执行警告。** Anneal 会用非交互式 permission bypass 启动 coding CLI。
 > 默认安装下它们以你的 macOS 用户身份、在 sandbox 之外运行，拥有该用户的文件
-> 系统与网络权限。AgentOS grant 约束的是 AgentOS API，不构成 host containment。
+> 系统与网络权限。Anneal grant 约束的是 Anneal API，不构成 host containment。
 > 只用可丢弃仓库，以及你愿意让 agent 修改的机器。
 
 ## 快速开始
@@ -120,8 +122,8 @@ Git，以及在同一 macOS 账号下**已安装且已登录**的官方 Codex CL
 Pi 都是可选的。
 
 ```sh
-git clone https://github.com/mosonlab/agentos.git
-cd agentos
+git clone https://github.com/mosonlab/anneal.git
+cd anneal
 git checkout v0.3.0
 npm ci
 npm run setup:local
@@ -145,19 +147,19 @@ Developer Preview。支持范围以及每一条主张背后的证据，记录在
 声明（仅英文）。它描述的是本仓库内记录的证据，不是 CLI provider 作出的兼容性
 承诺。
 
-AgentOS 的目标平台是 Apple Silicon 上的 macOS。Linux 未验证；Windows 按设计不
+Anneal 的目标平台是 Apple Silicon 上的 macOS。Linux 未验证；Windows 按设计不
 支持：runner 依赖 POSIX 进程组、路径和命令行为。
 
 Provider CLI、账号、认证、订阅、用量、速率限制、模型和 provider 侧可用性均由你
-自己负责。AgentOS 不提供 provider 凭据，也不提供使用资格。
+自己负责。Anneal 不提供 provider 凭据，也不提供使用资格。
 
 ## 认证与订阅
 
-AgentOS 不持有任何 provider 凭据。它启动的是你本机已经安装并登录的官方 CLI
-（Codex CLI、Claude Code 与 Pi），认证状态留在各个 CLI 自己的配置里，AgentOS
-既不读取也不转发。这里没有 AgentOS 账号，没有 API 反代，也没有要你粘贴的 key。
+Anneal 不持有任何 provider 凭据。它启动的是你本机已经安装并登录的官方 CLI
+（Codex CLI、Claude Code 与 Pi），认证状态留在各个 CLI 自己的配置里，Anneal
+既不读取也不转发。这里没有 Anneal 账号，没有 API 反代，也没有要你粘贴的 key。
 
-因此这些 CLI 支持哪种认证，AgentOS 就跑在哪种之上：ChatGPT 订阅登录、Claude
+因此这些 CLI 支持哪种认证，Anneal 就跑在哪种之上：ChatGPT 订阅登录、Claude
 Pro/Max 登录，或各 CLI 自己的 API key 模式，完全按你已经配好的样子。Pi 同样没有
 自己的账号，它走的是 Codex 那份登录。
 
@@ -167,7 +169,7 @@ Pro/Max 登录，或各 CLI 自己的 API key 模式，完全按你已经配好�
 bearer header 与 `Authorization`（[`docs/release/security.md`](docs/release/security.md)）。
 
 这些都不能替你裁定 provider 的条款。套餐额度、速率限制、用量配额，以及你的套餐是否
-允许这种编排方式，都在你和 provider 之间。AgentOS 不授予任何权益，也不替 CLI
+允许这种编排方式，都在你和 provider 之间。Anneal 不授予任何权益，也不替 CLI
 provider 作出兼容性承诺。
 
 ## 文档
@@ -183,7 +185,7 @@ provider 作出兼容性承诺。
 
 ## 支持
 
-AgentOS 是个人项目，不承诺提供支持或响应时间。安全报告请通过
+Anneal 是个人项目，不承诺提供支持或响应时间。安全报告请通过
 [`SECURITY.md`](SECURITY.md) 中的私密渠道提交；权威支持声明见
 [`docs/release/support-matrix.md`](docs/release/support-matrix.md)。
 


### PR DESCRIPTION
`AgentOS` is unfindable on GitHub. `rivet-dev/agentos` (4.4k stars) is an exact name match, `buildermethods/agent-os` (5.3k) holds the hyphenated form, and `ag2ai/ag2` (4.9k) advertises itself as "The Open-Source AgentOS". Searching the old name never surfaced this project, so the name was a permanent discovery handicap rather than a cosmetic one.

`Anneal` is the heat treatment that relieves the internal stresses left in worked metal — the defects come out in the process rather than at the scrap heap. That is what the chain does to code an agent wrote, so both READMEs carry a one-line gloss and the name reads as a claim instead of a label.

Scope is the public face only: the repository is renamed to `mosonlab/anneal` (GitHub redirects the old URL, so no external link breaks) and both READMEs carry the new product name and clone URL. Internal package names, launchd service names and filesystem paths still say `agentos`; they are migrated separately.

Verified: `npm run lint` and `npm run test:snapshot-scan` both pass.