### PR TITLE
fix(runner): preserve Codex resume authorization

### DIFF
--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -542,6 +542,14 @@ test("Codex fresh and resume launches pin the Run service tier explicitly", () =
   }
 });
 
+test("Codex fresh and resume launches preserve non-interactive tool authorization", () => {
+  const spec = runSpec();
+  const resume = { ...spec, providerConversationId: "thread-1", input: "continue" };
+  for (const args of [argsForRunner("CODEX", spec), argsForRunner("CODEX", spec, resume)]) {
+    assert.ok(args.includes("--dangerously-bypass-approvals-and-sandbox"));
+  }
+});
+
 test("native implementation subagents are pinned on fresh and resumed Codex launches", () => {
   const executioner = {
     ...claim,

--- a/packages/runner/src/adapters/codex.ts
+++ b/packages/runner/src/adapters/codex.ts
@@ -90,7 +90,8 @@ export const codexArgs = (spec: RunSpec, resume?: ResumeSpec): string[] => {
       ...(effort ? ["-c", `model_reasoning_effort="${effort}"`] : []),
       "-c", `service_tier="${serviceTier}"`,
       ...nativeSubagentArgs(spec.claim.run),
-      ...mcpArgs(spec.credentialsPath), resume.providerConversationId, "-",
+      ...mcpArgs(spec.credentialsPath),
+      "--dangerously-bypass-approvals-and-sandbox", resume.providerConversationId, "-",
     ]
     : [
       "exec", "--json", "-m", model,


### PR DESCRIPTION
## Problem

Codex fresh launches bypass interactive approvals, but resumed launches omit the same flag. Missing-output remediation therefore resumes inside the sandbox, cannot invoke AgentOS MCP under approval policy `never`, and cannot reach the loopback control plane as a fallback.

## Fix

Pass `--dangerously-bypass-approvals-and-sandbox` to Codex resume launches and assert fresh/resume authorization symmetry.

## Verification

- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) node --import tsx --test packages/runner/src/adapters.test.ts` (69/69)
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) node --import tsx --test packages/runner/src/run-output.test.ts` (12/12)
- `npm run lint`