### PR TITLE
fix(runner): settle persisted regression verdicts

### DIFF
--- a/packages/runner/src/run-output.test.ts
+++ b/packages/runner/src/run-output.test.ts
@@ -317,7 +317,7 @@ test("a successful run's completion carries its final output as the same tail", 
   }
 });
 
-test("a negative Regression verdict persists even when provider transport fails afterwards", async () => {
+test("a negative Regression verdict settles mechanically when provider transport fails afterwards", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-regression-transport-failure-"));
   try {
     const remote = await seedRemote(root);
@@ -347,7 +347,12 @@ test("a negative Regression verdict persists even when provider transport fails 
       baseHeadSha: "b".repeat(40),
       summary: "RF-2 remains open",
     });
-    assert.equal(controlPlane.completions.at(-1)?.terminalSuccess, false);
+    const completion = controlPlane.completions.at(-1);
+    assert.equal(completion?.terminalSuccess, true);
+    assert.equal(completion?.exitCode, 0);
+    assert.equal(completion?.signal, null);
+    assert.equal(completion?.terminalEventSeen, true);
+    assert.equal(completion?.terminationReason, null);
     assert.ok(controlPlane.eventBatches.flat().some(({ type }) => type === "REGRESSION_OUTPUT_HANDOFF_PERSISTED"));
     assert.equal(
       controlPlane.eventBatches.flat().some(({ type }) => type === "TASK_OUTPUT_REMEDIATION_STARTED"),

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -730,7 +730,13 @@ export const executeClaim = async (
       });
       return;
     }
-    const executionSucceeded = adapterExecutionSucceeded(evidence)
+    // A validated, fenced Regression handoff is the step's terminal product.
+    // Provider diagnostics that arrive after it must remain observable without
+    // turning the completed verification into another model retry.
+    const regressionMechanicallySettled = regressionHandoffPersisted
+      && remediationFailureReason === null
+      && budgetReason === null;
+    const executionSucceeded = (adapterExecutionSucceeded(evidence) || regressionMechanicallySettled)
       && remediationFailureReason === null
       && budgetReason === null;
     let delivery: Awaited<ReturnType<typeof deliverWorkspace>> | null = null;
@@ -817,20 +823,30 @@ export const executeClaim = async (
     // one heartbeat interval old — half the lease — and the completion call is
     // itself bounded by RUNNER_API_TIMEOUT_MS, so it cannot outlive that.
     lease.close();
+    const acceptedEvidence = regressionMechanicallySettled
+      ? {
+        ...evidence,
+        exitCode: 0,
+        signal: null,
+        terminalEventSeen: true,
+        terminalSuccess: true,
+        terminationReason: null,
+      }
+      : evidence;
     // The primary provider may have ended cleanly while the required
     // remediation protocol failed afterwards. Reflect that protocol failure in
     // the structured envelope too; otherwise the API correctly distrusts the
     // runner's asserted class and would classify the clean primary evidence as
     // TASK_FAILED instead of PROTOCOL_ERROR.
     const completionEvidence = remediationFailureReason
-      ? { ...evidence, terminalSuccess: false }
-      : evidence;
+      ? { ...acceptedEvidence, terminalSuccess: false }
+      : acceptedEvidence;
     await controlPlane.completeRun(config, claim, {
-      exitCode: evidence.exitCode,
-      signal: evidence.signal,
-      terminalEventSeen: evidence.terminalEventSeen,
-      terminalSuccess: succeeded && evidence.terminalSuccess,
-      terminationReason: budgetReason ?? evidence.terminationReason,
+      exitCode: completionEvidence.exitCode,
+      signal: completionEvidence.signal,
+      terminalEventSeen: completionEvidence.terminalEventSeen,
+      terminalSuccess: succeeded && completionEvidence.terminalSuccess,
+      terminationReason: budgetReason ?? completionEvidence.terminationReason,
       ...(classified ? { failureClass: classified.failureClass, retryable: classified.retryable } : {}),
       // A salvage push failure must not mask why the run itself failed.
       ...(!succeeded ? {
@@ -853,7 +869,7 @@ export const executeClaim = async (
           evidence: completionEvidence,
           deliveryFailure,
           runnerClass: classified?.failureClass ?? null,
-          terminationReason: budgetReason ?? evidence.terminationReason,
+          terminationReason: budgetReason ?? completionEvidence.terminationReason,
         }),
       }),
       ...gitResult,


### PR DESCRIPTION
## Summary
- treat a validated fenced Regression handoff as the step's terminal success
- retain provider trailing failures as diagnostics without spending another Run
- keep missing, invalid, cancelled, timed-out, and delivery-failed paths fail-closed

## Verification
- targeted Runner output and handoff tests
- Runner typecheck
- Biome lint
- production Run reproduced provider PROTOCOL_ERROR after an exact-head PASS handoff; the verdict persisted but the Run retried, motivating this settlement follow-up