### PR TITLE
fix(db): align regression verifier effort contract

### DIFF
--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   assertCanonicalAgentSources,
   CANONICAL_AGENT_DEFAULTS,
+  CANONICAL_AGENT_RUNTIME_TRANSITIONS,
   catalogRunnerForModel,
   DIRECT_TEMPLATE_NAME,
 } from "../src/agent-contract.js";
@@ -110,8 +111,12 @@ test("signed AgentOS model routing stays pinned in the canonical contract", () =
   });
   assert.deepEqual(canonical.get("regression-verifier"), {
     name: "regression-verifier",
-    model: "gpt-5.6-luna:max",
+    model: "gpt-5.6-luna:xhigh",
     runner: RunnerPreference.CODEX,
+  });
+  assert.deepEqual(CANONICAL_AGENT_RUNTIME_TRANSITIONS.get("regression-verifier"), {
+    from: { model: "gpt-5.6-luna:max", runnerPreference: RunnerPreference.CODEX },
+    to: { model: "gpt-5.6-luna:xhigh", runnerPreference: RunnerPreference.CODEX },
   });
   assert.deepEqual(canonical.get("librarian"), {
     name: "librarian",
@@ -175,7 +180,7 @@ test("the split review prompts enforce persisted-range, blindness, and regressio
   assert.doesNotMatch(blindReview, /service[-_ ]tier/iu);
   assert.doesNotMatch(blindReview, /codex exec review/u);
 
-  assert.equal(frontmatterValue(regressionVerification, "model"), "gpt-5.6-luna:max");
+  assert.equal(frontmatterValue(regressionVerification, "model"), "gpt-5.6-luna:xhigh");
   assert.equal(frontmatterValue(regressionVerification, "runner"), "codex");
   assert.equal(frontmatterValue(regressionVerification, "inboxAccess"), "false");
   assert.match(regressionVerification, /complete persisted review package/u);

--- a/packages/db/src/agent-contract.ts
+++ b/packages/db/src/agent-contract.ts
@@ -16,7 +16,7 @@ export const CANONICAL_AGENT_DEFAULTS = [
   { name: "merge-resolver", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
   { name: "plan", model: "claude-fable-5:medium", runner: RunnerPreference.CLAUDE },
   { name: "plan-reviser", model: "gpt-5.6-sol:high", runner: RunnerPreference.CODEX },
-  { name: "regression-verifier", model: "gpt-5.6-luna:max", runner: RunnerPreference.CODEX },
+  { name: "regression-verifier", model: "gpt-5.6-luna:xhigh", runner: RunnerPreference.CODEX },
   { name: "review-coordinator", model: "openai-codex/gpt-5.6-sol:xhigh", runner: RunnerPreference.PI },
   { name: "review-coordinator-opus", model: "claude-opus-5:high", runner: RunnerPreference.CLAUDE },
   { name: "review-coordinator-sol", model: "openai-codex/gpt-5.6-sol:xhigh", runner: RunnerPreference.PI },
@@ -54,14 +54,12 @@ export const CANONICAL_AGENT_RUNTIME_TRANSITIONS = new Map<string, {
     from: { model: "gpt-5.6-terra:high", runnerPreference: RunnerPreference.CODEX },
     to: { model: "openai-codex/gpt-5.6-luna:xhigh", runnerPreference: RunnerPreference.PI },
   }],
-  // 2026-08-27 ruling: regression verification is a narrow task with an
-  // objective test bedrock, the sweet spot for Luna at maximum effort; the
-  // cross-vendor value of a Claude pass is smallest where tests, not model
-  // judgement, hold the verdict. Supersedes the 2026-08-24 re-pin, whose
-  // target this from-value matches.
+  // 2026-08-28 ruling: xhigh is sufficient for regression verification's
+  // narrow, test-backed verdict. Supersedes the 2026-08-27 max-effort pin,
+  // whose target this from-value matches.
   ["regression-verifier", {
-    from: { model: "claude-opus-5:medium", runnerPreference: RunnerPreference.CLAUDE },
-    to: { model: "gpt-5.6-luna:max", runnerPreference: RunnerPreference.CODEX },
+    from: { model: "gpt-5.6-luna:max", runnerPreference: RunnerPreference.CODEX },
+    to: { model: "gpt-5.6-luna:xhigh", runnerPreference: RunnerPreference.CODEX },
   }],
   ["senior-dev", {
     from: { model: "gpt-5.6-sol:medium", runnerPreference: RunnerPreference.CODEX },

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -678,7 +678,7 @@ test("sync recreates a missing regression verifier and restores canonical bindin
   const verifier = await prisma.agent.findUniqueOrThrow({
     where: { projectId_name: { projectId: project.id, name: "regression-verifier" } },
   });
-  assert.equal(verifier.model, "gpt-5.6-luna:max");
+  assert.equal(verifier.model, "gpt-5.6-luna:xhigh");
   assert.equal(verifier.runnerPreference, RunnerPreference.CODEX);
   assert.equal(verifier.inboxAccess, false);
   const canonicalSteps = regressionSteps.filter(({ taskTemplate }) =>


### PR DESCRIPTION
## Summary
- align the canonical regression-verifier contract with the xhigh role frontmatter
- migrate uncustomized max-effort rows to xhigh
- update unit and database contract coverage

## Verification
- agent contract unit tests: 14 passed
- DB suite: 51 passed
- @anneal/db typecheck
- Biome targeted check