### PR TITLE
fix: recover pre-intent base drift

### DIFF
--- a/packages/api/src/base-drift-recovery-decision.ts
+++ b/packages/api/src/base-drift-recovery-decision.ts
@@ -105,7 +105,7 @@ const refusalReason = (refusal: Extract<CandidateLoad, { kind: "refused" }>): st
     case "tail-unresolved": return "current direct/compound regression and readiness tail cannot be resolved";
     case "tail-state-mismatch": return "merge tail task state is not the completed-readiness/stopped-executor shape";
     case "authorization-invalid": return `authorized readiness evidence is ${refusal.detail ?? "missing"}`;
-    case "intent-count": return "source executor run does not have exactly one server-bound merge intent";
+    case "intent-count": return "source executor run has multiple server-bound merge intents";
     case "intent-mismatch": return "executor intent does not match the selected authorization";
     case "authorized-base-mismatch": return "stop evidence does not match the authorized base SHA";
     case "readiness-head-mismatch": return "readiness output does not match the authorized head SHA";

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -121,6 +121,7 @@ const mechanicalStop = async (
   observedBaseSha: string,
   condition: StopCondition = "base-drift",
   evidence = JSON.stringify({ observed: observedBaseSha, authorized: authorizedBaseSha }),
+  recordIntent = true,
 ) => {
   const previous = await db.run.findFirst({ where: { taskId: seeded.integratorTask!.id }, orderBy: { runNumber: "desc" } });
   const run = previous?.status === "QUEUED"
@@ -136,14 +137,16 @@ const mechanicalStop = async (
     runId: run.id, projectId: seeded.project.id, taskId: seeded.integratorTask!.id,
     agentId: seeded.integratorAgent.id, runner: "CLAUDE", executionStatus: "SUCCEEDED",
   } });
-  await db.taskActivity.create({ data: {
-    taskId: seeded.integratorTask!.id, actorType: "merge-executor", body: "intent",
-    metadata: {
-      kind: MERGE_INTEGRATOR_KIND.intent, schemaVersion: 1, sourceRunId: run.id,
-      idempotencyKey: `123:${HEAD}:${authorizationActivityId}`, prNumber: 123,
-      headSha: HEAD, authorizationActivityId,
-    },
-  } });
+  if (recordIntent) {
+    await db.taskActivity.create({ data: {
+      taskId: seeded.integratorTask!.id, actorType: "merge-executor", body: "intent",
+      metadata: {
+        kind: MERGE_INTEGRATOR_KIND.intent, schemaVersion: 1, sourceRunId: run.id,
+        idempotencyKey: `123:${HEAD}:${authorizationActivityId}`, prNumber: 123,
+        headSha: HEAD, authorizationActivityId,
+      },
+    } });
+  }
   const outputBody = JSON.stringify({ outcome: "stopped", condition, evidence });
   await db.taskStepOutput.upsert({ where: { taskId: seeded.integratorTask!.id }, create: {
     taskId: seeded.integratorTask!.id, runId: run.id, kind: "merge-result", body: outputBody,
@@ -372,6 +375,51 @@ test("eligible direct and compound stops recover once under duplicate ticks and 
       1,
     );
   }
+});
+
+test("pre-intent base drift recovers without inventing an intent while duplicate intents fail closed", async () => {
+  const preIntent = await seedIntegratorChain(db, { label: "recover-pre-intent", shape: "canonical-compound-readiness" });
+  const authorization = await authorize(preIntent.readinessTask!.id, BASE);
+  const sourceRun = await mechanicalStop(
+    preIntent,
+    authorization.id,
+    BASE,
+    BASE_2,
+    "base-drift",
+    JSON.stringify({ observed: BASE_2, authorized: BASE }),
+    false,
+  );
+
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  const aggregate = await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: preIntent.integratorTask!.id },
+  });
+  assert.equal(aggregate.status, "REPAIRING");
+  assert.equal(aggregate.boundSourceRunId, sourceRun.id);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: preIntent.integratorTask!.id,
+    metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.intent },
+  } }), 0, "recovery does not fabricate irreversible-operation evidence");
+
+  await resetTestDb(db);
+  const ambiguous = await seedStopped("canonical-compound-readiness", "refuse-duplicate-intent");
+  const intent = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: ambiguous.integratorTask!.id,
+    metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.intent },
+  } });
+  await db.taskActivity.create({ data: {
+    taskId: intent.taskId,
+    actorType: intent.actorType,
+    actorId: intent.actorId,
+    body: intent.body,
+    metadata: intent.metadata as Prisma.InputJsonValue,
+  } });
+
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 0);
+  assert.equal((await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: ambiguous.integratorTask!.id },
+  })).failureReason, "source executor run has multiple server-bound merge intents");
+  assert.equal(await db.run.count({ where: { taskId: ambiguous.gateTask.id } }), 1);
 });
 
 test("two distinct executor drifts recover; the third queues no run and notifies once", async () => {

--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -199,10 +199,15 @@ const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<Ca
     orderBy: { createdAt: "asc" }, select: { metadata: true },
   });
   const intents = intentRows.map((row) => asJsonObject(row.metadata)).filter((metadata) => metadata?.sourceRunId === sourceRun.id);
-  if (intents.length !== 1) return refuse("intent-count");
-  const intent = intents[0]!;
-  if (intent.authorizationActivityId !== authorization.activityId
-    || intent.prNumber !== authorization.prNumber || intent.headSha !== authorization.headSha) {
+  // The executor's first pull-request read can observe base drift before the
+  // irreversible path writes an intent. A successful, run-bound stop with no
+  // intent is therefore the expected pre-intent shape and is safe to recover.
+  // Once an intent exists it must still bind the selected authorization, and
+  // multiple rows remain ambiguous rather than being guessed through.
+  if (intents.length > 1) return refuse("intent-count");
+  const intent = intents[0];
+  if (intent && (intent.authorizationActivityId !== authorization.activityId
+    || intent.prNumber !== authorization.prNumber || intent.headSha !== authorization.headSha)) {
     return refuse("intent-mismatch");
   }
   if (evidence.authorized !== authorization.baseSha) return refuse("authorized-base-mismatch");


### PR DESCRIPTION
## Summary
- allow a successful run-bound base-drift stop to recover before a merge intent exists
- keep authorization validation for one intent and fail closed on duplicates
- cover zero-intent recovery and duplicate-intent refusal in the DB suite

## Verification
- npm run typecheck -w @anneal/api
- targeted Biome and ESLint
- npm run test:db -w @anneal/api -- src/merge-base-drift-recovery.dbtest.ts (17 pass)