### PR TITLE
fix: reopen legacy base drift recovery

### DIFF
--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -422,6 +422,43 @@ test("pre-intent base drift recovers without inventing an intent while duplicate
   assert.equal(await db.run.count({ where: { taskId: ambiguous.gateTask.id } }), 1);
 });
 
+test("a legacy zero-intent validation failure reopens the same aggregate and recovers", async () => {
+  const seeded = await seedIntegratorChain(db, { label: "recover-legacy-pre-intent", shape: "canonical-compound-readiness" });
+  const authorization = await authorize(seeded.readinessTask!.id, BASE);
+  const sourceRun = await mechanicalStop(
+    seeded,
+    authorization.id,
+    BASE,
+    BASE_2,
+    "base-drift",
+    JSON.stringify({ observed: BASE_2, authorized: BASE }),
+    false,
+  );
+  const stop = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: seeded.integratorTask!.id,
+    actorType: "control-plane",
+    metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.result },
+  } });
+  const legacy = await db.mergeRecoveryAttempt.create({ data: {
+    integratorTaskId: seeded.integratorTask!.id,
+    sourceStopId: stop.id,
+    attempt: 1,
+    status: "FAILED",
+    failureReason: "source executor run does not have exactly one server-bound merge intent",
+    endedAt: new Date(),
+  } });
+
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  const aggregate = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: legacy.id } });
+  assert.equal(aggregate.status, "REPAIRING");
+  assert.equal(aggregate.boundSourceRunId, sourceRun.id);
+  assert.equal(aggregate.failureReason, null);
+  assert.equal(aggregate.endedAt, null);
+  assert.equal(await db.mergeRecoveryAttempt.count({ where: {
+    integratorTaskId: seeded.integratorTask!.id,
+  } }), 1, "the durable failed aggregate is reopened instead of replaced");
+});
+
 test("two distinct executor drifts recover; the third queues no run and notifies once", async () => {
   const seeded = await seedStopped("canonical-compound-readiness", "recover-limit");
   assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);

--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -39,6 +39,15 @@ import { stopMergeTail } from "./merge-tail-actions.js";
 type DbReader = PrismaClient | Prisma.TransactionClient;
 
 const SHA = /^[0-9a-f]{40}$/u;
+const LEGACY_PRE_INTENT_REFUSAL = "source executor run does not have exactly one server-bound merge intent";
+
+const isLegacyPreIntentRefusal = (attempt: MergeRecoveryAttempt): boolean => (
+  attempt.status === MergeRecoveryStatus.FAILED
+  && attempt.failureReason === LEGACY_PRE_INTENT_REFUSAL
+  && attempt.boundSourceRunId === null
+  && attempt.authorizationActivityId === null
+  && attempt.recoveryRunId === null
+);
 
 export const baseDriftRecoveryPollIntervalMs = (): number => {
   const raw = Number(process.env.MERGE_BASE_DRIFT_RECOVERY_POLL_INTERVAL_MS);
@@ -61,7 +70,27 @@ const ensureValidationAttemptLocked = async (
   candidate?: RecoveryCandidate,
 ): Promise<MergeRecoveryAttempt> => {
   const existing = await recoveryAttemptFor(tx, integratorTaskId, sourceStopId);
-  if (existing) return existing;
+  const candidateData = candidate ? {
+    boundSourceRunId: candidate.sourceRunId,
+    authorizationActivityId: candidate.authorizationActivityId,
+    readinessTaskId: candidate.readinessTaskId,
+    regressionTaskId: candidate.regressionTaskId,
+    repository: candidate.repository,
+    prNumber: candidate.prNumber,
+    targetBranch: candidate.targetBranch,
+    authorizedHeadSha: candidate.authorizedHeadSha,
+    authorizedBaseSha: candidate.authorizedBaseSha,
+    observedBaseSha: candidate.observedBaseSha,
+  } : {};
+  if (existing) {
+    if (!candidate || !isLegacyPreIntentRefusal(existing)) return existing;
+    return tx.mergeRecoveryAttempt.update({ where: { id: existing.id }, data: {
+      status: MergeRecoveryStatus.VALIDATING,
+      failureReason: null,
+      endedAt: null,
+      ...candidateData,
+    } });
+  }
   const latest = await tx.mergeRecoveryAttempt.aggregate({
     where: { integratorTaskId },
     _max: { attempt: true },
@@ -71,18 +100,7 @@ const ensureValidationAttemptLocked = async (
     sourceStopId,
     attempt: (latest._max.attempt ?? 0) + 1,
     status: MergeRecoveryStatus.VALIDATING,
-    ...(candidate ? {
-      boundSourceRunId: candidate.sourceRunId,
-      authorizationActivityId: candidate.authorizationActivityId,
-      readinessTaskId: candidate.readinessTaskId,
-      regressionTaskId: candidate.regressionTaskId,
-      repository: candidate.repository,
-      prNumber: candidate.prNumber,
-      targetBranch: candidate.targetBranch,
-      authorizedHeadSha: candidate.authorizedHeadSha,
-      authorizedBaseSha: candidate.authorizedBaseSha,
-      observedBaseSha: candidate.observedBaseSha,
-    } : {}),
+    ...candidateData,
   } });
 };
 
@@ -127,7 +145,9 @@ const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<Ca
   const stop = await latestRecordedStop(db as Prisma.TransactionClient, task.id);
   if (!stop || stop.condition !== "base-drift") return { kind: "skip" };
   const existingAttempt = await recoveryAttemptFor(db, task.id, stop.stopId);
-  if (existingAttempt && existingAttempt.status !== MergeRecoveryStatus.VALIDATING) return { kind: "skip" };
+  if (existingAttempt
+    && existingAttempt.status !== MergeRecoveryStatus.VALIDATING
+    && !isLegacyPreIntentRefusal(existingAttempt)) return { kind: "skip" };
   const refuse = (code: CandidateRefusalCode, detail?: string): CandidateLoad => ({
     kind: "refused", code, stopId: stop.stopId, ...(detail ? { detail } : {}),
   });


### PR DESCRIPTION
## Summary
- recognize the exact legacy zero-intent validation refusal as eligible for reclassification
- reopen the same durable aggregate only after current candidate evidence validates
- preserve fail-closed behavior for duplicate or mismatched intents

## Verification
- npm run typecheck -w @anneal/api
- targeted Biome and ESLint
- npm run test:db -w @anneal/api -- src/merge-base-drift-recovery.dbtest.ts (18 pass)