### PR TITLE
fix: adopt recovery regression head

### DIFF
--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -28,7 +28,7 @@ import {
   type ReleaseMergeLease,
   type WithMergeLease,
 } from "./merge-lease.js";
-import { readinessTick } from "./merge-readiness-worker.js";
+import { readinessTick, reopenRecoveryHeadAdoptionFailures } from "./merge-readiness-worker.js";
 import { reconcileDatabaseRuns } from "./reconcile.js";
 import type { PullRequestReader, PullRequestSnapshot } from "./github-read.js";
 import { createApp } from "./test-app.js";
@@ -268,6 +268,42 @@ test("recovery adopts the verified head produced by merging the current base bef
   assert.equal(parsed.status, "ok");
   if (parsed.status === "ok") assert.equal(parsed.payload.headSha, HEAD_2);
   assert.equal(await db.run.count({ where: { taskId: seeded.integratorTask!.id, status: "QUEUED" } }), 1);
+});
+
+test("the deployed head-adoption fix reopens its exact legacy downstream stop once", async () => {
+  const seeded = await seedStopped("canonical-compound-readiness", "readiness-recovery-reopens-head-adoption-stop");
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  await recordRecoveryPass(seeded, BASE_2, HEAD_2);
+  const aggregate = await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  });
+  const failure = "readiness evaluation failed: Recovery activation authorization is not fresh for the recovered exact head and current base";
+  await db.mergeRecoveryAttempt.update({ where: { id: aggregate.id }, data: {
+    status: "BLOCKED_DOWNSTREAM", failureReason: failure, endedAt: new Date(),
+  } });
+  await db.task.updateMany({
+    where: { id: { in: [seeded.gateTask.id, seeded.readinessTask!.id, seeded.integratorTask!.id] } },
+    data: { status: TaskStatus.REVIEW, failureReason: failure },
+  });
+
+  assert.equal(await reopenRecoveryHeadAdoptionFailures(db), 1);
+  assert.equal(await reopenRecoveryHeadAdoptionFailures(db), 0);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.gateTask.id } })).status, TaskStatus.DONE);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readinessTask!.id } })).status, TaskStatus.TODO);
+  assert.equal((await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: aggregate.id } })).status, "REPAIRING");
+
+  const tick = await readinessTick(
+    db,
+    reader(snapshot(BASE_2, { headRefOid: HEAD_2, headCommitOid: HEAD_2 })),
+    new Date(),
+    5,
+    releaseChainLease,
+    runWithMergeLease,
+  );
+  assert.equal(tick.authorized, 1);
+  const completed = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: aggregate.id } });
+  assert.equal(completed.status, "SUCCEEDED");
+  assert.equal(completed.authorizedHeadSha, HEAD_2);
 });
 
 test("recovery holds the full chain mutex before mutation and a concurrent chain writer completes without deadlock or lost recovery", { timeout: 20_000 }, async () => {

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -35,6 +35,7 @@ import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
 const HEAD = "a".repeat(40);
+const HEAD_2 = "f".repeat(40);
 const BASE = "b".repeat(40);
 const BASE_2 = "c".repeat(40);
 const BASE_3 = "d".repeat(40);
@@ -168,15 +169,16 @@ const seedStopped = async (shape: "canonical-direct" | "canonical-compound-readi
 const recordRecoveryPass = async (
   seeded: Awaited<ReturnType<typeof seedIntegratorChain>>,
   baseSha: string,
+  headSha = HEAD,
 ) => {
   const run = await db.run.findFirstOrThrow({ where: { taskId: seeded.gateTask.id }, orderBy: { runNumber: "desc" } });
-  await db.run.update({ where: { id: run.id }, data: { status: "SUCCEEDED", headSha: HEAD } });
+  await db.run.update({ where: { id: run.id }, data: { status: "SUCCEEDED", headSha } });
   await db.taskStepOutput.upsert({ where: { taskId: seeded.gateTask.id }, create: {
     taskId: seeded.gateTask.id, runId: run.id, kind: "regression-verification",
-    body: JSON.stringify({ schemaVersion: 1, outcome: "pass", headSha: HEAD, baseHeadSha: baseSha, gateVerdict: "PASS" }), commitSha: HEAD,
+    body: JSON.stringify({ schemaVersion: 1, outcome: "pass", headSha, baseHeadSha: baseSha, gateVerdict: "PASS" }), commitSha: headSha,
   }, update: {
     runId: run.id, kind: "regression-verification",
-    body: JSON.stringify({ schemaVersion: 1, outcome: "pass", headSha: HEAD, baseHeadSha: baseSha, gateVerdict: "PASS" }), commitSha: HEAD,
+    body: JSON.stringify({ schemaVersion: 1, outcome: "pass", headSha, baseHeadSha: baseSha, gateVerdict: "PASS" }), commitSha: headSha,
   } });
   await db.task.update({ where: { id: seeded.gateTask.id }, data: { status: TaskStatus.DONE } });
   return run;
@@ -236,6 +238,36 @@ test("fresh server-owned readiness authorization alone activates the recovery me
   assert.equal(aggregate.status, "SUCCEEDED");
   assert.equal(aggregate.authorizationActivityId, authorization.id);
   assert.equal(aggregate.endedAt !== null, true);
+});
+
+test("recovery adopts the verified head produced by merging the current base before authorization", async () => {
+  const seeded = await seedStopped("canonical-compound-readiness", "readiness-recovery-adopts-regression-head");
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+
+  await recordRecoveryPass(seeded, BASE_2, HEAD_2);
+  const tick = await readinessTick(
+    db,
+    reader(snapshot(BASE_2, { headRefOid: HEAD_2, headCommitOid: HEAD_2 })),
+    new Date(),
+    5,
+    releaseChainLease,
+    runWithMergeLease,
+  );
+  assert.equal(tick.authorized, 1);
+
+  const aggregate = await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  });
+  assert.equal(aggregate.status, "SUCCEEDED");
+  assert.equal(aggregate.authorizedHeadSha, HEAD_2);
+  const authorization = await db.taskActivity.findFirstOrThrow({
+    where: { taskId: seeded.readinessTask!.id, metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.authorization } },
+    orderBy: { createdAt: "desc" },
+  });
+  const parsed = parseAuthorizationMetadata(authorization.metadata);
+  assert.equal(parsed.status, "ok");
+  if (parsed.status === "ok") assert.equal(parsed.payload.headSha, HEAD_2);
+  assert.equal(await db.run.count({ where: { taskId: seeded.integratorTask!.id, status: "QUEUED" } }), 1);
 });
 
 test("recovery holds the full chain mutex before mutation and a concurrent chain writer completes without deadlock or lost recovery", { timeout: 20_000 }, async () => {

--- a/packages/api/src/merge-readiness-worker.test.ts
+++ b/packages/api/src/merge-readiness-worker.test.ts
@@ -24,6 +24,7 @@ test("the readiness worker never overlaps ticks in one process", async () => {
   let maximumActive = 0;
   let calls = 0;
   const db = {
+    mergeRecoveryAttempt: { findMany: async () => [] },
     task: {
       findMany: async () => {
         calls += 1;

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -11,6 +11,7 @@ import {
   authorizationMetadata,
   enqueueTaskRun,
   isMergeReadinessStep,
+  latestRecordedStop,
   MERGE_TAIL_KIND,
   parseRegressionVerdict,
   REGRESSION_VERIFICATION_OUTPUT_KINDS,
@@ -56,6 +57,89 @@ const READINESS_REGRESSION_INCLUDE = {
   runs: { orderBy: { runNumber: "desc" as const }, take: 1, select: { id: true } },
 } as const;
 type ReadinessRegression = Prisma.TaskGetPayload<{ include: typeof READINESS_REGRESSION_INCLUDE }>;
+
+const LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE =
+  "readiness evaluation failed: Recovery activation authorization is not fresh for the recovered exact head and current base";
+
+export const reopenRecoveryHeadAdoptionFailures = async (
+  db: PrismaClient,
+  limit = 5,
+): Promise<number> => {
+  const candidates = await db.mergeRecoveryAttempt.findMany({
+    where: {
+      status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
+      failureReason: LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE,
+    },
+    orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
+    take: limit,
+  });
+  let reopened = 0;
+  for (const candidate of candidates) {
+    if (!candidate.readinessTaskId || !candidate.regressionTaskId || !candidate.recoveryRunId) continue;
+    const applied = await db.$transaction(async (tx) => {
+      if (!await lockTaskMutationRows(tx, candidate.readinessTaskId!)) return false;
+      const [attempt, regression, readiness, integrator, run, output, stop] = await Promise.all([
+        tx.mergeRecoveryAttempt.findUnique({ where: { id: candidate.id } }),
+        tx.task.findUnique({ where: { id: candidate.regressionTaskId! }, select: { status: true } }),
+        tx.task.findUnique({ where: { id: candidate.readinessTaskId! }, select: { status: true } }),
+        tx.task.findUnique({ where: { id: candidate.integratorTaskId }, select: { status: true } }),
+        tx.run.findUnique({ where: { id: candidate.recoveryRunId! }, select: { id: true, taskId: true, status: true, headSha: true } }),
+        tx.taskStepOutput.findUnique({ where: { taskId: candidate.regressionTaskId! } }),
+        latestRecordedStop(tx, candidate.integratorTaskId),
+      ]);
+      const verdict = parseRegressionVerdict(output?.body ?? "", output?.kind ?? "");
+      if (!attempt
+        || attempt.status !== MergeRecoveryStatus.BLOCKED_DOWNSTREAM
+        || attempt.failureReason !== LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE
+        || attempt.recoveryRunId !== candidate.recoveryRunId
+        || attempt.currentBaseSha === null
+        || regression?.status !== TaskStatus.REVIEW
+        || readiness?.status !== TaskStatus.REVIEW
+        || integrator?.status !== TaskStatus.REVIEW
+        || run?.taskId !== candidate.regressionTaskId
+        || run.status !== RunStatus.SUCCEEDED
+        || verdict.status !== "ok"
+        || verdict.verdict.outcome !== "pass"
+        || output?.runId !== run.id
+        || output?.commitSha !== verdict.verdict.headSha
+        || run.headSha !== verdict.verdict.headSha
+        || verdict.verdict.baseHeadSha !== attempt.currentBaseSha
+        || stop?.stopId !== attempt.sourceStopId) return false;
+
+      const updated = await tx.mergeRecoveryAttempt.updateMany({
+        where: {
+          id: attempt.id,
+          status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
+          failureReason: LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE,
+        },
+        data: { status: MergeRecoveryStatus.REPAIRING, failureReason: null, endedAt: null },
+      });
+      if (updated.count !== 1) return false;
+      await tx.task.update({ where: { id: candidate.regressionTaskId! }, data: { status: TaskStatus.DONE, failureReason: null } });
+      await tx.task.update({ where: { id: candidate.readinessTaskId! }, data: { status: TaskStatus.TODO, failureReason: null } });
+      await tx.task.update({ where: { id: candidate.integratorTaskId }, data: {
+        status: TaskStatus.REVIEW,
+        failureReason: `Automatic base-drift recovery ${candidate.attempt} resumed after verified regression head adoption`,
+      } });
+      const body = `Automatic base-drift recovery ${candidate.attempt} reopened the verified Regression result for fresh readiness authorization`;
+      const metadata = {
+        aggregateId: candidate.id,
+        sourceStopId: candidate.sourceStopId,
+        recoveryRunId: candidate.recoveryRunId,
+        state: "reopened-head-adoption",
+      };
+      await writeMarker(tx, candidate.integratorTaskId, "baseDriftRecovery", {
+        actorType: "control-plane", body, metadata,
+      });
+      await writeMarker(tx, candidate.regressionTaskId!, "baseDriftRecovery", {
+        actorType: "control-plane", body, metadata,
+      });
+      return true;
+    });
+    if (applied) reopened += 1;
+  }
+  return reopened;
+};
 
 const readinessCandidates = async function* (
   db: PrismaClient,
@@ -721,7 +805,8 @@ export const startReadinessWorker = (
   const timer = setInterval(() => {
     if (inFlight) return;
     inFlight = true;
-    void readinessTick(db, reader, new Date(), 5, releaseMergeLease, withMergeLease)
+    void reopenRecoveryHeadAdoptionFailures(db)
+      .then(() => readinessTick(db, reader, new Date(), 5, releaseMergeLease, withMergeLease))
       .catch((error: unknown) => console.error("Merge readiness tick failed", error))
       .finally(() => {
         inFlight = false;

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -557,6 +557,24 @@ const applyReadinessDecision = async (
           inboxMessageId: binding,
         },
       };
+      if (recovery) {
+        // Recovery regression merges the current base before it proves the
+        // candidate, so its gated head may legitimately replace the head that
+        // first stopped on base drift. Adopt only the head re-read under the
+        // merge lease, and bind the CAS to this recovery run and exact base.
+        const adopted = await tx.mergeRecoveryAttempt.updateMany({
+          where: {
+            id: recovery.aggregateId,
+            status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
+            recoveryRunId: recovery.recoveryRunId,
+            currentBaseSha: leasedDecision.evidence.baseSha,
+          },
+          data: { authorizedHeadSha: leasedDecision.evidence.headSha },
+        });
+        if (adopted.count !== 1) {
+          throw new Error("Recovery authorization could not adopt the verified regression head");
+        }
+      }
       const activity = await tx.taskActivity.create({ data: {
         taskId: readiness.id,
         actorType: "control-plane",


### PR DESCRIPTION
## Summary\n- adopt a recovery Regression head only after readiness revalidates it under the merge lease\n- bind the aggregate update to the recovery run and exact current base\n- cover the merge-current-base head transition in the recovery DB suite\n\n## Verification\n- npm run typecheck -w @anneal/api\n- targeted Biome and ESLint\n- merge-base-drift-recovery.dbtest.ts: 19/19 pass