### PR TITLE
fix(api): recover legacy base drift failures

### DIFF
--- a/packages/api/src/base-drift-recovery-decision.test.ts
+++ b/packages/api/src/base-drift-recovery-decision.test.ts
@@ -67,6 +67,13 @@ test("all durable candidate refusal paths decide without a database", () => {
     assert.equal(decision.kind, code === "chain-active" ? "retry" : "ineligible", code);
     assert.notEqual("reason" in decision ? decision.reason : "", "", code);
   }
+  assert.deepEqual(recoveryDecision({
+    stage: "candidate",
+    load: { kind: "refused", code: "target-branch-mismatch", stopId: "stop-1" },
+  }), {
+    kind: "ineligible",
+    reason: "chain first-run target ref differs from the authorized base ref",
+  });
 });
 
 test("all fresh pull-request refusal paths decide without a database", () => {

--- a/packages/api/src/base-drift-recovery-decision.ts
+++ b/packages/api/src/base-drift-recovery-decision.ts
@@ -111,7 +111,7 @@ const refusalReason = (refusal: Extract<CandidateLoad, { kind: "refused" }>): st
     case "readiness-head-mismatch": return "readiness output does not match the authorized head SHA";
     case "target-unresolved": return `pull-request identity is ${refusal.detail ?? "unresolved"}`;
     case "target-mismatch": return "resolved repository or pull-request identity differs from the authorization";
-    case "target-branch-mismatch": return "authorized target ref differs from the chain target branch";
+    case "target-branch-mismatch": return "chain first-run target ref differs from the authorized base ref";
   }
 };
 

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -527,6 +527,63 @@ test("a legacy zero-intent validation failure reopens the same aggregate and rec
   } }), 1, "the durable failed aggregate is reopened instead of replaced");
 });
 
+test("a legacy target-branch false negative reopens only the empty failed aggregate", async () => {
+  const seeded = await seedIntegratorChain(db, {
+    label: "recover-legacy-target-branch",
+    shape: "canonical-compound-readiness",
+  });
+  await db.task.update({
+    where: { id: seeded.integratorTask!.id },
+    data: { targetBranch: "agentos/feature-branch" },
+  });
+  const authorization = await authorize(seeded.readinessTask!.id, BASE);
+  await mechanicalStop(seeded, authorization.id, BASE, BASE_2);
+  const stop = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: seeded.integratorTask!.id,
+    actorType: "control-plane",
+    metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.result },
+  } });
+  const legacy = await db.mergeRecoveryAttempt.create({ data: {
+    integratorTaskId: seeded.integratorTask!.id,
+    sourceStopId: stop.id,
+    attempt: 1,
+    status: "FAILED",
+    failureReason: "authorized target ref differs from the chain target branch",
+    endedAt: new Date(),
+  } });
+
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  const aggregate = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: legacy.id } });
+  assert.equal(aggregate.status, "REPAIRING");
+  assert.equal(aggregate.failureReason, null);
+  assert.equal(aggregate.targetBranch, "master");
+  assert.equal(await db.mergeRecoveryAttempt.count({ where: {
+    integratorTaskId: seeded.integratorTask!.id,
+  } }), 1, "the historical false-negative aggregate is reopened instead of replaced");
+});
+
+test("a target-branch failure with durable recovery identity remains terminal", async () => {
+  const seeded = await seedStopped("canonical-compound-readiness", "retain-bound-target-branch-failure");
+  const stop = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: seeded.integratorTask!.id,
+    actorType: "control-plane",
+    metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.result },
+  } });
+  const failed = await db.mergeRecoveryAttempt.create({ data: {
+    integratorTaskId: seeded.integratorTask!.id,
+    sourceStopId: stop.id,
+    attempt: 1,
+    status: "FAILED",
+    failureReason: "authorized target ref differs from the chain target branch",
+    repository: "acme/widgets",
+    endedAt: new Date(),
+  } });
+
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 0);
+  assert.equal((await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: failed.id } })).status, "FAILED");
+  assert.equal(await db.run.count({ where: { taskId: seeded.gateTask.id } }), 1);
+});
+
 test("two distinct executor drifts recover; the third queues no run and notifies once", async () => {
   const seeded = await seedStopped("canonical-compound-readiness", "recover-limit");
   assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
@@ -586,8 +643,12 @@ test("identity, target-ref, head, and evidence mismatches fail closed without a 
   }
 });
 
-test("a chain target branch that disagrees with the authorization fails closed", async () => {
+test("the chain first-run target branch must still agree with the authorization", async () => {
   const seeded = await seedIntegratorChain(db, { label: "refuse-chain-target", shape: "canonical-compound-readiness" });
+  await db.task.update({
+    where: { id: seeded.integratorTask!.id },
+    data: { targetBranch: "agentos/feature-branch" },
+  });
   const authorization = await authorize(seeded.readinessTask!.id, BASE);
   await mechanicalStop(seeded, authorization.id, BASE, BASE_2);
   await db.run.update({ where: { id: seeded.gateRun.id }, data: { targetBranch: "release" } });
@@ -597,6 +658,26 @@ test("a chain target branch that disagrees with the authorization fails closed",
     taskId: seeded.integratorTask!.id, kind: "MULTIPLE_CHOICE", status: "OPEN",
   } });
   assert.deepEqual((question.choices as Array<{ id: string }>).map((choice) => choice.id), ["abandon"]);
+});
+
+test("an integrator feature target recovers when the chain first run targets the authorized base", async () => {
+  const seeded = await seedIntegratorChain(db, {
+    label: "recover-integrator-feature-target",
+    shape: "canonical-compound-readiness",
+  });
+  await db.task.update({
+    where: { id: seeded.integratorTask!.id },
+    data: { targetBranch: "agentos/feature-branch" },
+  });
+  const authorization = await authorize(seeded.readinessTask!.id, BASE);
+  await mechanicalStop(seeded, authorization.id, BASE, BASE_2);
+  assert.equal((await db.run.findUniqueOrThrow({ where: { id: seeded.gateRun.id } })).targetBranch, "master");
+
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  assert.equal(await db.run.count({ where: { taskId: seeded.gateTask.id } }), 2);
+  assert.equal((await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  })).status, "REPAIRING");
 });
 
 test("foreign and incident stop conditions never enter automatic base-drift recovery", async () => {

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -11,10 +11,11 @@ import {
   PrismaClient,
   TaskStatus,
   authorizationMetadata,
+  openStopQuestion,
   parseAuthorizationMetadata,
   readMarkerHistory,
-  writeMarker,
   recordIntegratorStop,
+  writeMarker,
   type StopCondition,
 } from "@anneal/db";
 
@@ -537,7 +538,66 @@ test("a legacy target-branch false negative reopens only the empty failed aggreg
     data: { targetBranch: "agentos/feature-branch" },
   });
   const authorization = await authorize(seeded.readinessTask!.id, BASE);
+  const sourceRun = await mechanicalStop(seeded, authorization.id, BASE, BASE_2);
+  const stop = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: seeded.integratorTask!.id,
+    actorType: "control-plane",
+    metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.result },
+  } });
+  const legacy = await db.mergeRecoveryAttempt.create({ data: {
+    integratorTaskId: seeded.integratorTask!.id,
+    sourceStopId: stop.id,
+    attempt: 1,
+    status: "FAILED",
+    failureReason: "authorized target ref differs from the chain target branch",
+    endedAt: new Date(),
+  } });
+  const session = await db.session.findUniqueOrThrow({ where: { runId: sourceRun.id } });
+  const question = await openStopQuestion(db, {
+    integratorTaskId: seeded.integratorTask!.id,
+    stopId: stop.id,
+    condition: "base-drift",
+    evidence: JSON.stringify({ observed: BASE_2, authorized: BASE }),
+    agentId: seeded.integratorAgent.id,
+    sessionId: session.id,
+  });
+  assert.ok(question);
+  const openQuestion = await db.inboxMessage.findUniqueOrThrow({
+    where: { id: question.id },
+  });
+  assert.equal(openQuestion.status, "OPEN");
+  assert.deepEqual((openQuestion.choices as Array<{ id: string }>).map((choice) => choice.id), ["abandon"]);
+
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  const aggregate = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: legacy.id } });
+  assert.equal(aggregate.status, "REPAIRING");
+  assert.equal(aggregate.failureReason, null);
+  assert.equal(aggregate.targetBranch, "master");
+  assert.equal(await db.mergeRecoveryAttempt.count({ where: {
+    integratorTaskId: seeded.integratorTask!.id,
+  } }), 1, "the historical false-negative aggregate is reopened instead of replaced");
+  assert.equal((await db.inboxMessage.findUniqueOrThrow({ where: { id: question.id } })).status, "CLOSED");
+  assert.deepEqual(await db.$transaction((tx) => applyInboxDecisionTx(tx, {
+    inboxMessageId: question.id,
+    externalEventId: "stale-recovery-abandon",
+    decision: "abandon",
+  })), { duplicate: true, resumed: false });
+  assert.equal((await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: legacy.id } })).status, "REPAIRING");
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.integratorTask!.id } })).status, TaskStatus.REVIEW);
+});
+
+test("a legacy target-branch sentinel retires when current validation still refuses the chain", async () => {
+  const seeded = await seedIntegratorChain(db, {
+    label: "retire-legacy-target-branch",
+    shape: "canonical-compound-readiness",
+  });
+  await db.task.update({
+    where: { id: seeded.integratorTask!.id },
+    data: { targetBranch: "agentos/feature-branch" },
+  });
+  const authorization = await authorize(seeded.readinessTask!.id, BASE);
   await mechanicalStop(seeded, authorization.id, BASE, BASE_2);
+  await db.run.update({ where: { id: seeded.gateRun.id }, data: { targetBranch: "release" } });
   const stop = await db.taskActivity.findFirstOrThrow({ where: {
     taskId: seeded.integratorTask!.id,
     actorType: "control-plane",
@@ -552,14 +612,19 @@ test("a legacy target-branch false negative reopens only the empty failed aggreg
     endedAt: new Date(),
   } });
 
-  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
-  const aggregate = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: legacy.id } });
-  assert.equal(aggregate.status, "REPAIRING");
-  assert.equal(aggregate.failureReason, null);
-  assert.equal(aggregate.targetBranch, "master");
-  assert.equal(await db.mergeRecoveryAttempt.count({ where: {
-    integratorTaskId: seeded.integratorTask!.id,
-  } }), 1, "the historical false-negative aggregate is reopened instead of replaced");
+  assert.deepEqual(await baseDriftRecoveryTick(db, reader(snapshot(BASE_2))), {
+    examined: 1, recovered: 0, exhausted: 0, ineligible: 1,
+  });
+  const retired = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: legacy.id } });
+  assert.equal(retired.status, "FAILED");
+  assert.equal(
+    retired.failureReason,
+    "Historical base-drift recovery refusal retired after current validation: chain first-run target ref differs from the authorized base ref",
+  );
+  assert.equal(await db.run.count({ where: { taskId: seeded.gateTask.id } }), 1);
+  assert.deepEqual(await baseDriftRecoveryTick(db, reader(snapshot(BASE_2))), {
+    examined: 0, recovered: 0, exhausted: 0, ineligible: 0,
+  });
 });
 
 test("a target-branch failure with durable recovery identity remains terminal", async () => {

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -652,12 +652,20 @@ test("the chain first-run target branch must still agree with the authorization"
   const authorization = await authorize(seeded.readinessTask!.id, BASE);
   await mechanicalStop(seeded, authorization.id, BASE, BASE_2);
   await db.run.update({ where: { id: seeded.gateRun.id }, data: { targetBranch: "release" } });
-  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 0);
+  assert.deepEqual(await baseDriftRecoveryTick(db, reader(snapshot(BASE_2))), {
+    examined: 1, recovered: 0, exhausted: 0, ineligible: 1,
+  });
   assert.equal(await db.run.count({ where: { taskId: seeded.gateTask.id } }), 1);
+  assert.equal((await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  })).failureReason, "chain first-run target ref differs from the authorized base ref");
   const question = await db.inboxMessage.findFirstOrThrow({ where: {
     taskId: seeded.integratorTask!.id, kind: "MULTIPLE_CHOICE", status: "OPEN",
   } });
   assert.deepEqual((question.choices as Array<{ id: string }>).map((choice) => choice.id), ["abandon"]);
+  assert.deepEqual(await baseDriftRecoveryTick(db, reader(snapshot(BASE_2))), {
+    examined: 0, recovered: 0, exhausted: 0, ineligible: 0,
+  }, "the current refusal does not reuse the historical reopen sentinel");
 });
 
 test("an integrator feature target recovers when the chain first run targets the authorized base", async () => {

--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -8,6 +8,7 @@ import {
   Prisma,
   TaskStatus,
   asJsonObject,
+  closeIntegratorQuestions,
   enqueueTaskRun,
   isMergeReadinessStep,
   latestRecordedStop,
@@ -69,6 +70,10 @@ const isLegacyTargetBranchRefusal = (attempt: MergeRecoveryAttempt): boolean => 
 
 const isReopenableLegacyRefusal = (attempt: MergeRecoveryAttempt): boolean => (
   isLegacyPreIntentRefusal(attempt) || isLegacyTargetBranchRefusal(attempt)
+);
+
+const retiredLegacyRefusalReason = (reason: string): string => (
+  `Historical base-drift recovery refusal retired after current validation: ${reason}`
 );
 
 export const baseDriftRecoveryPollIntervalMs = (): number => {
@@ -350,7 +355,31 @@ const settleIneligible = async (
   const currentStop = await latestRecordedStop(tx, integratorTaskId);
   if (currentStop?.stopId !== stopId) return false;
   const existing = await recoveryAttemptFor(tx, integratorTaskId, stopId);
-  if (existing && existing.status !== MergeRecoveryStatus.VALIDATING) return false;
+  if (existing && existing.status !== MergeRecoveryStatus.VALIDATING) {
+    if (!isReopenableLegacyRefusal(existing)) return false;
+    const retiredReason = retiredLegacyRefusalReason(reason);
+    await tx.mergeRecoveryAttempt.update({ where: { id: existing.id }, data: {
+      failureReason: retiredReason,
+      endedAt: new Date(),
+    } });
+    await tx.task.update({ where: { id: integratorTaskId }, data: {
+      status: TaskStatus.REVIEW,
+      failureReason: `Automatic base-drift recovery refused: ${reason}`,
+    } });
+    await writeMarker(tx, integratorTaskId, "baseDriftRecovery", {
+      actorType: "control-plane",
+      body: retiredReason,
+      metadata: {
+        state: "legacy-refusal-retired",
+        integratorTaskId,
+        sourceStopId: stopId,
+        priorReason: existing.failureReason,
+        reason,
+      },
+    });
+    await openAbandonQuestion(tx, integratorTaskId, stopId);
+    return true;
+  }
   await settleIneligibleLocked(tx, integratorTaskId, stopId, reason, identity);
   return true;
 });
@@ -490,6 +519,7 @@ const queueRecovery = async (
     return { kind: "exhausted" };
   }
 
+  await closeIntegratorQuestions(tx, expected.integratorTaskId);
   await tx.task.update({ where: { id: expected.regressionTaskId }, data: { status: TaskStatus.TODO, failureReason: null } });
   await tx.task.update({ where: { id: expected.readinessTaskId }, data: { status: TaskStatus.TODO, failureReason: null } });
   await tx.task.update({ where: { id: expected.integratorTaskId }, data: {

--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -40,6 +40,7 @@ type DbReader = PrismaClient | Prisma.TransactionClient;
 
 const SHA = /^[0-9a-f]{40}$/u;
 const LEGACY_PRE_INTENT_REFUSAL = "source executor run does not have exactly one server-bound merge intent";
+const LEGACY_TARGET_BRANCH_REFUSAL = "authorized target ref differs from the chain target branch";
 
 const isLegacyPreIntentRefusal = (attempt: MergeRecoveryAttempt): boolean => (
   attempt.status === MergeRecoveryStatus.FAILED
@@ -47,6 +48,27 @@ const isLegacyPreIntentRefusal = (attempt: MergeRecoveryAttempt): boolean => (
   && attempt.boundSourceRunId === null
   && attempt.authorizationActivityId === null
   && attempt.recoveryRunId === null
+);
+
+const isLegacyTargetBranchRefusal = (attempt: MergeRecoveryAttempt): boolean => (
+  attempt.status === MergeRecoveryStatus.FAILED
+  && attempt.failureReason === LEGACY_TARGET_BRANCH_REFUSAL
+  && attempt.boundSourceRunId === null
+  && attempt.authorizationActivityId === null
+  && attempt.recoveryRunId === null
+  && attempt.readinessTaskId === null
+  && attempt.regressionTaskId === null
+  && attempt.repository === null
+  && attempt.prNumber === null
+  && attempt.targetBranch === null
+  && attempt.authorizedHeadSha === null
+  && attempt.authorizedBaseSha === null
+  && attempt.observedBaseSha === null
+  && attempt.currentBaseSha === null
+);
+
+const isReopenableLegacyRefusal = (attempt: MergeRecoveryAttempt): boolean => (
+  isLegacyPreIntentRefusal(attempt) || isLegacyTargetBranchRefusal(attempt)
 );
 
 export const baseDriftRecoveryPollIntervalMs = (): number => {
@@ -83,7 +105,7 @@ const ensureValidationAttemptLocked = async (
     observedBaseSha: candidate.observedBaseSha,
   } : {};
   if (existing) {
-    if (!candidate || !isLegacyPreIntentRefusal(existing)) return existing;
+    if (!candidate || !isReopenableLegacyRefusal(existing)) return existing;
     return tx.mergeRecoveryAttempt.update({ where: { id: existing.id }, data: {
       status: MergeRecoveryStatus.VALIDATING,
       failureReason: null,
@@ -147,7 +169,7 @@ const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<Ca
   const existingAttempt = await recoveryAttemptFor(db, task.id, stop.stopId);
   if (existingAttempt
     && existingAttempt.status !== MergeRecoveryStatus.VALIDATING
-    && !isLegacyPreIntentRefusal(existingAttempt)) return { kind: "skip" };
+    && !isReopenableLegacyRefusal(existingAttempt)) return { kind: "skip" };
   const refuse = (code: CandidateRefusalCode, detail?: string): CandidateLoad => ({
     kind: "refused", code, stopId: stop.stopId, ...(detail ? { detail } : {}),
   });
@@ -242,7 +264,9 @@ const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<Ca
     where: { task: { projectId: task.projectId, chainId: task.chainId, chainIndex: { not: null } } },
     orderBy: [{ task: { chainIndex: "asc" } }, { runNumber: "asc" }], select: { targetBranch: true },
   });
-  if (firstRun?.targetBranch !== authorization.baseRef || task.targetBranch !== authorization.baseRef) {
+  // The chain's first Run pins the authorized base. The integrator Task may
+  // instead carry the delivered feature branch propagated through the chain.
+  if (firstRun?.targetBranch !== authorization.baseRef) {
     return refuse("target-branch-mismatch");
   }
   return { kind: "candidate", candidate: {


### PR DESCRIPTION
## Summary
- use the chain first Run as the authorized base branch invariant
- reopen only the exact unbound historical target-branch false negative
- retire still-invalid legacy refusals and close stale stop questions when repair queues

## Verification
- recovery dbtest: 24/24 PASS
- recovery decision unit: 3/3 PASS
- API typecheck: PASS
- Biome and ESLint: PASS
- fresh Opus blind review: no blocking findings