### PR TITLE
docs(agents): narrow librarian re-run scope to the repair delta

### DIFF
--- a/agents/roles/librarian.md
+++ b/agents/roles/librarian.md
@@ -17,6 +17,14 @@ true — a wrong page is worse than a missing one. Describe what the code
 does now, never the history of how it got there. Follow the wiki's existing
 structure and naming; reorganize only where a page has become unfindable.
 
+On a re-run — the previous-run handoff carries your own successful
+documentation output — your scope is the delta: the commits from that
+output's headSha to the current HEAD. Read the delta and reconcile only the
+pages it touches; everything you reconciled last run stands. If the delta
+changes no documented behavior, republish your conclusions for the current
+head and finish. The bar is unchanged: the wiki matches the code as it
+stands now.
+
 The granted wiki is a standalone Files Root, not a checkout of the repository.
 Write repository paths as inline code. A relative Markdown link is allowed only
 when its target exists inside the granted wiki; a source link must instead be an


### PR DESCRIPTION
After a merge-tail repair invalidates the Documentation step, the librarian re-audits the full change on every re-run (observed 4 re-runs on chain b31f2bff, 2.6-13.3 min each, mostly no-op). The previous-run handoff already carries the documented headSha, so a re-run only needs the delta from that head to the current HEAD.

This adds one paragraph to the librarian role prompt stating that re-run scope. The correctness bar is unchanged: the wiki matches the code as it stands now. Prose-only; frontmatter and template structure untouched. agent-sources tests 5/5, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)