### PR TITLE
fix(api): filter repair task context to the kinds each repair reads

### DIFF
--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -421,14 +421,21 @@ export const createMergeTailRepairTask = async (
   // it. Without this the repair agent sees only the verdict summary and no
   // Feature brief, acceptance criteria, or review reports, and the narrowest
   // reading of that summary is the whole job it can do. Same query, ordering,
-  // and rendering as a chain step's: what the chain steps could see, the repair
-  // for those steps sees too.
+  // and rendering as a chain step's, filtered to the kinds each repair reads:
+  // intent and handoffs for every kind, the review reports only for the
+  // review-fix that must trace their finding ids. Planning-stage and
+  // documentation outputs repair nothing and stay out.
+  const repairPriorOutputKinds = input.repairKind === "review-fix"
+    ? ["spec", "implementation", "sol-findings", "blind-findings", "fixed-implementation"]
+    : input.repairKind === "gate-fix"
+      ? ["spec", "implementation", "fixed-implementation"]
+      : ["spec", "implementation"];
   const priorOutputs = await tx.taskStepOutput.findMany({
     where: { task: {
       projectId: regressionTask.projectId,
       chainId: regressionTask.chainId,
       chainIndex: { lt: regressionTask.chainIndex },
-    } },
+    }, kind: { in: repairPriorOutputKinds } },
     select: { kind: true, body: true, task: { select: { name: true, chainIndex: true } } },
     orderBy: { task: { chainIndex: "asc" } },
   });

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -384,24 +384,32 @@ test("a semantic FAIL skips the gate path and is repaired twice before it escala
   assert.match(notice.body, /after 2 automatic repair attempts/u);
 });
 
-test("a repair task carries the chain's persisted outputs its own detached row cannot reach", async () => {
+test("a repair task carries only the chain outputs its repair kind reads", async () => {
   for (const outcome of ["review-fail", "gate-fail", "refresh-conflict"] as const) {
     await resetTestDb(db);
     const seeded = await exercise(outcome);
-    const repair = await repairFor(seeded, outcome === "review-fail" ? "review-fix" : outcome === "gate-fail" ? "gate-fix" : "refresh-conflict");
+    const repairKind = outcome === "review-fail" ? "review-fix" : outcome === "gate-fail" ? "gate-fix" : "refresh-conflict";
+    const repair = await repairFor(seeded, repairKind);
     // Chain-detached by design: the claim path's prior-output lookup cannot
     // fire for this row, so the prompt is the only carrier.
     assert.equal(repair.chainId, null, outcome);
     assert.equal(repair.chainIndex, null, outcome);
     assert.match(repair.description, /Persisted outputs from prior template steps:/u, outcome);
     assert.ok(repair.description.includes(IMPLEMENTATION_BODY), outcome);
-    assert.ok(repair.description.includes(SOL_FINDINGS_BODY), outcome);
-    assert.ok(repair.description.includes(BLIND_FINDINGS_BODY), outcome);
-    // Chain order, and nothing from the Regression step that opened the repair.
-    assert.ok(
-      repair.description.indexOf(IMPLEMENTATION_BODY) < repair.description.indexOf(SOL_FINDINGS_BODY),
-      outcome,
-    );
+    if (repairKind === "review-fix") {
+      // Only the repair that traces finding ids reads the review reports,
+      // still in chain order.
+      assert.ok(repair.description.includes(SOL_FINDINGS_BODY), outcome);
+      assert.ok(repair.description.includes(BLIND_FINDINGS_BODY), outcome);
+      assert.ok(
+        repair.description.indexOf(IMPLEMENTATION_BODY) < repair.description.indexOf(SOL_FINDINGS_BODY),
+        outcome,
+      );
+    } else {
+      assert.ok(!repair.description.includes(SOL_FINDINGS_BODY), outcome);
+      assert.ok(!repair.description.includes(BLIND_FINDINGS_BODY), outcome);
+    }
+    // Nothing from the Regression step that opened the repair.
     assert.ok(!repair.description.includes("regression-verification"), outcome);
   }
 });


### PR DESCRIPTION
Merge-tail repair tasks (refresh-conflict / gate-fix / review-fix) inlined every prior chain output into the repair prompt — the all-outputs semantics PR #175 already retired for chain steps. On the last Full Assurance chain that meant ~85KB of context per repair incident, four times over.

Per-kind whitelist, additive over intent and handoffs:
- refresh-conflict: spec, implementation
- gate-fix: spec, implementation, fixed-implementation
- review-fix: spec, implementation, sol-findings, blind-findings, fixed-implementation (must trace finding ids)

Planning-stage and documentation outputs repair nothing and stay out. merge-tail-repair dbtests updated to per-kind expectations, 17/17 pass on a disposable PostgreSQL; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)