### PR TITLE
fix(api): adopt leased recovery evidence

### DIFF
--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -198,6 +198,24 @@ const finishRecoveryPass = async (
   });
 };
 
+const parkCurrentHeadAdoptionFailure = async (label: string) => {
+  const seeded = await seedStopped("canonical-compound-readiness", label);
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  await recordRecoveryPass(seeded, BASE_3, HEAD_2);
+  const aggregate = await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  });
+  const failure = "readiness evaluation failed: Recovery authorization could not adopt the verified regression head";
+  await db.mergeRecoveryAttempt.update({ where: { id: aggregate.id }, data: {
+    status: "BLOCKED_DOWNSTREAM", failureReason: failure, endedAt: new Date(),
+  } });
+  await db.task.updateMany({
+    where: { id: { in: [seeded.gateTask.id, seeded.readinessTask!.id, seeded.integratorTask!.id] } },
+    data: { status: TaskStatus.REVIEW, failureReason: failure },
+  });
+  return { seeded, aggregate, failure };
+};
+
 test("queued recovery keeps generic PATCH, retry, and enqueue blocked until readiness completes", async () => {
   const seeded = await seedStopped("canonical-compound-readiness", "queued-recovery-guard");
   assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
@@ -245,10 +263,10 @@ test("recovery adopts the verified head produced by merging the current base bef
   const seeded = await seedStopped("canonical-compound-readiness", "readiness-recovery-adopts-regression-head");
   assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
 
-  await recordRecoveryPass(seeded, BASE_2, HEAD_2);
+  await recordRecoveryPass(seeded, BASE_3, HEAD_2);
   const tick = await readinessTick(
     db,
-    reader(snapshot(BASE_2, { headRefOid: HEAD_2, headCommitOid: HEAD_2 })),
+    reader(snapshot(BASE_3, { headRefOid: HEAD_2, headCommitOid: HEAD_2 })),
     new Date(),
     5,
     releaseChainLease,
@@ -260,6 +278,7 @@ test("recovery adopts the verified head produced by merging the current base bef
     where: { integratorTaskId: seeded.integratorTask!.id },
   });
   assert.equal(aggregate.status, "SUCCEEDED");
+  assert.equal(aggregate.currentBaseSha, BASE_3);
   assert.equal(aggregate.authorizedHeadSha, HEAD_2);
   const authorization = await db.taskActivity.findFirstOrThrow({
     where: { taskId: seeded.readinessTask!.id, metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.authorization } },
@@ -267,8 +286,95 @@ test("recovery adopts the verified head produced by merging the current base bef
   });
   const parsed = parseAuthorizationMetadata(authorization.metadata);
   assert.equal(parsed.status, "ok");
-  if (parsed.status === "ok") assert.equal(parsed.payload.headSha, HEAD_2);
+  if (parsed.status === "ok") {
+    assert.equal(parsed.payload.baseSha, BASE_3);
+    assert.equal(parsed.payload.headSha, HEAD_2);
+  }
   assert.equal(await db.run.count({ where: { taskId: seeded.integratorTask!.id, status: "QUEUED" } }), 1);
+});
+
+test("recovery authorization fails closed when its aggregate changes after the leased read", async () => {
+  const seeded = await seedStopped("canonical-compound-readiness", "readiness-recovery-adoption-cas");
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  await recordRecoveryPass(seeded, BASE_3, HEAD_2);
+  const aggregate = await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  });
+  const mutateBeforeLeaseCallback: WithMergeLease = async (target, fn, leaseDb) => {
+    await leaseDb.mergeRecoveryAttempt.update({
+      where: { id: aggregate.id },
+      data: { recoveryRunId: seeded.gateRun.id },
+    });
+    return withMergeLease(target, fn, leaseDb, {
+      acquire: acquireChainLease,
+      release: releaseLeaseAdapter,
+    });
+  };
+
+  const tick = await readinessTick(
+    db,
+    reader(snapshot(BASE_3, { headRefOid: HEAD_2, headCommitOid: HEAD_2 })),
+    new Date(),
+    5,
+    releaseChainLease,
+    mutateBeforeLeaseCallback,
+  );
+  assert.deepEqual(tick, { claimed: 1, authorized: 0, requeued: 0, stopped: 1 });
+  const stopped = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: aggregate.id } });
+  assert.equal(stopped.status, "BLOCKED_DOWNSTREAM");
+  assert.equal(
+    stopped.failureReason,
+    "readiness evaluation failed: Recovery authorization could not adopt the verified regression head",
+  );
+  assert.equal(stopped.recoveryRunId, seeded.gateRun.id);
+  assert.equal(await db.run.count({ where: { taskId: seeded.integratorTask!.id, status: "QUEUED" } }), 0);
+  assert.equal(await reopenRecoveryHeadAdoptionFailures(db), 0, "the concurrent run-binding mutation stays closed");
+});
+
+test("the current head-adoption failure reopens once and adopts leased base and head evidence", async () => {
+  const { seeded, aggregate } = await parkCurrentHeadAdoptionFailure("readiness-recovery-reopens-current-adoption-stop");
+  assert.equal(aggregate.currentBaseSha, BASE_2);
+
+  assert.equal(await reopenRecoveryHeadAdoptionFailures(db), 1);
+  assert.equal(await reopenRecoveryHeadAdoptionFailures(db), 0);
+  const reopened = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: aggregate.id } });
+  assert.equal(reopened.status, "REPAIRING");
+  assert.equal(reopened.currentBaseSha, BASE_2, "reopen preserves the pre-lease aggregate base");
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.gateTask.id } })).status, TaskStatus.DONE);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readinessTask!.id } })).status, TaskStatus.TODO);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.integratorTask!.id } })).status, TaskStatus.REVIEW);
+
+  const tick = await readinessTick(
+    db,
+    reader(snapshot(BASE_3, { headRefOid: HEAD_2, headCommitOid: HEAD_2 })),
+    new Date(),
+    5,
+    releaseChainLease,
+    runWithMergeLease,
+  );
+  assert.equal(tick.authorized, 1);
+  const completed = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: aggregate.id } });
+  assert.equal(completed.status, "SUCCEEDED");
+  assert.equal(completed.currentBaseSha, BASE_3);
+  assert.equal(completed.authorizedHeadSha, HEAD_2);
+  assert.equal(await db.run.count({ where: { taskId: seeded.integratorTask!.id, status: "QUEUED" } }), 1);
+});
+
+test("current head-adoption reopen refuses different failures and run bindings", async () => {
+  let parked = await parkCurrentHeadAdoptionFailure("readiness-recovery-current-adoption-wrong-reason");
+  await db.mergeRecoveryAttempt.update({
+    where: { id: parked.aggregate.id },
+    data: { failureReason: `${parked.failure}: different` },
+  });
+  assert.equal(await reopenRecoveryHeadAdoptionFailures(db), 0);
+
+  await resetTestDb(db);
+  parked = await parkCurrentHeadAdoptionFailure("readiness-recovery-current-adoption-wrong-run");
+  await db.mergeRecoveryAttempt.update({
+    where: { id: parked.aggregate.id },
+    data: { recoveryRunId: parked.seeded.gateRun.id },
+  });
+  assert.equal(await reopenRecoveryHeadAdoptionFailures(db), 0);
 });
 
 test("the deployed head-adoption fix reopens its exact legacy downstream stop once", async () => {

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -61,6 +61,8 @@ type ReadinessRegression = Prisma.TaskGetPayload<{ include: typeof READINESS_REG
 
 const LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE =
   "readiness evaluation failed: Recovery activation authorization is not fresh for the recovered exact head and current base";
+const CURRENT_RECOVERY_HEAD_ADOPTION_FAILURE =
+  "readiness evaluation failed: Recovery authorization could not adopt the verified regression head";
 
 export const reopenRecoveryHeadAdoptionFailures = async (
   db: PrismaClient,
@@ -69,7 +71,7 @@ export const reopenRecoveryHeadAdoptionFailures = async (
   const candidates = await db.mergeRecoveryAttempt.findMany({
     where: {
       status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
-      failureReason: LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE,
+      failureReason: { in: [LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE, CURRENT_RECOVERY_HEAD_ADOPTION_FAILURE] },
     },
     orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
     take: limit,
@@ -89,11 +91,20 @@ export const reopenRecoveryHeadAdoptionFailures = async (
         latestRecordedStop(tx, candidate.integratorTaskId),
       ]);
       const verdict = parseRegressionVerdict(output?.body ?? "", output?.kind ?? "");
+      const context = recoveryContext(attempt);
+      const baseBindingMatchesFailure = attempt?.failureReason === LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE
+        ? verdict.status === "ok" && verdict.verdict.baseHeadSha === attempt.currentBaseSha
+        : attempt?.failureReason === CURRENT_RECOVERY_HEAD_ADOPTION_FAILURE
+          ? verdict.status === "ok" && verdict.verdict.baseHeadSha !== attempt.currentBaseSha
+          : false;
       if (!attempt
+        || !context
         || attempt.status !== MergeRecoveryStatus.BLOCKED_DOWNSTREAM
-        || attempt.failureReason !== LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE
+        || (attempt.failureReason !== LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE
+          && attempt.failureReason !== CURRENT_RECOVERY_HEAD_ADOPTION_FAILURE)
+        || attempt.readinessTaskId !== candidate.readinessTaskId
+        || attempt.regressionTaskId !== candidate.regressionTaskId
         || attempt.recoveryRunId !== candidate.recoveryRunId
-        || attempt.currentBaseSha === null
         || regression?.status !== TaskStatus.REVIEW
         || readiness?.status !== TaskStatus.REVIEW
         || integrator?.status !== TaskStatus.REVIEW
@@ -104,14 +115,27 @@ export const reopenRecoveryHeadAdoptionFailures = async (
         || output?.runId !== run.id
         || output?.commitSha !== verdict.verdict.headSha
         || run.headSha !== verdict.verdict.headSha
-        || verdict.verdict.baseHeadSha !== attempt.currentBaseSha
-        || stop?.stopId !== attempt.sourceStopId) return false;
+        || !baseBindingMatchesFailure
+        || stop?.stopId !== attempt.sourceStopId
+        || stop.sourceRunId !== context.sourceRunId) return false;
 
       const updated = await tx.mergeRecoveryAttempt.updateMany({
         where: {
           id: attempt.id,
           status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
-          failureReason: LEGACY_RECOVERY_HEAD_ADOPTION_FAILURE,
+          failureReason: attempt.failureReason,
+          boundSourceRunId: context.sourceRunId,
+          authorizationActivityId: context.authorizationActivityId,
+          recoveryRunId: context.recoveryRunId,
+          readinessTaskId: context.readinessTaskId,
+          regressionTaskId: context.regressionTaskId,
+          repository: context.repository,
+          prNumber: context.prNumber,
+          targetBranch: context.targetBranch,
+          authorizedHeadSha: context.authorizedHeadSha,
+          authorizedBaseSha: context.authorizedBaseSha,
+          observedBaseSha: context.observedBaseSha,
+          currentBaseSha: context.currentBaseSha,
         },
         data: { status: MergeRecoveryStatus.REPAIRING, failureReason: null, endedAt: null },
       });
@@ -663,15 +687,20 @@ const applyReadinessDecision = async (
         // Recovery regression merges the current base before it proves the
         // candidate, so its gated head may legitimately replace the head that
         // first stopped on base drift. Adopt only the head re-read under the
-        // merge lease, and bind the CAS to this recovery run and exact base.
+        // merge lease. Bind the CAS to the pre-lease recovery snapshot, then
+        // adopt both exact evidence fields atomically.
         const adopted = await tx.mergeRecoveryAttempt.updateMany({
           where: {
             id: recovery.aggregateId,
             status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
             recoveryRunId: recovery.recoveryRunId,
-            currentBaseSha: leasedDecision.evidence.baseSha,
+            currentBaseSha: recovery.currentBaseSha,
+            authorizedHeadSha: recovery.authorizedHeadSha,
           },
-          data: { authorizedHeadSha: leasedDecision.evidence.headSha },
+          data: {
+            currentBaseSha: leasedDecision.evidence.baseSha,
+            authorizedHeadSha: leasedDecision.evidence.headSha,
+          },
         });
         if (adopted.count !== 1) {
           throw new Error("Recovery authorization could not adopt the verified regression head");


### PR DESCRIPTION
## Summary
- compare recovery authorization against the pre-lease aggregate context
- atomically adopt the exact base and head verified under the merge lease
- narrowly reopen the exact downstream stop produced by the old CAS

## Verification
- recovery dbtest: 27/27 PASS
- readiness decision unit: 8/8 PASS
- API typecheck: PASS
- Biome and ESLint: PASS
- independent incident diagnosis confirmed the CAS and reopen contract