### PR TITLE
fix(deploy): report filtered release paths

### DIFF
--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -751,6 +751,7 @@ const main = async () => {
           retention: false,
           probeImmutability: true,
         });
+        for (const path of preparedRelease.excludedPaths) log(`EXCLUDED release-path path=${path}`);
       },
       verifyStableServicePaths: async () => {
         await verifyStableServicePaths();

--- a/scripts/deploy/release-directory.mjs
+++ b/scripts/deploy/release-directory.mjs
@@ -114,7 +114,7 @@ const assertRegularFile = (path, label) => {
  * intentionally based on path components: it does not try to infer secrets
  * from arbitrary application bytes, and it keeps credentials out even when a
  * build happened to leave them underneath a selected staging directory. */
-const SECRET_COMPONENT = /^(?:\.env(?:\..*)?|\.secrets?|secrets?(?:\..*)?|credentials?(?:\..*)?|.*\.(?:pem|key|p12|pfx))$/iu;
+const SECRET_COMPONENT = /^(?:\.env(?:\..*)?|\.secrets?(?:\..*)?|credentials?(?:\..*)?|.*\.(?:pem|key|p12|pfx))$/iu;
 const MUTABLE_COMPONENTS = new Set([
   "shared",
   "data",
@@ -189,7 +189,7 @@ const ensureDestinationDirectory = (path, label) => {
   else mkdirSync(path, { recursive: true, mode: 0o700 });
 };
 
-const sourceEntry = (source, destination, stageRoot, relativePath) => {
+const sourceEntry = (source, destination, stageRoot, relativePath, excludedPaths) => {
   let status;
   try { status = lstatSync(source); } catch (error) {
     failure("release-directory-missing", `${relativePath}-missing-${error?.code ?? "unreadable"}`);
@@ -209,8 +209,11 @@ const sourceEntry = (source, destination, stageRoot, relativePath) => {
     ensureDestinationDirectory(destination, "release-directory");
     for (const entry of readdirSync(source, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name))) {
       const childRelative = `${relativePath}/${entry.name}`;
-      if (forbiddenPath(childRelative)) continue;
-      sourceEntry(join(source, entry.name), join(destination, entry.name), stageRoot, childRelative);
+      if (forbiddenPath(childRelative)) {
+        excludedPaths.add(childRelative);
+        continue;
+      }
+      sourceEntry(join(source, entry.name), join(destination, entry.name), stageRoot, childRelative, excludedPaths);
     }
     return;
   }
@@ -227,7 +230,7 @@ const sourceEntry = (source, destination, stageRoot, relativePath) => {
 };
 
 const copySelectedPaths = ({ stageRoot, releaseDirectory, requiredPaths, optionalPaths }) => {
-  const copied = [];
+  const excludedPaths = new Set();
   const optional = new Set(optionalPaths);
   for (const path of requiredPaths) {
     const normalized = normalizeRelativePath(path, "stage-path");
@@ -239,10 +242,9 @@ const copySelectedPaths = ({ stageRoot, releaseDirectory, requiredPaths, optiona
       if (optional.has(relativePath)) continue;
       failure("release-directory-missing", `${relativePath}-missing`);
     }
-    sourceEntry(child, join(releaseDirectory, relativePath), stageRoot, relativePath);
-    copied.push(relativePath);
+    sourceEntry(child, join(releaseDirectory, relativePath), stageRoot, relativePath, excludedPaths);
   }
-  return copied;
+  return Object.freeze([...excludedPaths].sort((left, right) => left.localeCompare(right)));
 };
 
 const runtimeManifestPaths = (stageRoot, paths) => {
@@ -378,6 +380,19 @@ const readReleaseManifest = (releaseDirectory) => {
   return manifest;
 };
 
+const releaseManifestExcludedPaths = (manifest) => {
+  if (manifest.excludedPaths === undefined) return Object.freeze([]);
+  if (!Array.isArray(manifest.excludedPaths)
+    || manifest.excludedPaths.some((path) => typeof path !== "string" || !forbiddenPath(path))) {
+    failure("release-manifest-invalid", "excluded-paths");
+  }
+  const normalized = [...new Set(manifest.excludedPaths)].sort((left, right) => left.localeCompare(right));
+  if (JSON.stringify(normalized) !== JSON.stringify(manifest.excludedPaths)) {
+    failure("release-manifest-invalid", "excluded-paths-order");
+  }
+  return Object.freeze(normalized);
+};
+
 /** Verify a finalized tree before activation or reuse. A changed byte, changed
  * symlink target, wrong API stamp, or restored write permission is a deployment
  * failure, even if the directory name still looks like a valid release. */
@@ -396,6 +411,7 @@ export const verifyReleaseDirectory = (options = {}) => {
   if (manifest.releaseName !== `${expectedRevision}-${observedDigest}`) failure("release-manifest-invalid", "release-name-mismatch");
   const stamp = readApiBuildStamp(join(releaseDirectory, RELEASE_API_STAMP_PATH), expectedRevision);
   if (JSON.stringify(manifest.apiBuildStamp ?? null) !== JSON.stringify(stamp)) failure("release-manifest-invalid", "api-stamp-mismatch");
+  const excludedPaths = releaseManifestExcludedPaths(manifest);
   assertImmutablePermissions(releaseDirectory);
   return Object.freeze({
     releaseDirectory,
@@ -403,6 +419,7 @@ export const verifyReleaseDirectory = (options = {}) => {
     revision: expectedRevision,
     digest: observedDigest,
     files: manifest.files,
+    excludedPaths,
     apiBuildStamp: stamp,
   });
 };
@@ -472,7 +489,7 @@ export const assembleReleaseDirectory = (options = {}) => {
   let finalized = false;
   try {
     mkdirSync(temporary, { recursive: false, mode: 0o700 });
-    copySelectedPaths({
+    const excludedPaths = copySelectedPaths({
       stageRoot,
       releaseDirectory: temporary,
       requiredPaths: inputs.paths,
@@ -493,6 +510,7 @@ export const assembleReleaseDirectory = (options = {}) => {
       commit: revision,
       digest,
       files,
+      excludedPaths,
       apiBuildStamp: copiedApiBuildStamp,
       sharedPath: relative(temporary, sharedRoot).split(sep).join("/"),
     };
@@ -505,6 +523,7 @@ export const assembleReleaseDirectory = (options = {}) => {
       revision,
       digest,
       files,
+      excludedPaths,
       apiBuildStamp: copiedApiBuildStamp,
     });
     const postVerificationWriteProbe = options.postVerificationWriteProbe;

--- a/scripts/deploy/release-directory.test.mjs
+++ b/scripts/deploy/release-directory.test.mjs
@@ -23,6 +23,7 @@ import {
   probeReleaseImmutability,
   pruneReleaseDirectories,
   RELEASE_DIRECTORY_RETENTION_COUNT,
+  RELEASE_MANIFEST_FILE,
   verifyReleaseDirectory,
 } from "./release-directory.mjs";
 
@@ -113,6 +114,69 @@ test("assembles a deterministic versioned release and excludes shared/secrets", 
     });
     assert.equal(second.releaseName, result.releaseName);
     assert.equal(second.reused, true);
+  } finally {
+    cleanup(context);
+  }
+});
+
+test("preserves ordinary source modules named secrets", () => {
+  const context = fixture();
+  try {
+    writeFileSync(join(context.stageRoot, "packages/api/dist/secrets.js"), "export const encryptSecret = () => undefined;\n");
+    writeFileSync(join(context.stageRoot, "packages/api/dist/secrets.d.ts"), "export declare const encryptSecret: () => void;\n");
+    writeFileSync(join(context.stageRoot, "packages/api/dist/secrets.js.map"), "{}\n");
+    const result = assembleReleaseDirectory({
+      stageRoot: context.stageRoot,
+      deployRoot: context.deployRoot,
+      revision,
+      artifactPaths,
+    });
+    for (const name of ["secrets.js", "secrets.d.ts", "secrets.js.map"]) {
+      assert.equal(existsSync(join(result.releaseDirectory, "packages/api/dist", name)), true);
+    }
+  } finally {
+    cleanup(context);
+  }
+});
+
+test("excludes secret-shaped files from selected release artifacts", () => {
+  const context = fixture();
+  try {
+    const paths = [".secret", ".secrets.json", "credentials.json", "server.key"];
+    for (const path of paths) writeFileSync(join(context.stageRoot, "packages/api/dist", path), "sensitive\n");
+    const result = assembleReleaseDirectory({
+      stageRoot: context.stageRoot,
+      deployRoot: context.deployRoot,
+      revision,
+      artifactPaths,
+    });
+    for (const path of paths) {
+      assert.equal(existsSync(join(result.releaseDirectory, "packages/api/dist", path)), false);
+    }
+  } finally {
+    cleanup(context);
+  }
+});
+
+test("reports every secret-shaped path excluded during materialization", () => {
+  const context = fixture();
+  try {
+    mkdirSync(join(context.stageRoot, "node_modules/vendor/.secrets"), { recursive: true });
+    writeFileSync(join(context.stageRoot, "node_modules/vendor/.secrets/token"), "sensitive\n");
+    writeFileSync(join(context.stageRoot, "packages/api/dist/.env.production"), "sensitive\n");
+    const result = assembleReleaseDirectory({
+      stageRoot: context.stageRoot,
+      deployRoot: context.deployRoot,
+      revision,
+      artifactPaths,
+    });
+    assert.deepEqual(result.excludedPaths, [
+      "node_modules/vendor/.secrets",
+      "packages/api/dist/.env.production",
+    ]);
+    const manifest = JSON.parse(readFileSync(join(result.releaseDirectory, RELEASE_MANIFEST_FILE), "utf8"));
+    assert.deepEqual(manifest.excludedPaths, result.excludedPaths);
+    assert.deepEqual(verifyReleaseDirectory({ releaseDirectory: result.releaseDirectory }).excludedPaths, result.excludedPaths);
   } finally {
     cleanup(context);
   }


### PR DESCRIPTION
## Summary
- preserve ordinary source modules named secrets in immutable releases
- retain filtering for secret-shaped paths
- record excluded paths in release manifests and deploy logs

## Verification
- RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm run test:auto-deploy
- npm run lint