### PR TITLE
fix(deploy): include database maintenance runtime

### DIFF
--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -17,8 +17,10 @@ previous -> releases/...      pointer rollback target
 ```
 
 Release artifacts contain the compiled applications, runtime dependency graph,
-Prisma schema and generated client, native assets, deployment scripts, build
-stamps, and canonical agent sources. They contain no `.env`, credentials, or
+Prisma schema, DB maintenance source modules, generated client, native assets,
+deployment scripts, build stamps, and canonical agent sources. The verifier
+checks every Prisma maintenance import rooted at `packages/db/src` before the
+quiet window. Release artifacts contain no `.env`, credentials, or
 mutable operator state. Every excluded secret-shaped path is written to the
 builder log and the release manifest.
 

--- a/scripts/deploy/quiet-window-adapters.mjs
+++ b/scripts/deploy/quiet-window-adapters.mjs
@@ -148,6 +148,7 @@ export const DEPLOY_RELEASE_EXTRA_ARTIFACT_PATHS = Object.freeze([
   "package.json",
   "package-lock.json",
   "packages/db/prisma",
+  "packages/db/src",
   "packages/build-info/index.mjs",
   "packages/build-info/index.d.ts",
   "packages/build-info/package.json",

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -83,6 +83,12 @@ const minimalBuildTree = (root, revision) => {
     commit: revision,
     dirty: false,
   })}\n`);
+  const prisma = join(root, "packages/db/prisma");
+  const source = join(root, "packages/db/src");
+  mkdirSync(prisma, { recursive: true });
+  mkdirSync(source, { recursive: true });
+  writeFileSync(join(prisma, "preflight.ts"), 'import { census } from "../src/schema-census.js";\nvoid census;\n');
+  writeFileSync(join(source, "schema-census.ts"), "export const census = true;\n");
 };
 
 const removeTree = (root) => {
@@ -127,6 +133,7 @@ test("release artifact inventory includes deploy runtime and workspace dependenc
   assert.deepEqual(workspaceDependencyPaths(root), ["apps/web/node_modules", "packages/api/node_modules"]);
   const paths = deployReleaseArtifactPaths(root);
   assert.ok(paths.includes("scripts/deploy"));
+  assert.ok(paths.includes("packages/db/src"));
   for (const path of DEPLOY_REQUIRED_ARTIFACT_PATHS) assert.ok(paths.includes(path), path);
   rmSync(root, { recursive: true, force: true });
 });
@@ -180,7 +187,7 @@ test("standalone builder creates a verified exact-commit release", () => {
     nodeBinary: "/node",
     npmBinary: "/npm",
     requiredPaths: ["packages/api/dist"],
-    artifactPaths: () => ["packages/api/dist"],
+    artifactPaths: () => ["packages/api/dist", "packages/db/prisma", "packages/db/src"],
     optionalArtifactPaths: () => [],
     execute: (program, args, options = {}) => {
       commands.push({ program, args });
@@ -188,12 +195,34 @@ test("standalone builder creates a verified exact-commit release", () => {
     },
   });
   assert.equal(artifact.revision, revisions.to);
+  assert.deepEqual(artifact.dbMaintenanceSourceImports, ["schema-census"]);
   assert.match(artifact.releaseName, new RegExp(`^${revisions.to}-[0-9a-f]{64}$`, "u"));
   assert.equal(findReleaseArtifact({ deployRoot, revision: revisions.to }).releaseName, artifact.releaseName);
   assert.equal(commands.length, 4);
   assert.deepEqual(commands.slice(1).map(({ args }) => args.slice(-2)), [
     ["--detach", revisions.to], ["/npm", "ci"], ["run", "build"],
   ]);
+  removeTree(deployRoot);
+});
+
+test("artifact verification rejects an incomplete DB maintenance runtime before activation", () => {
+  const deployRoot = mkdtempSync(join(tmpdir(), "anneal-artifact-runtime-closure-"));
+  const source = join(deployRoot, "source");
+  mkdirSync(source);
+  minimalBuildTree(source, revisions.to);
+  const assembled = assembleReleaseDirectory({
+    stageRoot: source,
+    deployRoot,
+    revision: revisions.to,
+    artifactPaths: ["packages/api/dist", "packages/db/prisma"],
+    optionalArtifactPaths: [],
+  });
+  assert.throws(
+    () => verifyReleaseArtifact({ deployRoot, revision: revisions.to, releaseName: assembled.releaseName }),
+    (error) => error instanceof DeployFailure
+      && error.reason === "release-artifact-runtime-incomplete"
+      && error.detail === "packages/db/src-missing",
+  );
   removeTree(deployRoot);
 });
 

--- a/scripts/deploy/release-artifact.mjs
+++ b/scripts/deploy/release-artifact.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -18,6 +18,41 @@ const fail = (reason, detail) => {
   throw new DeployFailure(reason, detail);
 };
 
+const maintenanceSourceImports = (releaseDirectory) => {
+  const prismaRoot = join(releaseDirectory, "packages/db/prisma");
+  const sourceRoot = join(releaseDirectory, "packages/db/src");
+  if (!existsSync(prismaRoot) || lstatSync(prismaRoot).isSymbolicLink() || !lstatSync(prismaRoot).isDirectory()) {
+    fail("release-artifact-runtime-incomplete", "packages/db/prisma-missing");
+  }
+  if (!existsSync(sourceRoot) || lstatSync(sourceRoot).isSymbolicLink() || !lstatSync(sourceRoot).isDirectory()) {
+    fail("release-artifact-runtime-incomplete", "packages/db/src-missing");
+  }
+  const imports = new Set();
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) visit(path);
+      else if (entry.isFile() && entry.name.endsWith(".ts")) {
+        const source = readFileSync(path, "utf8");
+        for (const match of source.matchAll(/\bfrom\s+["']\.\.\/src\/(?<module>[^"']+)\.js["']/gu)) {
+          imports.add(match.groups.module);
+        }
+      }
+    }
+  };
+  visit(prismaRoot);
+  for (const imported of imports) {
+    if (imported.split("/").some((component) => component === ".." || component === "")) {
+      fail("release-artifact-runtime-incomplete", "packages/db/src-import-invalid");
+    }
+    const sourcePath = join(sourceRoot, `${imported}.ts`);
+    if (!existsSync(sourcePath) || !lstatSync(sourcePath).isFile()) {
+      fail("release-artifact-runtime-incomplete", `packages/db/src/${imported}.ts-missing`);
+    }
+  }
+  return Object.freeze([...imports].sort());
+};
+
 export const verifyReleaseArtifact = ({ deployRoot, revision, releaseName }) => {
   if (!SHA.test(revision ?? "")) fail("release-artifact-invalid", "target-commit-invalid");
   const identity = RELEASE.exec(releaseName ?? "")?.groups;
@@ -28,10 +63,12 @@ export const verifyReleaseArtifact = ({ deployRoot, revision, releaseName }) => 
   if (status.isSymbolicLink() || !status.isDirectory()) fail("release-artifact-invalid", "release-path-not-directory");
   try {
     const verified = verifyReleaseDirectory({ releaseDirectory, revision, digest: identity.digest });
+    const dbMaintenanceSourceImports = maintenanceSourceImports(verified.releaseDirectory);
     return Object.freeze({
       ...verified,
       releaseDirectoryIdentity: verified.releaseName,
       buildStamp: verified.apiBuildStamp,
+      dbMaintenanceSourceImports,
     });
   } catch (error) {
     if (error instanceof DeployFailure && error.reason === "release-digest-mismatch") {


### PR DESCRIPTION
Includes the complete packages/db/src maintenance runtime in immutable releases and verifies every Prisma ../src import before quiet-window acquisition. Regression covers the production failure mode. Verification: npm run test:auto-deploy; npm run lint; npm run test:snapshot-scan.