### PR TITLE
refactor(deploy): split retired adapter module

### DIFF
--- a/scripts/deploy/deploy-preflight.mjs
+++ b/scripts/deploy/deploy-preflight.mjs
@@ -16,8 +16,8 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
-import { BLOCKING_RUN_STATUSES, DeployFailure } from "./quiet-window-lib.mjs";
 import { DEPLOYMENT_LEDGER_RETENTION_COUNT, pruneDeploymentLedgers } from "./deployment-ledger.mjs";
+import { BLOCKING_RUN_STATUSES, DeployFailure } from "./quiet-window-lib.mjs";
 
 export const DEPLOY_BACKUP_RETENTION_COUNT = 14;
 export const DEPLOY_BACKUP_DAILY_RETENTION_DAYS = 30;
@@ -86,87 +86,6 @@ export const pruneDeployHistory = ({
     removedBackups: removedBackups.length,
   });
 };
-
-export const DEPLOY_REQUIRED_ARTIFACT_PATHS = Object.freeze([
-  "packages/github-client/dist",
-  "packages/db/dist",
-  "packages/api/dist",
-  "packages/runner/dist",
-  "packages/inbox/dist",
-  "packages/merge-executor/dist",
-  "apps/web/dist",
-  "node_modules",
-]);
-
-export const DEPLOY_OPTIONAL_ARTIFACT_PATHS = Object.freeze([
-  "packages/cli/dist",
-]);
-
-export const workspaceDependencyPaths = (root) => {
-  let manifest;
-  try {
-    manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
-  } catch (error) {
-    throw new DeployFailure("workspace-layout-invalid", error?.code ?? "package-json-unreadable");
-  }
-  if (!Array.isArray(manifest.workspaces) || manifest.workspaces.length === 0) {
-    throw new DeployFailure("workspace-layout-invalid", "workspaces-must-be-a-nonempty-array");
-  }
-  const paths = [];
-  for (const pattern of manifest.workspaces) {
-    if (typeof pattern !== "string" || !pattern.endsWith("/*") || pattern.slice(0, -2).includes("*")) {
-      throw new DeployFailure("workspace-layout-invalid", `unsupported-workspace-pattern-${String(pattern)}`);
-    }
-    const parent = pattern.slice(0, -2);
-    let entries;
-    try {
-      entries = readdirSync(join(root, parent), { withFileTypes: true });
-    } catch (error) {
-      throw new DeployFailure("workspace-layout-invalid", `${parent}-${error?.code ?? "unreadable"}`);
-    }
-    for (const entry of entries) {
-      if (entry.isDirectory() && existsSync(join(root, parent, entry.name, "package.json"))) {
-        paths.push(`${parent}/${entry.name}/node_modules`);
-      }
-    }
-  }
-  return Object.freeze([...new Set(paths)].sort());
-};
-
-export const deployArtifactPaths = (root) => Object.freeze([
-  ...DEPLOY_REQUIRED_ARTIFACT_PATHS.slice(0, -1),
-  ...DEPLOY_OPTIONAL_ARTIFACT_PATHS,
-  ...workspaceDependencyPaths(root),
-  "node_modules",
-]);
-
-/** Runtime material that is not part of the legacy rename publication. These
- * paths complete the immutable release around its dist trees and dependency
- * graph: native addons, Prisma migrations, runtime-loaded canonical sources,
- * and Vite/runner assets all resolve relative to the release root. */
-export const DEPLOY_RELEASE_EXTRA_ARTIFACT_PATHS = Object.freeze([
-  "package.json",
-  "package-lock.json",
-  "packages/db/prisma",
-  "packages/db/src",
-  "packages/build-info/index.mjs",
-  "packages/build-info/index.d.ts",
-  "packages/build-info/package.json",
-  "packages/api/build/Release/control_plane_directory.node",
-  "packages/runner/assets",
-  "apps/web/vite.config.ts",
-  "apps/web/src/lib/local-origin.ts",
-  "agents/foundational.md",
-  "agents/roles",
-  "agents/templates",
-  "scripts/deploy",
-  "scripts/merge-lease.sh",
-]);
-
-export const deployReleaseArtifactPaths = (root) => Object.freeze([
-  ...deployArtifactPaths(root),
-  ...DEPLOY_RELEASE_EXTRA_ARTIFACT_PATHS,
-]);
 
 export const blockingRunsStatement = (statuses = BLOCKING_RUN_STATUSES) => {
   const placeholders = statuses.map((_, index) => `$${index + 1}`).join(",");

--- a/scripts/deploy/install-launchd.mjs
+++ b/scripts/deploy/install-launchd.mjs
@@ -30,7 +30,7 @@ import {
   DEPLOY_OPTIONAL_ARTIFACT_PATHS,
   deployReleaseArtifactPaths,
   workspaceDependencyPaths,
-} from "./quiet-window-adapters.mjs";
+} from "./release-artifacts.mjs";
 import { assembleReleaseDirectory } from "./release-directory.mjs";
 import { activateReleasePointer } from "./release-pointer.mjs";
 import { DeployFailure } from "./quiet-window-lib.mjs";

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -34,7 +34,7 @@ import {
   acquireProcessLock,
   blockingRunsStatement,
   pruneDeployHistory,
-} from "./quiet-window-adapters.mjs";
+} from "./deploy-preflight.mjs";
 import { createProductionHost } from "./quiet-window-host.mjs";
 import { runCommandWithRetry } from "./quiet-window-retry.mjs";
 import { verifyBackupConfiguration } from "./install-launchd.mjs";

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -16,9 +16,9 @@ import {
 import {
   DEPLOY_REQUIRED_ARTIFACT_PATHS,
   deployReleaseArtifactPaths,
-  pruneDeployHistory,
   workspaceDependencyPaths,
-} from "./quiet-window-adapters.mjs";
+} from "./release-artifacts.mjs";
+import { pruneDeployHistory } from "./deploy-preflight.mjs";
 import { createDeploymentLedger, DEPLOYMENT_LEDGER_STATES } from "./deployment-ledger.mjs";
 import { createProductionHost } from "./quiet-window-host.mjs";
 import { renderLaunchdPlist } from "./install-launchd.mjs";
@@ -266,7 +266,7 @@ test("dry-run reports artifact readiness and performs no mutation", async () => 
 test("deploy source has no install/build fallback, checkout mutation, or legacy publication", () => {
   const source = readFileSync(new URL("./quiet-window-deploy.mjs", import.meta.url), "utf8");
   assert.doesNotMatch(source, /npm[^\n]*(?:ci|run["', ]+build)/u);
-  assert.doesNotMatch(source, /worktree|fast-forward|publishDirectories|assertProductionCheckout|inspectGitPreflight/u);
+  assert.doesNotMatch(source, /worktree|fast-forward|assertProductionCheckout|inspectGitPreflight/u);
   assert.ok(source.indexOf("verifyArtifact:") < source.indexOf("waitForQuiet:"));
   assert.match(source, /process\.env\.AGENTOS_REPOSITORY_ROOT/u);
 });

--- a/scripts/deploy/release-artifact.mjs
+++ b/scripts/deploy/release-artifact.mjs
@@ -7,7 +7,7 @@ import {
   DEPLOY_REQUIRED_ARTIFACT_PATHS,
   deployReleaseArtifactPaths,
   workspaceDependencyPaths,
-} from "./quiet-window-adapters.mjs";
+} from "./release-artifacts.mjs";
 import { assembleReleaseDirectory, verifyReleaseDirectory } from "./release-directory.mjs";
 import { DeployFailure } from "./quiet-window-lib.mjs";
 

--- a/scripts/deploy/release-artifacts.mjs
+++ b/scripts/deploy/release-artifacts.mjs
@@ -1,0 +1,93 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { DeployFailure } from "./quiet-window-lib.mjs";
+
+export const DEPLOY_REQUIRED_ARTIFACT_PATHS = Object.freeze([
+  "packages/github-client/dist",
+  "packages/db/dist",
+  "packages/api/dist",
+  "packages/runner/dist",
+  "packages/inbox/dist",
+  "packages/merge-executor/dist",
+  "apps/web/dist",
+  "node_modules",
+]);
+
+export const DEPLOY_OPTIONAL_ARTIFACT_PATHS = Object.freeze([
+  "packages/cli/dist",
+]);
+
+export const workspaceDependencyPaths = (root) => {
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+  } catch (error) {
+    throw new DeployFailure("workspace-layout-invalid", error?.code ?? "package-json-unreadable");
+  }
+  if (!Array.isArray(manifest.workspaces) || manifest.workspaces.length === 0) {
+    throw new DeployFailure("workspace-layout-invalid", "workspaces-must-be-a-nonempty-array");
+  }
+  const paths = [];
+  for (const pattern of manifest.workspaces) {
+    if (typeof pattern !== "string" || !pattern.endsWith("/*") || pattern.slice(0, -2).includes("*")) {
+      throw new DeployFailure("workspace-layout-invalid", `unsupported-workspace-pattern-${String(pattern)}`);
+    }
+    const parent = pattern.slice(0, -2);
+    let entries;
+    try {
+      entries = readdirSync(join(root, parent), { withFileTypes: true });
+    } catch (error) {
+      throw new DeployFailure("workspace-layout-invalid", `${parent}-${error?.code ?? "unreadable"}`);
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory() && existsSync(join(root, parent, entry.name, "package.json"))) {
+        paths.push(`${parent}/${entry.name}/node_modules`);
+      }
+    }
+  }
+  return Object.freeze([...new Set(paths)].sort());
+};
+
+export const deployArtifactPaths = (root) => Object.freeze([
+  ...DEPLOY_REQUIRED_ARTIFACT_PATHS.slice(0, -1),
+  ...DEPLOY_OPTIONAL_ARTIFACT_PATHS,
+  ...workspaceDependencyPaths(root),
+  "node_modules",
+]);
+
+export const RELEASE_RUNTIME_PATHS = Object.freeze([
+  ...DEPLOY_REQUIRED_ARTIFACT_PATHS,
+  "packages/db/prisma",
+  "packages/build-info/index.mjs",
+  "packages/build-info/index.d.ts",
+  "packages/build-info/package.json",
+]);
+
+/** Runtime material that completes the immutable release around its dist
+ * trees and dependency graph: native addons, Prisma migrations,
+ * runtime-loaded canonical sources, and Vite/runner assets all resolve
+ * relative to the release root. */
+export const DEPLOY_RELEASE_EXTRA_ARTIFACT_PATHS = Object.freeze([
+  "package.json",
+  "package-lock.json",
+  "packages/db/prisma",
+  "packages/db/src",
+  "packages/build-info/index.mjs",
+  "packages/build-info/index.d.ts",
+  "packages/build-info/package.json",
+  "packages/api/build/Release/control_plane_directory.node",
+  "packages/runner/assets",
+  "apps/web/vite.config.ts",
+  "apps/web/src/lib/local-origin.ts",
+  "agents/foundational.md",
+  "agents/roles",
+  "agents/templates",
+  "scripts/deploy",
+  "scripts/merge-lease.sh",
+]);
+
+export const deployReleaseArtifactPaths = (root) => Object.freeze([
+  ...deployArtifactPaths(root),
+  ...DEPLOY_RELEASE_EXTRA_ARTIFACT_PATHS,
+]);

--- a/scripts/deploy/release-directory.mjs
+++ b/scripts/deploy/release-directory.mjs
@@ -17,11 +17,6 @@ import {
 } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
-import {
-  DEPLOY_OPTIONAL_ARTIFACT_PATHS,
-  DEPLOY_REQUIRED_ARTIFACT_PATHS,
-  deployArtifactPaths,
-} from "./quiet-window-adapters.mjs";
 import { DeployFailure } from "./quiet-window-lib.mjs";
 
 /** The release tree is bounded to a small rollback window. A caller may retain
@@ -34,14 +29,6 @@ const REVISION = /^[0-9a-f]{40}$/u;
 const DIGEST = /^[0-9a-f]{64}$/u;
 const RELEASE_NAME = /^[0-9a-f]{40}-[0-9a-f]{64}$/u;
 const API_PACKAGE_NAMES = new Set(["@anneal/api", "@agentos/api"]);
-
-const RELEASE_RUNTIME_PATHS = Object.freeze([
-  ...DEPLOY_REQUIRED_ARTIFACT_PATHS,
-  "packages/db/prisma",
-  "packages/build-info/index.mjs",
-  "packages/build-info/index.d.ts",
-  "packages/build-info/package.json",
-]);
 
 const invalid = (detail) => {
   throw new DeployFailure("release-directory-invalid", detail);
@@ -259,30 +246,13 @@ const runtimeManifestPaths = (stageRoot, paths) => {
 
 const resolveInputs = ({ stageRoot, artifactPaths, optionalArtifactPaths }) => {
   const supplied = artifactPaths;
-  if (supplied !== undefined && !Array.isArray(supplied)) invalid("artifact-paths-must-be-an-array");
-  const explicitlySupplied = supplied !== undefined;
-  let selected;
-  let optional;
-  if (explicitlySupplied) {
-    // An explicit list is the caller's artifact inventory. Keeping that list
-    // exact makes an omitted runtime component a loud missing-artifact failure
-    // instead of silently changing the deploy contract under the caller.
-    selected = [...supplied];
-    optional = optionalArtifactPaths ?? [];
-  } else {
-    let discovered;
-    try { discovered = deployArtifactPaths(stageRoot); } catch {
-      discovered = [...RELEASE_RUNTIME_PATHS, ...DEPLOY_OPTIONAL_ARTIFACT_PATHS];
-    }
-    selected = [...discovered];
-    optional = [
-      ...DEPLOY_OPTIONAL_ARTIFACT_PATHS,
-      ...discovered.filter((path) => !DEPLOY_REQUIRED_ARTIFACT_PATHS.includes(path)
-        && !path.startsWith("packages/db/prisma")
-        && !path.startsWith("packages/build-info/")),
-    ];
-    selected.push("packages/db/prisma", "packages/build-info/index.mjs", "packages/build-info/index.d.ts", "packages/build-info/package.json");
-  }
+  if (supplied === undefined) failure("workspace-layout-invalid", "artifact-paths-missing");
+  if (!Array.isArray(supplied)) invalid("artifact-paths-must-be-an-array");
+  // An explicit list is the caller's artifact inventory. Keeping that list
+  // exact makes an omitted runtime component a loud missing-artifact failure
+  // instead of silently changing the deploy contract under the caller.
+  const selected = [...supplied];
+  const optional = optionalArtifactPaths ?? [];
   if (!Array.isArray(optional)) invalid("optional-artifact-paths-must-be-an-array");
   const normalizedSelected = [...new Set(selected.map((path) => normalizeRelativePath(path, "artifact-path")))];
   const normalizedOptional = new Set(optional.map((path) => normalizeRelativePath(path, "optional-artifact-path")));
@@ -290,7 +260,6 @@ const resolveInputs = ({ stageRoot, artifactPaths, optionalArtifactPaths }) => {
   return {
     paths: [...new Set(normalizedSelected)],
     optional: [...normalizedOptional],
-    explicitlySupplied,
   };
 };
 

--- a/scripts/deploy/release-directory.test.mjs
+++ b/scripts/deploy/release-directory.test.mjs
@@ -86,6 +86,24 @@ const artifactPaths = [
   "node_modules",
 ];
 
+test("rejects a missing artifact inventory for an invalid workspace layout", () => {
+  const context = fixture();
+  try {
+    assert.throws(
+      () => assembleReleaseDirectory({
+        stageRoot: context.stageRoot,
+        deployRoot: context.deployRoot,
+        revision,
+      }),
+      (error) => error instanceof DeployFailure
+        && error.reason === "workspace-layout-invalid"
+        && error.detail === "artifact-paths-missing",
+    );
+  } finally {
+    cleanup(context);
+  }
+});
+
 test("assembles a deterministic versioned release and excludes shared/secrets", () => {
   const context = fixture();
   try {


### PR DESCRIPTION
## Candidate

Candidate 08: retire the ADR-0004 deployment adapter container.

## Changes

1. Retired the remaining legacy publication surface by removing the last `publishDirectories` source assertion and deleting `quiet-window-adapters.mjs`. The function and its three self-supporting tests were already absent from baseline `4d19024e` via `60153baa`.
2. Removed `resolveInputs` implicit artifact discovery and its swallowed `DeployFailure`. A missing `artifactPaths` inventory now fails loudly with the existing `DeployFailure` type and `workspace-layout-invalid` reason.
3. Added `release-artifacts.mjs` as the authoritative home for release artifact path inventories and the workspace/artifact path functions. Updated the live artifact callers and tests to import it.
4. Added `deploy-preflight.mjs` as the home for the database blocking query, process lock, and deploy-history retention concerns. `quiet-window-deploy.mjs` imports these functions from the new module. `inspectGitPreflight` and its git checks were already absent from the specified baseline and were not reintroduced.
5. Removed `quiet-window-adapters.mjs` with no remaining imports.
6. Added a regression test proving that an invalid stage workspace with missing `artifactPaths` throws `workspace-layout-invalid` instead of producing a guessed inventory.

## Verification

- `npm install`: PASS
- `npm run lint`: PASS
- `npm run typecheck`: PASS
- `node --test scripts/deploy/release-directory.test.mjs`: PASS, 13/13
- `npm run test:auto-deploy`: PASS, 47/47
- `grep -rn publishDirectories scripts/ packages/ apps/`: no results
- `quiet-window-adapters.mjs`: absent
- `release-artifacts.mjs` and `deploy-preflight.mjs`: present
- `resolveInputs`: no catch fallback

## quiet-window-deploy.mjs diff evidence

`git diff --numstat 4d19024e..d239aebf -- scripts/deploy/quiet-window-deploy.mjs` reports `1 1`; the only changed line is the import source:

```diff
-} from "./quiet-window-adapters.mjs";
+} from "./deploy-preflight.mjs";
```

## Out of scope observed

- Baseline `4d19024e` had already removed `publishDirectories`, its dedicated tests, and `inspectGitPreflight`; this change did not restore or redesign them.
- No changes were made to `DEPLOY_STEPS`, `executeUpgrade` phase order, `quiet-window-host.mjs` methods, the production host object structure, deployment ledger roles, release pointer filesystem injection, launchd installation order, or `main()` statement order.
- No additional adjacent issue was changed.
