### PR TITLE
refactor(api): extract run cancellation adapter

### DIFF
--- a/packages/api/src/active-run-cancellation.dbtest.ts
+++ b/packages/api/src/active-run-cancellation.dbtest.ts
@@ -5,6 +5,7 @@ import { PrismaClient, RunStatus, SessionExecutionStatus, TaskStatus } from "@an
 
 import { suspendForInbox } from "./inbox.js";
 import { reconcileDatabaseRuns } from "./reconcile.js";
+import { acknowledgeCancellation, cancelRun } from "./run-cancel.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
@@ -89,14 +90,28 @@ test("every live provider status exposes one idempotent cancellation through hea
   for (const status of [RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING]) {
     const seeded = await seed(status);
     const requestId = `cancel-${status.toLowerCase()}`;
-    const requested = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, { requestId, reason: `stop ${status}` });
-    assert.equal(requested.status, 200);
-    assert.equal(requested.body.cancellationState, "requested");
+    const requested = await cancelRun(db, seeded.run.id, {
+      requestId,
+      reason: `stop ${status}`,
+      parkTask: false,
+    });
+    assert.ok(!("message" in requested));
+    assert.equal(requested.cancellationState, "requested");
 
-    const duplicate = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, { requestId, reason: "ignored duplicate wording" });
-    assert.equal(duplicate.status, 200);
-    assert.equal(duplicate.body.requestId, requestId);
-    assert.equal((await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, { requestId: `${requestId}-other`, reason: "other" })).status, 409);
+    const duplicate = await cancelRun(db, seeded.run.id, {
+      requestId,
+      reason: "ignored duplicate wording",
+      parkTask: false,
+    });
+    assert.ok(!("message" in duplicate));
+    assert.equal(duplicate.requestId, requestId);
+    const conflict = await cancelRun(db, seeded.run.id, {
+      requestId: `${requestId}-other`,
+      reason: "other",
+      parkTask: false,
+    });
+    assert.ok("message" in conflict);
+    assert.equal(conflict.reason, "conflict");
 
     const lateEvents = await call("POST", `/runner/runs/${seeded.run.id}/events`, RUNNER, {
       runnerId: RUNNER_ID,
@@ -115,14 +130,15 @@ test("every live provider status exposes one idempotent cancellation through hea
     assert.equal(observed.body.cancellation.requestId, requestId);
     assert.equal(observed.body.cancellation.reason, `stop ${status}`);
 
-    const acknowledged = await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
-      runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken, requestId,
+    const acknowledged = await acknowledgeCancellation(db, seeded.run.id, {
+      runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken!, requestId,
     });
-    assert.equal(acknowledged.status, 200);
-    assert.equal(acknowledged.body.status, RunStatus.CANCELLED);
-    assert.equal((await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
-      runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken, requestId,
-    })).status, 200);
+    assert.ok(!("message" in acknowledged));
+    assert.equal(acknowledged.status, RunStatus.CANCELLED);
+    const acknowledgementReplay = await acknowledgeCancellation(db, seeded.run.id, {
+      runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken!, requestId,
+    });
+    assert.ok(!("message" in acknowledgementReplay));
 
     const [run, task, successor, runs] = await Promise.all([
       db.run.findUniqueOrThrow({ where: { id: seeded.run.id } }),
@@ -167,49 +183,66 @@ test("mechanical merge Runs refuse cancellation before recording an intent", asy
   } });
   await db.task.update({ where: { id: seeded.task.id }, data: { templateId: template.id, templateStepId: step.id } });
 
-  const response = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+  const response = await cancelRun(db, seeded.run.id, {
     requestId: "cancel-mechanical",
     reason: "must be refused",
+    parkTask: false,
   });
-  assert.equal(response.status, 409);
-  assert.match(response.body.error, /Mechanical merge Runs cannot be cancelled/u);
+  assert.ok("message" in response);
+  assert.match(response.message, /Mechanical merge Runs cannot be cancelled/u);
   const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
   assert.equal(run.cancelRequestId, null);
   assert.equal(run.cancelRequestedAt, null);
+
+  assert.equal((await call("POST", `/runs/${seeded.run.id}/cancel`, RUNNER, {
+    requestId: "cancel-mechanical",
+    reason: "runner lacks operator authority",
+  })).status, 403);
+  assert.equal((await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+    requestId: "cancel-mechanical",
+    reason: "map module conflict",
+  })).status, 409);
 
   await db.run.update({ where: { id: seeded.run.id }, data: {
     cancelRequestId: "legacy-mechanical-cancel",
     cancelReason: "persisted before upgrade",
     cancelRequestedAt: new Date(),
   } });
-  const replay = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+  const replay = await cancelRun(db, seeded.run.id, {
     requestId: "legacy-mechanical-cancel",
     reason: "same request replay",
+    parkTask: false,
   });
-  assert.equal(replay.status, 200);
-  assert.equal(replay.body.cancellationState, "requested");
-  assert.equal((await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+  assert.ok(!("message" in replay));
+  assert.equal(replay.cancellationState, "requested");
+  const replayConflict = await cancelRun(db, seeded.run.id, {
     requestId: "different-mechanical-cancel",
     reason: "must conflict",
-  })).status, 409);
+    parkTask: false,
+  });
+  assert.ok("message" in replayConflict);
+  assert.equal(replayConflict.reason, "conflict");
 });
 
 test("cancellation acknowledgement persists a provisioning workspace before terminalizing", async () => {
   const seeded = await seed(RunStatus.PROVISIONING);
   await db.run.update({ where: { id: seeded.run.id }, data: { workspacePath: null, branch: null, baseSha: null } });
   const requestId = "cancel-with-workspace";
-  assert.equal((await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+  const requested = await cancelRun(db, seeded.run.id, {
     requestId,
     reason: "retain provisioning evidence",
-  })).status, 200);
-  assert.equal((await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
+    parkTask: false,
+  });
+  assert.ok(!("message" in requested));
+  const acknowledged = await acknowledgeCancellation(db, seeded.run.id, {
     runnerId: RUNNER_ID,
-    fencingToken: seeded.run.fencingToken,
+    fencingToken: seeded.run.fencingToken!,
     requestId,
     workspacePath: "/scratch/provisioning-evidence",
     branch: "codex/provisioning-evidence",
     baseSha: "a".repeat(40),
-  })).status, 200);
+  });
+  assert.ok(!("message" in acknowledged));
   const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
   assert.equal(run.status, RunStatus.CANCELLED);
   assert.equal(run.workspacePath, "/scratch/provisioning-evidence");
@@ -270,18 +303,18 @@ test("start and cancellation acknowledgement serialize to one Run and Session ou
     await reached;
     let cancellationSettled = false;
     const cancellation = (async () => {
-      const requested = await createApp(db).request(`/runs/${seeded.run.id}/cancel`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${OPERATOR}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ requestId: "cancel-start-race", reason: "operator stop" }),
+      const requested = await cancelRun(db, seeded.run.id, {
+        requestId: "cancel-start-race",
+        reason: "operator stop",
+        parkTask: false,
       });
-      assert.equal(requested.status, 200, await requested.text());
-      const acknowledged = await createApp(db).request(`/runner/runs/${seeded.run.id}/cancel/acknowledge`, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${RUNNER}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken, requestId: "cancel-start-race" }),
+      assert.ok(!("message" in requested));
+      const acknowledged = await acknowledgeCancellation(db, seeded.run.id, {
+        runnerId: RUNNER_ID,
+        fencingToken: seeded.run.fencingToken!,
+        requestId: "cancel-start-race",
       });
-      assert.equal(acknowledged.status, 200, await acknowledged.text());
+      assert.ok(!("message" in acknowledged));
       cancellationSettled = true;
     })();
     await new Promise<void>((resolve) => setTimeout(resolve, 100));
@@ -305,43 +338,43 @@ test("start and cancellation acknowledgement serialize to one Run and Session ou
 
 test("only an unclaimed QUEUED cancellation settles without runner acknowledgement", async () => {
   const queued = await seed(RunStatus.QUEUED);
-  const queuedResponse = await call("POST", `/runs/${queued.run.id}/cancel`, OPERATOR, {
-    requestId: "cancel-immediate-queued", reason: "operator stop",
+  const queuedResponse = await cancelRun(db, queued.run.id, {
+    requestId: "cancel-immediate-queued", reason: "operator stop", parkTask: false,
   });
-  assert.equal(queuedResponse.status, 200);
-  assert.equal(queuedResponse.body.cancellationState, "acknowledged");
+  assert.ok(!("message" in queuedResponse));
+  assert.equal(queuedResponse.cancellationState, "acknowledged");
   assert.ok((await db.run.findUniqueOrThrow({ where: { id: queued.run.id } })).cancelAcknowledgedAt);
 
   const waiting = await seed(RunStatus.WAITING_INBOX);
   const requestId = "cancel-waiting-provider-cleanup";
-  const waitingResponse = await call("POST", `/runs/${waiting.run.id}/cancel`, OPERATOR, {
-    requestId, reason: "operator stop",
+  const waitingResponse = await cancelRun(db, waiting.run.id, {
+    requestId, reason: "operator stop", parkTask: false,
   });
-  assert.equal(waitingResponse.status, 200);
-  assert.equal(waitingResponse.body.cancellationState, "requested");
+  assert.ok(!("message" in waitingResponse));
+  assert.equal(waitingResponse.cancellationState, "requested");
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: waiting.run.id } })).status, RunStatus.WAITING_INBOX);
-  const acknowledged = await call("POST", `/runner/runs/${waiting.run.id}/cancel/acknowledge`, RUNNER, {
-    runnerId: RUNNER_ID, fencingToken: waiting.run.fencingToken, requestId,
+  const acknowledged = await acknowledgeCancellation(db, waiting.run.id, {
+    runnerId: RUNNER_ID, fencingToken: waiting.run.fencingToken!, requestId,
   });
-  assert.equal(acknowledged.status, 200);
+  assert.ok(!("message" in acknowledged));
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: waiting.run.id } })).status, RunStatus.CANCELLED);
 });
 
 test("stop-and-park records cancellation intent and keeps the Task in Backlog after acknowledgement", async () => {
   const seeded = await seed(RunStatus.RUNNING);
   const requestId = "cancel-and-park";
-  const requested = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+  const requested = await cancelRun(db, seeded.run.id, {
     requestId, reason: "pause implementation", parkTask: true,
   });
-  assert.equal(requested.status, 200);
-  assert.equal(requested.body.cancellationState, "requested");
+  assert.ok(!("message" in requested));
+  assert.equal(requested.cancellationState, "requested");
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.task.id } })).status, TaskStatus.BACKLOG);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.successor.id } })).status, TaskStatus.TODO);
 
-  const acknowledged = await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
-    runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken, requestId,
+  const acknowledged = await acknowledgeCancellation(db, seeded.run.id, {
+    runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken!, requestId,
   });
-  assert.equal(acknowledged.status, 200);
+  assert.ok(!("message" in acknowledged));
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.task.id } })).status, TaskStatus.BACKLOG);
   assert.equal(await db.run.count({ where: { taskId: seeded.task.id, status: { in: [
     RunStatus.QUEUED, RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING, RunStatus.WAITING_INBOX,
@@ -398,16 +431,16 @@ test("stop-and-park takes the full-chain mutex while a sibling row is locked", {
   try {
     await siblingLockHeld;
     let cancellationSettled = false;
-    const cancellation = call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+    const cancellation = cancelRun(instrumentedCancellationClient, seeded.run.id, {
       requestId: "cancel-chain-mutex",
       reason: "pause chained implementation",
       parkTask: true,
-    }, instrumentedCancellationClient).finally(() => { cancellationSettled = true; });
+    }).finally(() => { cancellationSettled = true; });
     assert.equal(await observedLockScope, true);
     assert.equal(cancellationSettled, false);
     releaseSibling();
     const response = await cancellation;
-    assert.equal(response.status, 200);
+    assert.ok(!("message" in response));
     assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.task.id } })).status, TaskStatus.BACKLOG);
   } finally {
     releaseSibling();
@@ -446,16 +479,23 @@ test("a late runner acknowledgement backfills workspace evidence after reconcili
     baseSha: null,
   } });
   assert.equal(await reconcileDatabaseRuns(db, now), 1);
-  const response = await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
+  const replay = await cancelRun(db, seeded.run.id, {
+    requestId: "cancel-reconciled-first",
+    reason: "replayed after runner loss",
+    parkTask: false,
+  });
+  assert.ok(!("message" in replay));
+  assert.equal(replay.cancellationState, "unconfirmed");
+  const response = await acknowledgeCancellation(db, seeded.run.id, {
     runnerId: RUNNER_ID,
-    fencingToken: seeded.run.fencingToken,
+    fencingToken: seeded.run.fencingToken!,
     requestId: "cancel-reconciled-first",
     workspacePath: "/scratch/reconciled-first",
     branch: "codex/reconciled-first",
     baseSha: "b".repeat(40),
     worktreeContainmentViolations: ["/operator/worktrees/reconciled-first"],
   });
-  assert.equal(response.status, 200);
+  assert.ok(!("message" in response));
   const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
   assert.equal(run.status, RunStatus.CANCELLED);
   assert.ok(run.cancelAcknowledgedAt);
@@ -464,16 +504,16 @@ test("a late runner acknowledgement backfills workspace evidence after reconcili
   assert.equal(run.baseSha, "b".repeat(40));
   assert.deepEqual(run.worktreeContainmentViolations, ["/operator/worktrees/reconciled-first"]);
 
-  const conflicting = await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
+  const conflicting = await acknowledgeCancellation(db, seeded.run.id, {
     runnerId: RUNNER_ID,
-    fencingToken: seeded.run.fencingToken,
+    fencingToken: seeded.run.fencingToken!,
     requestId: "cancel-reconciled-first",
     workspacePath: "/scratch/must-not-overwrite",
     branch: "codex/must-not-overwrite",
     baseSha: "c".repeat(40),
     worktreeContainmentViolations: ["/operator/worktrees/must-not-overwrite"],
   });
-  assert.equal(conflicting.status, 200);
+  assert.ok(!("message" in conflicting));
   const preserved = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
   assert.equal(preserved.workspacePath, "/scratch/reconciled-first");
   assert.equal(preserved.branch, "codex/reconciled-first");
@@ -484,18 +524,19 @@ test("a late runner acknowledgement backfills workspace evidence after reconcili
 test("cancellation acknowledgement persists containment evidence without changing cancellation", async () => {
   const seeded = await seed(RunStatus.RUNNING);
   const requestId = "cancel-with-containment";
-  assert.equal((await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
-    requestId, reason: "stop after worktree escape",
-  })).status, 200);
+  const requested = await cancelRun(db, seeded.run.id, {
+    requestId, reason: "stop after worktree escape", parkTask: false,
+  });
+  assert.ok(!("message" in requested));
   const violations = ["/operator/worktrees/one", "/operator/worktrees/two"];
-  const acknowledged = await call("POST", `/runner/runs/${seeded.run.id}/cancel/acknowledge`, RUNNER, {
+  const acknowledged = await acknowledgeCancellation(db, seeded.run.id, {
     runnerId: RUNNER_ID,
-    fencingToken: seeded.run.fencingToken,
+    fencingToken: seeded.run.fencingToken!,
     requestId,
     worktreeContainmentViolations: violations,
   });
-  assert.equal(acknowledged.status, 200);
-  assert.equal(acknowledged.body.status, RunStatus.CANCELLED);
+  assert.ok(!("message" in acknowledged));
+  assert.equal(acknowledged.status, RunStatus.CANCELLED);
   const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
   assert.equal(run.status, RunStatus.CANCELLED);
   assert.deepEqual(run.worktreeContainmentViolations, violations);
@@ -536,12 +577,13 @@ test("reconciliation re-reads cancellation after its stale candidate snapshot", 
   try {
     const reconciliation = reconcileDatabaseRuns(reconcileDb, now);
     await reached;
-    const cancellation = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
+    const cancellation = await cancelRun(db, seeded.run.id, {
       requestId: "cancel-after-snapshot",
       reason: "operator stop",
+      parkTask: false,
     });
-    assert.equal(cancellation.status, 200);
-    assert.equal(cancellation.body.cancellationState, "requested");
+    assert.ok(!("message" in cancellation));
+    assert.equal(cancellation.cancellationState, "requested");
     releaseSnapshot();
     assert.equal(await reconciliation, 1);
   } finally {
@@ -562,11 +604,11 @@ test("a cancellation intent fences out a late Inbox suspension", async () => {
     where: { id: seeded.session!.id },
     data: { providerConversationId: "conversation-before-cancel" },
   });
-  const requested = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
-    requestId: "cancel-before-inbox", reason: "stop before question",
+  const requested = await cancelRun(db, seeded.run.id, {
+    requestId: "cancel-before-inbox", reason: "stop before question", parkTask: false,
   });
-  assert.equal(requested.status, 200);
-  assert.equal(requested.body.cancellationState, "requested");
+  assert.ok(!("message" in requested));
+  assert.equal(requested.cancellationState, "requested");
   await assert.rejects(
     suspendForInbox(db, {
       runId: seeded.run.id,
@@ -590,11 +632,11 @@ test("a completion that commits first remains authoritative", async () => {
     retryable: false, pushStatus: "NOT_REQUESTED", cleanupStatus: "RETAINED", workspaceRetained: true,
   });
   assert.equal(completed.status, 200);
-  const cancellation = await call("POST", `/runs/${seeded.run.id}/cancel`, OPERATOR, {
-    requestId: "cancel-too-late", reason: "too late",
+  const cancellation = await cancelRun(db, seeded.run.id, {
+    requestId: "cancel-too-late", reason: "too late", parkTask: false,
   });
-  assert.equal(cancellation.status, 200);
-  assert.equal(cancellation.body.cancellationState, "terminal");
+  assert.ok(!("message" in cancellation));
+  assert.equal(cancellation.cancellationState, "terminal");
   const run = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
   assert.equal(run.status, RunStatus.FAILED);
   assert.equal(run.cancelRequestId, null);

--- a/packages/api/src/active-run-cancellation.dbtest.ts
+++ b/packages/api/src/active-run-cancellation.dbtest.ts
@@ -343,6 +343,7 @@ test("only an unclaimed QUEUED cancellation settles without runner acknowledgeme
   });
   assert.ok(!("message" in queuedResponse));
   assert.equal(queuedResponse.cancellationState, "acknowledged");
+  assert.equal("reason" in queuedResponse, false);
   assert.ok((await db.run.findUniqueOrThrow({ where: { id: queued.run.id } })).cancelAcknowledgedAt);
 
   const waiting = await seed(RunStatus.WAITING_INBOX);

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -148,7 +148,6 @@ import {
   type RunFence,
   withFencedRun,
 } from "./run-fence.js";
-import { terminalizeRun } from "./run-terminal.js";
 import { InboxRunFenceRefusal, supersedeTaskInboxMessage, suspendForInbox } from "./inbox.js";
 import { createStarterInstallation, onboardingInput, onboardingStatus } from "./onboarding.js";
 import { preflightOnboardingRepository, RepositoryPreflightError } from "./onboarding-preflight.js";
@@ -182,6 +181,7 @@ import {
 } from "./revalidation.js";
 import { claimRun, OPERATOR_NOTE_METADATA_FIELD } from "./run-claim.js";
 import { completeRun } from "./run-completion.js";
+import { acknowledgeCancellation, cancelRun } from "./run-cancel.js";
 import { withoutUndefined } from "./without-undefined.js";
 import { versionPayload } from "./version.js";
 
@@ -3763,32 +3763,13 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/runner/runs/:runId/cancel/acknowledge", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, cancelAcknowledgeInput);
-    const result = await db.$transaction((tx) => terminalizeRun(tx, {
-      runId,
-      at: new Date(),
-      outcome: {
-        kind: "cancelled",
-        requestId: body.requestId,
-        runnerId: body.runnerId,
-        fencingToken: body.fencingToken,
-        actorId: body.runnerId,
-        cleanupConfirmed: true,
-        activity: "acknowledged",
-        ...(body.workspacePath === undefined ? {} : { workspacePath: body.workspacePath }),
-        ...(body.branch === undefined ? {} : { branch: body.branch }),
-        ...(body.baseSha === undefined ? {} : { baseSha: body.baseSha }),
-        ...(body.worktreeContainmentViolations === undefined
-          ? {}
-          : { worktreeContainmentViolations: body.worktreeContainmentViolations }),
-      },
-    }));
-    if (result === null) return refusalJson(context, refusal("conflict", "Run changed while cancellation was being acknowledged"));
+    const result = await acknowledgeCancellation(db, runId, body);
     if ("message" in result) return refusalJson(context, result);
-    const { leaseToRelease, ...settlement } = result;
+    const { releaseMergeLeaseTask, ...settlement } = result;
     // Cancellation is a terminal write. The lease target is deliberately
     // released only after that transaction commits, when the release adapter
     // can also record the confirmed deletion and its hold window.
-    await releaseChainLease(leaseToRelease, db);
+    await releaseChainLease(releaseMergeLeaseTask, db);
     return context.json(settlement);
   });
 
@@ -4430,135 +4411,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/runs/:runId/cancel", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, cancelRunInput);
-    const result = await db.$transaction(async (tx) => {
-      await lockRunRow(tx, runId);
-      const run = await tx.run.findUnique({
-        where: { id: runId },
-        select: {
-          id: true,
-          status: true,
-          taskId: true,
-          runNumber: true,
-          runnerId: true,
-          fencingToken: true,
-          leaseExpiresAt: true,
-          claimedAt: true,
-          cancelRequestId: true,
-          cancelReason: true,
-          cancelRequestedAt: true,
-          cancelAcknowledgedAt: true,
-          session: { select: { id: true } },
-          task: { select: { templateStep: { select: {
-            stepIndex: true,
-            outputKind: true,
-            taskTemplate: { select: { name: true } },
-          } } } },
-        },
-      });
-      if (!run) return refusal("not-found", "Run not found");
-      if (body.parkTask && !run.taskId) return refusal("conflict", "Run has no Task to park");
-      const parkTarget = body.parkTask && run.taskId ? await lockTaskMutationRows(tx, run.taskId) : null;
-      if (body.parkTask && run.taskId && !parkTarget) return refusal("not-found", "Task not found");
-      if (parkTarget && parkTarget.archivedAt !== null) {
-        return refusal("conflict", "Cannot park an archived task");
-      }
-      if (parkTarget?.status === TaskStatus.DONE) return refusal("conflict", "Cannot park a completed task");
-      const parkTask = async () => {
-        const task = parkTarget;
-        if (!task) return;
-        if (task.status === TaskStatus.BACKLOG) return null;
-        const reason = run.cancelRequestId ? run.cancelReason ?? body.reason : body.reason;
-        await tx.task.update({
-          where: { id: task.id },
-          data: { status: TaskStatus.BACKLOG, failureReason: reason },
-        });
-        await tx.taskActivity.create({ data: {
-          taskId: task.id,
-          actorType: "operator",
-          body: `Status changed: ${task.status} → ${TaskStatus.BACKLOG}`,
-          metadata: { runId: run.id, requestId: body.requestId, reason: "stop-and-park" },
-        } });
-      };
-      if (run.cancelRequestId) {
-        if (run.cancelRequestId !== body.requestId) {
-          return refusal("conflict", `Run already has cancellation request ${run.cancelRequestId}`);
-        }
-        await parkTask();
-        return {
-          runId: run.id,
-          taskId: run.taskId,
-          status: run.status,
-          cancellationState: run.cancelAcknowledgedAt
-            ? "acknowledged" as const
-            : run.status === RunStatus.CANCELLED ? "unconfirmed" as const : "requested" as const,
-          requestId: run.cancelRequestId,
-          reason: run.cancelReason,
-          releaseMergeLeaseTask: null,
-        };
-      }
-      if (executionModeFor(run.task?.templateStep ?? null) === "mechanical") {
-        return refusal("conflict", "Mechanical merge Runs cannot be cancelled after authorization");
-      }
-      if (!([RunStatus.QUEUED, ...activeRunStatuses] as RunStatus[]).includes(run.status)) {
-        return {
-          runId: run.id,
-          taskId: run.taskId,
-          status: run.status,
-          cancellationState: "terminal" as const,
-          requestId: body.requestId,
-          reason: null,
-          releaseMergeLeaseTask: null,
-        };
-      }
-      const now = new Date();
-      const requested = await tx.run.updateMany({
-        where: { id: run.id, cancelRequestId: null, status: run.status },
-        data: {
-          cancelRequestId: body.requestId,
-          cancelReason: body.reason,
-          cancelRequestedAt: now,
-          sessionTokenRevokedAt: now,
-        },
-      });
-      if (requested.count !== 1) return refusal("conflict", "Run changed while cancellation was being requested");
-      await parkTask();
-      if (run.taskId) await tx.taskActivity.create({ data: {
-        taskId: run.taskId,
-        actorType: "operator",
-        body: `Cancellation requested for Run ${run.runNumber}: ${body.reason}`,
-        metadata: { runId: run.id, requestId: body.requestId, priorStatus: run.status, state: "requested" },
-      } });
-      // An unclaimed Run has never had a provider process. Every claimed state,
-      // including WAITING_INBOX, requires runner-owned process cleanup or an
-      // explicitly unconfirmed terminalization after runner loss.
-      if (run.status === RunStatus.QUEUED) {
-        const terminal = await terminalizeRun(tx, {
-          runId: run.id,
-          at: now,
-          outcome: {
-            kind: "cancelled",
-            requestId: body.requestId,
-            cleanupConfirmed: true,
-            activity: "acknowledged",
-          },
-        });
-        if (terminal === null || "message" in terminal) return terminal;
-        const { leaseToRelease, ...settlement } = terminal;
-        return { ...settlement, releaseMergeLeaseTask: leaseToRelease };
-      }
-      return {
-        runId: run.id,
-        taskId: run.taskId,
-        status: run.status,
-        cancellationState: "requested" as const,
-        requestId: body.requestId,
-        reason: body.reason,
-        // Terminalization is still owed by the runner acknowledgement or by
-        // reconciliation, and only a terminal writer may free the lease.
-        releaseMergeLeaseTask: null,
-      };
-    });
-    if (result === null) return refusalJson(context, refusal("conflict", "Run changed while cancellation was being settled"));
+    const result = await cancelRun(db, runId, body);
     if ("message" in result) return refusalJson(context, result);
     const { releaseMergeLeaseTask, ...cancellation } = result;
     // A queued cancellation is the final consumer when no runner ever claims

--- a/packages/api/src/run-cancel.ts
+++ b/packages/api/src/run-cancel.ts
@@ -37,7 +37,7 @@ export type RunCancellation = {
   status: RunStatus;
   cancellationState: CancellationState;
   requestId: string;
-  reason: string | null;
+  reason?: string | null;
   releaseMergeLeaseTask: MergeLeaseTarget | null;
 };
 
@@ -178,7 +178,6 @@ export const cancelRun = async (
         status: terminal.status,
         cancellationState: "acknowledged" as const,
         requestId: body.requestId,
-        reason: body.reason,
         releaseMergeLeaseTask: terminal.leaseToRelease,
       };
     }

--- a/packages/api/src/run-cancel.ts
+++ b/packages/api/src/run-cancel.ts
@@ -1,0 +1,235 @@
+import {
+  executionModeFor,
+  lockRunRow,
+  type PrismaClient,
+  RunStatus,
+  TaskStatus,
+} from "@anneal/db";
+
+import type { MergeLeaseTarget } from "./merge-lease-hold.js";
+import type { Refusal } from "./refusal.js";
+import { activeRunStatuses } from "./run-fence.js";
+import { terminalizeRun } from "./run-terminal.js";
+import { taskStatusChangedActivity } from "./task-patch.js";
+import { lockTaskMutationRows } from "./task-write.js";
+
+export type CancellationState = "requested" | "acknowledged" | "unconfirmed" | "terminal";
+
+export type CancelRunInput = {
+  requestId: string;
+  reason: string;
+  parkTask: boolean;
+};
+
+export type CancellationAcknowledgementInput = {
+  runnerId: string;
+  fencingToken: string;
+  requestId: string;
+  workspacePath?: string | undefined;
+  branch?: string | undefined;
+  baseSha?: string | undefined;
+  worktreeContainmentViolations?: string[] | undefined;
+};
+
+export type RunCancellation = {
+  runId: string;
+  taskId: string | null;
+  status: RunStatus;
+  cancellationState: CancellationState;
+  requestId: string;
+  reason: string | null;
+  releaseMergeLeaseTask: MergeLeaseTarget | null;
+};
+
+export type CancellationAcknowledgement = {
+  runId: string;
+  taskId: string | null;
+  status: RunStatus;
+  cancellationState: CancellationState;
+  requestId: string;
+  releaseMergeLeaseTask: MergeLeaseTarget | null;
+};
+
+const refused = (reason: "not-found" | "conflict", message: string): Refusal => ({ reason, message });
+
+export const cancelRun = async (
+  db: PrismaClient,
+  runId: string,
+  body: CancelRunInput,
+): Promise<RunCancellation | Refusal> => {
+  const result = await db.$transaction(async (tx) => {
+    // Run owns cancellation and terminalization. Take that mutex before Task,
+    // matching completion so the two actions cannot enter the rows backwards.
+    await lockRunRow(tx, runId);
+    const run = await tx.run.findUnique({
+      where: { id: runId },
+      select: {
+        id: true,
+        status: true,
+        taskId: true,
+        runNumber: true,
+        runnerId: true,
+        fencingToken: true,
+        leaseExpiresAt: true,
+        claimedAt: true,
+        cancelRequestId: true,
+        cancelReason: true,
+        cancelRequestedAt: true,
+        cancelAcknowledgedAt: true,
+        session: { select: { id: true } },
+        task: { select: { templateStep: { select: {
+          stepIndex: true,
+          outputKind: true,
+          taskTemplate: { select: { name: true } },
+        } } } },
+      },
+    });
+    if (!run) return refused("not-found", "Run not found");
+    if (body.parkTask && !run.taskId) return refused("conflict", "Run has no Task to park");
+    const parkTarget = body.parkTask && run.taskId ? await lockTaskMutationRows(tx, run.taskId) : null;
+    if (body.parkTask && run.taskId && !parkTarget) return refused("not-found", "Task not found");
+    if (parkTarget?.archivedAt !== null && parkTarget !== null) {
+      return refused("conflict", "Cannot park an archived task");
+    }
+    if (parkTarget?.status === TaskStatus.DONE) return refused("conflict", "Cannot park a completed task");
+
+    const parkRequestedTask = async () => {
+      if (!parkTarget || parkTarget.status === TaskStatus.BACKLOG) return;
+      const reason = run.cancelRequestId ? run.cancelReason ?? body.reason : body.reason;
+      await tx.task.update({
+        where: { id: parkTarget.id },
+        data: { status: TaskStatus.BACKLOG, failureReason: reason },
+      });
+      await tx.taskActivity.create({ data: {
+        taskId: parkTarget.id,
+        ...taskStatusChangedActivity(parkTarget.status, TaskStatus.BACKLOG),
+      } });
+    };
+
+    if (run.cancelRequestId) {
+      if (run.cancelRequestId !== body.requestId) {
+        return refused("conflict", `Run already has cancellation request ${run.cancelRequestId}`);
+      }
+      await parkRequestedTask();
+      return {
+        runId: run.id,
+        taskId: run.taskId,
+        status: run.status,
+        cancellationState: run.cancelAcknowledgedAt
+          ? "acknowledged" as const
+          : run.status === RunStatus.CANCELLED ? "unconfirmed" as const : "requested" as const,
+        requestId: run.cancelRequestId,
+        reason: run.cancelReason,
+        releaseMergeLeaseTask: null,
+      };
+    }
+    if (executionModeFor(run.task?.templateStep ?? null) === "mechanical") {
+      return refused("conflict", "Mechanical merge Runs cannot be cancelled after authorization");
+    }
+    if (!([RunStatus.QUEUED, ...activeRunStatuses] as RunStatus[]).includes(run.status)) {
+      return {
+        runId: run.id,
+        taskId: run.taskId,
+        status: run.status,
+        cancellationState: "terminal" as const,
+        requestId: body.requestId,
+        reason: null,
+        releaseMergeLeaseTask: null,
+      };
+    }
+
+    const now = new Date();
+    const requested = await tx.run.updateMany({
+      where: { id: run.id, cancelRequestId: null, status: run.status },
+      data: {
+        cancelRequestId: body.requestId,
+        cancelReason: body.reason,
+        cancelRequestedAt: now,
+        sessionTokenRevokedAt: now,
+      },
+    });
+    if (requested.count !== 1) return refused("conflict", "Run changed while cancellation was being requested");
+    await parkRequestedTask();
+    if (run.taskId) await tx.taskActivity.create({ data: {
+      taskId: run.taskId,
+      actorType: "operator",
+      body: `Cancellation requested for Run ${run.runNumber}: ${body.reason}`,
+      metadata: { runId: run.id, requestId: body.requestId, priorStatus: run.status, state: "requested" },
+    } });
+
+    // An unclaimed Run has never had a provider process. Every claimed state,
+    // including WAITING_INBOX, requires runner-owned process cleanup or an
+    // explicitly unconfirmed terminalization after runner loss.
+    if (run.status === RunStatus.QUEUED) {
+      const terminal = await terminalizeRun(tx, {
+        runId: run.id,
+        at: now,
+        outcome: {
+          kind: "cancelled",
+          requestId: body.requestId,
+          cleanupConfirmed: true,
+          activity: "acknowledged",
+        },
+      });
+      if (terminal === null || "message" in terminal) return terminal;
+      return {
+        runId: terminal.runId,
+        taskId: terminal.taskId,
+        status: terminal.status,
+        cancellationState: "acknowledged" as const,
+        requestId: body.requestId,
+        reason: body.reason,
+        releaseMergeLeaseTask: terminal.leaseToRelease,
+      };
+    }
+    return {
+      runId: run.id,
+      taskId: run.taskId,
+      status: run.status,
+      cancellationState: "requested" as const,
+      requestId: body.requestId,
+      reason: body.reason,
+      // Terminalization is still owed by the runner acknowledgement or by
+      // reconciliation, and only a terminal writer may free the lease.
+      releaseMergeLeaseTask: null,
+    };
+  });
+
+  return result ?? refused("conflict", "Run changed while cancellation was being settled");
+};
+
+export const acknowledgeCancellation = async (
+  db: PrismaClient,
+  runId: string,
+  body: CancellationAcknowledgementInput,
+): Promise<CancellationAcknowledgement | Refusal> => {
+  const result = await db.$transaction((tx) => terminalizeRun(tx, {
+    runId,
+    at: new Date(),
+    outcome: {
+      kind: "cancelled",
+      requestId: body.requestId,
+      runnerId: body.runnerId,
+      fencingToken: body.fencingToken,
+      actorId: body.runnerId,
+      cleanupConfirmed: true,
+      activity: "acknowledged",
+      ...(body.workspacePath === undefined ? {} : { workspacePath: body.workspacePath }),
+      ...(body.branch === undefined ? {} : { branch: body.branch }),
+      ...(body.baseSha === undefined ? {} : { baseSha: body.baseSha }),
+      ...(body.worktreeContainmentViolations === undefined
+        ? {}
+        : { worktreeContainmentViolations: body.worktreeContainmentViolations }),
+    },
+  }));
+  if (result === null) return refused("conflict", "Run changed while cancellation was being acknowledged");
+  if ("message" in result) return result;
+  return {
+    runId: result.runId,
+    taskId: result.taskId,
+    status: result.status,
+    cancellationState: "acknowledged",
+    requestId: body.requestId,
+    releaseMergeLeaseTask: result.leaseToRelease,
+  };
+};

--- a/packages/api/src/task-patch.ts
+++ b/packages/api/src/task-patch.ts
@@ -23,6 +23,7 @@ import {
   hasActiveRun,
   isLiveStatus,
   reactivationBlocked,
+  type TaskActivityInput,
   writeTask,
   type TaskWriteRefusal,
 } from "./task-write.js";
@@ -31,6 +32,14 @@ import { withoutUndefined } from "./without-undefined.js";
 export type TaskPatchRefusal = Refusal;
 
 export type TaskPatchResult = { task: Task } | TaskPatchRefusal;
+
+export const taskStatusChangedActivity = (
+  previousStatus: TaskStatus,
+  status: TaskStatus,
+): TaskActivityInput => ({
+  actorType: "operator",
+  body: `Status changed: ${previousStatus} → ${status}`,
+});
 
 /** What the status write plans under the lock: a refusal this action owns, a
  *  replay of an already-decided gate, or the write itself. */
@@ -347,7 +356,7 @@ export const patchTask = async (
         return {
           update: updateData,
           activity: statusChanged
-            ? { actorType: "operator", body: `Status changed: ${locked.status} → ${body.status}` }
+            ? taskStatusChangedActivity(locked.status, body.status!)
             : null,
           value: { gate, previousStatus: locked.status },
         };


### PR DESCRIPTION
## Candidate

Candidate 11: complete the Run cancellation adapter seam.

## Changes

1. Added `packages/api/src/run-cancel.ts`, exporting `cancelRun` and `acknowledgeCancellation` with typed results or `Refusal`.
2. Moved cancellation transactions and the Run-then-Task lock order into the adapter. Lease targets remain return values and are never released inside the module.
3. Defined `CancellationState` as the named `requested | acknowledged | unconfirmed | terminal` union in `run-cancel.ts`.
4. Added and reused `taskStatusChangedActivity` so stop-and-park writes the same status-change body and metadata shape as `task-patch.ts`. The separate cancellation-request activity retains cancellation metadata because it records a different event.
5. Reduced both cancellation routes to parsing, adapter invocation, Refusal mapping, and post-commit `releaseChainLease`.
6. Converted cancellation behavior coverage in `active-run-cancellation.dbtest.ts` to direct module calls while retaining HTTP coverage for authorization and Refusal-to-status mapping. Existing Lease tests retain post-commit release coverage.

Direct-call conversions include:

- live-status cancellation request, idempotent replay, conflicting request, acknowledgement, and acknowledgement replay;
- mechanical Merge readiness cancellation refusal and legacy idempotent replay;
- QUEUED immediate acknowledgement and WAITING_INBOX requested state;
- reconciled cancellation replay returning `unconfirmed`;
- already-terminal completion returning `terminal`;
- stop-and-park lock-order and full-Chain mutex coverage.

## Verification

- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run test -w @anneal/api`: pass (632 passed, 1 skipped)
- `npm run test:db -w @anneal/api -- src/active-run-cancellation.dbtest.ts`: pass (13 passed)
- `packages/api/src/app.ts`: 4455 lines, down 147 from the 4602-line baseline
- `grep -rn "unconfirmed" packages/api/src/app.ts`: no results

## Out of scope observed

No adjacent issues observed. No changes were made to Merge Lease adapters, Run claim/completion internals, Merge readiness workers, other routes, or `packages/db/`.