### PR TITLE
refactor(api): settle repair completion in merge tail

### DIFF
--- a/packages/api/src/merge-tail-actions.test.ts
+++ b/packages/api/src/merge-tail-actions.test.ts
@@ -1,11 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { MergeRecoveryStatus, type Prisma, type RecoveryContext } from "@anneal/db";
+import {
+  type Marker,
+  MergeRecoveryStatus,
+  type Prisma,
+  type RecoveryContext,
+  TaskStatus,
+} from "@anneal/db";
 
 import {
   openDefenseAuditNotice,
   openMergeTailStopNotice,
+  settleMergeTailCompletion,
   stopMergeTail,
   type StopMergeTailInput,
 } from "./merge-tail-actions.js";
@@ -69,6 +76,68 @@ const stopTx = (recoveryStatus: MergeRecoveryStatus) => {
   } as unknown as Prisma.TransactionClient;
   return { tx, activities, notices, recoveryUpdates };
 };
+
+const repairAttempt = (repairKind: "refresh-conflict" | "gate-fix" | "review-fix"): Marker => ({
+  kind: "repairAttempt",
+  state: null,
+  regressionTaskId: "regression-1",
+  repairTaskId: "repair-1",
+  readinessTaskId: null,
+  repairKind,
+  headSha: "a".repeat(40),
+  baseHeadSha: "b".repeat(40),
+  baseSha: null,
+  startHeadSha: null,
+  resolvedHeadSha: null,
+  recoverySourceStopId: null,
+  raw: {},
+});
+
+const completionTx = (outputBody = "repair completed") => {
+  const activities: Array<Record<string, any>> = [];
+  const notices: Array<Record<string, any>> = [];
+  const taskUpdates: Array<Record<string, any>> = [];
+  const tx = {
+    taskStepOutput: {
+      findUnique: async () => ({ body: outputBody }),
+    },
+    task: {
+      update: async (args: Record<string, any>) => {
+        taskUpdates.push(args);
+        return {};
+      },
+    },
+    taskActivity: {
+      create: async ({ data }: { data: Record<string, any> }) => {
+        activities.push(data);
+        return {};
+      },
+    },
+    inboxMessage: {
+      upsert: async (args: Record<string, any>) => {
+        notices.push(args);
+        return {};
+      },
+    },
+  } as unknown as Prisma.TransactionClient;
+  return { tx, activities, notices, taskUpdates };
+};
+
+const completionInput = (
+  repairKind: "refresh-conflict" | "gate-fix" | "review-fix",
+  succeeded: boolean,
+  documentationTaskId?: string,
+) => ({
+  task: { id: "repair-1", documentationTaskId: documentationTaskId ?? null },
+  run: {
+    agentId: "agent-1",
+    sessionId: "session-1",
+    completedAt: new Date("2026-08-27T12:00:00.000Z"),
+  },
+  body: { headSha: "c".repeat(40) },
+  markers: [repairAttempt(repairKind)],
+  succeeded,
+});
 
 test("openMergeTailStopNotice derives its dedupe key from the task and reason", async () => {
   let upsert: Record<string, unknown> | undefined;
@@ -143,6 +212,80 @@ test("openDefenseAuditNotice records the triggered paths against the readiness t
   });
 });
 
+test("settleMergeTailCompletion records a successful repair", async () => {
+  const observed = completionTx();
+
+  const result = await settleMergeTailCompletion(observed.tx, completionInput("gate-fix", true));
+
+  assert.deepEqual(result, { handled: false, leaseOutcome: "continue" });
+  assert.equal(observed.notices.length, 0);
+  assert.deepEqual(observed.taskUpdates, []);
+  assert.equal(observed.activities.length, 1);
+  assert.deepEqual(observed.activities[0]?.metadata, {
+    schemaVersion: 1,
+    repairKind: "gate-fix",
+    repairTaskId: "repair-1",
+    startHeadSha: "a".repeat(40),
+    targetHeadSha: "b".repeat(40),
+    resolvedHeadSha: "c".repeat(40),
+    kind: "mergeTail.repairResult",
+  });
+});
+
+test("settleMergeTailCompletion stops a failed repair", async () => {
+  const observed = completionTx();
+
+  const result = await settleMergeTailCompletion(observed.tx, completionInput("review-fix", false));
+
+  assert.deepEqual(result, { handled: true, leaseOutcome: "stop" });
+  assert.deepEqual(observed.taskUpdates, [{
+    where: { id: "regression-1" },
+    data: {
+      status: TaskStatus.REVIEW,
+      failureReason: `review-fix repair repair-1 failed without closing the repair at ${"a".repeat(40)}`,
+    },
+  }]);
+  assert.equal(observed.activities[0]?.metadata?.state, "failed");
+  assert.equal(observed.notices.length, 1);
+});
+
+test("settleMergeTailCompletion stops when the resolver reports unable", async () => {
+  const observed = completionTx(JSON.stringify({
+    schemaVersion: 1,
+    outcome: "unable",
+    startHeadSha: "a".repeat(40),
+    targetHeadSha: "b".repeat(40),
+    blockingContradiction: "the two required histories conflict",
+  }));
+
+  const result = await settleMergeTailCompletion(observed.tx, completionInput("refresh-conflict", true));
+
+  assert.deepEqual(result, { handled: true, leaseOutcome: "stop" });
+  assert.equal(observed.activities.length, 0);
+  assert.equal(observed.notices.length, 1);
+  assert.deepEqual(observed.taskUpdates.map((update) => update.where.id), ["repair-1", "regression-1"]);
+  assert.equal(observed.taskUpdates[0]?.data?.status, TaskStatus.DONE);
+  assert.equal(observed.taskUpdates[1]?.data?.status, TaskStatus.REVIEW);
+});
+
+test("settleMergeTailCompletion moves Documentation back before Regression", async () => {
+  const observed = completionTx();
+
+  const result = await settleMergeTailCompletion(
+    observed.tx,
+    completionInput("review-fix", true, "documentation-1"),
+  );
+
+  assert.deepEqual(result, { handled: false, leaseOutcome: "continue" });
+  assert.deepEqual(observed.taskUpdates, [{
+    where: { id: "documentation-1" },
+    data: {
+      status: TaskStatus.TODO,
+      failureReason: "documentation invalidated by review-fix repair repair-1",
+    },
+  }]);
+});
+
 test("stopMergeTail owns the phase by recovery matrix", async () => {
   const at = new Date("2026-08-27T12:00:00.000Z");
   const cases: Array<{
@@ -152,7 +295,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
     markerStates: string[];
     noticeKey: RegExp;
     recoveryTarget: MergeRecoveryStatus | null;
-    leaseToRelease: { chainId: string; projectId: string } | null;
+    result: { leaseToRelease: { chainId: string; projectId: string } | null } | undefined;
   }> = [
     {
       name: "regression without recovery",
@@ -161,7 +304,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
       markerStates: ["stopped"],
       noticeKey: /^merge-tail-stop:regression-1:/u,
       recoveryTarget: null,
-      leaseToRelease: { chainId: "chain-1", projectId: "project-1" },
+      result: undefined,
     },
     {
       name: "regression during recovery",
@@ -170,7 +313,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
       markerStates: ["tail-stopped", "tail-stopped"],
       noticeKey: /:stop-1:regression$/u,
       recoveryTarget: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
-      leaseToRelease: { chainId: "chain-1", projectId: "project-1" },
+      result: undefined,
     },
     {
       name: "readiness without recovery",
@@ -179,7 +322,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
       markerStates: ["stopped"],
       noticeKey: /^merge-readiness-stop:readiness-1:/u,
       recoveryTarget: null,
-      leaseToRelease: { chainId: "chain-1", projectId: "project-1" },
+      result: { leaseToRelease: { chainId: "chain-1", projectId: "project-1" } },
     },
     {
       name: "readiness during recovery",
@@ -188,7 +331,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
       markerStates: ["tail-stopped", "tail-stopped", "stopped"],
       noticeKey: /:stop-1:readiness$/u,
       recoveryTarget: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
-      leaseToRelease: { chainId: "chain-1", projectId: "project-1" },
+      result: { leaseToRelease: { chainId: "chain-1", projectId: "project-1" } },
     },
     {
       name: "recovery validation",
@@ -201,7 +344,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
       markerStates: ["ineligible"],
       noticeKey: /:ineligible:stop-1$/u,
       recoveryTarget: MergeRecoveryStatus.FAILED,
-      leaseToRelease: null,
+      result: undefined,
     },
     {
       name: "recovery exhausted",
@@ -214,7 +357,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
       markerStates: ["exhausted"],
       noticeKey: /:exhausted:stop-1$/u,
       recoveryTarget: MergeRecoveryStatus.FAILED,
-      leaseToRelease: null,
+      result: undefined,
     },
     {
       name: "repair",
@@ -227,13 +370,16 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
       markerStates: ["failed"],
       noticeKey: /^merge-tail-stop:regression-1:/u,
       recoveryTarget: null,
-      leaseToRelease: { chainId: "chain-1", projectId: "project-1" },
+      result: undefined,
     },
   ];
 
   for (const entry of cases) {
     const observed = stopTx(entry.status);
-    assert.deepEqual(await stopMergeTail(observed.tx, entry.input), { leaseToRelease: entry.leaseToRelease }, entry.name);
+    const result = entry.input.phase === "readiness"
+      ? await stopMergeTail(observed.tx, entry.input)
+      : await stopMergeTail(observed.tx, entry.input);
+    assert.deepEqual(result, entry.result, entry.name);
     assert.deepEqual(
       observed.activities.map((activity) => (activity.metadata as Record<string, unknown>).state),
       entry.markerStates,

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -3,11 +3,16 @@ import { createHash } from "node:crypto";
 import {
   asJsonObject,
   enqueueTaskRun,
+  isIntegratorStep,
+  isRegressionVerificationOutputKind,
+  latestMarker,
   MAX_MERGE_TAIL_REPAIR_ATTEMPTS,
   MERGE_TAIL_KIND,
   MERGE_TAIL_SCHEMA_VERSION,
   mergeRecoveryTransitionAllowed,
   MergeRecoveryStatus,
+  type Marker,
+  parseResolverResult,
   parseRegressionVerdict,
   Prisma,
   readMarkerHistory,
@@ -20,7 +25,7 @@ import {
 
 import { FAILURE_REASON_LIMIT, truncateFailureReason } from "./failure-reason.js";
 import { canonicalOutputRefusal } from "./canonical-task-output.js";
-import { settleLease } from "./merge-lease.js";
+import { settleLease, type LeaseSettlementOutcome } from "./merge-lease.js";
 import type { MergeLeaseTarget } from "./merge-lease-hold.js";
 
 /**
@@ -259,6 +264,9 @@ export type StopMergeTailInput =
 
 export type StopMergeTailResult = { leaseToRelease: MergeLeaseTarget | null };
 
+type ReadinessStopMergeTailInput = Extract<StopMergeTailInput, { phase: "readiness" }>;
+type CompletionOwnedStopMergeTailInput = Exclude<StopMergeTailInput, ReadinessStopMergeTailInput>;
+
 const transitionRecovery = async (
   tx: DbTx,
   aggregateId: string,
@@ -294,11 +302,23 @@ const stopNotice = async (
   }, update: {} });
 };
 
-/** Persist one merge-tail stop and return the Chain Lease its caller may release after commit. */
-export const stopMergeTail = async (
+/**
+ * Persist one merge-tail stop. Readiness is the only phase that returns a
+ * Lease target because its worker must release after commit; Run completion
+ * owns Lease settlement for regression and repair, while recovery owns none.
+ */
+export function stopMergeTail(
+  tx: DbTx,
+  input: ReadinessStopMergeTailInput,
+): Promise<StopMergeTailResult>;
+export function stopMergeTail(
+  tx: DbTx,
+  input: CompletionOwnedStopMergeTailInput,
+): Promise<void>;
+export async function stopMergeTail(
   tx: DbTx,
   input: StopMergeTailInput,
-): Promise<StopMergeTailResult> => {
+): Promise<StopMergeTailResult | void> {
   if (input.phase === "regression" || input.phase === "readiness") {
     const recovery = input.recovery;
     const body = recovery
@@ -367,8 +387,11 @@ export const stopMergeTail = async (
         await stopNotice(tx, { taskId: input.regressionTaskId, body, dedupeKey });
       }
     }
-    const lease = await settleLease(tx, { taskId: input.regressionTaskId, outcome: "stop" });
-    return { leaseToRelease: lease.leaseToRelease };
+    if (input.phase === "readiness") {
+      const lease = await settleLease(tx, { taskId: input.regressionTaskId, outcome: "stop" });
+      return { leaseToRelease: lease.leaseToRelease };
+    }
+    return;
   }
 
   if (input.phase === "repair") {
@@ -394,8 +417,7 @@ export const stopMergeTail = async (
       ...(input.sessionId ? { sessionId: input.sessionId } : {}),
       reason: input.reason,
     });
-    const lease = await settleLease(tx, { taskId: input.regressionTaskId, outcome: "stop" });
-    return { leaseToRelease: lease.leaseToRelease };
+    return;
   }
 
   await transitionRecovery(tx, input.aggregateId, MergeRecoveryStatus.FAILED, {
@@ -430,7 +452,162 @@ export const stopMergeTail = async (
       ? `Automatic base-drift recovery refused: ${input.reason}`
       : input.reason,
   } });
-  return { leaseToRelease: null };
+}
+
+type MergeTailCompletionTask = {
+  id: string;
+  documentationTaskId?: string | null;
+  templateStep?: {
+    stepIndex: number;
+    outputKind: string;
+    taskTemplate?: { name: string } | null;
+  } | null;
+};
+
+export type MergeTailCompletionResult = {
+  handled: boolean;
+  leaseOutcome: LeaseSettlementOutcome;
+};
+
+/**
+ * Settle the merge-tail state owned by one terminal Run completion. The caller
+ * invokes this only for a successful Run or a failure that did not create a
+ * retry; ordinary task completion and follow-up activation remain its work.
+ */
+export const settleMergeTailCompletion = async (
+  tx: DbTx,
+  input: {
+    task: MergeTailCompletionTask;
+    run: { agentId: string; sessionId: string; completedAt: Date };
+    body: { headSha?: string | null };
+    markers: Marker[];
+    succeeded: boolean;
+  },
+): Promise<MergeTailCompletionResult> => {
+  const repairMarker = latestMarker(input.markers, "repairAttempt");
+  const repairCompletion = Boolean(repairMarker?.regressionTaskId);
+  const terminalFailureStopsLease = isIntegratorStep(input.task.templateStep)
+    || isRegressionVerificationOutputKind(input.task.templateStep?.outputKind)
+    || repairCompletion;
+
+  if (!input.succeeded) {
+    if (repairMarker?.regressionTaskId) {
+      const reason = `${repairMarker.repairKind} repair ${input.task.id} failed without closing the repair at ${repairMarker.headSha}`;
+      await stopMergeTail(tx, {
+        phase: "repair",
+        regressionTaskId: repairMarker.regressionTaskId,
+        repairTaskId: input.task.id,
+        repairKind: repairMarker.repairKind,
+        startHeadSha: repairMarker.headSha,
+        targetHeadSha: repairMarker.baseHeadSha,
+        resolvedHeadSha: input.body.headSha ?? null,
+        reason,
+        at: input.run.completedAt,
+        agentId: input.run.agentId,
+        sessionId: input.run.sessionId,
+      });
+    }
+    return {
+      handled: repairCompletion,
+      leaseOutcome: terminalFailureStopsLease ? "stop" : "continue",
+    };
+  }
+
+  if (!repairMarker?.regressionTaskId) {
+    return {
+      handled: false,
+      leaseOutcome: isIntegratorStep(input.task.templateStep) ? "stop" : "continue",
+    };
+  }
+
+  const repairOutput = await tx.taskStepOutput.findUnique({
+    where: { taskId: input.task.id },
+    select: { body: true },
+  });
+  let repairUnable = false;
+  let reportedUnable = false;
+  let resolvedHeadSha = input.body.headSha ?? null;
+  if (repairMarker.repairKind === "refresh-conflict") {
+    const parsedResolver = parseResolverResult(repairOutput?.body);
+    const expectedStart = repairMarker.headSha;
+    const expectedTarget = repairMarker.baseHeadSha;
+    const bindingError = parsedResolver.status === "invalid"
+      ? parsedResolver.reason
+      : parsedResolver.result.startHeadSha !== expectedStart || parsedResolver.result.targetHeadSha !== expectedTarget
+        ? "merge-resolver output is bound to stale start or target heads"
+        : parsedResolver.result.outcome === "resolved" && parsedResolver.result.resolvedHeadSha !== input.body.headSha
+          ? "merge-resolver output resolved head does not match the delivered run head"
+          : null;
+    if (bindingError) {
+      repairUnable = true;
+      const reason = `refresh-conflict repair ${input.task.id} returned invalid output: ${bindingError}`;
+      await tx.task.update({ where: { id: input.task.id }, data: { status: TaskStatus.DONE, failureReason: reason } });
+      await tx.task.update({ where: { id: repairMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
+      await writeMarker(tx, repairMarker.regressionTaskId, "repairResult", {
+        actorType: "control-plane",
+        body: `Automatic refresh-conflict attempt stopped: ${reason}`,
+        metadata: {
+          repairKind: "refresh-conflict",
+          repairTaskId: input.task.id,
+          startHeadSha: expectedStart,
+          targetHeadSha: expectedTarget,
+          resolvedHeadSha: input.body.headSha ?? null,
+          state: "invalid-output",
+          reason: bindingError,
+        },
+      });
+      await openMergeTailStopNotice(tx, {
+        taskId: repairMarker.regressionTaskId,
+        agentId: input.run.agentId,
+        sessionId: input.run.sessionId,
+        reason,
+      });
+    } else if (parsedResolver.status === "ok") {
+      reportedUnable = parsedResolver.result.outcome === "unable";
+      resolvedHeadSha = parsedResolver.result.outcome === "resolved" ? parsedResolver.result.resolvedHeadSha : null;
+    }
+  }
+
+  // gate-fix and review-fix agents have no JSON wire contract; their
+  // successful delivered head is the completion evidence.
+  if (reportedUnable) {
+    repairUnable = true;
+    const reason = `${String(repairMarker.repairKind)} repair ${input.task.id} reported unable at ${String(repairMarker.headSha)}`;
+    await tx.task.update({ where: { id: input.task.id }, data: { status: TaskStatus.DONE, failureReason: reason } });
+    await tx.task.update({ where: { id: repairMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
+    await openMergeTailStopNotice(tx, {
+      taskId: repairMarker.regressionTaskId,
+      agentId: input.run.agentId,
+      sessionId: input.run.sessionId,
+      reason,
+    });
+  } else if (!repairUnable) {
+    await writeMarker(tx, repairMarker.regressionTaskId, "repairResult", {
+      actorType: "control-plane",
+      body: `Automatic ${String(repairMarker.repairKind)} attempt completed: ${String(repairMarker.headSha)} -> ${input.body.headSha ?? "missing-head"}`,
+      metadata: {
+        repairKind: repairMarker.repairKind,
+        repairTaskId: input.task.id,
+        startHeadSha: repairMarker.headSha,
+        targetHeadSha: repairMarker.baseHeadSha,
+        resolvedHeadSha,
+      },
+    });
+    if (input.task.documentationTaskId) {
+      await tx.task.update({
+        where: { id: input.task.documentationTaskId },
+        data: {
+          status: TaskStatus.TODO,
+          failureReason: `documentation invalidated by ${String(repairMarker.repairKind)} repair ${input.task.id}`,
+        },
+      });
+    }
+  }
+
+  return {
+    handled: repairUnable,
+    leaseOutcome: repairUnable ? "stop" : "continue",
+  };
 };
 
 export const createMergeTailRepairTask = async (

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -25,7 +25,6 @@ import {
   mechanicalPrincipalRefusal,
   openRun,
   parseMergeResult,
-  parseResolverResult,
   Prisma,
   type PrismaClient,
   readMarkers,
@@ -34,7 +33,6 @@ import {
   RunStatus,
   stepRole,
   TaskStatus,
-  writeMarker,
 } from "@anneal/db";
 import { z } from "zod";
 
@@ -56,10 +54,9 @@ import {
 import {
   handleRegressionCompletion,
   mergeTailRequeueForRun,
-  openMergeTailStopNotice,
   recordMergeTailRequeue,
   regressionVerdictForRun,
-  stopMergeTail,
+  settleMergeTailCompletion,
 } from "./merge-tail-actions.js";
 import { explainFenceRefusal, fenceRefusalResponse, fencedRunWhere, type RunFence } from "./run-fence.js";
 import { terminalizeRun } from "./run-terminal.js";
@@ -557,41 +554,15 @@ export const completeRun = async (
       if (opened.ok) retryCreated = true;
       else retryRefusal = opened.refusal;
     }
-    if (!succeeded && !retryCreated && (mechanical
-      || isRegressionVerificationOutputKind(run.task?.templateStep?.outputKind)
-      || mergeTailAuxiliary)) {
-      leaseOutcome = "stop";
-    }
     if (run.taskId) {
       const budgetExhausted = !succeeded && retryable && !durableNegativeRegressionVerdict
         && !retryCreated && !retryRefusal;
       let canonicalOutputFailure: string | null = null;
-      if (!succeeded && !retryCreated && run.task) {
-        // The same markers the success path above read, from the same scan.
-        const failedRepair = latestMarker(tailMarkers, "repairAttempt");
-        if (failedRepair?.regressionTaskId) {
-          const reason = `${failedRepair.repairKind} repair ${run.taskId} failed without closing the repair at ${failedRepair.headSha}`;
-          await stopMergeTail(tx, {
-            phase: "repair",
-            regressionTaskId: failedRepair.regressionTaskId,
-            repairTaskId: run.taskId,
-            repairKind: failedRepair.repairKind,
-            startHeadSha: failedRepair.headSha,
-            targetHeadSha: failedRepair.baseHeadSha,
-            resolvedHeadSha: body.headSha ?? null,
-            reason,
-            at: now,
-            agentId: run.agentId,
-            sessionId: run.session.id,
-          });
-        }
-      }
       // §4.0 outcome branching. The executor's own fenced write is the only
       // writer of a step-12 output: neither synthesis nor the metadata update
       // may touch it, because a synthesized body would read as a merge that
       // never happened.
       if (succeeded && mechanical && run.task) {
-        leaseOutcome = "stop";
         const persisted = await tx.taskStepOutput.findUnique({
           where: { taskId: run.taskId }, select: { kind: true, body: true },
         });
@@ -664,12 +635,26 @@ export const completeRun = async (
               reason: outputRefusal,
             },
           } });
-          if (isRegressionVerificationOutputKind(run.task.templateStep?.outputKind)) {
-            leaseOutcome = "stop";
-          }
         }
         canonicalOutputFailure = outputRefusal;
       }
+      const mergeTailCompletion = run.task && (succeeded || !retryCreated)
+        ? await settleMergeTailCompletion(tx, {
+            task: {
+              id: run.task.id,
+              templateStep: run.task.templateStep,
+              documentationTaskId: repairDocumentationTask?.id ?? null,
+            },
+            run: { agentId: run.agentId, sessionId: run.session.id, completedAt: now },
+            body: { headSha: body.headSha ?? null },
+            markers: tailMarkers,
+            succeeded,
+          })
+        : { handled: false, leaseOutcome: "continue" as const };
+      leaseOutcome = canonicalOutputFailure
+        && isRegressionVerificationOutputKind(run.task?.templateStep?.outputKind)
+        ? "stop"
+        : mergeTailCompletion.leaseOutcome;
       if (durableNegativeRegressionVerdict && run.task?.templateId) {
         await handleRegressionCompletion(tx, {
           task: run.task,
@@ -722,87 +707,13 @@ export const completeRun = async (
           );
         }
       } else if (succeeded && run.task && (run.task.chainId || mergeTailAuxiliary)) {
-        let repairUnable = false;
-        if (repairMarker?.regressionTaskId) {
-          const repairOutput = await tx.taskStepOutput.findUnique({ where: { taskId: run.taskId }, select: { body: true } });
-          let reportedUnable = false;
-          let resolvedHeadSha = body.headSha ?? null;
-          if (repairMarker.repairKind === "refresh-conflict") {
-            const parsedResolver = parseResolverResult(repairOutput?.body);
-            const expectedStart = repairMarker.headSha;
-            const expectedTarget = repairMarker.baseHeadSha;
-            const bindingError = parsedResolver.status === "invalid"
-              ? parsedResolver.reason
-              : parsedResolver.result.startHeadSha !== expectedStart || parsedResolver.result.targetHeadSha !== expectedTarget
-                ? "merge-resolver output is bound to stale start or target heads"
-                : parsedResolver.result.outcome === "resolved" && parsedResolver.result.resolvedHeadSha !== body.headSha
-                  ? "merge-resolver output resolved head does not match the delivered run head"
-                  : null;
-            if (bindingError) {
-              repairUnable = true;
-              const reason = `refresh-conflict repair ${run.taskId} returned invalid output: ${bindingError}`;
-              await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: reason } });
-              await tx.task.update({ where: { id: repairMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-              await writeMarker(tx, repairMarker.regressionTaskId, "repairResult", {
-                actorType: "control-plane",
-                body: `Automatic refresh-conflict attempt stopped: ${reason}`,
-                metadata: {
-                  repairKind: "refresh-conflict",
-                  repairTaskId: run.taskId,
-                  startHeadSha: expectedStart,
-                  targetHeadSha: expectedTarget,
-                  resolvedHeadSha: body.headSha ?? null,
-                  state: "invalid-output",
-                  reason: bindingError,
-                },
-              });
-              await openMergeTailStopNotice(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
-            } else if (parsedResolver.status === "ok") {
-              reportedUnable = parsedResolver.result.outcome === "unable";
-              resolvedHeadSha = parsedResolver.result.outcome === "resolved" ? parsedResolver.result.resolvedHeadSha : null;
-            }
-          }
-          // gate-fix and review-fix agents have no JSON wire contract; their
-          // successful delivered head is the completion evidence.
-          if (reportedUnable) {
-            repairUnable = true;
-            const reason = `${String(repairMarker.repairKind)} repair ${run.taskId} reported unable at ${String(repairMarker.headSha)}`;
-            await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DONE, failureReason: reason } });
-            await tx.task.update({ where: { id: repairMarker.regressionTaskId }, data: { status: TaskStatus.REVIEW, failureReason: reason } });
-            await openMergeTailStopNotice(tx, { taskId: repairMarker.regressionTaskId, agentId: run.agentId, sessionId: run.session.id, reason });
-          } else if (!repairUnable) {
-            await writeMarker(tx, repairMarker.regressionTaskId, "repairResult", {
-              actorType: "control-plane",
-              body: `Automatic ${String(repairMarker.repairKind)} attempt completed: ${String(repairMarker.headSha)} -> ${body.headSha ?? "missing-head"}`,
-              metadata: {
-                repairKind: repairMarker.repairKind,
-                repairTaskId: run.taskId,
-                startHeadSha: repairMarker.headSha,
-                targetHeadSha: repairMarker.baseHeadSha,
-                resolvedHeadSha,
-              },
-            });
-            if (repairDocumentationTask) {
-              await tx.task.update({
-                where: { id: repairDocumentationTask.id },
-                data: {
-                  status: TaskStatus.TODO,
-                  failureReason: `documentation invalidated by ${String(repairMarker.repairKind)} repair ${run.taskId}`,
-                },
-              });
-            }
-          }
-        }
-        if (repairUnable) {
-          // The failed repair owns the stop; never activate its follow-up.
-          leaseOutcome = "stop";
-        } else if (run.task.approvalGate) {
+        if (!mergeTailCompletion.handled && run.task.approvalGate) {
           const claimed = await tx.task.updateMany({
             where: { id: run.taskId, status: completionTaskStatus! },
             data: { status: TaskStatus.REVIEW, failureReason: null },
           });
           if (claimed.count === 1) await gateQuestion(tx, run.taskId, run.id, process.env.FEISHU_DEFAULT_CHAT_ID ?? null);
-        } else {
+        } else if (!mergeTailCompletion.handled) {
           const completed = await tx.task.updateMany({
             where: { id: run.taskId, status: completionTaskStatus! }, data: { status: TaskStatus.DONE, failureReason: null },
           });


### PR DESCRIPTION
## Candidate

09

## Changes

1. Added `settleMergeTailCompletion` to `merge-tail-actions.ts`. It owns terminal repair failure, resolver output qualification and binding, `reportedUnable`, `repairResult` markers, and moving the Documentation Step back before Regression.
2. Replaced the duplicated repair block in `completeRun` with one module call and one `leaseOutcome` assignment. The number of `leaseOutcome =` sites is now 3, down from 6.
3. Selected stop contract option (b). Repair and recovery phases return `void`; Regression also returns `void` because its only production path is Run completion, which settles the Lease after the transaction. Merge readiness remains the only phase returning `leaseToRelease`, because its worker must consume that exact target after commit. Phase-specific overloads prevent callers from receiving a value they can silently discard.
4. Added fake transaction tests for successful repair, terminal failed repair, resolver `reportedUnable`, and Documentation Step rollback.

## Repair Lease behavior

| Repair branch | Before `leaseOutcome` | After `leaseOutcome` |
| --- | --- | --- |
| Failed Run with retry created | `continue` | `continue` |
| Terminal failed repair | `stop` | `stop` |
| Invalid resolver output or stale binding | `stop` | `stop` |
| Resolver reports unable | `stop` | `stop` |
| Successful refresh-conflict repair | `continue` | `continue` |
| Successful gate-fix or review-fix repair | `continue` | `continue` |
| Successful repair moves Documentation Step back | `continue` | `continue` |
| Successful repair without a Documentation Step falls back to Regression | `continue` | `continue` |

## Verification

- `npm run lint`: PASS
- `npm run typecheck`: PASS
- `npm run test -w @anneal/api`: PASS, 636 passed and 1 opt-in test skipped
- `npm run test:db -w @anneal/api -- src/merge-tail-repair.dbtest.ts`: PASS, 23 passed
- `merge-tail-actions.test.ts`: PASS, including the 4 new fake transaction cases
- `grep -c "leaseOutcome =" packages/api/src/run-completion.ts`: 3

## Out of scope observed

No adjacent issue was changed. The out-of-scope Merge readiness worker, merge Lease module, recovery transition table, base-drift worker, Regression completion logic, and cancellation route were left untouched.