### PR TITLE
refactor(api): narrow base drift recovery decisions

### DIFF
--- a/packages/api/src/base-drift-recovery-decision.test.ts
+++ b/packages/api/src/base-drift-recovery-decision.test.ts
@@ -1,13 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { PrismaClient } from "@anneal/db";
+
 import {
   candidateRefusalCodes,
-  recoveryDecision,
+  classifyCandidate,
+  classifyDurable,
+  classifyFresh,
+  classifyRetryBudget,
   type CandidateLoad,
+  type FreshRecoveryFacts,
   type RecoveryCandidate,
   type RecoveryPullRequestFacts,
 } from "./base-drift-recovery-decision.js";
+import { settleRecovery } from "./merge-base-drift-worker.js";
 
 const HEAD = "a".repeat(40);
 const BASE = "b".repeat(40);
@@ -43,8 +50,10 @@ const snapshot = (overrides: Partial<RecoveryPullRequestFacts> = {}): RecoveryPu
   ...overrides,
 });
 
-const freshDecision = (overrides: Partial<Parameters<typeof recoveryDecision>[0] & { stage: "fresh" }> = {}) => recoveryDecision({
-  stage: "fresh",
+type SnapshotFacts = Extract<FreshRecoveryFacts, { kind: "snapshot" }>;
+
+const freshDecision = (overrides: Partial<SnapshotFacts> = {}) => classifyFresh({
+  kind: "snapshot",
   candidate,
   snapshot: snapshot(),
   comparisonAvailable: true,
@@ -63,17 +72,22 @@ test("all durable candidate refusal paths decide without a database", () => {
       ...(code === "authorization-invalid" ? { detail: "ambiguous" } : {}),
       ...(code === "target-unresolved" ? { detail: "repository" } : {}),
     };
-    const decision = recoveryDecision({ stage: "candidate", load });
+    const decision = classifyCandidate(load);
     assert.equal(decision.kind, code === "chain-active" ? "retry" : "ineligible", code);
     assert.notEqual("reason" in decision ? decision.reason : "", "", code);
   }
-  assert.deepEqual(recoveryDecision({
-    stage: "candidate",
-    load: { kind: "refused", code: "target-branch-mismatch", stopId: "stop-1" },
+  assert.deepEqual(classifyCandidate({
+    kind: "refused", code: "target-branch-mismatch", stopId: "stop-1",
   }), {
     kind: "ineligible",
     reason: "chain first-run target ref differs from the authorized base ref",
+    stopId: "stop-1",
   });
+});
+
+test("candidate classification narrows skip and inspect outcomes", () => {
+  assert.deepEqual(classifyCandidate({ kind: "skip" }), { kind: "skip" });
+  assert.deepEqual(classifyCandidate({ kind: "candidate", candidate }), { kind: "inspect", candidate });
 });
 
 test("all fresh pull-request refusal paths decide without a database", () => {
@@ -93,7 +107,15 @@ test("all fresh pull-request refusal paths decide without a database", () => {
   }
 });
 
-test("ancestry refusal, retry, queue, exhaustion, and skip are explicit decisions", () => {
+test("fresh classification narrows reader facts and snapshot outcomes", () => {
+  assert.deepEqual(classifyFresh({ kind: "reader-unavailable" }), {
+    kind: "retry",
+    reason: "server-side GitHub reader is unavailable",
+  });
+  assert.deepEqual(classifyFresh({ kind: "reader-failure", reason: "reader timeout" }), {
+    kind: "retry",
+    reason: "reader timeout",
+  });
   assert.equal(freshDecision({ comparisonAvailable: false }).kind, "ineligible");
   assert.equal(freshDecision({ authorizedAdvance: { status: "diverged", behindBy: 1 } }).kind, "ineligible");
   assert.equal(freshDecision({
@@ -101,22 +123,23 @@ test("ancestry refusal, retry, queue, exhaustion, and skip are explicit decision
     observedAdvance: { status: "behind", behindBy: 1 },
   }).kind, "ineligible");
   assert.deepEqual(freshDecision(), { kind: "queue", candidate, currentBaseSha: CURRENT });
+});
 
-  assert.deepEqual(recoveryDecision({
-    stage: "classification-retry",
+test("retry-budget classification narrows retry and ineligible outcomes", () => {
+  assert.deepEqual(classifyRetryBudget({
     reason: "reader timeout",
     validationAttempts: 0,
     maxAttempts: 2,
   }), { kind: "retry", reason: "reader timeout", classificationAttempt: 1 });
-  assert.equal(recoveryDecision({
-    stage: "classification-retry",
+  assert.equal(classifyRetryBudget({
     reason: "reader timeout",
     validationAttempts: 2,
     maxAttempts: 2,
   }).kind, "ineligible");
+});
 
-  assert.equal(recoveryDecision({
-    stage: "durable",
+test("durable classification narrows skip, retry, ineligible, exhausted, and queue outcomes", () => {
+  assert.equal(classifyDurable({
     expected: candidate,
     load: { kind: "candidate", candidate },
     aggregateValidating: true,
@@ -124,8 +147,7 @@ test("ancestry refusal, retry, queue, exhaustion, and skip are explicit decision
     maxRecoveries: 2,
     currentBaseSha: CURRENT,
   }).kind, "exhausted");
-  assert.deepEqual(recoveryDecision({
-    stage: "durable",
+  assert.deepEqual(classifyDurable({
     expected: candidate,
     load: { kind: "candidate", candidate },
     aggregateValidating: false,
@@ -133,4 +155,87 @@ test("ancestry refusal, retry, queue, exhaustion, and skip are explicit decision
     maxRecoveries: 2,
     currentBaseSha: CURRENT,
   }), { kind: "skip" });
+  assert.equal(classifyDurable({
+    expected: candidate,
+    load: { kind: "refused", code: "chain-active", stopId: candidate.stopId },
+    aggregateValidating: true,
+    recoveryCount: 0,
+    maxRecoveries: 2,
+    currentBaseSha: CURRENT,
+  }).kind, "retry");
+  assert.equal(classifyDurable({
+    expected: candidate,
+    load: { kind: "candidate", candidate: { ...candidate, sourceRunId: "run-2" } },
+    aggregateValidating: true,
+    recoveryCount: 0,
+    maxRecoveries: 2,
+    currentBaseSha: CURRENT,
+  }).kind, "ineligible");
+  assert.deepEqual(classifyDurable({
+    expected: candidate,
+    load: { kind: "candidate", candidate },
+    aggregateValidating: true,
+    recoveryCount: 0,
+    maxRecoveries: 2,
+    currentBaseSha: CURRENT,
+  }), { kind: "queue", candidate, currentBaseSha: CURRENT });
+});
+
+test("settleRecovery maps persistence outcomes to tick deltas without a database", async () => {
+  const calls: string[] = [];
+  let retryOutcome: "retryable" | "ineligible" | "skipped" = "retryable";
+  let ineligibleSettled = false;
+  const operations = {
+    recordRetry: async (
+      _db: PrismaClient,
+      taskId: string,
+      stopId: string,
+      reason: string,
+    ): Promise<"retryable" | "ineligible" | "skipped"> => {
+      calls.push(`retry:${taskId}:${stopId}:${reason}`);
+      return retryOutcome;
+    },
+    settleIneligible: async (
+      _db: PrismaClient,
+      taskId: string,
+      stopId: string,
+      reason: string,
+      identity?: Partial<RecoveryCandidate>,
+    ): Promise<boolean> => {
+      calls.push(`ineligible:${taskId}:${stopId}:${reason}:${identity?.repository ?? "none"}`);
+      return ineligibleSettled;
+    },
+  };
+  const db = {} as PrismaClient;
+  const task = { id: "integrator-1", identity: candidate };
+
+  assert.deepEqual(await settleRecovery(
+    db, task, candidate.stopId, { kind: "retry", reason: "reader timeout" }, operations,
+  ), { recovered: 0, exhausted: 0, ineligible: 0 });
+  retryOutcome = "ineligible";
+  assert.deepEqual(await settleRecovery(
+    db, task, candidate.stopId, { kind: "retry", reason: "reader unavailable" }, operations,
+  ), { recovered: 0, exhausted: 0, ineligible: 1 });
+  assert.deepEqual(await settleRecovery(
+    db, task, candidate.stopId, { kind: "ineligible", reason: "head changed" }, operations,
+  ), { recovered: 0, exhausted: 0, ineligible: 0 });
+  ineligibleSettled = true;
+  assert.deepEqual(await settleRecovery(
+    db, task, candidate.stopId, { kind: "ineligible", reason: "base changed" }, operations,
+  ), { recovered: 0, exhausted: 0, ineligible: 1 });
+  assert.deepEqual(await settleRecovery(
+    db, task, candidate.stopId, { kind: "recovered" }, operations,
+  ), { recovered: 1, exhausted: 0, ineligible: 0 });
+  assert.deepEqual(await settleRecovery(
+    db, task, candidate.stopId, { kind: "exhausted" }, operations,
+  ), { recovered: 0, exhausted: 1, ineligible: 0 });
+  assert.deepEqual(await settleRecovery(
+    db, task, candidate.stopId, { kind: "skip" }, operations,
+  ), { recovered: 0, exhausted: 0, ineligible: 0 });
+  assert.deepEqual(calls, [
+    "retry:integrator-1:stop-1:reader timeout",
+    "retry:integrator-1:stop-1:reader unavailable",
+    "ineligible:integrator-1:stop-1:head changed:acme/widgets",
+    "ineligible:integrator-1:stop-1:base changed:acme/widgets",
+  ]);
 });

--- a/packages/api/src/base-drift-recovery-decision.ts
+++ b/packages/api/src/base-drift-recovery-decision.ts
@@ -58,41 +58,29 @@ export type RecoveryPullRequestFacts = {
   mergeQueueEntry: unknown | null;
 };
 
-export type RecoveryFacts =
-  | { stage: "candidate"; load: CandidateLoad }
-  | { stage: "reader-unavailable" }
-  | { stage: "reader-failure"; reason: string }
+export type FreshRecoveryFacts =
+  | { kind: "reader-unavailable" }
+  | { kind: "reader-failure"; reason: string }
   | {
-      stage: "fresh";
+      kind: "snapshot";
       candidate: RecoveryCandidate;
       snapshot: RecoveryPullRequestFacts;
       comparisonAvailable: boolean;
       authorizedAdvance: Comparison | null;
       observedAdvance: Comparison | null;
-    }
-  | {
-      stage: "classification-retry";
-      reason: string;
-      validationAttempts: number;
-      maxAttempts: number;
-    }
-  | {
-      stage: "durable";
-      expected: RecoveryCandidate;
-      load: CandidateLoad;
-      aggregateValidating: boolean;
-      recoveryCount: number;
-      maxRecoveries: number;
-      currentBaseSha: string;
     };
 
-export type RecoveryDecision =
-  | { kind: "inspect"; candidate: RecoveryCandidate }
-  | { kind: "queue"; candidate: RecoveryCandidate; currentBaseSha: string }
-  | { kind: "retry"; reason: string; classificationAttempt?: number }
-  | { kind: "ineligible"; reason: string }
-  | { kind: "exhausted"; reason: string }
-  | { kind: "skip" };
+export type Skip = { kind: "skip" };
+export type Retry = { kind: "retry"; reason: string };
+export type Ineligible = { kind: "ineligible"; reason: string };
+export type Inspect = { kind: "inspect"; candidate: RecoveryCandidate };
+export type Queue = { kind: "queue"; candidate: RecoveryCandidate; currentBaseSha: string };
+export type Exhausted = { kind: "exhausted"; reason: string };
+
+export type CandidateDecision = Skip | (Retry & { stopId: string }) | (Ineligible & { stopId: string }) | Inspect;
+export type FreshDecision = Retry | Ineligible | Queue;
+export type DurableDecision = Skip | Retry | Ineligible | Exhausted | Queue;
+export type RetryBudgetDecision = (Retry & { classificationAttempt: number }) | Ineligible;
 
 const refusalReason = (refusal: Extract<CandidateLoad, { kind: "refused" }>): string => {
   switch (refusal.code) {
@@ -115,11 +103,19 @@ const refusalReason = (refusal: Extract<CandidateLoad, { kind: "refused" }>): st
   }
 };
 
-const candidateDecision = (load: CandidateLoad): RecoveryDecision => {
-  if (load.kind === "skip") return { kind: "skip" };
-  if (load.kind === "candidate") return { kind: "inspect", candidate: load.candidate };
-  const reason = refusalReason(load);
-  return load.code === "chain-active" ? { kind: "retry", reason } : { kind: "ineligible", reason };
+export const classifyCandidate = (load: CandidateLoad): CandidateDecision => {
+  switch (load.kind) {
+    case "skip":
+      return { kind: "skip" };
+    case "candidate":
+      return { kind: "inspect", candidate: load.candidate };
+    case "refused": {
+      const reason = refusalReason(load);
+      return load.code === "chain-active"
+        ? { kind: "retry", reason, stopId: load.stopId }
+        : { kind: "ineligible", reason, stopId: load.stopId };
+    }
+  }
 };
 
 const candidatesMatch = (left: RecoveryCandidate, right: RecoveryCandidate): boolean => {
@@ -133,45 +129,19 @@ const candidatesMatch = (left: RecoveryCandidate, right: RecoveryCandidate): boo
 
 /**
  * Owns every base-drift recovery classification rule. The worker reads durable
- * and remote facts, then applies this result; this module performs no I/O.
+ * and remote facts, then applies these stage-specific results without widening
+ * their decision unions; this module performs no I/O.
  */
-export const recoveryDecision = (facts: RecoveryFacts): RecoveryDecision => {
-  switch (facts.stage) {
-    case "candidate":
-      return candidateDecision(facts.load);
+export function classifyFresh(facts: Extract<FreshRecoveryFacts, { kind: "reader-unavailable" }>): Retry;
+export function classifyFresh(facts: Extract<FreshRecoveryFacts, { kind: "reader-failure" }>): Retry;
+export function classifyFresh(facts: Extract<FreshRecoveryFacts, { kind: "snapshot" }>): FreshDecision;
+export function classifyFresh(facts: FreshRecoveryFacts): FreshDecision {
+  switch (facts.kind) {
     case "reader-unavailable":
       return { kind: "retry", reason: "server-side GitHub reader is unavailable" };
     case "reader-failure":
       return { kind: "retry", reason: facts.reason };
-    case "classification-retry": {
-      const classificationAttempt = facts.validationAttempts + 1;
-      if (classificationAttempt > facts.maxAttempts) {
-        return {
-          kind: "ineligible",
-          reason: `classification retry limit ${facts.maxAttempts} reached after transient failure: ${facts.reason}`,
-        };
-      }
-      return { kind: "retry", reason: facts.reason, classificationAttempt };
-    }
-    case "durable": {
-      if (!facts.aggregateValidating) return { kind: "skip" };
-      const loaded = candidateDecision(facts.load);
-      if (loaded.kind === "skip") {
-        return { kind: "ineligible", reason: "durable chain state changed during fresh recovery verification" };
-      }
-      if (loaded.kind !== "inspect") return loaded;
-      if (!candidatesMatch(loaded.candidate, facts.expected)) {
-        return { kind: "ineligible", reason: "durable chain state changed during fresh recovery verification" };
-      }
-      if (facts.recoveryCount >= facts.maxRecoveries) {
-        return {
-          kind: "exhausted",
-          reason: `automatic recovery limit ${facts.maxRecoveries} reached for ${facts.expected.repository}#${facts.expected.prNumber} targeting ${facts.expected.targetBranch}`,
-        };
-      }
-      return { kind: "queue", candidate: facts.expected, currentBaseSha: facts.currentBaseSha };
-    }
-    case "fresh":
+    case "snapshot":
       break;
   }
 
@@ -222,4 +192,50 @@ export const recoveryDecision = (facts: RecoveryFacts): RecoveryDecision => {
     }
   }
   return { kind: "queue", candidate, currentBaseSha: snapshot.baseSha };
+}
+
+export const classifyDurable = (facts: {
+  expected: RecoveryCandidate;
+  load: CandidateLoad;
+  aggregateValidating: boolean;
+  recoveryCount: number;
+  maxRecoveries: number;
+  currentBaseSha: string;
+}): DurableDecision => {
+  if (!facts.aggregateValidating) return { kind: "skip" };
+  switch (facts.load.kind) {
+    case "skip":
+      return { kind: "ineligible", reason: "durable chain state changed during fresh recovery verification" };
+    case "refused": {
+      const reason = refusalReason(facts.load);
+      return facts.load.code === "chain-active" ? { kind: "retry", reason } : { kind: "ineligible", reason };
+    }
+    case "candidate":
+      break;
+  }
+  if (!candidatesMatch(facts.load.candidate, facts.expected)) {
+    return { kind: "ineligible", reason: "durable chain state changed during fresh recovery verification" };
+  }
+  if (facts.recoveryCount >= facts.maxRecoveries) {
+    return {
+      kind: "exhausted",
+      reason: `automatic recovery limit ${facts.maxRecoveries} reached for ${facts.expected.repository}#${facts.expected.prNumber} targeting ${facts.expected.targetBranch}`,
+    };
+  }
+  return { kind: "queue", candidate: facts.expected, currentBaseSha: facts.currentBaseSha };
+};
+
+export const classifyRetryBudget = (facts: {
+  reason: string;
+  validationAttempts: number;
+  maxAttempts: number;
+}): RetryBudgetDecision => {
+  const classificationAttempt = facts.validationAttempts + 1;
+  if (classificationAttempt > facts.maxAttempts) {
+    return {
+      kind: "ineligible",
+      reason: `classification retry limit ${facts.maxAttempts} reached after transient failure: ${facts.reason}`,
+    };
+  }
+  return { kind: "retry", reason: facts.reason, classificationAttempt };
 };

--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -29,11 +29,16 @@ import {
 
 import { createGitHubReader, type PullRequestReader, type PullRequestSnapshot } from "./github-read.js";
 import {
-  recoveryDecision,
+  classifyCandidate,
+  classifyDurable,
+  classifyFresh,
+  classifyRetryBudget,
   type CandidateLoad,
   type CandidateRefusalCode,
+  type Ineligible,
   type RecoveryCandidate,
   type RecoveryIdentity,
+  type Retry,
 } from "./base-drift-recovery-decision.js";
 import { stopMergeTail } from "./merge-tail-actions.js";
 
@@ -395,23 +400,22 @@ const recordClassificationRetry = async (
   if (currentStop?.stopId !== stopId) return "skipped";
   const attempt = await ensureValidationAttemptLocked(tx, integratorTaskId, stopId);
   if (attempt.status !== MergeRecoveryStatus.VALIDATING) return "skipped";
-  const decision = recoveryDecision({
-    stage: "classification-retry",
+  const decision = classifyRetryBudget({
     reason,
     validationAttempts: attempt.validationAttempts,
     maxAttempts: MAX_BASE_DRIFT_CLASSIFICATION_RETRIES,
   });
-  if (decision.kind === "ineligible") {
-    await settleIneligibleLocked(
-      tx,
-      integratorTaskId,
-      stopId,
-      decision.reason,
-    );
-    return "ineligible";
-  }
-  if (decision.kind !== "retry" || decision.classificationAttempt === undefined) {
-    throw new Error(`Unexpected classification retry decision ${decision.kind}`);
+  switch (decision.kind) {
+    case "ineligible":
+      await settleIneligibleLocked(
+        tx,
+        integratorTaskId,
+        stopId,
+        decision.reason,
+      );
+      return "ineligible";
+    case "retry":
+      break;
   }
   const classificationAttempt = decision.classificationAttempt;
   await tx.mergeRecoveryAttempt.update({
@@ -461,8 +465,7 @@ const queueRecovery = async (
     targetBranch: expected.targetBranch,
     recoveryRunId: { not: null },
   } });
-  const decision = recoveryDecision({
-    stage: "durable",
+  const decision = classifyDurable({
     expected,
     load: loaded,
     aggregateValidating: aggregate.status === MergeRecoveryStatus.VALIDATING,
@@ -470,10 +473,18 @@ const queueRecovery = async (
     maxRecoveries: MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES,
     currentBaseSha,
   });
-  if (decision.kind === "skip") return { kind: "skip" };
-  if (decision.kind === "retry") return { kind: "retry", reason: decision.reason };
-  if (decision.kind === "ineligible") return { kind: "ineligible", reason: decision.reason };
-  if (decision.kind === "inspect") throw new Error("Durable recovery decision cannot request another remote inspection");
+  switch (decision.kind) {
+    case "skip":
+      return { kind: "skip" };
+    case "retry":
+      return { kind: "retry", reason: decision.reason };
+    case "ineligible":
+      return { kind: "ineligible", reason: decision.reason };
+    case "exhausted":
+      break;
+    case "queue":
+      break;
+  }
   const attempt = aggregate.attempt;
   const common = {
     sourceStopId: expected.stopId,
@@ -491,32 +502,35 @@ const queueRecovery = async (
     readinessTaskId: expected.readinessTaskId,
     regressionTaskId: expected.regressionTaskId,
   };
-  if (decision.kind === "exhausted") {
-    await stopMergeTail(tx, {
-      phase: "recovery-exhausted",
-      aggregateId: aggregate.id,
-      integratorTaskId: expected.integratorTaskId,
-      sourceStopId: expected.stopId,
-      reason: decision.reason,
-      at: now,
-      attempt,
-      recoveryData: {
-        boundSourceRunId: expected.sourceRunId,
-        authorizationActivityId: expected.authorizationActivityId,
-        readinessTaskId: expected.readinessTaskId,
-        regressionTaskId: expected.regressionTaskId,
-        repository: expected.repository,
-        prNumber: expected.prNumber,
-        targetBranch: expected.targetBranch,
-        authorizedHeadSha: expected.authorizedHeadSha,
-        authorizedBaseSha: expected.authorizedBaseSha,
-        observedBaseSha: expected.observedBaseSha,
-        currentBaseSha,
-      },
-      markerMetadata: common,
-    });
-    await openAbandonQuestion(tx, expected.integratorTaskId, expected.stopId);
-    return { kind: "exhausted" };
+  switch (decision.kind) {
+    case "exhausted":
+      await stopMergeTail(tx, {
+        phase: "recovery-exhausted",
+        aggregateId: aggregate.id,
+        integratorTaskId: expected.integratorTaskId,
+        sourceStopId: expected.stopId,
+        reason: decision.reason,
+        at: now,
+        attempt,
+        recoveryData: {
+          boundSourceRunId: expected.sourceRunId,
+          authorizationActivityId: expected.authorizationActivityId,
+          readinessTaskId: expected.readinessTaskId,
+          regressionTaskId: expected.regressionTaskId,
+          repository: expected.repository,
+          prNumber: expected.prNumber,
+          targetBranch: expected.targetBranch,
+          authorizedHeadSha: expected.authorizedHeadSha,
+          authorizedBaseSha: expected.authorizedBaseSha,
+          observedBaseSha: expected.observedBaseSha,
+          currentBaseSha,
+        },
+        markerMetadata: common,
+      });
+      await openAbandonQuestion(tx, expected.integratorTaskId, expected.stopId);
+      return { kind: "exhausted" };
+    case "queue":
+      break;
   }
 
   await closeIntegratorQuestions(tx, expected.integratorTaskId);
@@ -558,7 +572,58 @@ const queueRecovery = async (
   return { kind: "recovered" };
 });
 
+export type RecoveryTickDelta = { recovered: number; exhausted: number; ineligible: number };
+
+type RecoverySettlementTask = {
+  id: string;
+  identity?: Partial<RecoveryIdentity>;
+};
+
+type RecoverySettlementDecision = Retry | Ineligible | QueueRecoveryResult;
+
+type RecoverySettlementOperations = {
+  recordRetry: typeof recordClassificationRetry;
+  settleIneligible: typeof settleIneligible;
+};
+
+const recoverySettlementOperations: RecoverySettlementOperations = {
+  recordRetry: recordClassificationRetry,
+  settleIneligible,
+};
+
+export const settleRecovery = async (
+  db: PrismaClient,
+  task: RecoverySettlementTask,
+  stopId: string,
+  decision: RecoverySettlementDecision,
+  operations: RecoverySettlementOperations = recoverySettlementOperations,
+): Promise<RecoveryTickDelta> => {
+  const tickDelta: RecoveryTickDelta = { recovered: 0, exhausted: 0, ineligible: 0 };
+  switch (decision.kind) {
+    case "skip":
+      return tickDelta;
+    case "recovered":
+      return { ...tickDelta, recovered: 1 };
+    case "exhausted":
+      return { ...tickDelta, exhausted: 1 };
+    case "retry": {
+      const outcome = await operations.recordRetry(db, task.id, stopId, decision.reason);
+      return outcome === "ineligible" ? { ...tickDelta, ineligible: 1 } : tickDelta;
+    }
+    case "ineligible": {
+      const settled = await operations.settleIneligible(db, task.id, stopId, decision.reason, task.identity);
+      return settled ? { ...tickDelta, ineligible: 1 } : tickDelta;
+    }
+  }
+};
+
 export type BaseDriftRecoveryTickResult = { examined: number; recovered: number; exhausted: number; ineligible: number };
+
+const addTickDelta = (result: BaseDriftRecoveryTickResult, delta: RecoveryTickDelta): void => {
+  result.recovered += delta.recovered;
+  result.exhausted += delta.exhausted;
+  result.ineligible += delta.ineligible;
+};
 
 export const baseDriftRecoveryTick = async (
   db: PrismaClient,
@@ -586,23 +651,21 @@ export const baseDriftRecoveryTick = async (
       cursor = task.id;
       if (result.examined >= limit) break;
       const loaded = await loadCandidate(db, task.id);
-      const candidateDecision = recoveryDecision({ stage: "candidate", load: loaded });
-      if (candidateDecision.kind === "skip") continue;
-      result.examined += 1;
-      if (candidateDecision.kind === "retry" || candidateDecision.kind === "ineligible") {
-        if (loaded.kind !== "refused") throw new Error(`Candidate ${task.id} has no refusal binding`);
-        if (candidateDecision.kind === "retry") {
-          const outcome = await recordClassificationRetry(db, task.id, loaded.stopId, candidateDecision.reason);
-          if (outcome === "ineligible") result.ineligible += 1;
-        } else if (await settleIneligible(db, task.id, loaded.stopId, candidateDecision.reason)) {
-          result.ineligible += 1;
-        }
-        continue;
-      }
-      if (candidateDecision.kind !== "inspect") {
-        throw new Error(`Unexpected candidate recovery decision ${candidateDecision.kind}`);
+      const candidateDecision = classifyCandidate(loaded);
+      switch (candidateDecision.kind) {
+        case "skip":
+          continue;
+        case "retry":
+        case "ineligible":
+          result.examined += 1;
+          addTickDelta(result, await settleRecovery(db, task, candidateDecision.stopId, candidateDecision));
+          continue;
+        case "inspect":
+          result.examined += 1;
+          break;
       }
       const candidate = candidateDecision.candidate;
+      const settlementTask = { id: task.id, identity: candidate };
       const validation = await db.$transaction(async (tx) => {
         if (!await lockRecoveryChain(tx, candidate.integratorTaskId)) return false;
         const attempt = await ensureValidationAttemptLocked(tx, candidate.integratorTaskId, candidate.stopId, candidate);
@@ -610,12 +673,8 @@ export const baseDriftRecoveryTick = async (
       });
       if (!validation) continue;
       if (!reader) {
-        const decision = recoveryDecision({ stage: "reader-unavailable" });
-        if (decision.kind !== "retry") throw new Error(`Unexpected reader decision ${decision.kind}`);
-        const outcome = await recordClassificationRetry(
-          db, task.id, candidate.stopId, decision.reason,
-        );
-        if (outcome === "ineligible") result.ineligible += 1;
+        const decision = classifyFresh({ kind: "reader-unavailable" });
+        addTickDelta(result, await settleRecovery(db, settlementTask, candidate.stopId, decision));
         continue;
       }
       let snapshot: PullRequestSnapshot;
@@ -641,42 +700,31 @@ export const baseDriftRecoveryTick = async (
           clearTimeout(timer);
         }
       } catch (error: unknown) {
-        const decision = recoveryDecision({
-          stage: "reader-failure",
+        const decision = classifyFresh({
+          kind: "reader-failure",
           reason: `fresh server-side repository read failed (${error instanceof Error ? error.name : "unknown error"})`,
         });
-        if (decision.kind !== "retry") throw new Error(`Unexpected reader failure decision ${decision.kind}`);
-        const outcome = await recordClassificationRetry(db, task.id, candidate.stopId, decision.reason);
-        if (outcome === "ineligible") result.ineligible += 1;
+        addTickDelta(result, await settleRecovery(db, settlementTask, candidate.stopId, decision));
         continue;
       }
-      const fresh = recoveryDecision({
-        stage: "fresh",
+      const fresh = classifyFresh({
+        kind: "snapshot",
         candidate,
         snapshot,
         comparisonAvailable: reader.compareCommits !== undefined,
         authorizedAdvance,
         observedAdvance,
       });
-      if (fresh.kind === "ineligible") {
-        if (await settleIneligible(db, task.id, candidate.stopId, fresh.reason, candidate)) result.ineligible += 1;
-        continue;
+      switch (fresh.kind) {
+        case "retry":
+        case "ineligible":
+          addTickDelta(result, await settleRecovery(db, settlementTask, candidate.stopId, fresh));
+          continue;
+        case "queue":
+          break;
       }
-      if (fresh.kind === "retry") {
-        const outcome = await recordClassificationRetry(db, task.id, candidate.stopId, fresh.reason);
-        if (outcome === "ineligible") result.ineligible += 1;
-        continue;
-      }
-      if (fresh.kind !== "queue") throw new Error(`Unexpected fresh recovery decision ${fresh.kind}`);
       const outcome = await queueRecovery(db, candidate, fresh.currentBaseSha, now);
-      if (outcome.kind === "recovered") result.recovered += 1;
-      else if (outcome.kind === "exhausted") result.exhausted += 1;
-      else if (outcome.kind === "ineligible") {
-        if (await settleIneligible(db, task.id, candidate.stopId, outcome.reason, candidate)) result.ineligible += 1;
-      } else if (outcome.kind === "retry") {
-        const retry = await recordClassificationRetry(db, task.id, candidate.stopId, outcome.reason);
-        if (retry === "ineligible") result.ineligible += 1;
-      }
+      addTickDelta(result, await settleRecovery(db, settlementTask, candidate.stopId, outcome));
     }
     if (tasks.length < pageSize) break;
   }


### PR DESCRIPTION
## Candidate

Candidate 12: narrow base-drift decision unions by recovery stage and centralize settlement.

## Changes

1. Replaced the shared `recoveryDecision` entrypoint with stage-specific classifiers:
   - candidate: before, the shared six-kind union while only `Skip | Retry | Ineligible | Inspect` was reachable; after, `classifyCandidate` exposes exactly that four-kind union.
   - fresh: before, the shared six-kind union while only `Retry | Ineligible | Queue` was reachable; after, `classifyFresh` exposes exactly that three-kind union, including reader unavailable/failure facts.
   - durable: before, the shared six-kind union while only `Skip | Retry | Ineligible | Exhausted | Queue` was reachable; after, `classifyDurable` exposes exactly that five-kind union.
   - retry budget: before, the shared six-kind union while only `Retry | Ineligible` was reachable; after, `classifyRetryBudget` exposes exactly that two-kind union, with `classificationAttempt` required on `Retry`.
2. Updated each recovery stage in `merge-base-drift-worker.ts` to call its narrow classifier and removed every impossible-decision `Unexpected` throw.
3. Added `settleRecovery(db, task, stopId, decision) -> tickDelta`, centralizing classification retry persistence, ineligible settlement, and recovered/exhausted/ineligible tick accounting.
4. Added direct pure tests for all four narrow classifiers and direct non-dbtest coverage for `settleRecovery` persistence outcomes and tick deltas.

The existing retry, ineligible, queue, skip, exhausted, and tickDelta behavior is unchanged. Fresh and durable ineligible settlement still records the same recovery identity; retry-budget exhaustion retains its existing settlement path.

## Validation

- `npm install`: pass
- `npm run lint`: pass
- `npm run typecheck`: pass
- `npm run test -w @anneal/api`: pass (636 passed, 0 failed, 1 skipped)
- `npm run test:db -w @anneal/api -- src/merge-base-drift-recovery.dbtest.ts`: pass (27 passed, 0 failed)
- `grep -c "Unexpected" packages/api/src/merge-base-drift-worker.ts`: `0`
- `git diff --check`: pass

## Out of scope observed

- Prisma emits its existing deprecation warning for `package.json#prisma`; no adjacent configuration was changed.
- No changes were made to `merge-tail-actions.ts`, `merge-readiness-worker.ts`, `packages/db/src/merge-tail.ts`, Lease acquisition, Lease holding, or Merge readiness rules.
