### PR TITLE
refactor(deploy): centralize quiet-window phase order

### DIFF
--- a/scripts/deploy/deploy-phases.mjs
+++ b/scripts/deploy/deploy-phases.mjs
@@ -1,0 +1,43 @@
+const phase = (scope, name, hostMethod, mutating, ledgerState = null) => Object.freeze({
+  scope,
+  name,
+  hostMethod,
+  mutating,
+  ledgerState,
+});
+
+/**
+ * The declaration is ordered across the main prefix and the host upgrade. A
+ * prefix entry names the main operation that owns the boundary; an upgrade
+ * entry names the production-host method that executes it.
+ */
+export const DEPLOY_PHASES = Object.freeze([
+  phase("prefix", "parse-arguments", "parseArgs", false),
+  phase("prefix", "check-escalation", "checkEscalation", false),
+  phase("prefix", "acquire-deploy-lock", "acquireLock", false),
+  phase("prefix", "read-revisions", "readRevisions", false),
+  phase("prefix", "check-already-deployed", "checkAlreadyDeployed", false),
+  phase("prefix", "start-deployment-ledger", "startDeploymentLedger", false, "STARTED"),
+  phase("prefix", "prepare-release-artifact", "prepareReleaseArtifact", true, "ARTIFACT_PREPARED"),
+  phase("upgrade", "verify-release-artifact", "verifyArtifact", false, "ARTIFACT_VERIFIED"),
+  phase("upgrade", "acquire-quiet-window", "waitForQuiet", false),
+  phase("upgrade", "prepare-operation-workspace", "prepareWorkspace", true),
+  phase("upgrade", "verify-stable-service-paths", "verifyStableServicePaths", false),
+  phase("upgrade", "backup", "backup", true, "BACKED_UP"),
+  phase("upgrade", "guarded-migration", "guardedMigration", true, "SCHEMA_ADVANCED"),
+  phase("upgrade", "generate-prisma-client", "generatePrismaClient", true),
+  phase("upgrade", "canonical-prompt-sync", "syncCanonicalPrompts", true),
+  phase("upgrade", "verify-runtime-prisma-client", "verifyRuntimePrismaClient", false),
+  phase("upgrade", "assert-quiet-before-restart", "assertQuietBeforeRestart", false),
+  phase("upgrade", "publish-build", "publishBuild", true, "ACTIVATED"),
+  phase("upgrade", "restart-services", "restartServices", true),
+  phase("upgrade", "verify-services", "verifyServices", false, "VERIFIED"),
+]);
+
+export const PREFIX_DEPLOY_PHASES = Object.freeze(
+  DEPLOY_PHASES.filter(({ scope }) => scope === "prefix"),
+);
+
+export const UPGRADE_DEPLOY_PHASES = Object.freeze(
+  DEPLOY_PHASES.filter(({ scope }) => scope === "upgrade"),
+);

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -4,9 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
+import { PREFIX_DEPLOY_PHASES, UPGRADE_DEPLOY_PHASES } from "./deploy-phases.mjs";
 import {
   DeployFailure,
-  DEPLOY_STEPS,
   SERVICE_LABELS,
   deployedBuildStampRefusal,
   dryRunDecision,
@@ -29,29 +29,28 @@ const revisions = { from: "a".repeat(40), to: "b".repeat(40) };
 
 const fixture = (failure = null) => {
   const calls = [];
+  const phaseCalls = [];
   const records = [];
   const state = { serving: "previous", escalated: null };
   const step = (name, work = async () => undefined) => async (...args) => {
     calls.push(name);
+    phaseCalls.push(name);
     if (failure === name) throw new DeployFailure(`${name}-failed`, "fixture");
     return work(...args);
   };
+  const support = (name, work = async () => undefined) => async (...args) => {
+    calls.push(name);
+    return work(...args);
+  };
   const releaseName = `${revisions.to}-${"c".repeat(64)}`;
-  const host = {
-    verifyArtifact: step("verify-artifact", async () => ({
+  const phaseWork = {
+    verifyArtifact: async () => ({
       releaseDirectoryIdentity: releaseName,
       buildStamp: { packageName: "@anneal/api", commit: revisions.to, dirty: false },
-    })),
-    waitForQuiet: step("wait-for-quiet"),
-    prepareWorkspace: step("prepare-workspace"),
-    verifyStableServicePaths: step("verify-stable-service-paths"),
-    backup: step("backup", async () => ({ backupIdentity: "fixture.dump" })),
-    guardedMigration: step("guarded-migration", async () => ({ migrationTailBefore: "before", migrationTailAfter: "after" })),
-    generatePrismaClient: step("generate-prisma-client"),
-    syncCanonicalPrompts: step("canonical-prompt-sync"),
-    verifyRuntimePrismaClient: step("verify-runtime-prisma-client"),
-    assertQuietBeforeRestart: step("quiet-recheck"),
-    publishBuild: step("publish-build", async () => {
+    }),
+    backup: async () => ({ backupIdentity: "fixture.dump" }),
+    guardedMigration: async () => ({ migrationTailBefore: "before", migrationTailAfter: "after" }),
+    publishBuild: async () => {
       state.serving = "candidate";
       return {
         releaseDirectoryIdentity: releaseName,
@@ -59,10 +58,14 @@ const fixture = (failure = null) => {
         rollback: async () => { calls.push("rollback-build"); state.serving = "previous"; },
         commit: async () => { calls.push("commit-build"); },
       };
-    }),
-    restartServices: step("restart-services"),
-    verifyServices: step("verify-services"),
-    restorePreviousServices: step("restore-services"),
+    },
+  };
+  const host = {
+    ...Object.fromEntries(UPGRADE_DEPLOY_PHASES.map(({ name, hostMethod }) => [
+      hostMethod,
+      step(name, phaseWork[hostMethod]),
+    ])),
+    restorePreviousServices: support("restore-services"),
     escalate: async (record) => { calls.push("escalate"); state.escalated = record; },
     notify: async (record) => { calls.push(`notify-${record.outcome}`); },
     cleanupWorkspace: async () => { calls.push("cleanup-workspace"); },
@@ -71,7 +74,7 @@ const fixture = (failure = null) => {
     start: (metadata) => { records.push({ state: "STARTED", metadata }); },
     record: (name, metadata) => { records.push({ state: name, metadata }); },
   };
-  return { host, calls, records, state, ledger };
+  return { host, calls, phaseCalls, records, state, ledger };
 };
 
 const minimalBuildTree = (root, revision) => {
@@ -121,6 +124,26 @@ test("deployed build stamps require an exact clean commit", () => {
 
 test("production host requires the artifact-only mechanisms", () => {
   assert.throws(() => createProductionHost({}), /production-host-adapter-missing:verifyArtifact/u);
+  for (const { hostMethod } of UPGRADE_DEPLOY_PHASES) {
+    const { host } = fixture();
+    delete host[hostMethod];
+    assert.throws(
+      () => createProductionHost(host),
+      new RegExp(`production-host-adapter-missing:${hostMethod}`, "u"),
+    );
+  }
+});
+
+test("main prefix phase order declares the current artifact deployment boundaries", () => {
+  assert.deepEqual(PREFIX_DEPLOY_PHASES.map(({ name }) => name), [
+    "parse-arguments",
+    "check-escalation",
+    "acquire-deploy-lock",
+    "read-revisions",
+    "check-already-deployed",
+    "start-deployment-ledger",
+    "prepare-release-artifact",
+  ]);
 });
 
 test("release artifact inventory includes deploy runtime and workspace dependencies", () => {
@@ -142,30 +165,39 @@ test("successful activation verifies artifact before acquiring the quiet window"
   const { host, calls, records, ledger } = fixture();
   assert.deepEqual(await executeUpgrade(host, revisions, { ledger }), { ok: true });
   assert.deepEqual(calls, [
-    "verify-artifact", "wait-for-quiet", "prepare-workspace", "verify-stable-service-paths", "backup",
+    "verify-release-artifact", "acquire-quiet-window", "prepare-operation-workspace", "verify-stable-service-paths", "backup",
     "guarded-migration", "generate-prisma-client", "canonical-prompt-sync", "verify-runtime-prisma-client",
-    "quiet-recheck", "publish-build", "restart-services", "verify-services", "notify-success", "commit-build",
+    "assert-quiet-before-restart", "publish-build", "restart-services", "verify-services", "notify-success", "commit-build",
     "cleanup-workspace",
   ]);
   assert.deepEqual(records.map(({ state }) => state), [
     "STARTED", "ARTIFACT_VERIFIED", "BACKED_UP", "SCHEMA_ADVANCED", "ACTIVATED", "VERIFIED", "SUCCEEDED",
   ]);
-  assert.ok(calls.indexOf("verify-artifact") < calls.indexOf("wait-for-quiet"));
 });
 
 test("missing artifact records FAILED without quiet-window, build, or activation", async () => {
   const { host, calls, records, ledger } = fixture();
   host.verifyArtifact = async () => {
-    calls.push("verify-artifact");
+    calls.push("verify-release-artifact");
     throw new DeployFailure("release-artifact-missing", revisions.to);
   };
   const result = await executeUpgrade(host, revisions, { ledger });
   assert.equal(result.ok, false);
   assert.equal(result.failure.reason, "release-artifact-missing");
-  assert.equal(calls.includes("wait-for-quiet"), false);
+  assert.equal(calls.includes("acquire-quiet-window"), false);
   assert.equal(calls.includes("publish-build"), false);
   assert.equal(calls.some((call) => /dependencies|install/u.test(call)), false);
   assert.equal(records.at(-1).state, "FAILED");
+});
+
+test("each declared upgrade phase stops execution at its first failure", async () => {
+  const phaseNames = UPGRADE_DEPLOY_PHASES.map(({ name }) => name);
+  for (const [index, name] of phaseNames.entries()) {
+    const { host, phaseCalls } = fixture(name);
+    const result = await executeUpgrade(host, revisions);
+    assert.equal(result.ok, false, name);
+    assert.deepEqual(phaseCalls, phaseNames.slice(0, index + 1), name);
+  }
 });
 
 test("service verification failure rolls back before restoring services", async () => {
@@ -251,6 +283,8 @@ test("artifact verification reports content digest mismatch distinctly", () => {
 
 test("dry-run reports artifact readiness and performs no mutation", async () => {
   const calls = [];
+  const execution = fixture();
+  assert.deepEqual(await executeUpgrade(execution.host, revisions, { ledger: execution.ledger }), { ok: true });
   const result = await dryRunDecision({
     revisions: async () => ({ from: revisions.from, to: revisions.to }),
     blockingRuns: async () => [],
@@ -260,14 +294,16 @@ test("dry-run reports artifact readiness and performs no mutation", async () => 
   });
   assert.equal(result.artifact.ok, true);
   assert.deepEqual(calls, ["artifact"]);
-  assert.equal(result.lines.filter((line) => line.includes("mutation=skipped")).length, DEPLOY_STEPS.length);
+  const plannedPhases = result.lines
+    .filter((line) => line.startsWith("DRY-RUN plan step="))
+    .map((line) => line.match(/^DRY-RUN plan step=([^ ]+) mutation=skipped$/u)?.[1]);
+  assert.deepEqual(plannedPhases, execution.phaseCalls);
 });
 
 test("deploy source has no install/build fallback, checkout mutation, or legacy publication", () => {
   const source = readFileSync(new URL("./quiet-window-deploy.mjs", import.meta.url), "utf8");
   assert.doesNotMatch(source, /npm[^\n]*(?:ci|run["', ]+build)/u);
   assert.doesNotMatch(source, /worktree|fast-forward|assertProductionCheckout|inspectGitPreflight/u);
-  assert.ok(source.indexOf("verifyArtifact:") < source.indexOf("waitForQuiet:"));
   assert.match(source, /process\.env\.AGENTOS_REPOSITORY_ROOT/u);
 });
 

--- a/scripts/deploy/quiet-window-host.mjs
+++ b/scripts/deploy/quiet-window-host.mjs
@@ -1,14 +1,11 @@
-const METHODS = Object.freeze([
-  "verifyArtifact", "waitForQuiet", "prepareWorkspace", "backup",
-  "guardedMigration", "generatePrismaClient", "syncCanonicalPrompts", "verifyRuntimePrismaClient",
-  "verifyStableServicePaths",
-  "assertQuietBeforeRestart", "publishBuild", "restartServices", "verifyServices",
-  "restorePreviousServices", "escalate", "notify", "cleanupWorkspace",
-]);
+import { UPGRADE_DEPLOY_PHASES } from "./deploy-phases.mjs";
 
 /** Import-safe production-host composition boundary used by the real job and harness. */
 export const createProductionHost = (adapters) => {
-  for (const method of METHODS) {
+  for (const { hostMethod: method } of UPGRADE_DEPLOY_PHASES) {
+    if (typeof adapters[method] !== "function") throw new TypeError(`production-host-adapter-missing:${method}`);
+  }
+  for (const method of ["restorePreviousServices", "escalate", "notify", "cleanupWorkspace"]) {
     if (typeof adapters[method] !== "function") throw new TypeError(`production-host-adapter-missing:${method}`);
   }
   return Object.freeze({ ...adapters });

--- a/scripts/deploy/quiet-window-lib.mjs
+++ b/scripts/deploy/quiet-window-lib.mjs
@@ -1,19 +1,6 @@
-export const BLOCKING_RUN_STATUSES = Object.freeze(["claimed", "provisioning", "running"]);
+import { UPGRADE_DEPLOY_PHASES } from "./deploy-phases.mjs";
 
-export const DEPLOY_STEPS = Object.freeze([
-  "verify-release-artifact",
-  "acquire-quiet-window",
-  "prepare-operation-workspace",
-  "verify-stable-service-paths",
-  "backup",
-  "guarded-migration",
-  "generate-prisma-client",
-  "canonical-prompt-sync",
-  "verify-runtime-prisma-client",
-  "publish-build",
-  "restart-services",
-  "verify-services",
-]);
+export const BLOCKING_RUN_STATUSES = Object.freeze(["claimed", "provisioning", "running"]);
 
 export const SERVICE_LABELS = Object.freeze([
   "com.agentos.api",
@@ -116,82 +103,101 @@ export const executeUpgrade = async (host, initialRevisions, options = {}) => {
       }
       else await recordLedger("STARTED");
     }
-    const artifact = await host.verifyArtifact(revisions.to);
-    candidateBuildStamp = artifact?.buildStamp ?? null;
-    context = {
-      ...context,
-      activatedBuildStamp: candidateBuildStamp,
-      releaseDirectoryIdentity: artifact?.releaseDirectoryIdentity ?? null,
-    };
-    await recordLedger("ARTIFACT_VERIFIED");
-    await host.waitForQuiet();
-    await host.prepareWorkspace(artifact);
-    await host.verifyStableServicePaths();
-    const backup = await host.backup();
-    context = { ...context, backupIdentity: backup?.backupIdentity ?? null };
-    await recordLedger("BACKED_UP");
-    const migration = await host.guardedMigration();
-    context = {
-      ...context,
-      migrationTailBefore: migration?.migrationTailBefore ?? null,
-      migrationTailAfter: migration?.migrationTailAfter ?? null,
-    };
-    schemaAdvanced = true;
-    await recordLedger("SCHEMA_ADVANCED");
-    await host.generatePrismaClient();
-    await host.syncCanonicalPrompts();
-    await host.verifyRuntimePrismaClient();
-    await host.assertQuietBeforeRestart();
-    activationAttempted = true;
-    try {
-      publication = await host.publishBuild();
-      activationOutcomeProven = publication !== null && publication !== undefined;
-    } catch (error) {
-      if (error instanceof DeployFailure && ["build-swap-failed", "release-pointer-activation-failed"].includes(error.reason)) {
-        activationOutcomeProven = true;
+    let artifact = null;
+    let publicationReady = false;
+    const executePhase = async ({ hostMethod }) => {
+      switch (hostMethod) {
+        case "verifyArtifact": {
+          artifact = await host[hostMethod](revisions.to);
+          candidateBuildStamp = artifact?.buildStamp ?? null;
+          context = {
+            ...context,
+            activatedBuildStamp: candidateBuildStamp,
+            releaseDirectoryIdentity: artifact?.releaseDirectoryIdentity ?? null,
+          };
+          break;
+        }
+        case "prepareWorkspace":
+          await host[hostMethod](artifact);
+          break;
+        case "backup": {
+          const backup = await host[hostMethod]();
+          context = { ...context, backupIdentity: backup?.backupIdentity ?? null };
+          break;
+        }
+        case "guardedMigration": {
+          const migration = await host[hostMethod]();
+          context = {
+            ...context,
+            migrationTailBefore: migration?.migrationTailBefore ?? null,
+            migrationTailAfter: migration?.migrationTailAfter ?? null,
+          };
+          schemaAdvanced = true;
+          break;
+        }
+        case "publishBuild":
+          activationAttempted = true;
+          try {
+            publication = await host[hostMethod]();
+            publicationReady = true;
+            activationOutcomeProven = publication !== null && publication !== undefined;
+          } catch (error) {
+            if (error instanceof DeployFailure && ["build-swap-failed", "release-pointer-activation-failed"].includes(error.reason)) {
+              activationOutcomeProven = true;
+            }
+            throw error;
+          }
+          context = {
+            ...context,
+            activatedBuildStamp: candidateBuildStamp,
+            ...(publication?.releaseDirectoryIdentity
+              ? { releaseDirectoryIdentity: publication.releaseDirectoryIdentity }
+              : publication?.releaseIdentity?.name
+                ? { releaseDirectoryIdentity: publication.releaseIdentity.name }
+                : {}),
+            ...(publication?.pointerOldTarget !== undefined ? { pointerOldTarget: publication.pointerOldTarget } : {}),
+            ...(publication?.pointerNewTarget !== undefined ? { pointerNewTarget: publication.pointerNewTarget } : {}),
+            ...(publication?.releaseIdentity ? { releaseIdentity: publication.releaseIdentity } : {}),
+            ...(publication?.pointerTransition ? { pointerTransition: publication.pointerTransition } : {}),
+          };
+          break;
+        case "verifyServices": {
+          const verification = await host[hostMethod](revisions);
+          context = {
+            ...context,
+            activatedBuildStamp: verification?.activatedBuildStamp ?? context.activatedBuildStamp,
+          };
+          break;
+        }
+        default:
+          await host[hostMethod]();
       }
-      throw error;
-    }
+    };
     try {
-      context = {
-        ...context,
-        activatedBuildStamp: candidateBuildStamp,
-        ...(publication?.releaseDirectoryIdentity
-          ? { releaseDirectoryIdentity: publication.releaseDirectoryIdentity }
-          : publication?.releaseIdentity?.name
-            ? { releaseDirectoryIdentity: publication.releaseIdentity.name }
-            : {}),
-        ...(publication?.pointerOldTarget !== undefined ? { pointerOldTarget: publication.pointerOldTarget } : {}),
-        ...(publication?.pointerNewTarget !== undefined ? { pointerNewTarget: publication.pointerNewTarget } : {}),
-        ...(publication?.releaseIdentity ? { releaseIdentity: publication.releaseIdentity } : {}),
-        ...(publication?.pointerTransition ? { pointerTransition: publication.pointerTransition } : {}),
-      };
-      await recordLedger("ACTIVATED");
-      await host.restartServices();
-      const verification = await host.verifyServices(revisions);
-      context = {
-        ...context,
-        activatedBuildStamp: verification?.activatedBuildStamp ?? context.activatedBuildStamp,
-      };
-      await recordLedger("VERIFIED");
+      for (const phase of UPGRADE_DEPLOY_PHASES) {
+        await executePhase(phase);
+        if (phase.ledgerState !== null) await recordLedger(phase.ledgerState);
+      }
       await recordLedger("SUCCEEDED");
       await host.notify({ outcome: "success", reason: "deployed", ...revisions });
     } catch (error) {
-      try {
-        const rollbackPointerOutcome = await publication.rollback();
-        if (rollbackPointerOutcome !== null && rollbackPointerOutcome !== undefined) {
-          const durableOutcome = typeof rollbackPointerOutcome === "string"
-            ? rollbackPointerOutcome
-            : rollbackPointerOutcome.operation && rollbackPointerOutcome.oldTarget && rollbackPointerOutcome.newTarget
-              ? `${rollbackPointerOutcome.operation}:${rollbackPointerOutcome.oldTarget}->${rollbackPointerOutcome.newTarget}`
-              : String(rollbackPointerOutcome.outcome ?? rollbackPointerOutcome);
-          context = { ...context, rollbackPointerOutcome: durableOutcome };
+      if (publicationReady) {
+        try {
+          const rollbackPointerOutcome = await publication.rollback();
+          if (rollbackPointerOutcome !== null && rollbackPointerOutcome !== undefined) {
+            const durableOutcome = typeof rollbackPointerOutcome === "string"
+              ? rollbackPointerOutcome
+              : rollbackPointerOutcome.operation && rollbackPointerOutcome.oldTarget && rollbackPointerOutcome.newTarget
+                ? `${rollbackPointerOutcome.operation}:${rollbackPointerOutcome.oldTarget}->${rollbackPointerOutcome.newTarget}`
+                : String(rollbackPointerOutcome.outcome ?? rollbackPointerOutcome);
+            context = { ...context, rollbackPointerOutcome: durableOutcome };
+          }
+          await host.restorePreviousServices();
+          activationOutcomeProven = true;
+        } catch (recoveryError) {
+          activationOutcomeProven = false;
+          throw recoveryError;
         }
-        await host.restorePreviousServices();
-        activationOutcomeProven = true;
-      } catch (recoveryError) {
-        activationOutcomeProven = false;
-        throw recoveryError;
       }
       throw error;
     }
@@ -270,6 +276,6 @@ export const dryRunDecision = async (host) => {
     `DRY-RUN services=${services.ok ? "ready" : "not-ready"}`,
     `DRY-RUN backup=${backup.ok ? "ready" : "not-ready"} mode=${backup.mode}${backup.reason ? ` reason=${backup.reason}` : ""}`,
   ];
-  for (const step of DEPLOY_STEPS) lines.push(`DRY-RUN plan step=${step} mutation=skipped`);
+  for (const phase of UPGRADE_DEPLOY_PHASES) lines.push(`DRY-RUN plan step=${phase.name} mutation=skipped`);
   return { quiet, revisions, runs, artifact, services, backup, lines };
 };


### PR DESCRIPTION
## Candidate

03: use one ordered phase table for quiet-window deployment.

## Changes

1. Added `scripts/deploy/deploy-phases.mjs` with one ordered table. Every phase declares `name`, `hostMethod`, `mutating`, and `ledgerState`; `scope` distinguishes the main prefix from the host upgrade.
2. Changed `executeUpgrade(host, revisions, { ledger })` to traverse the upgrade rows while preserving its signature, ledger metadata, rollback boundary, cleanup, and stop-on-first-failure behavior.
3. Changed `dryRunDecision` to print the upgrade rows from the same table. The test now directly compares dry-run phase names with the phase names actually called by `executeUpgrade`; it does not compare only a count or another constant.
4. Changed `createProductionHost` to validate every upgrade `hostMethod` from the table, and changed the test fixture to generate phase stubs from those rows.
5. Declared the current main prefix order in the same table and replaced source-text ordering checks with direct phase-order assertions.
6. Removed the duplicated deploy-step and production-host method lists and their repeated fixture mapping.

## Full phase order

Prefix:

1. `parse-arguments`
2. `check-escalation`
3. `acquire-deploy-lock`
4. `read-revisions`
5. `check-already-deployed`
6. `start-deployment-ledger`
7. `prepare-release-artifact`

Upgrade and dry run:

1. `verify-release-artifact`
2. `acquire-quiet-window`
3. `prepare-operation-workspace`
4. `verify-stable-service-paths`
5. `backup`
6. `guarded-migration`
7. `generate-prisma-client`
8. `canonical-prompt-sync`
9. `verify-runtime-prisma-client`
10. `assert-quiet-before-restart`
11. `publish-build`
12. `restart-services`
13. `verify-services`

Candidate 08 replaced the former `create-stage` host phase with the current-baseline `prepare-operation-workspace` phase. That current counterpart and the restart-preceding quiet recheck (`assert-quiet-before-restart`) are now both present in dry-run output; no retired checkout or adapter path was restored.

## Validation

- `npm run lint`: PASS
- `npm run typecheck`: PASS
- `RUNNER_WORKSPACE_ROOT="$(mktemp -d)" npm run test:auto-deploy`: PASS, 49/49
- `grep -rn "DEPLOY_STEPS\|METHODS" scripts/deploy/`: no results
- `rg -n "indexOf\\(source\\)" scripts/deploy/quiet-window-deploy.test.mjs`: no results

## Out of scope observed

- The specified baseline `bfa1ac4bdbf910abdc91844596e9854072801b6a` does not contain `docs/adr/0004-artifact-based-deployment-ledger.md`; `docs/adr/` contains 0001 through 0003. This change preserves the stated release-directory, atomic-current-pointer, record-only-ledger, and wrapper-first constraints without adding or changing documentation.
- Candidate 08 removed the production-checkout mutation path and retired `quiet-window-adapters.mjs`. This change did not restore either path.
