### PR TITLE
feat(board): project operator move targets

### DIFF
--- a/apps/web/src/components/desktop-board.tsx
+++ b/apps/web/src/components/desktop-board.tsx
@@ -1,6 +1,6 @@
 import { type DragEvent, type ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
-import { CARD_PAGE_SIZE, COLUMNS, type BoardEntry, type Edges, clampScroll, columnStep, edgeState, normalizeBoardEntries, operatorMoveTargets, sameEdges, scrollKey, storedScroll } from "../lib/board";
+import { CARD_PAGE_SIZE, COLUMNS, type BoardEntry, type Edges, clampScroll, columnStep, edgeState, normalizeBoardEntries, sameEdges, scrollKey, storedScroll } from "../lib/board";
 import { useT } from "../lib/i18n";
 import { storage } from "../lib/storage";
 import type { BoardTask, TaskStatus } from "../lib/types";
@@ -115,7 +115,7 @@ export const BoardColumn = ({ column, tasks, loading, dragOver, onDragOver, onDr
     >
       {visibleTasks.map((entry) => entry.kind === "chain"
         ? <ChainAggregateCard key={entry.id} aggregate={entry.aggregate} members={entry.members} representativeTaskId={entry.representativeTaskId} actions={aggregateActions} />
-        : <TaskCard key={entry.id} task={entry.task} actions={actions} draggable={operatorMoveTargets(entry.task).length > 0} />)}
+        : <TaskCard key={entry.id} task={entry.task} actions={actions} draggable={entry.task.moveTargets.length > 0} />)}
       {previousCount > 0 || nextCount > 0 ? (
         <div className={COLUMN_PAGER}>
           {previousCount > 0 ? (

--- a/apps/web/src/components/task-card.tsx
+++ b/apps/web/src/components/task-card.tsx
@@ -1,13 +1,12 @@
 import { type DragEvent, type MouseEvent, type ReactNode, memo, useEffect, useState } from "react";
 
 import { chainPositionMarker } from "../lib/chain";
-import { api } from "../lib/api";
 import { duration, money, timeAgo, usageCostLabel } from "../lib/format";
-import { chainBinding, chainBindingLabel, operatorMoveTargets, retryable, scheduleLabel, statusLabel } from "../lib/board";
+import { chainBinding, chainBindingLabel, retryable, scheduleLabel, statusLabel } from "../lib/board";
 import { type Translate, useT } from "../lib/i18n";
 import { mergeBadge } from "../lib/merge-outcome";
 import { navigate } from "../lib/router";
-import type { BoardTask, TaskStartability, TaskStatus } from "../lib/types";
+import type { BoardTask, TaskStatus } from "../lib/types";
 import { cn } from "../lib/utils";
 import { IconRobot, IconUser } from "./icons";
 import { DOT, DOT_TONE, Pill, ROW, RowMenu, type RowMenuEntry } from "./ui";
@@ -159,8 +158,8 @@ export const RunningCardTime = ({ task, t }: { task: BoardTask; t: Translate }):
   return <>{cardTime(task, t, now)}</>;
 };
 
-const menu = (task: BoardTask, actions: CardActions, t: Translate, startable: boolean): RowMenuEntry[] => {
-  const targets = operatorMoveTargets(task, startable);
+const menu = (task: BoardTask, actions: CardActions, t: Translate): RowMenuEntry[] => {
+  const targets = task.moveTargets;
   return [
   ...(retryable(task, task.latestRun) ? [{ label: t("common.retry"), onSelect: () => actions.onRetry(task) }] : []),
   // Only where there is an error to copy, and it copies the whole of it — the
@@ -170,24 +169,15 @@ const menu = (task: BoardTask, actions: CardActions, t: Translate, startable: bo
   { label: t("common.delete"), danger: true, onSelect: () => actions.onDelete(task) },
   // The keyboard's and touch's replacement for the drag (K15/K16).
   ...(targets.length === 0 ? [] : [{ kind: "heading" as const, label: t("tasks.menu.moveTo") }]),
-  ...targets.map((status) => ({
-    label: statusLabel(status),
-    onSelect: () => actions.onMove(task, status),
+  ...targets.map((target) => ({
+    label: statusLabel(target.status),
+    onSelect: () => actions.onMove(task, target.status),
   })),
   ];
 };
 
 const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNode => {
   const t = useT();
-  const [startable, setStartable] = useState(false);
-  useEffect(() => setStartable(false), [task.id, task.status]);
-  const readStartability = (open: boolean): void => {
-    if (!open || task.assigneeType !== "AGENT" || !["BACKLOG", "TODO"].includes(task.status)) return;
-    void api.get<TaskStartability>(`/tasks/${task.id}/startability`).then(
-      (verdict) => setStartable(verdict.startable),
-      () => setStartable(false),
-    );
-  };
   const assignee = task.assigneeAgent?.title ?? null;
   const schedule = scheduleLabel(task);
   const hasScheduleRow = schedule !== null || task.approvalGate || task.source === "CRON" || task.source === "WEBHOOK";
@@ -213,7 +203,7 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
       <h3 className="min-w-0 flex-1 text-[13px] leading-[1.45]">
         <a data-card-title="" href={`#/tasks/${task.id}`} className={TASK_TITLE}>{title}</a>
       </h3>
-      <RowMenu items={menu(task, actions, t, startable)} label={t("tasks.card.actionsFor", { name: task.name })} onOpenChange={readStartability} />
+      <RowMenu items={menu(task, actions, t)} label={t("tasks.card.actionsFor", { name: task.name })} />
     </div>
     <div className={TASK_META}>
       {hasScheduleRow ? <div data-card-schedule="" className={TASK_META_ROW}>

--- a/apps/web/src/lib/board.ts
+++ b/apps/web/src/lib/board.ts
@@ -249,42 +249,6 @@ export const retryable = (
   return task.status === "REVIEW" || task.failureReason !== null || run.status !== "SUCCEEDED";
 };
 
-/**
- * The status destinations an operator may ask the board to perform.
- *
- * Backlog and Todo are operator-owned queue states. A human may also settle a
- * task by marking it Done; agent execution states are owned by the runner and
- * are therefore never exposed as ordinary status PATCH destinations. Doing for
- * an unstarted agent task is the one exception in the returned list: the card
- * routes that destination through the startability/confirmation flow, so it is
- * not a bare machine-status write.
- *
- * A chain (including a merge-tail repair task) derives its status from the
- * chain projection. A task bound to a predecessor is similarly not an
- * operator-owned status surface, even when an older board response has no
- * chain binding on the row.
- */
-export const operatorMoveTargets = (task: Pick<BoardTask, "status" | "assigneeType" | "chainId" | "chainName" | "repairOf"> & {
-  blockedOn?: BoardTask["blockedOn"];
-  chainProgress?: BoardTask["chainProgress"];
-}, startable = true): TaskStatus[] => {
-  if (chainBinding(task) !== null
-    || task.chainProgress !== null && task.chainProgress !== undefined
-    || task.blockedOn !== null && task.blockedOn !== undefined) return [];
-
-  const queueTargets = task.status === "BACKLOG"
-    ? ["TODO" as const]
-    : task.status === "TODO"
-      ? ["BACKLOG" as const]
-      : [];
-  if (task.assigneeType === "HUMAN") {
-    return task.status === "DONE" ? queueTargets : [...queueTargets, "DONE"];
-  }
-  // Doing is a start action for an unstarted agent task. Its callback must use
-  // `moveAction`, which turns it into the same confirmation flow as a drop.
-  return startable && (task.status === "TODO" || task.status === "BACKLOG") ? [...queueTargets, "DOING"] : queueTargets;
-};
-
 /* -------------------------------------------------------------- persistence */
 
 /** Per project, so switching projects never inherits another board's tab or

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -2,6 +2,7 @@
  *  Decimal columns arrive as strings, DateTime as ISO strings. */
 
 export type TaskStatus = "BACKLOG" | "TODO" | "DOING" | "REVIEW" | "DONE";
+export type TaskMoveTarget = { status: TaskStatus; via: "patch" | "start" };
 /** How a task came to exist. A recurring definition stays MANUAL; only its
  *  fired copies are CRON. */
 export type TaskSource = "MANUAL" | "CRON" | "WEBHOOK";
@@ -289,6 +290,7 @@ export type Task = {
   targetBranch: string | null;
   failureReason: string | null;
   status: TaskStatus;
+  moveTargets: TaskMoveTarget[];
   assigneeType: AssigneeType;
   executionOwner: ExecutionOwner;
   approvalGate: boolean;
@@ -349,6 +351,7 @@ export type BoardTask = {
   name: string;
   displayName: string;
   status: TaskStatus;
+  moveTargets: TaskMoveTarget[];
   assigneeType: AssigneeType;
   failureReason: string | null;
   scheduleKind: "NOW" | "AT" | "CRON";

--- a/apps/web/src/pages/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail.tsx
@@ -250,9 +250,6 @@ export const TaskPrompt = ({ description }: { description: string }): ReactNode 
   );
 };
 
-// BACKLOG first, so the header select can park a task as well as move it on.
-const STATUSES: TaskStatus[] = ["BACKLOG", "TODO", "DOING", "REVIEW", "DONE"];
-
 const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
   const { data: task, error, reload } = usePoll<Task>(`/tasks/${taskId}`);
   const output = usePoll<TaskStepOutput>(`/tasks/${taskId}/output`, 10_000);
@@ -284,6 +281,16 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
 
   const patch = (body: Record<string, unknown>): void => {
     void run(async () => { await api.patch(`/tasks/${taskId}`, body); reload(); });
+  };
+  const moveStatus = (status: TaskStatus): void => {
+    void run(async () => {
+      const target = task.moveTargets.find((candidate) => candidate.status === status);
+      if (!target) throw new Error(`Task ${task.id} does not expose ${status} as an operator move target`);
+      if (target.via === "start") await api.post(`/tasks/${taskId}/start`, {});
+      else await api.patch(`/tasks/${taskId}`, { status });
+      reload();
+      startability.reload();
+    });
   };
   const retry = (): void => {
     void run(async () => { await api.post(`/tasks/${taskId}/retry`, {}); reload(); });
@@ -362,11 +369,12 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
             `select:disabled` rule at all, so this control rendered at full opacity
             with the UA cursor while a patch was in flight. The primitive dims to
             50% and shows `not-allowed` (ui/select.tsx:21). */}
-        {task.chainId === null ? (
-          <Select className="w-[130px] disabled:opacity-100 disabled:cursor-default" value={task.status} disabled={pending} onChange={(event) => patch({ status: event.target.value })}>
-            {STATUSES.map((status) => <option key={status} value={status}>{t(`status.task.${status}`)}</option>)}
+        {task.moveTargets.length > 0 ? (
+          <Select className="w-[130px] disabled:opacity-100 disabled:cursor-default" value={task.status} disabled={pending} onChange={(event) => moveStatus(event.target.value as TaskStatus)}>
+            <option value={task.status}>{t(`status.task.${task.status}`)}</option>
+            {task.moveTargets.map(({ status }) => <option key={status} value={status}>{t(`status.task.${status}`)}</option>)}
           </Select>
-        ) : <span className="text-[11.5px] text-muted-foreground">{t("taskDetail.chainStatusReadonly")}</span>}
+        ) : task.chainId === null ? null : <span className="text-[11.5px] text-muted-foreground">{t("taskDetail.chainStatusReadonly")}</span>}
         {retryable(task, task.runs[0]) ? (
           <Button type="button" variant="legacy" size="legacy" disabled={pending} onClick={retry}><IconRefresh />{t("common.retry")}</Button>
         ) : null}

--- a/apps/web/src/pages/Tasks.tsx
+++ b/apps/web/src/pages/Tasks.tsx
@@ -1,14 +1,14 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "../lib/api";
-import { type BoardEntry, type Counts, boardEntries, boardEntriesByStatus, chainBinding, chainBindingLabel, countByStatus, defaultTab, focusAfterMove, operatorMoveTargets, orderColumn, parseStatus, statusLabel, tabKey, taskBoardEntry } from "../lib/board";
+import { type BoardEntry, type Counts, boardEntries, boardEntriesByStatus, chainBinding, chainBindingLabel, countByStatus, defaultTab, focusAfterMove, orderColumn, parseStatus, statusLabel, tabKey, taskBoardEntry } from "../lib/board";
 import { formatT } from "../lib/format";
 import { useAction, useMediaQuery, usePoll } from "../lib/hooks";
 import { useT } from "../lib/i18n";
 import { useProjectScope } from "../lib/project";
 import { replace, useQuery } from "../lib/router";
 import { storage } from "../lib/storage";
-import type { BoardTask, TaskStartability, TaskStatus } from "../lib/types";
+import type { BoardTask, TaskMoveTarget, TaskStartability, TaskStatus } from "../lib/types";
 import { cn } from "../lib/utils";
 import { DesktopBoard } from "../components/desktop-board";
 import { MobileTaskList } from "../components/mobile-task-list";
@@ -63,9 +63,8 @@ export const ChainFilterControl = ({ name, onClear }: { name: string; onClear: (
 
 export type HeldRows = Map<string, { key: string; row: BoardTask }>;
 
-export const moveAction = (status: TaskStatus, startable: boolean): "confirm-start" | "patch" => (
-  status === "DOING" && startable ? "confirm-start" : "patch"
-);
+export const moveAction = (via: TaskMoveTarget["via"]): "confirm-start" | "patch" =>
+  via === "start" ? "confirm-start" : "patch";
 
 export const startabilityRefusal = (verdict: TaskStartability): string => {
   const reasons = Object.entries(verdict.checklist)
@@ -150,7 +149,7 @@ export const useTaskStartConfirmation = (reload: () => void): {
 
   const requestForMove = useCallback(async (taskId: string): Promise<boolean> => {
     const verdict = await api.get<TaskStartability>(`/tasks/${taskId}/startability`);
-    if (moveAction("DOING", verdict.startable) === "patch") throw new Error(startabilityRefusal(verdict));
+    if (!verdict.startable) throw new Error(startabilityRefusal(verdict));
     setError(null);
     setRequest(verdict);
     return true;
@@ -282,8 +281,15 @@ export const TasksPage = (): ReactNode => {
   const move = useCallback((taskId: string, status: TaskStatus): void => {
     const task = latest.current.find((candidate) => candidate.id === taskId);
     if (!task || task.status === status) return;
+    const target = task.moveTargets.find((candidate) => candidate.status === status);
+    if (!target) {
+      const message = moveNotAllowedNotice(task, status);
+      setNotice(message);
+      setAnnouncement(message);
+      return;
+    }
     void run(async () => {
-      if (status === "DOING" && await start.requestForMove(taskId)) return;
+      if (moveAction(target.via) === "confirm-start" && await start.requestForMove(taskId)) return;
       recordMove(task, status);
       await api.patch(`/tasks/${taskId}`, { status });
       reload();
@@ -293,7 +299,7 @@ export const TasksPage = (): ReactNode => {
   const drop = useCallback((taskId: string, status: TaskStatus): void => {
     const task = latest.current.find((candidate) => candidate.id === taskId);
     if (!task || task.status === status) return;
-    if (!operatorMoveTargets(task).includes(status)) {
+    if (!task.moveTargets.some((target) => target.status === status)) {
       const message = moveNotAllowedNotice(task, status);
       setNotice(message);
       setAnnouncement(message);

--- a/apps/web/src/tests/automations.test.tsx
+++ b/apps/web/src/tests/automations.test.tsx
@@ -8,7 +8,7 @@ import type { Task } from "../lib/types";
 const task = (overrides: Partial<Task> = {}): Task => ({
   id: "t1", projectId: "p1", assigneeAgentId: "a1", repoId: "r1", templateId: null, templateStepId: null,
   name: "Nightly digest", description: "d", workingDirectory: null, targetBranch: null,
-  failureReason: null, status: "TODO", assigneeType: "AGENT", executionOwner: "agent", approvalGate: false, scheduleKind: "CRON",
+  failureReason: null, status: "TODO", moveTargets: [], assigneeType: "AGENT", executionOwner: "agent", approvalGate: false, scheduleKind: "CRON",
   runAt: new Date(Date.now() + 3_600_000).toISOString(), cron: "0 9 * * *", timezone: "Asia/Shanghai",
   maxDurationMin: 120, stallTimeoutMin: 10, maxSessionsPerTask: 5,
   createdAt: "2026-08-16T00:00:00.000Z", updatedAt: "2026-08-16T00:00:00.000Z",

--- a/apps/web/src/tests/board.test.tsx
+++ b/apps/web/src/tests/board.test.tsx
@@ -8,7 +8,7 @@ import {
 import type { BoardTask, ChainProgress } from "../lib/types";
 
 const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
-  id: "t1", name: "Ship the thing", displayName: overrides.name ?? "Ship the thing", status: "TODO", failureReason: null,
+  id: "t1", name: "Ship the thing", displayName: overrides.name ?? "Ship the thing", status: "TODO", moveTargets: [], failureReason: null,
   assigneeType: "HUMAN", createdAt: "2026-08-15T00:00:00.000Z",
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null,
   approvalGate: false, templateId: null, source: "MANUAL", chainId: null, chainIndex: null,

--- a/apps/web/src/tests/chain-aggregate-board.test.tsx
+++ b/apps/web/src/tests/chain-aggregate-board.test.tsx
@@ -13,7 +13,7 @@ import { useTaskStartConfirmation } from "../pages/Tasks";
 import { installDom, reactDom } from "./dom-harness";
 
 const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
-  id: "task-1", name: "Release: Build", displayName: "Build", status: "TODO", failureReason: null,
+  id: "task-1", name: "Release: Build", displayName: "Build", status: "TODO", moveTargets: [], failureReason: null,
   assigneeType: "AGENT", createdAt: "2026-08-28T00:00:00.000Z", updatedAt: "2026-08-28T01:00:00.000Z",
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null, approvalGate: false, templateId: null,
   source: "MANUAL", chainId: null, chainIndex: null, chainName: null, assigneeAgent: null,

--- a/apps/web/src/tests/merge-outcome.test.tsx
+++ b/apps/web/src/tests/merge-outcome.test.tsx
@@ -40,7 +40,7 @@ const noop = (): void => undefined;
 const ACTIONS = { onMove: noop, onRetry: noop, onArchive: noop, onDelete: noop, onCopyError: noop, onFilterChain: noop };
 
 const boardTask = (overrides: Partial<BoardTask> = {}): BoardTask => ({
-  id: "t1", name: "Merge execution", displayName: overrides.name ?? "Merge execution", status: "DONE", failureReason: null,
+  id: "t1", name: "Merge execution", displayName: overrides.name ?? "Merge execution", status: "DONE", moveTargets: [], failureReason: null,
   assigneeType: "AGENT", createdAt: "2026-08-17T00:00:00.000Z",
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null,
   approvalGate: false, templateId: null, source: "MANUAL", chainId: "c1", chainIndex: 10,

--- a/apps/web/src/tests/task-detail-navigation.test.tsx
+++ b/apps/web/src/tests/task-detail-navigation.test.tsx
@@ -17,6 +17,9 @@ const task = (id: string, name: string, promptIndex: number, chainId: string | n
   templateId: null, templateStepId: null, name,
   description: prompts[promptIndex]!.prompt,
   workingDirectory: null, targetBranch: "main", failureReason: null, status: "TODO",
+  moveTargets: chainId === null
+    ? [{ status: "BACKLOG", via: "patch" }, { status: "DOING", via: "start" }]
+    : [],
   assigneeType: "AGENT", executionOwner: "agent", approvalGate: false, scheduleKind: "NOW", runAt: null,
   cron: null, timezone: null, maxDurationMin: 120, stallTimeoutMin: 10,
   maxSessionsPerTask: 3, createdAt: now, updatedAt: now, assigneeAgent: null,
@@ -201,7 +204,7 @@ test("task-id switches expose a clean loading shell and destination-scoped actio
     await act(async () => { start.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })); });
     await settle();
 
-    assert.ok(mutations.some((item) => item.url === "/tasks/b" && item.method === "PATCH"));
+    assert.ok(mutations.some((item) => item.url === "/tasks/b/start" && item.method === "POST"));
     assert.ok(mutations.some((item) => item.url === "/tasks/b/archive" && item.method === "POST"));
     assert.ok(mutations.some((item) => item.url === "/tasks/b/activity" && item.body.includes("destination comment")), JSON.stringify(mutations));
     assert.ok(mutations.some((item) => item.url === "/tasks/c/start" && item.method === "POST"));

--- a/apps/web/src/tests/tasks-board.test.tsx
+++ b/apps/web/src/tests/tasks-board.test.tsx
@@ -18,7 +18,7 @@ import { installDom, reactDom } from "./dom-harness";
 const en = (key: string, vars?: Record<string, string | number>): string => translate("en", key, vars);
 
 const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
-  id: "t1", name: "Ship the thing", displayName: overrides.name ?? "Ship the thing", status: "TODO", failureReason: null,
+  id: "t1", name: "Ship the thing", displayName: overrides.name ?? "Ship the thing", status: "TODO", moveTargets: [], failureReason: null,
   assigneeType: "HUMAN", createdAt: "2026-08-15T00:00:00.000Z",
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null,
   approvalGate: false, templateId: null, source: "MANUAL", chainId: null, chainIndex: null,
@@ -101,11 +101,9 @@ test("the board has five columns, in order, with Backlog first", () => {
   }
 });
 
-test("only a startable desktop drop onto Doing asks for start confirmation", () => {
-  for (const { status } of COLUMNS) {
-    assert.equal(moveAction(status, true), status === "DOING" ? "confirm-start" : "patch");
-    assert.equal(moveAction(status, false), "patch");
-  }
+test("the projected transport selects the move execution flow", () => {
+  assert.equal(moveAction("start"), "confirm-start");
+  assert.equal(moveAction("patch"), "patch");
 });
 
 test("start and drop refusals explain the observed server verdict", () => {

--- a/apps/web/src/tests/tasks-tabs.test.tsx
+++ b/apps/web/src/tests/tasks-tabs.test.tsx
@@ -23,7 +23,7 @@ const head = (active: TasksTab): string => renderToStaticMarkup(
 const task = (overrides: Partial<Task> = {}): Task => ({
   id: "t1", projectId: "p1", assigneeAgentId: null, repoId: null, templateId: null, templateStepId: null,
   name: "Ship the thing", description: "d", workingDirectory: null, targetBranch: null,
-  failureReason: null, status: "DONE", assigneeType: "AGENT", executionOwner: "agent", approvalGate: false, scheduleKind: "NOW",
+  failureReason: null, status: "DONE", moveTargets: [], assigneeType: "AGENT", executionOwner: "agent", approvalGate: false, scheduleKind: "NOW",
   runAt: null, cron: null, timezone: null,
   maxDurationMin: 120, stallTimeoutMin: 10, maxSessionsPerTask: 5,
   createdAt: "2026-08-16T00:00:00.000Z", updatedAt: "2026-08-16T00:00:00.000Z",

--- a/apps/web/src/tests/tasks-transitions.test.tsx
+++ b/apps/web/src/tests/tasks-transitions.test.tsx
@@ -3,12 +3,11 @@ import test from "node:test";
 import { act, type ReactNode, useCallback, useState } from "react";
 
 import type { CardActions } from "../components/task-card";
-import { operatorMoveTargets } from "../lib/board";
 import type { BoardTask, TaskStatus } from "../lib/types";
 import { installDom, reactDom } from "./dom-harness";
 
 const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
-  id: "t1", name: "Ship the thing", displayName: overrides.displayName ?? overrides.name ?? "Ship the thing", status: "TODO",
+  id: "t1", name: "Ship the thing", displayName: overrides.displayName ?? overrides.name ?? "Ship the thing", status: "TODO", moveTargets: [],
   assigneeType: "HUMAN", failureReason: null, createdAt: "2026-08-15T00:00:00.000Z",
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null,
   approvalGate: false, templateId: null, source: "MANUAL", chainId: null, chainIndex: null,
@@ -21,29 +20,6 @@ const actions = (onMove: CardActions["onMove"] = noop): CardActions => ({
   onMove, onRetry: noop, onArchive: noop, onDelete: noop, onCopyError: noop, onFilterChain: noop,
 });
 
-test("operator move targets keep machine statuses out of ordinary menus", () => {
-  assert.deepEqual(operatorMoveTargets(task({ assigneeType: "HUMAN", status: "TODO" })), ["BACKLOG", "DONE"]);
-  assert.deepEqual(operatorMoveTargets(task({ assigneeType: "HUMAN", status: "DOING" })), ["DONE"]);
-  assert.deepEqual(operatorMoveTargets(task({ assigneeType: "HUMAN", status: "REVIEW" })), ["DONE"]);
-  assert.deepEqual(operatorMoveTargets(task({ assigneeType: "HUMAN", status: "DONE" })), []);
-
-  // Doing is present only as the agent's start action. The menu never offers a
-  // Review or Done PATCH for an agent, and a callback below proves Doing cannot
-  // silently become one either.
-  assert.deepEqual(operatorMoveTargets(task({ assigneeType: "AGENT", status: "TODO" })), ["BACKLOG", "DOING"]);
-  assert.deepEqual(operatorMoveTargets(task({ assigneeType: "AGENT", status: "BACKLOG" })), ["TODO", "DOING"]);
-  assert.deepEqual(operatorMoveTargets(task({ assigneeType: "AGENT", status: "DOING" })), []);
-  assert.deepEqual(operatorMoveTargets(task({ assigneeType: "AGENT", status: "REVIEW" })), []);
-  assert.deepEqual(operatorMoveTargets(task({ assigneeType: "AGENT", status: "DONE" })), []);
-});
-
-test("predecessor-bound and chain-derived cards have no operator status targets", () => {
-  assert.deepEqual(operatorMoveTargets(task({ blockedOn: { taskId: "p1", taskName: "Build first" } })), []);
-  assert.deepEqual(operatorMoveTargets(task({ chainId: "c1", chainName: "Release", chainIndex: 0 })), []);
-  assert.deepEqual(operatorMoveTargets(task({ chainProgress: { chainId: "c1", done: 0, total: 1, activeStepName: "Build", activeStatus: "todo", currentLayer: 1, layerCount: 1, position: 1 } })), []);
-  assert.deepEqual(operatorMoveTargets(task({ repairOf: { chainId: "c1", chainName: "Release", repairKind: "gate-fix" } })), []);
-});
-
 type TaskCardComponent = typeof import("../components/task-card").TaskCard;
 type UseTaskStartConfirmation = typeof import("../pages/Tasks").useTaskStartConfirmation;
 
@@ -52,7 +28,8 @@ const StartMenuHarness = ({ Card, useStart, row, onMutation }: { Card: TaskCardC
   const [error, setError] = useState<string | null>(null);
   const onMove = useCallback((selected: BoardTask, status: TaskStatus): void => {
     void (async () => {
-      if (status === "DOING" && await start.requestForMove(selected.id)) return;
+      const target = selected.moveTargets.find((candidate) => candidate.status === status);
+      if (target?.via === "start" && await start.requestForMove(selected.id)) return;
       onMutation(status);
     })().catch((reason: unknown) => setError(reason instanceof Error ? reason.message : String(reason)));
   }, [onMutation, start.requestForMove]);
@@ -123,13 +100,17 @@ test("the agent menu Doing action opens confirmation and never PATCHes", async (
   } });
   const root = (await reactDom()).createRoot(container);
   try {
-    await act(async () => root.render(<StartMenuHarness Card={TaskCard} useStart={useTaskStartConfirmation} row={task({ assigneeType: "AGENT", assigneeAgent: { id: "a1", title: "Senior dev", model: "gpt-5.6-luna:max" } })} onMutation={(status) => mutations.push(status)} />));
+    await act(async () => root.render(<StartMenuHarness Card={TaskCard} useStart={useTaskStartConfirmation} row={task({
+      assigneeType: "AGENT",
+      assigneeAgent: { id: "a1", title: "Senior dev", model: "gpt-5.6-luna:max" },
+      moveTargets: [{ status: "BACKLOG", via: "patch" }, { status: "DOING", via: "start" }],
+    })} onMutation={(status) => mutations.push(status)} />));
     await settle();
     const doing = await openDoing(dom);
     await act(async () => doing.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
     await settle();
     assert.ok(container.querySelector("[data-confirmation]"), container.innerHTML);
-    assert.equal(requests.filter(({ method, path }) => method === "GET" && path === "/api/tasks/t1/startability").length, 2);
+    assert.equal(requests.filter(({ method, path }) => method === "GET" && path === "/api/tasks/t1/startability").length, 1);
     assert.equal(requests.some(({ method }) => method === "PATCH"), false);
     assert.deepEqual(mutations, []);
 
@@ -173,7 +154,7 @@ test("a non-startable agent menu does not advertise Doing", async () => {
     await settle();
     assert.equal([...dom.window.document.querySelectorAll<HTMLElement>("[role='menuitem']")]
       .some((item) => item.textContent?.trim() === "Doing"), false);
-    assert.equal(requests.filter(({ method, path }) => method === "GET" && path === "/api/tasks/t1/startability").length, 1);
+    assert.equal(requests.filter(({ method, path }) => method === "GET" && path === "/api/tasks/t1/startability").length, 0);
     assert.equal(requests.some(({ method }) => method === "PATCH"), false);
     assert.deepEqual(mutations, []);
   } finally {

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -2367,19 +2367,21 @@ const boardDatabase = (
       },
       groupBy: async () => [],
     },
+    agentRepoAccess: { findMany: async () => [] },
     taskActivity: { findMany: async () => extras.activity ?? [] },
   } as unknown as PrismaClient;
 };
 
 const taskRow = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
-  id: "t1", projectId: "p1", name: "Ship the thing", status: "TODO", failureReason: null,
+  id: "t1", projectId: "p1", name: "Ship the thing", status: "TODO", assigneeType: "AGENT",
+  assigneeAgentId: "a1", repoId: "r1", archivedAt: null, maxSessionsPerTask: 5, failureReason: null,
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null, approvalGate: false,
-  templateId: null, source: "MANUAL", chainId: null, chainIndex: null,
+  templateId: null, source: "MANUAL", chainId: null, chainIndex: null, chainLayer: null, dispatchAfterTaskId: null,
   createdAt: new Date("2026-08-16T00:00:00.000Z"),
   updatedAt: new Date("2026-08-16T00:00:00.000Z"), templateStep: null,
-  assigneeAgent: { id: "a1", title: "Senior Developer", model: "gpt-5.6-sol:medium" },
+  assigneeAgent: { id: "a1", title: "Senior Developer", model: "gpt-5.6-sol:medium", archivedAt: null },
   runs: [{
-    id: "r1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5",
+    id: "r1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5", budgetGrants: 0,
     session: { costUsd: "0.42", inputTokens: null, cachedInputTokens: null, outputTokens: null, startedAt: null, endedAt: null },
   }],
   ...overrides,
@@ -2391,7 +2393,9 @@ const getTasks = async (database: PrismaClient, query: string, headers: Record<s
   });
 
 const taskDetailDatabase = (task: Record<string, unknown>): PrismaClient => ({
-  task: { findUnique: async () => task },
+  task: { findUnique: async () => task, findMany: async () => [task] },
+  run: { groupBy: async () => [] },
+  agentRepoAccess: { findMany: async () => [{ projectId: task.projectId, agentId: task.assigneeAgentId, repoId: task.repoId }] },
   mergeRecoveryAttempt: { findFirst: async () => null },
 } as unknown as PrismaClient);
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -82,6 +82,7 @@ import {
 import {
   etagFor,
   etagMatches,
+  operatorMoveTargets,
   readBoard,
   readChainRepairTaskIds,
   readRepairChainByTask,
@@ -2447,6 +2448,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       },
     });
     if (!task) return context.json({ error: "Task not found" }, 404);
+    const admission = await readStepAdmission(db, task.id, { locked: false });
+    if (!admission.task || !admission.verdict) {
+      throw new Error(`Task ${task.id} disappeared while projecting operator move targets`);
+    }
     const recoveryRow = await db.mergeRecoveryAttempt.findFirst({
       where: task.chainId
         ? { integratorTask: { projectId: task.projectId, chainId: task.chainId } }
@@ -2464,6 +2469,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return context.json({
       ...task,
       executionOwner: chainExecutionOwner(task),
+      moveTargets: operatorMoveTargets(task, admission.verdict),
       taskCost: serializeUsageCost(sumUsageCosts(usageCosts.filter((cost) => cost !== null))),
       mergeOutcome,
       mergeRecovery,

--- a/packages/api/src/board.test.ts
+++ b/packages/api/src/board.test.ts
@@ -26,6 +26,10 @@ const row = (overrides: Partial<BoardRow> = {}): BoardRow => ({
   name: "Ship the thing",
   status: "TODO" as BoardRow["status"],
   assigneeType: "AGENT" as BoardRow["assigneeType"],
+  assigneeAgentId: null,
+  repoId: null,
+  archivedAt: null,
+  maxSessionsPerTask: 5,
   failureReason: null,
   scheduleKind: "NOW" as BoardRow["scheduleKind"],
   runAt: null,
@@ -45,6 +49,8 @@ const row = (overrides: Partial<BoardRow> = {}): BoardRow => ({
   runs: [],
   ...overrides,
 });
+
+const moveContext = { hasRepoGrant: false, chainPredecessorsDone: true };
 
 const member = (overrides: Partial<BoardChainMember> = {}): BoardChainMember => ({
   id: "step-1",
@@ -144,11 +150,51 @@ test("readBoard resolves every bound row in one deduplicated predecessor lookup"
 test("the board projection carries every field the board consumes and nothing else", () => {
   // Spelled out rather than derived: a field added to the projection is a
   // deliberate act with a payload cost, so it has to be added here too.
-  assert.deepEqual(Object.keys(boardCard(row(), null)).sort(), [
+  assert.deepEqual(Object.keys(boardCard(row(), null, moveContext)).sort(), [
     "approvalGate", "assigneeAgent", "assigneeType", "blockedOn", "chainAggregate", "chainId", "chainIndex", "chainName", "chainProgress", "createdAt", "cron", "displayName",
-    "failureReason", "id", "latestRun", "mergeOutcome", "name", "repairOf", "runAt", "scheduleKind", "source", "status",
+    "failureReason", "id", "latestRun", "mergeOutcome", "moveTargets", "name", "repairOf", "runAt", "scheduleKind", "source", "status",
     "taskCost", "templateId", "timezone", "updatedAt",
   ]);
+});
+
+test("the board projection carries the operator transition matrix", () => {
+  const targets = (overrides: Partial<BoardRow>, context = moveContext) =>
+    boardCard(row(overrides), null, context).moveTargets;
+  const startableAgent = {
+    assigneeType: "AGENT" as const,
+    assigneeAgentId: "a1",
+    repoId: "r1",
+    assigneeAgent: { id: "a1", title: "Developer", model: "gpt-5.6-sol", archivedAt: null },
+  };
+  const startable = { hasRepoGrant: true, chainPredecessorsDone: true };
+
+  assert.deepEqual(targets({ assigneeType: "HUMAN", status: "TODO" }), [
+    { status: "BACKLOG", via: "patch" }, { status: "DONE", via: "patch" },
+  ]);
+  assert.deepEqual(targets({ assigneeType: "HUMAN", status: "DOING" }), [{ status: "DONE", via: "patch" }]);
+  assert.deepEqual(targets({ assigneeType: "HUMAN", status: "REVIEW" }), [{ status: "DONE", via: "patch" }]);
+  assert.deepEqual(targets({ assigneeType: "HUMAN", status: "DONE" }), []);
+  assert.deepEqual(targets({ ...startableAgent, status: "TODO" }, startable), [
+    { status: "BACKLOG", via: "patch" }, { status: "DOING", via: "start" },
+  ]);
+  assert.deepEqual(targets({ ...startableAgent, status: "BACKLOG" }, startable), [
+    { status: "TODO", via: "patch" }, { status: "DOING", via: "start" },
+  ]);
+  assert.deepEqual(targets({ ...startableAgent, status: "DOING" }, startable), []);
+  assert.deepEqual(targets({ ...startableAgent, status: "REVIEW" }, startable), []);
+  assert.deepEqual(targets({ ...startableAgent, status: "DONE" }, startable), []);
+  assert.deepEqual(targets({ assigneeType: "HUMAN", status: "TODO" }, {
+    hasRepoGrant: false, chainPredecessorsDone: false,
+  }), []);
+
+  const humanApprovalGate = targets({
+    assigneeType: "HUMAN", approvalGate: true, chainId: "c1", chainIndex: 2, status: "TODO",
+  });
+  assert.deepEqual(humanApprovalGate, [{ status: "DONE", via: "patch" }]);
+
+  const agentTargets = targets({ ...startableAgent, status: "TODO" }, startable);
+  assert.deepEqual(agentTargets.find(({ status }) => status === "DOING"), { status: "DOING", via: "start" });
+  assert.equal(agentTargets.some(({ status, via }) => via === "patch" && ["DOING", "REVIEW", "DONE"].includes(status)), false);
 });
 
 test("a repair task is bound to the chain of the regression task its marker names", () => {
@@ -166,9 +212,9 @@ test("a repair task is bound to the chain of the regression task its marker name
   // A regression task that is itself chain-detached binds nothing.
   assert.equal(repairBinding(markerFromMetadata({ kind: "mergeTail.repairAttempt", repairKind: "review-fix", regressionTaskId: "reg-1" }), () => null), null);
   assert.equal(repairBinding(null, chain), null);
-  assert.equal(boardCard(row(), null).repairOf, null);
+  assert.equal(boardCard(row(), null, moveContext).repairOf, null);
   assert.deepEqual(
-    boardCard(row(), null, undefined, null, { chainId: "c1", chainName: "Release", repairKind: "review-fix" }).repairOf,
+    boardCard(row(), null, moveContext, undefined, null, { chainId: "c1", chainName: "Release", repairKind: "review-fix" }).repairOf,
     { chainId: "c1", chainName: "Release", repairKind: "review-fix" },
   );
 });
@@ -246,14 +292,14 @@ test("chainAggregate offers activation after a bound predecessor has settled", (
 test("chainAggregate sums member usage and groups a detached repair without inflating steps", () => {
   const aggregate = chainAggregate("c1", "Release", [
     member({ id: "step-1", status: "DONE", chainIndex: 0, chainLayer: 0, runs: [
-      { id: "run-1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5", session: session({ costUsd: "1.25" }) },
+      { id: "run-1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5", budgetGrants: 0, session: session({ costUsd: "1.25" }) },
     ] }),
     member({ id: "step-2", status: "DONE", chainIndex: 1, chainLayer: 1 }),
   ], [
     member({
       id: "repair", name: "Merge-tail repair", displayName: "Merge-tail repair", chainId: null,
       chainIndex: null, chainLayer: null, status: "TODO", runs: [
-        { id: "run-2", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5", session: session({ costUsd: "0.50" }) },
+        { id: "run-2", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5", budgetGrants: 0, session: session({ costUsd: "0.50" }) },
       ],
     }),
   ]);
@@ -272,15 +318,15 @@ test("chainAggregate sums member usage and groups a detached repair without infl
 
 test("blockedOn is projected from the resolved predecessor without storing its status", () => {
   const predecessor = { id: "after-1", name: "Finish the release", status: "DOING" as BoardRow["status"] };
-  const blocked = boardCard(row({ dispatchAfterTaskId: predecessor.id }), null, undefined, predecessor);
+  const blocked = boardCard(row({ dispatchAfterTaskId: predecessor.id }), null, moveContext, undefined, predecessor);
   assert.deepEqual(blocked.blockedOn, { taskId: predecessor.id, taskName: predecessor.name });
 
-  const resolved = boardCard(row({ dispatchAfterTaskId: predecessor.id }), null, undefined, {
+  const resolved = boardCard(row({ dispatchAfterTaskId: predecessor.id }), null, moveContext, undefined, {
     ...predecessor, status: "DONE" as BoardRow["status"],
   });
   assert.equal(resolved.blockedOn, null);
 
-  const unbound = boardCard(row(), null);
+  const unbound = boardCard(row(), null, moveContext);
   assert.equal(unbound.blockedOn, null);
   const { blockedOn: _blockedOn, ...rest } = unbound;
   assert.deepEqual(rest, {
@@ -304,6 +350,7 @@ test("blockedOn is projected from the resolved predecessor without storing its s
     updatedAt: new Date("2026-08-16T00:00:00.000Z"),
     assigneeAgent: null,
     chainProgress: null,
+    moveTargets: [{ status: "BACKLOG", via: "patch" }],
     latestRun: null,
     taskCost: null,
     mergeOutcome: null,
@@ -314,15 +361,15 @@ test("blockedOn is projected from the resolved predecessor without storing its s
 
 test("the card's merge outcome is bound to the run it shows, and is null everywhere else", () => {
   const merged = JSON.stringify({ outcome: "merged", mergeCommitSha: "a".repeat(40) });
-  const run = { id: "r1", runNumber: 3, status: "SUCCEEDED", model: "gpt-5.6-sol", session: null };
+  const run = { id: "r1", runNumber: 3, status: "SUCCEEDED", model: "gpt-5.6-sol", budgetGrants: 0, session: null };
   // §SF-1: an ordinary step's output is not a malformed merge result, it is not
   // a merge result at all, and 112 board cards must not each carry a marker.
-  assert.equal(boardCard(row({ runs: [run], stepOutput: { kind: "code-review", body: "fine", runId: "r1" } }), null).mergeOutcome, null);
-  assert.equal(boardCard(row({ runs: [], stepOutput: { kind: "merge-result", body: merged, runId: "r1" } }), null).mergeOutcome, null);
+  assert.equal(boardCard(row({ runs: [run], stepOutput: { kind: "code-review", body: "fine", runId: "r1" } }), null, moveContext).mergeOutcome, null);
+  assert.equal(boardCard(row({ runs: [], stepOutput: { kind: "merge-result", body: merged, runId: "r1" } }), null, moveContext).mergeOutcome, null);
   // A stop recorded by an earlier run is not the newest run's outcome.
-  assert.equal(boardCard(row({ runs: [run], stepOutput: { kind: "merge-result", body: merged, runId: "r0" } }), null).mergeOutcome, null);
+  assert.equal(boardCard(row({ runs: [run], stepOutput: { kind: "merge-result", body: merged, runId: "r0" } }), null, moveContext).mergeOutcome, null);
   assert.deepEqual(
-    boardCard(row({ runs: [run], stepOutput: { kind: "merge-result", body: merged, runId: "r1" } }), null).mergeOutcome,
+    boardCard(row({ runs: [run], stepOutput: { kind: "merge-result", body: merged, runId: "r1" } }), null, moveContext).mergeOutcome,
     { outcome: "merged", condition: null, incident: false },
   );
 });
@@ -330,11 +377,11 @@ test("the card's merge outcome is bound to the run it shows, and is null everywh
 test("the projection drops the Run and Session columns the board never reads", () => {
   const card = boardCard(row({
     runs: [{
-      id: "r1", runNumber: 3, status: "FAILED", model: "claude-opus-5",
+      id: "r1", runNumber: 3, status: "FAILED", model: "claude-opus-5", budgetGrants: 0,
       // The real row carries ~45 more columns; only these fields survive.
       session: session({ costUsd: "1.25", startedAt: new Date("2026-08-16T00:00:00Z"), endedAt: new Date("2026-08-16T00:02:00Z") }),
     }],
-  }), null);
+  }), null, moveContext);
   assert.deepEqual(card.latestRun, {
     id: "r1", runNumber: 3, status: "FAILED", model: "claude-opus-5", costUsd: "1.25",
     startedAt: new Date("2026-08-16T00:00:00Z"), endedAt: new Date("2026-08-16T00:02:00Z"),
@@ -346,20 +393,20 @@ test("the latest run carries its own claimed model, not the assignee's current o
   // The board card labels the run line with this; a re-tiered agent must not
   // relabel a run that already happened.
   const card = boardCard(row({
-    assigneeAgent: { id: "a1", title: "merge-resolver", model: "gpt-5.6-sol:high" },
-    runs: [{ id: "r1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5:medium", session: null }],
-  }), null);
+    assigneeAgent: { id: "a1", title: "merge-resolver", model: "gpt-5.6-sol:high", archivedAt: null },
+    runs: [{ id: "r1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5:medium", budgetGrants: 0, session: null }],
+  }), null, moveContext);
   assert.equal(card.latestRun?.model, "claude-opus-5:medium");
   assert.equal(card.assigneeAgent?.model, "gpt-5.6-sol:high");
 });
 
 test("a task with no runs reports no latest run rather than an empty one", () => {
-  assert.equal(boardCard(row(), null).latestRun, null);
+  assert.equal(boardCard(row(), null, moveContext).latestRun, null);
 });
 
 test("a run with no session reports a null cost, not a zero one", () => {
   // `0` would read as "this run spent nothing"; the runner simply never said.
-  const card = boardCard(row({ runs: [{ id: "r1", runNumber: 1, status: "RUNNING", model: "gpt-5.6-sol", session: null }] }), null);
+  const card = boardCard(row({ runs: [{ id: "r1", runNumber: 1, status: "RUNNING", model: "gpt-5.6-sol", budgetGrants: 0, session: null }] }), null, moveContext);
   assert.equal(card.taskCost, null);
 });
 
@@ -367,7 +414,7 @@ test("a Decimal cost is serialised as the string the web client reads", () => {
   // Prisma hands back a Decimal instance, not a string, and `JSON.stringify`
   // of one is `{"s":1,"e":0,...}` unless it is stringified on the way out.
   const decimal = new Prisma.Decimal("0.42");
-  const card = boardCard(row({ runs: [{ id: "r1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5", session: session({ costUsd: decimal }) }] }), null);
+  const card = boardCard(row({ runs: [{ id: "r1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5", budgetGrants: 0, session: session({ costUsd: decimal }) }] }), null, moveContext);
   assert.equal(card.taskCost?.costUsd, "0.42");
   assert.equal(card.latestRun?.costUsd, "0.42");
   assert.match(JSON.stringify(card), /"costUsd":"0\.42"/);
@@ -375,11 +422,11 @@ test("a Decimal cost is serialised as the string the web client reads", () => {
 
 test("task cost sums every run including failures and marks an estimated summand", () => {
   const card = boardCard(row({ runs: [
-    { id: "r2", runNumber: 2, status: "SUCCEEDED", model: "gpt-5.6-luna:max", session: session({
+    { id: "r2", runNumber: 2, status: "SUCCEEDED", model: "gpt-5.6-luna:max", budgetGrants: 0, session: session({
       inputTokens: 1_000_000, cachedInputTokens: 0, outputTokens: 0,
     }) },
-    { id: "r1", runNumber: 1, status: "FAILED", model: "claude-opus-5:high", session: session({ costUsd: "1.25" }) },
-  ] }), null);
+    { id: "r1", runNumber: 1, status: "FAILED", model: "claude-opus-5:high", budgetGrants: 0, session: session({ costUsd: "1.25" }) },
+  ] }), null, moveContext);
   assert.deepEqual(card.latestRun, { id: "r2", runNumber: 2, status: "SUCCEEDED", model: "gpt-5.6-luna:max", costUsd: null, startedAt: null, endedAt: null });
   assert.equal(card.taskCost?.costUsd, "1.45");
   assert.equal(card.taskCost?.estimated, true);
@@ -387,10 +434,10 @@ test("task cost sums every run including failures and marks an estimated summand
 
 test("mixed-model native subagent Runs use the pinned Luna estimate", () => {
   const card = boardCard(row({ runs: [{
-    id: "r1", runNumber: 1, status: "SUCCEEDED", model: "gpt-5.6-sol:high",
+    id: "r1", runNumber: 1, status: "SUCCEEDED", model: "gpt-5.6-sol:high", budgetGrants: 0,
     subagentModel: "gpt-5.6-luna:max",
     session: session({ nativeChildUsed: true, inputTokens: 1_000_000, cachedInputTokens: 0, outputTokens: 100_000 }),
-  }] }), null);
+  }] }), null, moveContext);
   assert.equal(card.taskCost?.costUsd, "0.32");
   assert.equal(card.taskCost?.estimated, true);
   assert.equal(card.taskCost?.inputTokens, 1_000_000);
@@ -398,22 +445,22 @@ test("mixed-model native subagent Runs use the pinned Luna estimate", () => {
 
 test("a native subagent grant without an observed child uses the root estimate", () => {
   const card = boardCard(row({ runs: [{
-    id: "r1", runNumber: 1, status: "SUCCEEDED", model: "gpt-5.6-sol:high",
+    id: "r1", runNumber: 1, status: "SUCCEEDED", model: "gpt-5.6-sol:high", budgetGrants: 0,
     subagentModel: "gpt-5.6-luna:max",
     session: session({ nativeChildUsed: false, inputTokens: 1_000_000, cachedInputTokens: 0, outputTokens: 100_000 }),
-  }] }), null);
+  }] }), null, moveContext);
   assert.equal(card.taskCost?.costUsd, "8");
   assert.equal(card.taskCost?.estimated, true);
 });
 
 test("the assignee carries the model spec the card shows", () => {
-  const card = boardCard(row({ assigneeAgent: { id: "a1", title: "Frontend Developer", model: "gpt-5.6-sol:medium" } }), null);
+  const card = boardCard(row({ assigneeAgent: { id: "a1", title: "Frontend Developer", model: "gpt-5.6-sol:medium", archivedAt: null } }), null, moveContext);
   assert.deepEqual(card.assigneeAgent, { id: "a1", title: "Frontend Developer", model: "gpt-5.6-sol:medium" });
 });
 
 test("the card carries task ownership even when no agent is assigned", () => {
-  assert.equal(boardCard(row({ assigneeType: "HUMAN", assigneeAgent: null }), null).assigneeType, "HUMAN");
-  assert.equal(boardCard(row({ assigneeType: "AGENT", assigneeAgent: null }), null).assigneeType, "AGENT");
+  assert.equal(boardCard(row({ assigneeType: "HUMAN", assigneeAgent: null }), null, moveContext).assigneeType, "HUMAN");
+  assert.equal(boardCard(row({ assigneeType: "AGENT", assigneeAgent: null }), null, moveContext).assigneeType, "AGENT");
 });
 
 test("chain names are derived only from the exact persisted template-step suffix", () => {
@@ -431,8 +478,8 @@ test("direct chains derive one verified shared display prefix without changing s
   assert.deepEqual(display.get("build"), { chainName: "Release", displayName: "Build" });
   assert.deepEqual(display.get("review"), { chainName: "Release", displayName: "Review" });
   assert.equal(rows[0]!.name, "Release: Build");
-  assert.deepEqual(boardCard(rows[0]!, null, display.get("build")), {
-    ...boardCard(rows[0]!, null), chainName: "Release", displayName: "Build",
+  assert.deepEqual(boardCard(rows[0]!, null, moveContext, display.get("build")), {
+    ...boardCard(rows[0]!, null, moveContext), chainName: "Release", displayName: "Build",
   });
 });
 
@@ -506,7 +553,7 @@ test("readBoard restores archived primary facts when only a detached repair is v
   const regression = row({
     id: "regression", chainId: "c1", chainIndex: 1, chainLayer: 1,
     name: "Release: Regression", templateStep: { name: "Regression" }, status: "DONE",
-    runs: [{ id: "run-regression", runNumber: 1, status: "SUCCEEDED", model: "gpt-5.6-sol", session: session({ costUsd: "1.25" }) }],
+    runs: [{ id: "run-regression", runNumber: 1, status: "SUCCEEDED", model: "gpt-5.6-sol", budgetGrants: 0, session: session({ costUsd: "1.25" }) }],
   });
   const implementation = row({
     id: "implementation", chainId: "c1", chainIndex: 0, chainLayer: 0,
@@ -544,7 +591,7 @@ test("readBoard does not invent a direct-chain name from a duplicated single row
 
 test("the failure reason is carried in full, because Copy error hands it over", () => {
   const long = `${"/very/long/path/segment".repeat(80)} failed`;
-  assert.equal(boardCard(row({ failureReason: long }), null).failureReason, long);
+  assert.equal(boardCard(row({ failureReason: long }), null, moveContext).failureReason, long);
 });
 
 test("a board card is an order of magnitude smaller than the row it projects", () => {
@@ -552,14 +599,14 @@ test("a board card is an order of magnitude smaller than the row it projects", (
   // bar is a 250KB initial payload, so a card has ~2.2KB to spend and uses far
   // less than that whenever the task did not fail.
   const card = boardCard(row({
-    assigneeAgent: { id: "cmsuawxym0000mpoyd5ga82sm", title: "Implementation Plan Executioner", model: "gpt-5.6-sol:medium" },
-    runs: [{ id: "cmsuawxym0001mpoyd5ga82sm", runNumber: 2, status: "SUCCEEDED", model: "claude-opus-5", session: session({ costUsd: "0.42" }) }],
-  }), null);
+    assigneeAgent: { id: "cmsuawxym0000mpoyd5ga82sm", title: "Implementation Plan Executioner", model: "gpt-5.6-sol:medium", archivedAt: null },
+    runs: [{ id: "cmsuawxym0001mpoyd5ga82sm", runNumber: 2, status: "SUCCEEDED", model: "claude-opus-5", budgetGrants: 0, session: session({ costUsd: "0.42" }) }],
+  }), null, moveContext);
   // The card carries both cost surfaces — the latest run's own cost and the
   // cross-run task total, ownership and the creation timestamp used for queue
-  // order — so the clean-card bound sits at 900, still under half the ~2.2KB
-  // acceptance budget.
-  assert.ok(Buffer.byteLength(JSON.stringify(card)) < 900, "a clean card must stay well inside its budget");
+  // order — so the clean-card bound remains under half the ~2.2KB acceptance
+  // budget even with executable move targets.
+  assert.ok(Buffer.byteLength(JSON.stringify(card)) < 1_100, "a clean card must stay well inside its budget");
 });
 
 /* --------------------------------------------------------------- the ETag */

--- a/packages/api/src/board.ts
+++ b/packages/api/src/board.ts
@@ -26,7 +26,15 @@ import {
 } from "@anneal/db";
 
 import { chainExecutionOwner, type ChainExecutionOwner } from "./chain-execution-owner.js";
-import { chainKey, chainProgressByChain, positions, type ChainProgress } from "./chain.js";
+import {
+  blockingPredecessor,
+  chainKey,
+  chainProgressByChain,
+  positions,
+  taskStartability,
+  type ChainProgress,
+} from "./chain.js";
+import { operatorStatusTransitionRefusal } from "./task-patch.js";
 
 /**
  * The Tasks board's own wire shape.
@@ -40,9 +48,12 @@ import { chainKey, chainProgressByChain, positions, type ChainProgress } from ".
  * drift. `?view=board` is the caller saying which fields it will actually read.
  *
  * Every field here is consumed by the board surface: nearly all by `TaskCard`,
- * with `createdAt` used by `TasksPage` to order the Backlog queue. Adding one is
- * a deliberate act; the point of the shape is that its cost is legible.
+ * with `createdAt` used by `TasksPage` to order the Backlog queue and
+ * `moveTargets` routing operator moves. Adding one is a deliberate act; the
+ * point of the shape is that its cost is legible.
  */
+export type BoardMoveTarget = { status: TaskStatusType; via: "patch" | "start" };
+
 export type BoardCard = {
   id: string;
   name: string;
@@ -68,6 +79,7 @@ export type BoardCard = {
   updatedAt: Date;
   assigneeAgent: { id: string; title: string; model: string } | null;
   chainProgress: (ChainProgress & { position: number | null }) | null;
+  moveTargets: BoardMoveTarget[];
   latestRun: {
     id: string;
     runNumber: number;
@@ -170,6 +182,10 @@ export type BoardRow = {
   name: string;
   status: TaskStatusType;
   assigneeType: AssigneeType;
+  assigneeAgentId: string | null;
+  repoId: string | null;
+  archivedAt: Date | null;
+  maxSessionsPerTask: number;
   failureReason: string | null;
   scheduleKind: ScheduleKind;
   runAt: Date | null;
@@ -184,7 +200,7 @@ export type BoardRow = {
   dispatchAfterTaskId: string | null;
   createdAt: Date;
   updatedAt: Date;
-  assigneeAgent: { id: string; title: string; model: string } | null;
+  assigneeAgent: { id: string; title: string; model: string; archivedAt: Date | null } | null;
   templateStep: { name: string } | null;
   runs: Array<{
     id: string;
@@ -192,6 +208,7 @@ export type BoardRow = {
     status: string;
     model: string;
     subagentModel?: string | null;
+    budgetGrants: number;
     session: {
       nativeChildUsed: boolean;
       costUsd: NonNullable<Parameters<typeof runSessionUsageCost>[0]["session"]>["costUsd"];
@@ -221,6 +238,34 @@ export type SerializedUsageCost = Omit<UsageCost, "costUsd"> & { costUsd: string
 
 export const serializeUsageCost = (cost: UsageCost | null): SerializedUsageCost | null =>
   cost === null ? null : { ...cost, costUsd: decimal(cost.costUsd) };
+
+const TASK_STATUSES: TaskStatusType[] = [
+  TaskStatus.BACKLOG,
+  TaskStatus.TODO,
+  TaskStatus.DOING,
+  TaskStatus.REVIEW,
+  TaskStatus.DONE,
+];
+
+/** Project operator destinations from the same ownership refusal used by
+ * `PATCH /tasks/:id`. A startable standalone Agent queue task may additionally
+ * reach Doing through the start action; it is never represented as a PATCH. */
+export const operatorMoveTargets = (
+  task: Pick<BoardRow, "assigneeType" | "chainId" | "status">,
+  startability: { startable: boolean; checklist: { predecessorsDone: boolean } },
+): BoardMoveTarget[] => {
+  const targets = TASK_STATUSES.flatMap((status): BoardMoveTarget[] => {
+    if (status === task.status) return [];
+    const refusal = operatorStatusTransitionRefusal(task, status);
+    if (refusal === null) return [{ status, via: "patch" }];
+    const startsStandaloneAgent = status === TaskStatus.DOING
+      && task.chainId === null
+      && task.assigneeType === "AGENT"
+      && (task.status === TaskStatus.BACKLOG || task.status === TaskStatus.TODO);
+    return startsStandaloneAgent && startability.startable ? [{ status, via: "start" }] : [];
+  });
+  return startability.checklist.predecessorsDone ? targets : [];
+};
 
 /** The fields of a primary step or detached repair needed by the aggregate. */
 export type BoardChainMember = {
@@ -441,6 +486,7 @@ export const chainDisplayByTask = (rows: readonly Pick<BoardRow, "id" | "project
 export const boardCard = (
   row: BoardRow,
   chainProgress: (ChainProgress & { position: number | null }) | null,
+  moveContext: { hasRepoGrant: boolean; chainPredecessorsDone: boolean },
   display: ChainDisplay = { chainName: taskChainName(row), displayName: row.name },
   predecessor: BoardBlockedOnTask | null = null,
   repairOf: RepairBinding | null = null,
@@ -449,6 +495,24 @@ export const boardCard = (
   const taskCost = sumUsageCosts(row.runs.flatMap((item) => item.session === null
     ? []
     : [runSessionUsageCost(item)!]));
+  const budgetGrants = row.runs.reduce<number | null>((highest, item) => (
+    highest === null ? item.budgetGrants : Math.max(highest, item.budgetGrants)
+  ), null);
+  const startability = taskStartability({
+    status: row.status,
+    assigneeType: row.assigneeType,
+    assigneeAgentId: row.assigneeAgentId,
+    repoId: row.repoId,
+    archivedAt: row.archivedAt,
+    assigneeAgent: row.assigneeAgent === null ? null : { archivedAt: row.assigneeAgent.archivedAt },
+    hasRepoGrant: moveContext.hasRepoGrant,
+    dispatchAfterTaskId: row.dispatchAfterTaskId,
+    dispatchAfter: predecessor === null ? null : { status: predecessor.status },
+  }, {
+    total: row.runs.length,
+    active: row.runs.some((item) => ACTIVE_RUN_STATUSES.includes(item.status as (typeof ACTIVE_RUN_STATUSES)[number])),
+    budgetGrants,
+  }, row.maxSessionsPerTask, moveContext.chainPredecessorsDone);
   return {
     id: row.id,
     name: row.name,
@@ -475,6 +539,7 @@ export const boardCard = (
       ? null
       : { id: row.assigneeAgent.id, title: row.assigneeAgent.title, model: row.assigneeAgent.model },
     chainProgress,
+    moveTargets: operatorMoveTargets(row, startability),
     latestRun: latestRunProjection(row.runs),
     taskCost: serializeUsageCost(taskCost),
     // Bound to the run the card actually shows: a stop recorded by run 1 is not
@@ -734,6 +799,7 @@ const boardChainRows = async (
           status: true,
           model: true,
           subagentModel: true,
+          budgetGrants: true,
           session: {
             select: {
               nativeChildUsed: true,
@@ -758,16 +824,17 @@ export const readBoard = async (db: PrismaClient, scope: TaskReadScope): Promise
     where: taskWhere(scope),
     orderBy: taskOrderBy,
     select: {
-      id: true, projectId: true, name: true, status: true, assigneeType: true, failureReason: true,
+      id: true, projectId: true, name: true, status: true, assigneeType: true,
+      assigneeAgentId: true, repoId: true, archivedAt: true, maxSessionsPerTask: true, failureReason: true,
       scheduleKind: true, runAt: true, cron: true, timezone: true, approvalGate: true,
       templateId: true, source: true, chainId: true, chainIndex: true, chainLayer: true, createdAt: true, updatedAt: true,
       dispatchAfterTaskId: true,
-      assigneeAgent: { select: { id: true, title: true, model: true } },
+      assigneeAgent: { select: { id: true, title: true, model: true, archivedAt: true } },
       templateStep: { select: { name: true } },
       runs: {
         orderBy: { runNumber: "desc" },
         select: {
-          id: true, runNumber: true, status: true, model: true, subagentModel: true,
+          id: true, runNumber: true, status: true, model: true, subagentModel: true, budgetGrants: true,
           session: {
             select: {
               nativeChildUsed: true, costUsd: true, inputTokens: true, cachedInputTokens: true, outputTokens: true,
@@ -825,6 +892,19 @@ export const readBoard = async (db: PrismaClient, scope: TaskReadScope): Promise
     });
     for (const predecessor of predecessors) predecessorById.set(predecessor.id, predecessor);
   }
+
+  const grantInputs = rows.flatMap((row) => (
+    row.assigneeAgentId === null || row.repoId === null
+      ? []
+      : [{ projectId: row.projectId, agentId: row.assigneeAgentId, repoId: row.repoId }]
+  ));
+  const grantRows = grantInputs.length === 0 ? [] : await db.agentRepoAccess.findMany({
+    where: { OR: grantInputs },
+    select: { projectId: true, agentId: true, repoId: true },
+  });
+  const grantKey = (value: { projectId: string; agentId: string; repoId: string }): string =>
+    `${value.projectId}\u0000${value.agentId}\u0000${value.repoId}`;
+  const granted = new Set(grantRows.map(grantKey));
 
   if (repairChainByTask.size > 0) {
     const chainNameByKey = new Map<string, string | null>();
@@ -902,9 +982,25 @@ export const readBoard = async (db: PrismaClient, scope: TaskReadScope): Promise
     const key = row.chainId === null
       ? repairKey
       : chainKey({ projectId: row.projectId, chainId: row.chainId });
+    let chainPredecessorsDone = true;
+    if (row.chainId !== null) {
+      const chainGroup = membersByChain.get(chainKey({ projectId: row.projectId, chainId: row.chainId }));
+      if (chainGroup === undefined) {
+        throw new Error(`Board move target projection is missing Chain ${row.chainId}`);
+      }
+      chainPredecessorsDone = blockingPredecessor(chainGroup.primary, row.id) === null;
+    }
     const card = boardCard(
       row,
       progressFor(row),
+      {
+        hasRepoGrant: row.assigneeAgentId !== null && row.repoId !== null && granted.has(grantKey({
+          projectId: row.projectId,
+          agentId: row.assigneeAgentId,
+          repoId: row.repoId,
+        })),
+        chainPredecessorsDone,
+      },
       displayByTask.get(row.id),
       row.dispatchAfterTaskId === null ? null : predecessorById.get(row.dispatchAfterTaskId) ?? null,
       repairByTask.get(row.id) ?? null,


### PR DESCRIPTION
## Candidate

Candidate 01: Board projection carries executable operator status targets.

## Changes

1. Added required BoardCard.moveTargets entries with status and via. Patch targets call the same operatorStatusTransitionRefusal used by the write path; Agent Doing start targets use taskStartability.
2. Updated the BoardCard wire-shape invariant and projection field assertions.
3. Removed the web operatorMoveTargets rule copy. TaskCard, DesktopBoard, and Tasks now render or route card.moveTargets, including via-based start handling.
4. Updated the single-Task response and TaskDetail status control to use the same required moveTargets field; removed the local five-status array.
5. Removed TaskCard menu-open startability requests. Startability is revalidated only when the operator selects a start target.
6. Moved the 13 transition-policy assertions from the web suite to the API board projection suite; retained rendering-focused web coverage.
7. Exposed Done via patch for a Chain HUMAN Approval gate Step, matching the authoritative write-path behavior.

## Validation

- npm run lint: PASS
- npm run typecheck: PASS
- npm run test -w @anneal/api: PASS (634 tests; 633 pass, 1 skip)
- npm run build -w @anneal/web: PASS
- npm run test -w @anneal/web: PASS (541 tests; 540 pass, 1 skip)
- Acceptance greps and git diff --check: PASS

## Out of scope observed

None. No conflict between operatorStatusTransitionRefusal and taskStartability was found.