### PR TITLE
refactor: share board projection contract

### DIFF
--- a/apps/web/src/components/chain-aggregate-card.tsx
+++ b/apps/web/src/components/chain-aggregate-card.tsx
@@ -35,12 +35,14 @@ const ACTIVE_RUNS = new Set(["QUEUED", "CLAIMED", "PROVISIONING", "RUNNING"]);
 const chainName = (aggregate: ChainAggregate): string => aggregate.chainName ?? aggregate.chainId.slice(0, 8);
 
 const memberPosition = (aggregate: ChainAggregate, members: readonly BoardTask[]): number => {
-  const fromFrontier = aggregate.frontier?.position;
+  const fromFrontier = aggregate.frontier.position;
   if (fromFrontier !== null && fromFrontier !== undefined) return fromFrontier;
-  const frontier = aggregate.frontier === null ? null : members.find((member) => member.id === aggregate.frontier?.taskId);
-  const fromMember = frontier?.chainProgress?.position ?? (frontier?.chainIndex === null || frontier?.chainIndex === undefined ? null : frontier.chainIndex + 1);
+  const frontier = members.find((member) => member.id === aggregate.frontier.taskId);
+  const fromMember = frontier === undefined
+    ? null
+    : frontier.chainProgress?.position ?? (frontier.chainIndex === null ? null : frontier.chainIndex + 1);
   if (fromMember !== null && fromMember !== undefined) return fromMember;
-  const done = aggregate.statusCounts.DONE ?? 0;
+  const done = aggregate.statusCounts.DONE;
   return aggregate.stepCount === 0 ? 0 : Math.min(aggregate.stepCount, done + 1);
 };
 
@@ -48,8 +50,8 @@ const aggregateCost = (value: ChainAggregate["totalCost"]): string =>
   value === null ? "—" : usageCostLabel(value);
 
 const runLine = (aggregate: ChainAggregate, t: Translate): ReactNode => {
-  const run = aggregate.frontier?.latestRun;
-  if (run === null || run === undefined) return null;
+  const run = aggregate.frontier.latestRun;
+  if (run === null) return null;
   const active = ACTIVE_RUNS.has(run.status);
   const tone = run.status === "SUCCEEDED" ? "green" : run.status === "FAILED" || run.status === "TIMED_OUT" || run.status === "LOST" ? "red" : "amber";
   const elapsed = active && run.startedAt !== null ? t("tasks.card.runningDuration", { duration: duration(run.startedAt, null) }) : null;
@@ -86,11 +88,11 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
   actions?: ChainAggregateActions | undefined;
 }): ReactNode => {
   const t = useT();
-  const representative = representativeTaskId ?? aggregate.frontier?.taskId ?? members[0]?.id ?? aggregate.chainId;
+  const representative = representativeTaskId ?? aggregate.frontier.taskId;
   const title = chainName(aggregate);
   const position = memberPosition(aggregate, members);
   const state = aggregate.activation.state;
-  const predecessor = aggregate.activation.predecessor ?? null;
+  const predecessor = aggregate.activation.predecessor;
   const memberTaskIds = members.map((member) => member.id);
   const handlers: ChainAggregateActions = actions ?? { onActivate: () => undefined, onFilter: () => undefined, onArchive: () => undefined };
   const frontierRun = runLine(aggregate, t);
@@ -117,22 +119,20 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
         <span>{t("tasks.aggregate.progress", { current: position, total: aggregate.stepCount })}</span>
         <Pill tone={STATE_TONE[state]}>{t(`tasks.aggregate.state.${state}`)}</Pill>
       </div>
-      {aggregate.frontier === null ? null : (
-        <div data-chain-frontier="" className={META_ROW}>
-          <span className="line-clamp-2 min-w-0 [overflow-wrap:anywhere]">{aggregate.frontier.title}</span>
-          <button
-            type="button"
-            className="ml-auto flex-none rounded-full border border-border bg-secondary px-[7px] py-[1px] text-secondary-foreground hover:text-foreground"
-            title={t("tasks.aggregate.filter")}
-            aria-label={t("tasks.card.filterChain", { name: title })}
-            onClick={(event) => { event.stopPropagation(); handlers.onFilter(aggregate); }}
-          >
-            {t("tasks.aggregate.filter")}
-          </button>
-        </div>
-      )}
+      <div data-chain-frontier="" className={META_ROW}>
+        <span className="line-clamp-2 min-w-0 [overflow-wrap:anywhere]">{aggregate.frontier.title}</span>
+        <button
+          type="button"
+          className="ml-auto flex-none rounded-full border border-border bg-secondary px-[7px] py-[1px] text-secondary-foreground hover:text-foreground"
+          title={t("tasks.aggregate.filter")}
+          aria-label={t("tasks.card.filterChain", { name: title })}
+          onClick={(event) => { event.stopPropagation(); handlers.onFilter(aggregate); }}
+        >
+          {t("tasks.aggregate.filter")}
+        </button>
+      </div>
       {frontierRun === null ? null : <div className={META_ROW}>{frontierRun}</div>}
-      {aggregate.frontier?.failureReason === null || aggregate.frontier?.failureReason === undefined ? null : (
+      {aggregate.frontier.failureReason === null ? null : (
         <div data-chain-failure="" className={cn(META_ROW, FAILURE)}>{aggregate.frontier.failureReason}</div>
       )}
       {state === "parked-unactivated" && aggregate.activation.taskId !== null ? (

--- a/apps/web/src/components/chain-list.tsx
+++ b/apps/web/src/components/chain-list.tsx
@@ -162,7 +162,7 @@ export const ChainRow = ({
   onStart: (step: ChainStep) => void;
 }): ReactNode => {
   const t = useT();
-  const blockedOn = step.blockedOn ?? null;
+  const blockedOn = step.blockedOn;
   const note = step.status === "BACKLOG" ? t("chain.parked") : step.failureReason;
   const held = step.holdRefusal !== null;
   const showStart = step.startAction !== null || blockedOn !== null || held;

--- a/apps/web/src/lib/board.ts
+++ b/apps/web/src/lib/board.ts
@@ -66,7 +66,7 @@ export type ChainBinding = { id: string; name: string | null };
  */
 export const chainBinding = (task: Pick<BoardTask, "chainId" | "chainName" | "repairOf">): ChainBinding | null => {
   if (task.chainId !== null) return { id: task.chainId, name: task.chainName };
-  const repair = task.repairOf ?? null;
+  const repair = task.repairOf;
   return repair === null ? null : { id: repair.chainId, name: repair.chainName };
 };
 
@@ -101,7 +101,7 @@ export const isBoardEntry = (value: BoardEntry | BoardTask): value is BoardEntry
  * chain even though they have no chain columns of their own. */
 export const boardEntries = (tasks: readonly BoardTask[]): BoardEntry[] => {
   const order: Array<TaskBoardEntry | { kind: "chain-group"; id: string }> = [];
-  const groups = new Map<string, { binding: ChainBinding; members: BoardTask[] }>();
+  const groups = new Map<string, { members: BoardTask[] }>();
   for (const task of tasks) {
     const binding = chainBinding(task);
     if (binding === null) {
@@ -111,18 +111,17 @@ export const boardEntries = (tasks: readonly BoardTask[]): BoardEntry[] => {
     const group = groups.get(binding.id);
     if (group) group.members.push(task);
     else {
-      groups.set(binding.id, { binding, members: [task] });
+      groups.set(binding.id, { members: [task] });
       order.push({ kind: "chain-group", id: binding.id });
     }
   }
   return order.map((item): BoardEntry => {
     if (item.kind !== "chain-group") return item;
     const group = groups.get(item.id)!;
-    const { binding, members } = group;
-    const aggregate = members.find((member) => member.chainAggregate !== null && member.chainAggregate !== undefined)?.chainAggregate;
-    if (aggregate === null || aggregate === undefined) {
-      throw new Error(`Board response omitted the aggregate for chain ${binding.id}`);
-    }
+    const { members } = group;
+    const aggregate = members.find((member): member is BoardTask & { chainAggregate: ChainAggregate } => (
+      member.chainAggregate !== null
+    ))!.chainAggregate;
     const representativeTaskId = aggregate.detailTaskId;
     return {
       kind: "chain",

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,18 +1,50 @@
 /** Wire shapes as serialised by the control plane (packages/db/prisma/schema.prisma).
  *  Decimal columns arrive as strings, DateTime as ISO strings. */
 
-export type TaskStatus = "BACKLOG" | "TODO" | "DOING" | "REVIEW" | "DONE";
-export type TaskMoveTarget = { status: TaskStatus; via: "patch" | "start" };
-/** How a task came to exist. A recurring definition stays MANUAL; only its
- *  fired copies are CRON. */
-export type TaskSource = "MANUAL" | "CRON" | "WEBHOOK";
-export type AssigneeType = "AGENT" | "HUMAN";
+import type {
+  AssigneeType,
+  ChainControl,
+  ChainProgress,
+  ChainStep,
+  ExecutionOwner,
+  MergeOutcome,
+  MergeRecovery,
+  RunStatus,
+  TaskMoveTarget,
+  TaskSource,
+  TaskStatus,
+  UsageCost,
+} from "@anneal/db/board-contract";
+
+export type {
+  AssigneeType,
+  BoardCard,
+  BoardChainActivationState,
+  BoardChainAggregate,
+  BoardChainFrontier,
+  BoardLatestRun,
+  BoardMoveTarget,
+  BoardTask,
+  ChainAggregate,
+  ChainAggregateState,
+  ChainControl,
+  ChainFrontier,
+  ChainProgress,
+  ChainStep,
+  ExecutionOwner,
+  MergeOutcome,
+  MergeRecovery,
+  RunStatus,
+  ScheduleKind,
+  TaskMoveTarget,
+  TaskSource,
+  TaskStatus,
+  UsageCost,
+} from "@anneal/db/board-contract";
+
 export type RunnerKind = "CLAUDE" | "CODEX" | "PI";
 export type RunnerPreference = RunnerKind | "AUTO" | "INHERIT";
 export type CodexServiceTier = "DEFAULT" | "FAST";
-export type RunStatus =
-  | "QUEUED" | "CLAIMED" | "PROVISIONING" | "RUNNING" | "WAITING_INBOX"
-  | "SUCCEEDED" | "FAILED" | "TIMED_OUT" | "CANCELLED" | "LOST";
 export type SessionExecutionStatus =
   | "REQUESTED" | "PROVISIONING" | "RUNNING" | "WAITING_INBOX"
   | "SUCCEEDED" | "FAILED" | "TIMED_OUT" | "CANCELLED" | "LOST";
@@ -192,32 +224,6 @@ export type Session = {
   } | null;
 };
 
-/**
- * §SF-1. The server's parse of a task's persisted `merge-result` output; the
- * client never reads the fenced body itself, so the run row, the sessions pill
- * and the board card cannot disagree about what a mechanical merge did.
- *
- * `incident` marks the two conditions that are discovered *after* the merge
- * landed — those read as a red Incident rather than an amber Stopped.
- */
-export type MergeOutcome = {
-  outcome: "merged" | "stopped" | "malformed";
-  condition: string | null;
-  incident: boolean;
-};
-
-export type MergeRecovery = {
-  id: string;
-  attempt: number;
-  status: "VALIDATING" | "REPAIRING" | "AWAITING_AUTHORIZATION" | "BLOCKED_DOWNSTREAM" | "SUCCEEDED" | "FAILED";
-  phase: "validation" | "repair" | "authorization-wait" | "downstream-stop" | "succeeded" | "actual-failure";
-  sourceStopId: string;
-  boundSourceRunId: string | null;
-  recoveryRunId: string | null;
-  failureReason: string | null;
-  updatedAt: string;
-};
-
 export type Run = {
   id: string;
   projectId: string;
@@ -334,109 +340,6 @@ export type Task = {
   recurringFireCount: number;
 };
 
-/**
- * One Tasks board card, as `GET /tasks?view=board` serialises it
- * (packages/api/src/board.ts).
- *
- * A projection of `Task`, not a subset type of it: the board reads one run and
- * the agent identity and model, so the wire shape says exactly that rather than shipping the
- * whole `Run`, its `Session` and the `Repo` for every card. Measured on the live
- * board, the full shape is 1,581,550 bytes for 112 tasks and this one is 76,947.
- *
- * `failureReason` is *not* truncated here: the card clamps it to three lines,
- * and the card menu's `Copy error` hands over the whole thing.
- */
-export type BoardTask = {
-  id: string;
-  name: string;
-  displayName: string;
-  status: TaskStatus;
-  moveTargets: TaskMoveTarget[];
-  assigneeType: AssigneeType;
-  failureReason: string | null;
-  scheduleKind: "NOW" | "AT" | "CRON";
-  runAt: string | null;
-  cron: string | null;
-  timezone: string | null;
-  approvalGate: boolean;
-  templateId: string | null;
-  source: TaskSource;
-  chainId: string | null;
-  chainIndex: number | null;
-  chainName: string | null;
-  createdAt: string;
-  updatedAt: string;
-  assigneeAgent: { id: string; title: string; model: string } | null;
-  chainProgress: ChainProgress | null;
-  /** API-computed predecessor binding state; absent for older board responses. */
-  blockedOn?: { taskId: string; taskName: string } | null;
-  latestRun: {
-    id: string;
-    runNumber: number;
-    status: RunStatus;
-    /** The model the run was claimed with, which is what the card labels the run
-     *  with; the assignee's current model is a different, later fact. */
-    model: string;
-    costUsd: string | null;
-    startedAt: string | null;
-    endedAt: string | null;
-  } | null;
-  taskCost: UsageCost | null;
-  /** §SF-1, bound to `latestRun`: null whenever the newest run is not the run
-   *  that recorded the outcome. */
-  mergeOutcome?: MergeOutcome | null;
-  /** The chain an autonomous merge-tail repair task repairs. A repair task is
-   *  chain-detached by design, so this is the only thing that puts its card with
-   *  the chain it belongs to. Null on every other card, absent for older board
-   *  responses. */
-  repairOf?: { chainId: string; chainName: string | null; repairKind: string } | null;
-  /** API-computed board projection for the chain this task belongs to. Every
-   * member carries the same aggregate so the web can collapse a chain without
-   * fetching a second resource. Null on standalone tasks. */
-  chainAggregate?: ChainAggregate | null;
-};
-
-export type UsageCost = {
-  costUsd: string | null;
-  estimated: boolean;
-  inputTokens: number | null;
-  cachedInputTokens: number | null;
-  outputTokens: number | null;
-};
-
-export type ChainAggregateState = "parked-unactivated" | "waiting-on-predecessor" | "running" | "idle" | "settled";
-
-/** One chain as it appears on the board. This is a projection, not a Task row:
- * the server owns the frontier and status derivation so the board never
- * invents a state between polls. */
-export type ChainAggregate = {
-  chainId: string;
-  chainName: string | null;
-  stepCount: number;
-  statusCounts: Partial<Record<TaskStatus, number>>;
-  detailTaskId: string;
-  status: TaskStatus;
-  frontier: {
-    taskId: string;
-    title: string;
-    status: TaskStatus;
-    latestRun: BoardTask["latestRun"];
-    failureReason: string | null;
-    /** The API may include the dense one-based step ordinal. Older projections
-     * can leave it out; the renderer falls back to the member's chain columns. */
-    position?: number | null;
-  } | null;
-  activation: {
-    state: ChainAggregateState;
-    predecessor?: { taskId: string; taskName: string } | null;
-    taskId: string | null;
-  };
-  /** Aggregate usage keeps the same shape as a task's usage projection. */
-  totalCost: UsageCost | null;
-  createdAt: string;
-  updatedAt: string;
-};
-
 /** `GET /projects/:projectId/costs`. Every amount is a decimal string, as every
  *  other money field on the wire is. */
 export type CostsReport = {
@@ -505,59 +408,6 @@ export type TaskStartability = {
     repo: { id: string; name: string } | null;
     targetBranch: string | null;
   };
-};
-
-export type ChainProgress = {
-  chainId: string;
-  done: number;
-  total: number;
-  activeStepName: string;
-  activeStatus: string;
-  /** Dense one-based ordinal of the active stored execution layer. */
-  currentLayer: number;
-  /** Number of distinct execution layers in the chain. */
-  layerCount: number;
-  /** This task's 1-based ordinal within its chain. */
-  position: number | null;
-};
-
-export type ExecutionOwner = "agent" | "human" | "control-plane" | "merge-executor";
-
-export type ChainStep = {
-  taskId: string;
-  position: number;
-  chainIndex: number | null;
-  /** Stored execution layer; null is tolerated while an older control plane is migrating. */
-  layer: number | null;
-  name: string;
-  stepName: string;
-  status: TaskStatus;
-  approvalGate: boolean;
-  assigneeType: AssigneeType;
-  executionOwner: ExecutionOwner;
-  agent: { id: string; title: string } | null;
-  archivedAt: string | null;
-  failureReason: string | null;
-  latestRun: { id: string; status: RunStatus; runNumber: number } | null;
-  /** The API's own answer, not a second derivation: the button's enabled state
-   *  and the route's guard must not be able to disagree. */
-  startable: boolean;
-  startAction: "start" | "recover" | null;
-  /** Server-owned Chain hold refusal; null when the hold does not bar this Step. */
-  holdRefusal: string | null;
-  /** API-computed predecessor binding state; absent for older chain responses. */
-  blockedOn?: { taskId: string; name: string; status: TaskStatus } | null;
-  currentExecution: boolean;
-  mergeRecovery?: MergeRecovery | null;
-};
-
-export type ChainControl = {
-  state: "held" | "released";
-  heldLayer: number | null;
-  heldAt: string | null;
-  holdRequestId: string | null;
-  holdReason: string | null;
-  releasedAt: string | null;
 };
 
 export type Chain = {

--- a/apps/web/src/tests/board.test.tsx
+++ b/apps/web/src/tests/board.test.tsx
@@ -13,6 +13,7 @@ const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null,
   approvalGate: false, templateId: null, source: "MANUAL", chainId: null, chainIndex: null,
   chainName: null, updatedAt: "2026-08-16T00:00:00.000Z", assigneeAgent: null, chainProgress: null, latestRun: null, taskCost: null,
+  blockedOn: null, mergeOutcome: null, repairOf: null, chainAggregate: null,
   ...overrides,
 });
 

--- a/apps/web/src/tests/chain-aggregate-board.test.tsx
+++ b/apps/web/src/tests/chain-aggregate-board.test.tsx
@@ -17,7 +17,8 @@ const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
   assigneeType: "AGENT", createdAt: "2026-08-28T00:00:00.000Z", updatedAt: "2026-08-28T01:00:00.000Z",
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null, approvalGate: false, templateId: null,
   source: "MANUAL", chainId: null, chainIndex: null, chainName: null, assigneeAgent: null,
-  chainProgress: null, latestRun: null, taskCost: null, blockedOn: null, repairOf: null, ...overrides,
+  chainProgress: null, latestRun: null, taskCost: null, blockedOn: null, mergeOutcome: null,
+  repairOf: null, chainAggregate: null, ...overrides,
 });
 
 const aggregate = (overrides: Partial<ChainAggregate> = {}): ChainAggregate => ({
@@ -32,8 +33,8 @@ const aggregate = (overrides: Partial<ChainAggregate> = {}): ChainAggregate => (
 const chainStep = (id: string, position: number, status: TaskStatus, projection: ChainAggregate, overrides: Partial<BoardTask> = {}): BoardTask => task({
   id, name: `Release: ${id}`, displayName: id, chainId: projection.chainId, chainIndex: position - 1, chainName: projection.chainName,
   status, chainAggregate: projection, chainProgress: {
-    chainId: projection.chainId, done: projection.statusCounts.DONE ?? 0, total: projection.stepCount,
-    activeStepName: projection.frontier?.title ?? "", activeStatus: projection.frontier?.status ?? "done",
+    chainId: projection.chainId, done: projection.statusCounts.DONE, total: projection.stepCount,
+    activeStepName: projection.frontier.title, activeStatus: projection.frontier.status,
     currentLayer: position, layerCount: projection.stepCount, position,
   }, ...overrides,
 });
@@ -66,8 +67,8 @@ test("aggregate placement follows API-derived frontier status and counts entries
   ] as const) {
     const projection = aggregate({
       status,
-      statusCounts: { TODO: status === "TODO" ? 12 : 0, DOING: status === "DOING" ? 1 : 0, REVIEW: status === "REVIEW" ? 1 : 0, DONE: status === "DONE" ? 12 : 0 },
-      frontier: status === "DONE" ? null : { taskId: "frontier", title: "Frontier", status, latestRun: null, failureReason: null, position: 3 },
+      statusCounts: { BACKLOG: 0, TODO: status === "TODO" ? 12 : 0, DOING: status === "DOING" ? 1 : 0, REVIEW: status === "REVIEW" ? 1 : 0, DONE: status === "DONE" ? 12 : 0 },
+      frontier: { taskId: "frontier", title: "Frontier", status, latestRun: null, failureReason: null, position: 3 },
     });
     const rows = Array.from({ length: 12 }, (_, index) => chainStep(`step-${index}`, index + 1, status === "DONE" ? "DONE" : index === 2 ? status : "TODO", projection));
     const grouped = boardEntriesByStatus(boardEntries(rows));

--- a/apps/web/src/tests/chain-list.test.tsx
+++ b/apps/web/src/tests/chain-list.test.tsx
@@ -21,6 +21,7 @@ const step = (position: number, overrides: Partial<ChainStep> = {}): ChainStep =
   executionOwner: "agent",
   agent: { id: "a1", title: "Builder" }, archivedAt: null, failureReason: null, latestRun: null,
   startable: false, startAction: null, holdRefusal: null, blockedOn: null, currentExecution: false,
+  mergeRecovery: null,
   ...overrides,
 });
 

--- a/apps/web/src/tests/merge-outcome.test.tsx
+++ b/apps/web/src/tests/merge-outcome.test.tsx
@@ -46,6 +46,7 @@ const boardTask = (overrides: Partial<BoardTask> = {}): BoardTask => ({
   approvalGate: false, templateId: null, source: "MANUAL", chainId: "c1", chainIndex: 10,
   chainName: null, updatedAt: "2026-08-18T00:00:00.000Z", assigneeAgent: null, chainProgress: null,
   latestRun: { id: "run-1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5:medium", costUsd: null, startedAt: null, endedAt: null }, taskCost: null,
+  blockedOn: null, mergeOutcome: null, repairOf: null, chainAggregate: null,
   ...overrides,
 });
 

--- a/apps/web/src/tests/task-detail-navigation.test.tsx
+++ b/apps/web/src/tests/task-detail-navigation.test.tsx
@@ -52,7 +52,7 @@ const chainFor = (taskId: string): Chain => ({
     status: "TODO", approvalGate: false, assigneeType: "AGENT", executionOwner: "agent",
     agent: { id: "agent-1", title: "Builder" }, archivedAt: null,
     failureReason: null, latestRun: null, startable: true, startAction: "start", holdRefusal: null,
-    currentExecution: false,
+    blockedOn: null, currentExecution: false, mergeRecovery: null,
   }],
 });
 

--- a/apps/web/src/tests/tasks-board.test.tsx
+++ b/apps/web/src/tests/tasks-board.test.tsx
@@ -23,6 +23,7 @@ const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null,
   approvalGate: false, templateId: null, source: "MANUAL", chainId: null, chainIndex: null,
   chainName: null, updatedAt: "2026-08-16T00:00:00.000Z", assigneeAgent: null, chainProgress: null, blockedOn: null, latestRun: null, taskCost: null,
+  mergeOutcome: null, repairOf: null, chainAggregate: null,
   ...overrides,
 });
 
@@ -347,7 +348,7 @@ test("Archive All confirms the project-wide Done scope even while one chain is v
   storage.set("agentos.projectId", "p1");
   const settledAggregate = (chainId: string, chainName: string, taskId: string) => ({
     chainId, chainName, detailTaskId: taskId, stepCount: 1,
-    statusCounts: { DONE: 1 }, status: "DONE" as const,
+    statusCounts: { BACKLOG: 0, TODO: 0, DOING: 0, REVIEW: 0, DONE: 1 }, status: "DONE" as const,
     frontier: { taskId, title: "Review", status: "DONE" as const, latestRun: null, failureReason: null, position: 1 },
     activation: { state: "settled" as const, predecessor: null, taskId }, totalCost: null,
     createdAt: "2026-08-15T00:00:00.000Z", updatedAt: "2026-08-16T00:00:00.000Z",

--- a/apps/web/src/tests/tasks-transitions.test.tsx
+++ b/apps/web/src/tests/tasks-transitions.test.tsx
@@ -12,6 +12,7 @@ const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
   scheduleKind: "NOW", runAt: null, cron: null, timezone: null,
   approvalGate: false, templateId: null, source: "MANUAL", chainId: null, chainIndex: null,
   chainName: null, updatedAt: "2026-08-16T00:00:00.000Z", assigneeAgent: null, chainProgress: null, blockedOn: null, latestRun: null, taskCost: null,
+  mergeOutcome: null, repairOf: null, chainAggregate: null,
   ...overrides,
 });
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -67,6 +67,7 @@ import {
   type MergeRecoveryAttempt,
   loadAgentSources,
 } from "@anneal/db";
+import type { ChainStep as ChainStepContract } from "@anneal/db/board-contract";
 import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import { bodyLimit } from "hono/body-limit";
@@ -2637,7 +2638,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
           ? { taskId: dispatchAfter.id, name: dispatchAfter.name, status: dispatchAfter.status }
           : null,
         mergeRecovery,
-      })),
+      } satisfies ChainStepContract<Date>)),
     });
   });
   app.post("/tasks/:taskId/chain/hold", async (context) => {

--- a/packages/api/src/board.test.ts
+++ b/packages/api/src/board.test.ts
@@ -361,7 +361,7 @@ test("blockedOn is projected from the resolved predecessor without storing its s
 
 test("the card's merge outcome is bound to the run it shows, and is null everywhere else", () => {
   const merged = JSON.stringify({ outcome: "merged", mergeCommitSha: "a".repeat(40) });
-  const run = { id: "r1", runNumber: 3, status: "SUCCEEDED", model: "gpt-5.6-sol", budgetGrants: 0, session: null };
+  const run = { id: "r1", runNumber: 3, status: "SUCCEEDED" as const, model: "gpt-5.6-sol", budgetGrants: 0, session: null };
   // §SF-1: an ordinary step's output is not a malformed merge result, it is not
   // a merge result at all, and 112 board cards must not each carry a marker.
   assert.equal(boardCard(row({ runs: [run], stepOutput: { kind: "code-review", body: "fine", runId: "r1" } }), null, moveContext).mergeOutcome, null);

--- a/packages/api/src/board.ts
+++ b/packages/api/src/board.ts
@@ -11,7 +11,6 @@ import {
   TaskStatus,
   type Agent,
   type AssigneeType,
-  type MergeOutcomeProjection,
   type Marker,
   type Prisma,
   type PrismaClient,
@@ -24,6 +23,17 @@ import {
   type TaskStatus as TaskStatusType,
   type UsageCost,
 } from "@anneal/db";
+import type {
+  BoardCard as BoardContractCard,
+  BoardChainActivationState as BoardContractChainActivationState,
+  BoardChainAggregate as BoardContractChainAggregate,
+  BoardChainFrontier as BoardContractChainFrontier,
+  BoardLatestRun as BoardContractLatestRun,
+  BoardMoveTarget as BoardContractMoveTarget,
+  RepairBinding as BoardContractRepairBinding,
+  RunStatus as BoardRunStatus,
+  UsageCost as BoardUsageCost,
+} from "@anneal/db/board-contract";
 
 import { chainExecutionOwner, type ChainExecutionOwner } from "./chain-execution-owner.js";
 import {
@@ -52,127 +62,25 @@ import { operatorStatusTransitionRefusal } from "./task-patch.js";
  * `moveTargets` routing operator moves. Adding one is a deliberate act; the
  * point of the shape is that its cost is legible.
  */
-export type BoardMoveTarget = { status: TaskStatusType; via: "patch" | "start" };
+export type BoardMoveTarget = BoardContractMoveTarget;
+export type BoardCard = BoardContractCard<Date>;
+export type BoardLatestRun = BoardContractLatestRun<Date>;
+export type BoardChainActivationState = BoardContractChainActivationState;
+export type BoardChainFrontier = BoardContractChainFrontier<Date>;
+export type BoardChainAggregate = BoardContractChainAggregate<Date>;
+export type RepairBinding = BoardContractRepairBinding;
 
-export type BoardCard = {
-  id: string;
-  name: string;
-  /** Display-only title with a verified chain prefix removed. */
-  displayName: string;
-  status: TaskStatusType;
-  assigneeType: AssigneeType;
-  /** Full text, not a truncation: the card clamps it to three lines but the
-   *  card menu's `Copy error` hands the operator the whole thing. */
-  failureReason: string | null;
-  scheduleKind: ScheduleKind;
-  runAt: Date | null;
-  cron: string | null;
-  timezone: string | null;
-  approvalGate: boolean;
-  templateId: string | null;
-  source: TaskSource;
-  chainId: string | null;
-  chainIndex: number | null;
-  chainName: string | null;
-  blockedOn: { taskId: string; taskName: string } | null;
-  createdAt: Date;
-  updatedAt: Date;
-  assigneeAgent: { id: string; title: string; model: string } | null;
-  chainProgress: (ChainProgress & { position: number | null }) | null;
-  moveTargets: BoardMoveTarget[];
-  latestRun: {
-    id: string;
-    runNumber: number;
-    status: string;
-    /** The model snapshot taken when the run was claimed, not the assignee's
-     *  current configuration: a re-tiered agent must not relabel a past run. */
-    model: string;
-    costUsd: string | null;
-    startedAt: Date | null;
-    endedAt: Date | null;
-  } | null;
-  taskCost: SerializedUsageCost | null;
-  /**
-   * §SF-1. Parsed server-side from the task's persisted `merge-result` output,
-   * and null for every non-integrator task. A mechanical merge that stopped ends
-   * its run SUCCEEDED — correctly, because it executed its contract — so a
-   * run-centric card that reads only the protocol status renders a stop or a
-   * post-merge incident as a green Done. This is what the card renders instead.
-   */
-  mergeOutcome: MergeOutcomeProjection | null;
-  /**
-   * The chain a merge-tail repair task repairs.
-   *
-   * A repair task is deliberately chain-detached — no `chainId`, `chainIndex` or
-   * `templateId` — so its own columns say nothing about where it came from, and
-   * the board drew it as a loose card beside the chain that produced it. The
-   * `repairAttempt` marker it carries names the regression task, and that task's
-   * chain is what this reports. Null for every card that is not a repair task.
-   */
-  repairOf: RepairBinding | null;
-  /**
-   * The chain projection, carried once by one visible member. Standalone tasks
-   * and the remaining members carry null; the web groups all rows by binding.
-   */
-  chainAggregate: BoardChainAggregate | null;
-};
-
-export type BoardLatestRun = {
-  id: string;
-  runNumber: number;
-  status: string;
-  /** The model snapshot taken when the run was claimed, not the assignee's
-   * current configuration: a re-tiered agent must not relabel a past run. */
-  model: string;
-  costUsd: string | null;
-  startedAt: Date | null;
-  endedAt: Date | null;
-};
-
-export type BoardChainActivationState =
-  | "parked-unactivated"
-  | "waiting-on-predecessor"
-  | "running"
-  | "idle"
-  | "settled";
-
-export type BoardChainFrontier = {
-  taskId: string;
-  title: string;
-  status: TaskStatusType;
-  latestRun: BoardLatestRun | null;
-  failureReason: string | null;
-  /** Dense one-based position among primary steps; null for a repair frontier. */
-  position?: number | null;
-};
-
-export type BoardChainAggregate = {
-  chainId: string;
-  chainName: string | null;
-  /** Number of primary chain steps. Detached repairs never inflate this. */
-  stepCount: number;
-  /** Status counts for primary steps only, used for progress. */
-  statusCounts: Record<TaskStatusType, number>;
-  /** A persisted primary member whose task page renders the chain detail. */
-  detailTaskId: string;
-  /** Derived board column; this is not a persisted Task status. */
-  status: TaskStatusType;
-  frontier: BoardChainFrontier;
-  activation: {
-    state: BoardChainActivationState;
-    predecessor: { taskId: string; taskName: string } | null;
-    /** Step zero is the only board activation target. */
-    taskId: string | null;
-  };
-  totalCost: SerializedUsageCost | null;
-  /** Earliest member creation and latest member update, for aggregate age. */
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-/** What a repair card needs to sit with its chain: the chain it belongs to and
- *  which kind of repair it is. */
-export type RepairBinding = { chainId: string; chainName: string | null; repairKind: string };
+type JsonSerialized<T> = T extends Date
+  ? string
+  : T extends readonly (infer Item)[]
+    ? JsonSerialized<Item>[]
+    : T extends object
+      ? { [Key in keyof T]: JsonSerialized<T[Key]> }
+      : T;
+type ContractCheck<T extends BoardContractCard> = T;
+/** Compile-time proof that JSON serialization turns the native projection into
+ * the shared browser contract, including every required field. */
+export type SerializedBoardCardProjection = ContractCheck<JsonSerialized<BoardCard>>;
 
 /** The Prisma row shape `boardCard` needs — declared structurally so `readBoard`
  *  can select exactly these columns and nothing else. */
@@ -205,7 +113,7 @@ export type BoardRow = {
   runs: Array<{
     id: string;
     runNumber: number;
-    status: string;
+    status: BoardRunStatus;
     model: string;
     subagentModel?: string | null;
     budgetGrants: number;
@@ -234,7 +142,7 @@ export type BoardBlockedOnTask = {
 const decimal = (value: unknown): string | null =>
   (value === null || value === undefined ? null : String(value));
 
-export type SerializedUsageCost = Omit<UsageCost, "costUsd"> & { costUsd: string | null };
+export type SerializedUsageCost = BoardUsageCost;
 
 export const serializeUsageCost = (cost: UsageCost | null): SerializedUsageCost | null =>
   cost === null ? null : { ...cost, costUsd: decimal(cost.costUsd) };
@@ -290,7 +198,7 @@ const latestRunProjection = (runs: readonly BoardRow["runs"][number][] | null | 
   const run = runs?.[0];
   return run === undefined
     ? null
-    : {
+    : ({
         id: run.id,
         runNumber: run.runNumber,
         status: run.status,
@@ -298,7 +206,7 @@ const latestRunProjection = (runs: readonly BoardRow["runs"][number][] | null | 
         costUsd: decimal(run.session?.costUsd),
         startedAt: run.session?.startedAt ?? null,
         endedAt: run.session?.endedAt ?? null,
-      };
+      } satisfies BoardLatestRun);
 };
 
 const memberUsageCost = (member: Pick<BoardChainMember, "runs">): UsageCost | null =>
@@ -431,7 +339,7 @@ export const chainAggregate = (
     totalCost: serializeUsageCost(totalCost),
     createdAt,
     updatedAt,
-  };
+  } satisfies BoardChainAggregate;
 };
 
 /** The instantiated chain name is persisted as the prefix of every task name.
@@ -549,7 +457,7 @@ export const boardCard = (
       : null,
     repairOf,
     chainAggregate: null,
-  };
+  } satisfies BoardCard;
 };
 
 /**

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,6 +18,10 @@
       "types": "./src/model-routing.ts",
       "import": "./dist/model-routing.js"
     },
+    "./board-contract": {
+      "types": "./src/board-contract.ts",
+      "import": "./dist/board-contract.js"
+    },
     "./service-lock": {
       "types": "./src/service-maintenance-lock.ts",
       "import": "./dist/service-maintenance-lock.js"

--- a/packages/db/src/board-contract.test.ts
+++ b/packages/db/src/board-contract.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const source = readFileSync(fileURLToPath(new URL("./board-contract.ts", import.meta.url)), "utf8");
+
+test("the browser-safe board contract imports no runtime dependency", () => {
+  const specifiers = [
+    ...source.matchAll(/(?:^|\n)\s*(?:import|export)[^;]*?from\s+"([^"]+)"/gu),
+    ...source.matchAll(/(?:^|\n)\s*import\s+"([^"]+)"/gu),
+    ...source.matchAll(/\brequire\s*\(\s*"([^"]+)"/gu),
+    ...source.matchAll(/\bimport\s*\(\s*"([^"]+)"/gu),
+  ].map((match) => match[1]);
+  assert.deepEqual(specifiers, []);
+});
+
+test("the package publishes the board contract as an isolated subpath", () => {
+  const manifest = JSON.parse(readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8"));
+  assert.deepEqual(manifest.exports["./board-contract"], {
+    types: "./src/board-contract.ts",
+    import: "./dist/board-contract.js",
+  });
+});

--- a/packages/db/src/board-contract.ts
+++ b/packages/db/src/board-contract.ts
@@ -1,0 +1,189 @@
+/**
+ * Browser-safe serialized contracts for the Tasks board and Chain detail.
+ *
+ * This module deliberately imports nothing. String-literal unions mirror the
+ * persisted enums without making a browser consumer load Prisma, and the
+ * default `DateTime` parameter is the ISO string produced on the HTTP wire.
+ * Server projections may instantiate the same contract with `Date` before
+ * JSON serialization.
+ */
+
+export type TaskStatus = "BACKLOG" | "TODO" | "DOING" | "REVIEW" | "DONE";
+export type TaskSource = "MANUAL" | "CRON" | "WEBHOOK";
+export type AssigneeType = "AGENT" | "HUMAN";
+export type ScheduleKind = "NOW" | "AT" | "CRON";
+export type RunStatus =
+  | "QUEUED" | "CLAIMED" | "PROVISIONING" | "RUNNING" | "WAITING_INBOX"
+  | "SUCCEEDED" | "FAILED" | "TIMED_OUT" | "CANCELLED" | "LOST";
+export type ExecutionOwner = "agent" | "human" | "control-plane" | "merge-executor";
+
+export type BoardMoveTarget = { status: TaskStatus; via: "patch" | "start" };
+export type TaskMoveTarget = BoardMoveTarget;
+
+export type UsageCost = {
+  /** A serialized Decimal, or null when cost is unavailable. */
+  costUsd: string | null;
+  estimated: boolean;
+  inputTokens: number | null;
+  cachedInputTokens: number | null;
+  outputTokens: number | null;
+};
+
+/** The server's parse of a persisted `merge-result`; post-merge conditions set
+ * `incident` so run-centric clients distinguish them from pre-merge stops. */
+export type MergeOutcome = {
+  outcome: "merged" | "stopped" | "malformed";
+  condition: string | null;
+  incident: boolean;
+};
+
+export type MergeRecovery<DateTime = string> = {
+  id: string;
+  attempt: number;
+  status: "VALIDATING" | "REPAIRING" | "AWAITING_AUTHORIZATION" | "BLOCKED_DOWNSTREAM" | "SUCCEEDED" | "FAILED";
+  phase: "validation" | "repair" | "authorization-wait" | "downstream-stop" | "succeeded" | "actual-failure";
+  sourceStopId: string;
+  boundSourceRunId: string | null;
+  recoveryRunId: string | null;
+  failureReason: string | null;
+  updatedAt: DateTime;
+};
+
+export type ChainProgress = {
+  chainId: string;
+  done: number;
+  total: number;
+  activeStepName: string;
+  activeStatus: string;
+  /** Dense one-based ordinal of the active stored execution layer. */
+  currentLayer: number;
+  /** Number of distinct execution layers in the chain. */
+  layerCount: number;
+  /** This task's one-based ordinal within its Chain. */
+  position: number | null;
+};
+
+export type BoardLatestRun<DateTime = string> = {
+  id: string;
+  runNumber: number;
+  status: RunStatus;
+  /** The model snapshot taken when the Run was claimed. */
+  model: string;
+  /** A serialized Decimal, or null when cost is unavailable. */
+  costUsd: string | null;
+  startedAt: DateTime | null;
+  endedAt: DateTime | null;
+};
+
+export type RepairBinding = {
+  chainId: string;
+  chainName: string | null;
+  repairKind: string;
+};
+
+export type ChainAggregateState =
+  | "parked-unactivated"
+  | "waiting-on-predecessor"
+  | "running"
+  | "idle"
+  | "settled";
+export type BoardChainActivationState = ChainAggregateState;
+
+export type ChainFrontier<DateTime = string> = {
+  taskId: string;
+  title: string;
+  status: TaskStatus;
+  latestRun: BoardLatestRun<DateTime> | null;
+  failureReason: string | null;
+  /** Dense one-based position among primary Steps; omitted for a repair. */
+  position?: number | null;
+};
+export type BoardChainFrontier<DateTime = string> = ChainFrontier<DateTime>;
+
+export type ChainAggregate<DateTime = string> = {
+  chainId: string;
+  chainName: string | null;
+  /** Number of primary Chain Steps. Detached repairs never inflate this. */
+  stepCount: number;
+  /** Status counts for every primary-Step status. */
+  statusCounts: Record<TaskStatus, number>;
+  detailTaskId: string;
+  /** Derived board column; this is not a persisted Task status. */
+  status: TaskStatus;
+  frontier: ChainFrontier<DateTime>;
+  activation: {
+    state: ChainAggregateState;
+    predecessor: { taskId: string; taskName: string } | null;
+    taskId: string | null;
+  };
+  totalCost: UsageCost | null;
+  createdAt: DateTime;
+  updatedAt: DateTime;
+};
+export type BoardChainAggregate<DateTime = string> = ChainAggregate<DateTime>;
+
+export type BoardCard<DateTime = string> = {
+  id: string;
+  name: string;
+  displayName: string;
+  status: TaskStatus;
+  moveTargets: BoardMoveTarget[];
+  assigneeType: AssigneeType;
+  failureReason: string | null;
+  scheduleKind: ScheduleKind;
+  runAt: DateTime | null;
+  cron: string | null;
+  timezone: string | null;
+  approvalGate: boolean;
+  templateId: string | null;
+  source: TaskSource;
+  chainId: string | null;
+  chainIndex: number | null;
+  chainName: string | null;
+  blockedOn: { taskId: string; taskName: string } | null;
+  createdAt: DateTime;
+  updatedAt: DateTime;
+  assigneeAgent: { id: string; title: string; model: string } | null;
+  chainProgress: ChainProgress | null;
+  latestRun: BoardLatestRun<DateTime> | null;
+  taskCost: UsageCost | null;
+  mergeOutcome: MergeOutcome | null;
+  repairOf: RepairBinding | null;
+  /** Carried once by one visible member of each Chain; null otherwise. */
+  chainAggregate: ChainAggregate<DateTime> | null;
+};
+
+/** The browser-facing name retained by the web app's existing consumers. */
+export type BoardTask = BoardCard<string>;
+
+export type ChainStep<DateTime = string> = {
+  taskId: string;
+  position: number;
+  chainIndex: number | null;
+  layer: number | null;
+  name: string;
+  stepName: string;
+  status: TaskStatus;
+  approvalGate: boolean;
+  assigneeType: AssigneeType;
+  executionOwner: ExecutionOwner;
+  agent: { id: string; title: string } | null;
+  archivedAt: DateTime | null;
+  failureReason: string | null;
+  latestRun: { id: string; status: RunStatus; runNumber: number } | null;
+  startable: boolean;
+  startAction: "start" | "recover" | null;
+  holdRefusal: string | null;
+  blockedOn: { taskId: string; name: string; status: TaskStatus } | null;
+  currentExecution: boolean;
+  mergeRecovery: MergeRecovery<DateTime> | null;
+};
+
+export type ChainControl<DateTime = string> = {
+  state: "held" | "released";
+  heldLayer: number | null;
+  heldAt: DateTime | null;
+  holdRequestId: string | null;
+  holdReason: string | null;
+  releasedAt: DateTime | null;
+};


### PR DESCRIPTION
## Candidate

Candidate 10: shared Board projection serialization contract; remove the weakened web mirror.

## Changes

1. Added the browser-safe `@anneal/db/board-contract` export subpath. It contains only type declarations, defaults `DateTime` to the serialized `string` wire shape, represents Decimal costs as `string`, and keeps `BoardCard.moveTargets` required.
2. Replaced API-local Board/Chain projection declarations with native `<Date>` instantiations of the shared contract. `boardCard`, `chainAggregate`, latest-run projection, and Chain detail Steps use `satisfies`; `JsonSerialized<BoardCard>` additionally proves the native Board projection becomes the default browser contract after JSON serialization.
3. Changed `apps/web/src/lib/types.ts` to import and re-export the shared Board/Chain types. Existing `./types` consumer imports are unchanged; web-owned view models remain local.
4. Made `blockedOn`, `mergeOutcome`, `repairOf`, `chainAggregate`, Chain activation predecessor, ChainStep `blockedOn`, and ChainStep `mergeRecovery` required nullable fields. `ChainAggregate.frontier` is non-null and `statusCounts` is a complete `Record<TaskStatus, number>`. `frontier.position` remains optional because detached repairs omit that property on the real wire.
5. Removed the Board render-path `Board response omitted...` throw and the nullish/undefined compatibility branches that existed only for the weakened mirror.
6. Added subpath export and no-import purity tests, and updated type-level fixtures to carry the server-required fields.

## Validation

- `npm run lint`: PASS
- `npm run typecheck`: PASS
- `npm run test -w @anneal/web`: PASS, 540 passed / 1 skipped
- `npm run test -w @anneal/api`: PASS, 637 passed / 1 skipped
- `node --import tsx --test packages/db/src/board-contract.test.ts`: PASS, 2 passed
- `grep -rn "Board response omitted" apps/web/src`: no results
- `git diff --check`: PASS before commit

No `docs/` files changed, so `npm run test:snapshot-scan` was not required.

## Negative typecheck evidence

Temporarily removed the required `moveTargets` property from the server `boardCard()` return and ran:

```text
npm run typecheck -w @anneal/api
```

The expected compile-time failure was:

```text
src/board.ts(424,3): error TS2741: Property 'moveTargets' is missing ... but required in type 'BoardCard'.
src/board.ts(459,5): error TS1360: Type ... does not satisfy the expected type 'BoardCard'.
  Property 'moveTargets' is missing ... but required in type 'BoardCard'.
```

The correct projection was then restored. `npm run typecheck -w @anneal/api` and the root `npm run typecheck` both pass at the committed head.

## Out of scope observed

- `TriggerFire.progress` still reuses the Board-oriented `ChainProgress` type, while the Trigger fires projection does not add the Board card's `position`. Sharing or changing the Trigger response contract is outside Candidate 10, so no Trigger route or behavior was changed.
