### PR TITLE
docs: rewrite README around the unattended workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,122 +2,70 @@
 
 # Anneal
 
-**AI can write code now. Nobody has the capacity to review all of it.**
+**You write the specs. It clears the board.**
 
-Anneal is the part that reviews it: a local control plane for coding agents.
-You write the spec. A chain takes it from there — plan, review, implement,
-verify, merge — and every run stays observable and reviewable.
-
-*Annealing is the heat treatment that relieves the internal stresses left in
-worked metal. The defects come out in the process.*
+Anneal is a local control plane for coding agents. Queue tasks in the
+evening, and chains plan, review, implement, verify and merge them
+unattended — on the Codex and Claude subscriptions you are already
+signed in to.
 
 [![status](https://img.shields.io/badge/status-developer%20preview-orange)](#status)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20Apple%20Silicon-lightgrey)](#status)
 [![node](https://img.shields.io/badge/node-22.17.0-brightgreen)](.nvmrc)
 
-[Install](#quick-start) · [Docs](#documentation) · [Status](#status) · [简体中文](README.zh-CN.md)
+[Install](#quick-start) · [How it works](#how-it-works) · [Status](#status) · [简体中文](README.zh-CN.md)
 
 <img src="docs/media/parallel-tasks.gif" alt="Multiple tasks running in parallel across the board" width="880">
 
 </div>
 
-## What it is
+## The workflow it is built for
 
-Anneal connects tasks, agents, repository and file grants, isolated run
-records, provider event streams, human questions, review gates and git delivery
-into one workflow that runs entirely on your own machine.
+During the day you do one thing: write specs. In the evening you queue
+them as tasks on the board. Overnight, a chain picks up each task and
+takes it the whole way — plan, plan review, implementation, two
+independent code reviews, fix application, regression verification, and
+the merge itself. In the morning you read the pull requests that matter,
+open an agent window on the ones you care about, and iterate until you
+are satisfied.
 
-It orchestrates the official Codex CLI, Claude Code and Pi that you have
-already installed and signed in to, so the subscription logins those CLIs
-already hold are what it runs on. Anneal supplies no credential of its own and
-resells no subscription. See
-[Authentication and subscriptions](#authentication-and-subscriptions).
+Between those points nothing needs you. A chain only stops for you when
+an agent asks a question through the Inbox, when a step you marked as
+gated needs a human decision, or when a run escalates. You are not
+sitting in front of it; the board is what you come back to.
 
-## What it changes
+## What you get
 
-A Full Assurance task chain covers the whole delivery path: specification,
-plan, plan review, implementation, two independent code reviews, fix
-application, regression verification, merge readiness and the merge itself. A
-Direct chain omits the specification and planning stages. Agent steps carry
-their own role, prompt, model and reasoning effort; mechanical readiness and
-merge steps do not. Outputs flow only to the downstream consumers declared by
-the template, including both parallel review findings flowing to the fix step.
+- **Spec in, merge out.** A task card becomes a branch, a pull request
+  and a merge behind the merge gate, with every intermediate artifact —
+  plan, review findings, fix dispositions, regression results — recorded
+  and reviewable.
+- **Parallel by default.** Chains for different tasks and different
+  repositories run at the same time; throughput comes from how many
+  runners you register, not from your hours.
+- **Your subscriptions, no keys.** Anneal launches the official Codex
+  CLI, Claude Code and Pi you have already installed and signed in to.
+  It holds no credential of its own, runs no proxy, and there is no key
+  to paste in.
+- **Review is the product.** Every step's output is the next step's
+  input, and every run record stays on your machine for you to audit.
 
-Once a chain starts it advances on its own. You step in when an agent asks you
-something through the Inbox, when a step you marked as gated needs a human
-decision, or when a run escalates. Everything between those points
-runs unattended, including delivery: a branch, an optional pull request, and a
-merge behind the merge gate.
-
-That changes what limits you. Throughput comes from how many runners you have
-registered rather than from your hours: chains for different tasks and different
-repositories are in flight at the same time, and you read review output instead
-of typing the implementation.
-
-Long-horizon autonomy is not wired yet. A Goal is stored and edited but nothing
-schedules work from it, so a chain is still started by you or by a webhook
-trigger, not by a standing objective. See [Status](#status).
-
-<div align="center">
-
-<img src="docs/media/agents.png" alt="Agents view: each agent's role, model, reasoning effort and runner" width="880">
-
-<sub>Agents: a role, a prompt, a model and effort, and the runner it goes to.</sub>
-
-</div>
-
-## Board columns
-
-The board shows where work sits in the intent-to-delivery flow. The [Backlog
-card lifecycle](docs/governance/task-routing-v1.md#backlog-card-lifecycle) in
-the task-routing contract defines card creation, dispatch, and archival; the
-definitions here cover the column semantics.
-
-- **Backlog — intent.** An un-instantiated brief that is still being refined,
-  awaits a decision, or is deliberately parked; it is not connected to
-  execution. For an indefinitely parked HUMAN card, prefix its title with
-  `Parked:`.
-- **Todo — runnable execution.** An instantiated chain or step whose
-  specification of record is final, runnable now or waiting for activation or
-  a dependency unlock. The entry boundary is explicit: un-instantiated intent
-  enters the board in Backlog; instantiated chains and their steps enter in
-  Todo and then move through the later columns.
-- **Doing — active execution.** The runner has activated an AGENT task and work
-  is in progress.
-- **Review — awaiting a lifecycle decision.** An AGENT task is paused for an
-  approval or review gate, or has surfaced a run issue that needs attention
-  before the chain can continue.
-- **Done — complete.** The task or chain step is finished.
-
-An operator can stop and park a running chain step, which returns it to Backlog
-as a parked step. Resume it with **Start now** or **Recover parked step**, not
-ordinary card dispatch.
-
-The operator owns Backlog and Todo transitions and marking HUMAN tasks Done.
-The runner and chain scheduler own Doing, Review, and Done transitions for
-AGENT tasks. In the usual flow, the operator moves finalized intent from
-Backlog to Todo, then the runner advances each instantiated step through Doing,
-Review, and Done.
-
-## It is built by its own chains
+## Anneal is built with Anneal
 
 The pull requests in this repository are specified, planned, reviewed,
-implemented and merged by the chain below, running on one Mac. That is what the
-eight days between the first preview release and the third look like from the
-inside.
+implemented and merged by Anneal's own chains, running on one Mac.
+Chain-delivered commits carry `Co-Authored-By: Anneal Chain` and
+`X-Anneal-Run` / `X-Anneal-Step` trailers, so you can check in the git
+log which commits the chains produced.
 
-Attribution for chain-delivered commits is not yet explicit in git history, so
-treat this as a statement about how the work is done rather than a number you
-can check. Making it checkable is the next preview's job.
+## How it works
 
-## The twelve-step chain
-
-The Full Assurance template that ships with Anneal. Every step binds a role,
-and every role carries its own runner, model and reasoning effort.
-
-`Sol` and `Luna` in the table below are not Anneal names: they are the GPT-5.6
-variants the Codex CLI exposes, bound as `gpt-5.6-sol` and `gpt-5.6-luna`.
+A chain instantiates a template of steps. Each step binds an agent role
+— a prompt, a model, a reasoning effort and the runner CLI it executes
+on — and the flagship Full Assurance template covers delivery in twelve
+steps. `Sol` and `Luna` below are the GPT-5.6 variants the Codex CLI
+exposes.
 
 <details>
 <summary><b>The twelve steps in full</b> — role, runner, model and effort for each</summary>
@@ -147,32 +95,22 @@ variants the Codex CLI exposes, bound as `gpt-5.6-sol` and `gpt-5.6-luna`.
 
 </div>
 
-Steps 6 and 7 are parallel siblings: the blind review never sees the other's
-output, and step 8 adjudicates both. Step 5's root session dispatches native
-subagents pinned to Luna at maximum effort, at most eight concurrent.
-
-Role bindings live in
+Steps 6 and 7 are parallel siblings: the blind review never sees the
+other's output, and step 8 adjudicates both. Role bindings live in
 [`agents/templates/compound-engineer-workflow/`](agents/templates/compound-engineer-workflow)
-and the models in [`agents/roles/`](agents/roles). A model or effort changed in
-the console is a persisted runtime override and is not replaced by a later
-seed.
-
-> **Developer Preview 4 (v0.4.0).** Interfaces, configuration and stored data
-> shapes may change between preview releases, and the only upgrade path is a
-> fresh install.
->
-> **Host execution.** Anneal launches coding CLIs with non-interactive
-> permission bypass. By default they run as your macOS user, outside a sandbox,
-> with that user's filesystem and network authority. Anneal grants constrain
-> Anneal APIs; they are not host containment. Use a disposable repository and a
-> machine you are willing to let an agent modify.
+and the models in [`agents/roles/`](agents/roles). Board column
+semantics are defined in the
+[task-routing contract](docs/governance/task-routing-v1.md).
 
 ## Quick start
 
-You need an Apple Silicon Mac with Node.js `22.17.0` from `.nvmrc` (installation requires
-Node.js satisfying `^20.19.0 || ^22.13.0 || >=24` and refuses anything else), npm 10.9.2+,
-Docker Compose, Git, and the official Codex CLI already signed in under the same
-macOS account. Claude Code and Pi are optional.
+You need:
+
+- an Apple Silicon Mac
+- Node.js `22.17.0` (from `.nvmrc`) and npm 10.9.2+
+- Docker Compose and Git
+- the official Codex CLI signed in under the same macOS account
+  (Claude Code and Pi optional)
 
 ```sh
 git clone https://github.com/mosonlab/anneal.git
@@ -185,83 +123,44 @@ docker compose up -d --wait --wait-timeout 60 postgres
 npm run db:migrate:release -- --fresh
 ```
 
-Then start `npm run dev:api`, `npm run dev:runner` and `npm run dev:web`, in
-that order, in three terminals, and open `http://127.0.0.1:5173`.
-
-This is the short form. The literal sequence, including its filesystem, port,
-runner identity and repository preflights, is in
-[`docs/release/developer-preview.md`](docs/release/developer-preview.md),
-with the remaining installation detail in [`docs/install.md`](docs/install.md).
+Then start `npm run dev:api`, `npm run dev:runner` and `npm run dev:web`
+in three terminals, in that order, and open `http://127.0.0.1:5173`.
+The full sequence with its preflights is in
+[`docs/release/developer-preview.md`](docs/release/developer-preview.md).
 
 ## Status
 
-Developer Preview. What is supported, and the evidence behind every claim, is
-recorded in [`docs/release/support-matrix.md`](docs/release/support-matrix.md),
-the authoritative support statement. It describes evidence held in this
-repository, not compatibility promises by the CLI providers.
+Developer Preview 4 (v0.4.0): interfaces and stored data shapes may
+change between previews, and the only upgrade path is a fresh install.
+macOS on Apple Silicon only.
 
-Anneal targets macOS on Apple Silicon. Linux is unverified, and Windows is
-unsupported by design: the runner relies on POSIX process-group, path and
-command behavior.
+**Read before pointing this at anything you care about:** Anneal
+launches coding CLIs with non-interactive permission bypass, as your
+macOS user, outside a sandbox. Use a disposable repository and a machine
+you are willing to let an agent modify. Details in
+[`docs/release/security.md`](docs/release/security.md).
 
-Provider CLIs, accounts, authentication, subscriptions, usage allowances, rate
-limits, models, and provider-side availability remain yours. Anneal supplies no
-provider credential and no entitlement.
-
-## Authentication and subscriptions
-
-Anneal holds no provider credential. It launches the official CLIs you have
-already installed and signed in to (Codex CLI, Claude Code and Pi), and their
-authentication stays where each CLI keeps it, in that CLI's own configuration.
-Anneal neither reads it nor forwards it, and there is no Anneal account, no
-API proxy and no key to paste in.
-
-Whatever authentication those CLIs support is therefore what Anneal runs on: a
-ChatGPT subscription login, a Claude Pro/Max login, or each CLI's own API-key
-mode, exactly as you already configured it. Pi carries no account of its own
-either: it authenticates through the Codex login.
-
-You can check this. The runner constructs the
-child environment for the provider process rather than copying the host
-environment wholesale
-([`docs/architecture.md`](docs/architecture.md), `packages/runner/src/adapters/`),
-and the release check scans this checkout for token variables, bearer headers
-and `Authorization` ([`docs/release/security.md`](docs/release/security.md)).
-
-None of that settles a provider's terms for you. Plan limits,
-rate limits, usage allowances, and whether your plan permits this kind of
-orchestration are between you and the provider. Anneal grants no entitlement
-and makes no compatibility promise for a CLI provider.
+The provider CLIs, their authentication and their plan terms stay
+between you and the provider: Anneal neither reads nor forwards their
+credentials and grants no entitlement. The authoritative support
+statement is
+[`docs/release/support-matrix.md`](docs/release/support-matrix.md).
 
 ## Documentation
 
-- [Architecture and security model](docs/architecture.md): how the console,
-  API, runner and provider CLIs fit together, and what the grants do and do not
-  contain.
-- [Installation notes and verification](docs/install.md): environment file,
-  migrations, merge executor, and the check sequence.
-- [Security](docs/release/security.md): read before pointing this at
-  anything you care about.
-- [Migration and recovery](docs/release/migration-and-recovery.md): read
-  before putting data in it.
-- [Release notes](docs/release/v0.4.0-release-notes.md) ·
-  [Contributing](CONTRIBUTING.md)
-
-## Support
-
-Anneal is a personal project with no support or response-time commitments. Send
-security reports through the private channel in [`SECURITY.md`](SECURITY.md),
-and see [`docs/release/support-matrix.md`](docs/release/support-matrix.md) for
-the authoritative support statement.
+[Architecture](docs/architecture.md) ·
+[Install](docs/install.md) ·
+[Security](docs/release/security.md) ·
+[Migration and recovery](docs/release/migration-and-recovery.md) ·
+[Release notes](docs/release/v0.4.0-release-notes.md) ·
+[Contributing](CONTRIBUTING.md) ·
+[Support](SECURITY.md)
 
 ## Credits and license
 
-The chain's role and step prompts owe more than inspiration: five skills from
-[mattpocock/skills](https://github.com/mattpocock/skills) supply their working
-text, carried verbatim and wrapped in paragraphs written here for this
-platform's contracts. That work is MIT-licensed, `Copyright (c) 2026 Matt
-Pocock`, and the notice is in
-[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
-
-This snapshot is licensed under the [MIT License](LICENSE); the snapshot
-boundary is defined by [`public-snapshot.json`](public-snapshot.json).
+Five skills from
+[mattpocock/skills](https://github.com/mattpocock/skills) (MIT,
+Copyright (c) 2026 Matt Pocock) supply working text for the chain's
+prompts; see [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). This
+snapshot is licensed under the [MIT License](LICENSE), with its boundary
+defined by [`public-snapshot.json`](public-snapshot.json).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,151 +2,102 @@
 
 # Anneal
 
-**AI 现在能写代码了，但没人有能力审完它写的东西。**
+**你只写 spec，它清空看板。**
 
-Anneal 就是负责审的那一层：面向 coding agent 的本地控制平面。你只写规格，
-剩下的交给一条链——计划、评审、实现、验证、合入，每一次 run 都可观察、可评审。
+Anneal 是运行在你本机的 coding agent 控制平面。晚上把任务挂进看板，
+任务链会无人值守地完成计划、评审、实现、验证与合并——全程跑在你已经
+登录的 Codex 与 Claude 订阅上。
 
-*退火是消除金属加工后内应力的热处理工序。缺陷在工序里被消掉，而不是留到成品上。*
-
-[![status](https://img.shields.io/badge/status-developer%20preview-orange)](#支持状态)
+[![status](https://img.shields.io/badge/status-developer%20preview-orange)](#当前状态)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![platform](https://img.shields.io/badge/platform-macOS%20Apple%20Silicon-lightgrey)](#支持状态)
+[![platform](https://img.shields.io/badge/platform-macOS%20Apple%20Silicon-lightgrey)](#当前状态)
 [![node](https://img.shields.io/badge/node-22.17.0-brightgreen)](.nvmrc)
 
-[安装](#快速开始) · [文档](#文档) · [支持状态](#支持状态) · [English](README.md)
+[安装](#快速开始) · [工作原理](#工作原理) · [当前状态](#当前状态) · [English](README.md)
 
-<img src="docs/media/parallel-tasks.gif" alt="看板上的多个任务正在并行运行" width="880">
-
-</div>
-
-## 这是什么
-
-Anneal 把任务、agent、仓库与文件授权、独立的运行记录、provider 事件流、人工
-提问、评审关卡和 git 交付串成一个工作流，全部跑在你自己的机器上。
-
-它编排的是你已经安装并完成认证的官方 Codex CLI、Claude Code 与 Pi：这些 CLI
-手里已有的订阅登录，就是它运行所依赖的全部认证。Anneal 自己不提供任何凭据，
-也不转售任何订阅，详见[认证与订阅](#认证与订阅)。
-
-## 它改变了什么
-
-Full Assurance 任务链覆盖完整的交付路径：写规格、计划、计划评审、实现、两轮独立
-代码评审、应用修复、回归验证、合并就绪判定，直到合并本身；Direct 任务链省略规格与
-计划阶段。Agent 步骤带有自己的角色、提示词、模型与推理档位，机械执行的 readiness
-与 merge 步骤则没有。输出只流向模板声明的下游消费者，包括让两路并行评审结果共同
-进入 fix 步骤。
-
-链一旦启动就自行推进。需要你出面的只有三种时刻：agent 通过 Inbox 向你提问、你
-显式设为 gated 的步骤需要人工裁决、或者某次 run 升级（escalate）。其余时间它无人
-值守地跑，交付也在其中：推分支、可选地开 PR、并在 merge gate 之后合入。
-
-这改变的是你的瓶颈在哪里。吞吐取决于你注册了多少 runner，而不是你的工时：不同
-任务、不同仓库的链同时在飞，你在读评审产出，不在敲实现。
-
-长时程自治还没接线。Goal 能存能编辑，但没有任何东西从 Goal 调度工作，所以链仍然
-由你或 webhook 触发启动，而不是由一个常驻目标驱动。见
-[支持状态](#支持状态)。
-
-<div align="center">
-
-<img src="docs/media/agents.png" alt="Agents 视图：每个 agent 的角色、模型、推理档位与 runner" width="880">
-
-<sub>Agents：一个角色、一段提示词、一个模型与档位，以及它派往的 runner。</sub>
+<img src="docs/media/parallel-tasks.gif" alt="看板上多个任务并行推进" width="880">
 
 </div>
 
-## 看板列
+## 它服务的工作流
 
-看板展示工作在从意图到交付的流程中所处的位置。任务路由约定中的
-[Backlog 卡片生命周期](docs/governance/task-routing-v1.md#backlog-card-lifecycle)
-定义了卡片的创建、派发与归档；这里仅定义各列的语义。
+白天你只做一件事：写 spec。晚上把它们作为任务挂进看板。夜里，任务链
+接过每个任务并走完全程——计划、计划评审、实现、两次相互独立的代码评审、
+修复落地、回归验证，直至合并。第二天早上，你只读真正重要的 pull
+request，对在意的那几个开一个 agent 窗口，和 AI 迭代到满意为止。
 
-- **Backlog — 意图。** 尚未实例化、仍在完善、等待决定或被刻意搁置的 brief；
-  它尚未进入执行。对于无限期搁置的 HUMAN 卡片，在标题前加 `Parked:`。
-- **Todo — 可运行的执行项。** 规格记录已经确定、现在可运行或正在等待激活或
-  依赖解锁的已实例化链或步骤。入口边界很明确：未实例化的意图从 Backlog 进入
-  看板；已实例化的链及其步骤从 Todo 进入，再流转到后续各列。
-- **Doing — 正在执行。** runner 已激活 AGENT 任务，工作正在进行。
-- **Review — 等待生命周期决定。** AGENT 任务因 approval 或 review gate 暂停，
-  或出现需要先处理的 run 问题，链才能继续。
-- **Done — 已完成。** 任务或链步骤已经完成。
+在这些节点之间它不需要你。链只在三种情况下停下来等你：agent 通过
+Inbox 向你提问、你标记为 gated 的步骤需要人来决策、或某次运行升级
+（escalate）。你不必守在它前面；看板是你回来时要看的东西。
 
-operator 可以停止并搁置正在运行的链步骤；该步骤会以已搁置步骤的形式回到
-Backlog。请用 **Start now** 或 **Recover parked step** 恢复它，而不是用普通卡片
-派发流程。
+## 你得到什么
 
-Backlog 与 Todo 的状态流转以及将 HUMAN 任务标记为 Done 由 operator 负责；
-AGENT 任务的 Doing、Review 与 Done 状态流转由 runner 和链调度器负责。通常，
-operator 将已定稿的意图从 Backlog 移到 Todo，随后 runner 推动每个已实例化步骤
-依次经过 Doing、Review 与 Done。
+- **Spec 进，merge 出。** 一张任务卡最终成为一个分支、一个 pull
+  request 和一次通过 merge gate 的合并；中间的每个产物——计划、评审
+  发现、修复裁决、回归结果——都被记录、可回看。
+- **默认并行。** 不同任务、不同仓库的链同时在飞；吞吐量取决于你注册了
+  多少 runner，而不是你的工时。
+- **用你的订阅，不用 API key。** Anneal 启动的是你已经安装并登录的官方
+  Codex CLI、Claude Code 和 Pi。它自己不持有任何凭据，不做代理，也没有
+  任何要粘贴的 key。
+- **评审就是产品。** 每一步的输出都是下一步的输入，每次运行的记录都留
+  在你的机器上供你审计。
 
-## 它由自己的链构建
+## Anneal 由 Anneal 构建
 
-本仓库的 pull request，其规格、计划、评审、实现与合入，都由下面这条链在一台
-Mac 上完成。第一个预览版到第三个预览版之间的八天，从里面看就是这个样子。
+这个仓库里的 pull request 由 Anneal 自己的任务链完成规格、计划、评审、
+实现与合并，全部跑在一台 Mac 上。链交付的提交带有
+`Co-Authored-By: Anneal Chain` 以及 `X-Anneal-Run` / `X-Anneal-Step`
+trailer，你可以直接在 git log 里核对哪些提交出自链。
 
-链交付的 commit 在 git 历史里还没有明确的归属标记，所以这句话说的是工作方式，
-不是一个你现在就能核对的数字。把它变成可核对的，是下一个预览版的任务。
+## 工作原理
 
-## 十二步任务链
-
-Anneal 自带的 Full Assurance 模板。每一步绑定一个角色，每个角色自带 runner、
-模型与推理档位。
-
-下表里的 `Sol` 与 `Luna` 不是 Anneal 造的词，是 Codex CLI 暴露的 GPT-5.6 变体，
-绑定名为 `gpt-5.6-sol` 与 `gpt-5.6-luna`。
+链由模板实例化而来。每一步绑定一个 agent 角色——提示词、模型、推理档位
+以及执行它的 runner CLI；旗舰的 Full Assurance 模板用十二步覆盖整条交付
+路径。下表中的 `Sol` 和 `Luna` 是 Codex CLI 暴露的 GPT-5.6 变体。
 
 <details>
-<summary><b>十二步完整表</b> —— 每一步的角色、runner、模型与档位</summary>
+<summary><b>完整十二步</b>——每一步的角色、runner、模型与档位</summary>
 
 | # | 步骤 | Agent 角色 | 做什么 | Runner | 模型 · 档位 |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 写规格 | `spec` | 把任务转成作准的规格说明 | Claude | Claude Opus 5 · high |
-| 2 | 规划 | `plan` | 把规格切成可并行的垂直曳光弹切片 | Claude | Claude Fable 5 · medium |
-| 3 | 规划评审 | `review-coordinator` | 对着规格与冻结基线逐片评审 | Pi | GPT-5.6 Sol · xhigh |
-| 4 | 修订规划 | `plan-reviser` | 在全新会话里按评审结论就地改切片 | Codex | GPT-5.6 Sol · high |
-| 5 | 实现 | `implementation-plan-executioner` | 从活的依赖前沿执行切片集，并开出 PR | Codex | GPT-5.6 Sol · high，子代理为 GPT-5.6 Luna · max |
-| 6 | 代码评审 | `review-coordinator-sol` | 在钉死的 base 与 head 上评审集成后的 diff | Pi | GPT-5.6 Sol · xhigh |
-| 7 | 盲评 | `review-coordinator-opus` | 对同一份 diff 再评一次，看不到第 6 步的结论 | Claude | Claude Opus 5 · high |
-| 8 | 应用评审修复 | `senior-dev` | 对两份评审的每条结论逐条裁决，并落实采纳项 | Codex | GPT-5.6 Sol · high |
-| 9 | 文档 | `librarian` | 把内部文档更新到与交付代码一致 | Pi | GPT-5.6 Luna · xhigh |
+| 1 | 写 spec | `spec` | 把任务转为正式规格 | Claude | Claude Opus 5 · high |
+| 2 | 计划 | `plan` | 把规格切成可并行的垂直切片 | Claude | Claude Fable 5 · medium |
+| 3 | 计划评审 | `review-coordinator` | 对照规格与冻结基线评审每个切片 | Pi | GPT-5.6 Sol · xhigh |
+| 4 | 修订计划 | `plan-reviser` | 在全新会话中按评审发现修订切片集 | Codex | GPT-5.6 Sol · high |
+| 5 | 实现 | `implementation-plan-executioner` | 按依赖前沿执行切片集并开出 pull request | Codex | GPT-5.6 Sol · high，子代理 GPT-5.6 Luna · max |
+| 6 | 代码评审 | `review-coordinator-sol` | 在钉住的 base 与 head 上评审集成后的 diff | Pi | GPT-5.6 Sol · xhigh |
+| 7 | 盲评 | `review-coordinator-opus` | 对同一 diff 再评一次，看不到第 6 步的发现 | Claude | Claude Opus 5 · high |
+| 8 | 落地评审修复 | `senior-dev` | 裁决两轮评审的全部发现并落地采纳项 | Codex | GPT-5.6 Sol · high |
+| 9 | 文档 | `librarian` | 让内部文档与交付代码保持一致 | Pi | GPT-5.6 Luna · xhigh |
 | 10 | 回归验证 | `regression-verifier` | 刷新到目标分支并重跑回归 | Codex | GPT-5.6 Luna · max |
-| 11 | 合并就绪 | — | 重算 head，要求每份未结评审清空，签发精确 head 的合并授权 | — | 机械步，不跑模型 |
-| 12 | 执行合并 | `merge-integrator` | 对着线上 PR 重新校验每一项前置条件，然后合并 | — | 机械步，不跑模型 |
+| 11 | 合并就绪 | — | 重算 head，要求所有评审清零，签发精确到 head 的授权 | — | 机械步骤，无模型运行 |
+| 12 | 合并执行 | `merge-integrator` | 对照线上 pull request 复核全部前置条件后合并 | — | 机械步骤，无模型运行 |
 
 </details>
 
 <div align="center">
 
-<img src="docs/media/chain.png" alt="任务详情：十二步链的每一步及其角色与状态，上方是已完成的 run，下方是任务提示词" width="880">
+<img src="docs/media/chain.png" alt="任务详情：十二步链及各步角色与状态" width="880">
 
-<sub>运行中的一条链：第 4 步执行中，第 6、7 步作为并行同层等待。</sub>
+<sub>一条在飞的链：第 4 步运行中，第 6、7 步作为并行兄弟等待。</sub>
 
 </div>
 
-第 6、7 步是并行同层：盲评看不到对方的输出，由第 8 步一并裁决。第 5 步的根会话
-派发原生子代理，档位钉死在 Luna max，最多八个并发。
-
+第 6、7 步是并行兄弟：盲评看不到另一路的输出，第 8 步同时裁决两者。
 角色绑定在
 [`agents/templates/compound-engineer-workflow/`](agents/templates/compound-engineer-workflow)，
-模型在 [`agents/roles/`](agents/roles)。在控制台改过的模型或档位是持久化的运行时
-覆盖，后续 seed 不会替换它。
-
-> **Developer Preview 4（v0.4.0）。** 接口、配置与已存数据的形状都可能在预览版
-> 之间变动，预览版之间除全新安装外没有升级路径。
->
-> **裸机执行警告。** Anneal 会用非交互式 permission bypass 启动 coding CLI。
-> 默认安装下它们以你的 macOS 用户身份、在 sandbox 之外运行，拥有该用户的文件
-> 系统与网络权限。Anneal grant 约束的是 Anneal API，不构成 host containment。
-> 只用可丢弃仓库，以及你愿意让 agent 修改的机器。
+模型定义在 [`agents/roles/`](agents/roles)。看板各列的语义见
+[task-routing 契约](docs/governance/task-routing-v1.md)。
 
 ## 快速开始
 
-你需要一台 Apple Silicon Mac，以及 `.nvmrc` 记录的 Node.js `22.17.0`（安装强制要求
-Node.js 满足 `^20.19.0 || ^22.13.0 || >=24`，其余版本会被拒绝）、npm 10.9.2+、Docker Compose、
-Git，以及在同一 macOS 账号下**已安装且已登录**的官方 Codex CLI。Claude Code 与
-Pi 都是可选的。
+你需要：
+
+- Apple Silicon 的 Mac
+- Node.js `22.17.0`（见 `.nvmrc`）与 npm 10.9.2+
+- Docker Compose 与 Git
+- 在同一 macOS 账户下已登录的官方 Codex CLI（Claude Code 与 Pi 可选）
 
 ```sh
 git clone https://github.com/mosonlab/anneal.git
@@ -159,69 +110,39 @@ docker compose up -d --wait --wait-timeout 60 postgres
 npm run db:migrate:release -- --fresh
 ```
 
-随后在三个终端里依次启动 `npm run dev:api`、`npm run dev:runner`、
-`npm run dev:web`，并打开 `http://127.0.0.1:5173`。
+然后依次在三个终端启动 `npm run dev:api`、`npm run dev:runner`、
+`npm run dev:web`，打开 `http://127.0.0.1:5173`。完整流程与各项预检见
+[`docs/release/developer-preview.md`](docs/release/developer-preview.md)。
 
-以上是简写形式。包含文件系统、端口、runner identity 与仓库 preflight 的逐字序列
-在 [`docs/release/developer-preview.md`](docs/release/developer-preview.md)，
-其余安装细节在英文页面 [`docs/install.md`](docs/install.md)。除本页外，内部文档仅
-提供英文版。
+## 当前状态
 
-## 支持状态
+Developer Preview 4（v0.4.0）：接口与存储数据形态在 preview 之间可能
+变化，唯一升级路径是全新安装。仅支持 Apple Silicon 上的 macOS。
 
-Developer Preview。支持范围以及每一条主张背后的证据，记录在
-[`docs/release/support-matrix.md`](docs/release/support-matrix.md)，那是权威支持
-声明（仅英文）。它描述的是本仓库内记录的证据，不是 CLI provider 作出的兼容性
-承诺。
+**把它指向任何你在乎的东西之前先读这段：** Anneal 以非交互的权限旁路
+方式启动 coding CLI，以你的 macOS 用户身份运行，不在沙箱内。请使用可
+丢弃的仓库和一台你愿意让 agent 修改的机器。详见
+[`docs/release/security.md`](docs/release/security.md)。
 
-Anneal 的目标平台是 Apple Silicon 上的 macOS。Linux 未验证；Windows 按设计不
-支持：runner 依赖 POSIX 进程组、路径和命令行为。
-
-Provider CLI、账号、认证、订阅、用量、速率限制、模型和 provider 侧可用性均由你
-自己负责。Anneal 不提供 provider 凭据，也不提供使用资格。
-
-## 认证与订阅
-
-Anneal 不持有任何 provider 凭据。它启动的是你本机已经安装并登录的官方 CLI
-（Codex CLI、Claude Code 与 Pi），认证状态留在各个 CLI 自己的配置里，Anneal
-既不读取也不转发。这里没有 Anneal 账号，没有 API 反代，也没有要你粘贴的 key。
-
-因此这些 CLI 支持哪种认证，Anneal 就跑在哪种之上：ChatGPT 订阅登录、Claude
-Pro/Max 登录，或各 CLI 自己的 API key 模式，完全按你已经配好的样子。Pi 同样没有
-自己的账号，它走的是 Codex 那份登录。
-
-这一点你可以自己核实。runner 是为 provider 子进程构造环境，而不是整份复制
-宿主环境（[`docs/architecture.md`](docs/architecture.md)、
-`packages/runner/src/adapters/`）；发布检查会扫描这份 checkout 里的 token 变量、
-bearer header 与 `Authorization`（[`docs/release/security.md`](docs/release/security.md)）。
-
-这些都不能替你裁定 provider 的条款。套餐额度、速率限制、用量配额，以及你的套餐是否
-允许这种编排方式，都在你和 provider 之间。Anneal 不授予任何权益，也不替 CLI
-provider 作出兼容性承诺。
+Provider CLI、它们的认证与套餐条款始终在你和 provider 之间：Anneal 不
+读取、不转发它们的凭据，也不授予任何使用权。权威支持声明见
+[`docs/release/support-matrix.md`](docs/release/support-matrix.md)。
 
 ## 文档
 
-除本页外，内部文档仅提供英文版。
+[架构](docs/architecture.md) ·
+[安装](docs/install.md) ·
+[安全](docs/release/security.md) ·
+[迁移与恢复](docs/release/migration-and-recovery.md) ·
+[发布说明](docs/release/v0.4.0-release-notes.md) ·
+[贡献指南](CONTRIBUTING.md) ·
+[支持](SECURITY.md)
 
-- [架构与安全模型](docs/architecture.md)：控制台、API、runner 与 provider
-  CLI 如何拼在一起，以及 grant 约束了什么、没约束什么。
-- [安装细节与验证](docs/install.md)：环境文件、迁移、merge executor 与检查序列。
-- [安全](docs/release/security.md)：在把它指向任何你在乎的东西之前先读。
-- [迁移与恢复](docs/release/migration-and-recovery.md)：在往里放数据之前先读。
-- [发布说明](docs/release/v0.4.0-release-notes.md) · [贡献](CONTRIBUTING.md)
+## 致谢与许可
 
-## 支持
-
-Anneal 是个人项目，不承诺提供支持或响应时间。安全报告请通过
-[`SECURITY.md`](SECURITY.md) 中的私密渠道提交；权威支持声明见
-[`docs/release/support-matrix.md`](docs/release/support-matrix.md)。
-
-## 致谢与许可证
-
-任务链的角色与步骤提示词欠的不止是启发：其行文主体来自
-[mattpocock/skills](https://github.com/mattpocock/skills) 的五个技能，逐字沿用，
-外面包着为本平台契约另写的段落。上游以 MIT 授权，`Copyright (c) 2026 Matt
-Pocock`，声明在 [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。
-
-本快照以 [MIT License](LICENSE) 授权；快照边界由
+链提示词的工作文本采用了
+[mattpocock/skills](https://github.com/mattpocock/skills)（MIT，
+Copyright (c) 2026 Matt Pocock）中的五个技能，见
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。本快照以
+[MIT License](LICENSE) 许可，快照边界由
 [`public-snapshot.json`](public-snapshot.json) 定义。

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -104,3 +104,35 @@ A backlog card is a dispatch-ready brief waiting for a decision, not a work item
   3. Independent — dispatch in parallel, no justification needed; the merge tail and the deploy quiet window already serialize delivery.
   Serialize an independent pair anyway when the merge would be clean but the semantics unsafe — schema migrations touching the same tables, changes to the same fail-closed enforcement path, behavior coupled across disjoint files (examples, not a closed list).
 - Archive the card at the moment of instantiation. The archived card remains recoverable in the Archived view; re-dispatching its work is a new decision, not a revival of the card.
+
+## Board column semantics
+
+The board shows where work sits in the intent-to-delivery flow. The
+[Backlog card lifecycle](#backlog-card-lifecycle) defines card creation,
+dispatch, and archival; the definitions here cover the column semantics.
+
+- **Backlog — intent.** An un-instantiated brief that is still being refined,
+  awaits a decision, or is deliberately parked; it is not connected to
+  execution. For an indefinitely parked HUMAN card, prefix its title with
+  `Parked:`.
+- **Todo — runnable execution.** An instantiated chain or step whose
+  specification of record is final, runnable now or waiting for activation or
+  a dependency unlock. The entry boundary is explicit: un-instantiated intent
+  enters the board in Backlog; instantiated chains and their steps enter in
+  Todo and then move through the later columns.
+- **Doing — active execution.** The runner has activated an AGENT task and work
+  is in progress.
+- **Review — awaiting a lifecycle decision.** An AGENT task is paused for an
+  approval or review gate, or has surfaced a run issue that needs attention
+  before the chain can continue.
+- **Done — complete.** The task or chain step is finished.
+
+An operator can stop and park a running chain step, which returns it to Backlog
+as a parked step. Resume it with **Start now** or **Recover parked step**, not
+ordinary card dispatch.
+
+The operator owns Backlog and Todo transitions and marking HUMAN tasks Done.
+The runner and chain scheduler own Doing, Review, and Done transitions for
+AGENT tasks. In the usual flow, the operator moves finalized intent from
+Backlog to Todo, then the runner advances each instantiated step through Doing,
+Review, and Done.


### PR DESCRIPTION
Rewrites README.md and README.zh-CN.md for a first-time visitor: lead with the spec-in, board-cleared workflow, surface subscription reuse and Anneal-builds-Anneal (now verifiable via commit trailers), and compress Quick start, Status, auth and credits. Board column semantics move to docs/governance/task-routing-v1.md; the stale 'attribution not yet checkable' caveat is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnQLL2jyVM48vsuEnhUkxF