### PR TITLE
Candidate 06: encapsulate readiness claims in a handle

### DIFF
--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -32,22 +32,26 @@ import {
   type ReadinessInput,
 } from "./readiness-decision.js";
 import {
-  noteLeaseHandoff,
   releaseMergeLease,
   withMergeLease,
   type ReleaseMergeLease,
   type WithMergeLease,
 } from "./merge-lease.js";
 import type { MergeLeaseTarget } from "./merge-lease-hold.js";
+import {
+  claimReadinessStep,
+  READINESS_CLAIM_LEASE_MS,
+  type ReadinessClaimHandle,
+  type ReadinessLeaseOwnership,
+} from "./readiness-claim.js";
 
 export const readinessPollIntervalMs = (): number => {
   const raw = Number(process.env.MERGE_READINESS_POLL_INTERVAL_MS);
   return Number.isFinite(raw) && raw >= 250 ? Math.floor(raw) : 2_000;
 };
 
-const READINESS_CLAIM_PREFIX = "merge-readiness-claim:";
 export { READINESS_READ_BUDGET_MS };
-export const READINESS_CLAIM_LEASE_MS = 60_000;
+export { READINESS_CLAIM_LEASE_MS };
 const READINESS_CANDIDATE_INCLUDE = {
   templateStep: { include: { taskTemplate: { select: { name: true } } } },
   repo: true,
@@ -205,32 +209,6 @@ const recoveryContextFor = async (
   return recoveryContext(row);
 };
 
-const readinessClaim = (now: Date): string => (
-  `${READINESS_CLAIM_PREFIX}${randomUUID()}|${new Date(now.getTime() + READINESS_CLAIM_LEASE_MS).toISOString()}`
-);
-
-const expiredReadinessClaim = (reason: string | null, now: Date): boolean => {
-  if (!reason?.startsWith(READINESS_CLAIM_PREFIX)) return false;
-  const expiry = Date.parse(reason.slice(reason.lastIndexOf("|") + 1));
-  return Number.isFinite(expiry) && expiry <= now.getTime();
-};
-
-const renewReadinessClaim = async (
-  db: PrismaClient,
-  readinessTaskId: string,
-  claimReason: string,
-): Promise<string | null> => {
-  const renewed = readinessClaim(new Date());
-  const held = await db.$transaction(async (tx) => {
-    await lockTaskMutationRows(tx, readinessTaskId);
-    return tx.task.updateMany({
-      where: { id: readinessTaskId, status: TaskStatus.DOING, failureReason: claimReason },
-      data: { failureReason: renewed },
-    });
-  });
-  return held.count === 1 ? renewed : null;
-};
-
 const stopReadiness = async (
   db: PrismaClient,
   input: {
@@ -238,34 +216,38 @@ const stopReadiness = async (
     regressionTaskId: string;
     reason: string;
     recovery: RecoveryContext | null;
-    claimReason: string;
   },
-  releaseChainLease: ReleaseMergeLease,
-): Promise<boolean> => {
-  const transition = await db.$transaction(async (tx) => {
-    await lockTaskMutationRows(tx, input.readinessTaskId);
-    const held = await tx.task.updateMany({
-      where: { id: input.readinessTaskId, status: TaskStatus.DOING, failureReason: input.claimReason },
-      data: { failureReason: input.claimReason },
-    });
-    if (held.count !== 1) return { applied: false as const, leaseToRelease: null };
-    const stopped = await stopMergeTail(tx, {
-      phase: "readiness",
-      readinessTaskId: input.readinessTaskId,
-      regressionTaskId: input.regressionTaskId,
-      reason: input.reason,
-      recovery: input.recovery,
-      at: new Date(),
-    });
-    return { applied: true as const, leaseToRelease: stopped.leaseToRelease };
+  claim: ReadinessClaimHandle,
+): Promise<{
+  applied: boolean;
+  leaseToRelease: MergeLeaseTarget | null;
+  ownership: ReadinessLeaseOwnership;
+}> => db.$transaction(async (tx) => {
+  const settlement = await claim.settle(tx, {
+    kind: "finish",
+    at: new Date(),
+    apply: async (client) => {
+      const stopped = await stopMergeTail(client, {
+        phase: "readiness",
+        readinessTaskId: input.readinessTaskId,
+        regressionTaskId: input.regressionTaskId,
+        reason: input.reason,
+        recovery: input.recovery,
+        at: new Date(),
+      });
+      return { value: stopped, ownership: "released" as const };
+    },
   });
-  if (!transition.applied) return false;
-  // `stopMergeTail` resolves the owning project and chain while the mutation is
-  // locked. Pass that target through unchanged so a shared chainId cannot be
-  // attributed to the readiness project's neighboring tail.
-  await releaseChainLease(transition.leaseToRelease, db);
-  return true;
-};
+  if (!settlement.settled) {
+    return { applied: false, leaseToRelease: null, ownership: settlement.ownership };
+  }
+  if (settlement.claim !== "released") throw new Error("Readiness stop retained a finished claim");
+  return {
+    applied: true,
+    leaseToRelease: settlement.value.leaseToRelease,
+    ownership: settlement.ownership,
+  };
+});
 
 export type ReadinessTickResult = { claimed: number; authorized: number; requeued: number; stopped: number };
 
@@ -279,63 +261,73 @@ const requeueRegression = async (
     reason: string;
     now: Date;
     recovery: RecoveryContext | null;
-    claimReason: string;
   },
-): Promise<boolean> => db.$transaction(async (tx) => {
-    await lockTaskMutationRows(tx, input.readinessTaskId);
-    const held = await tx.task.updateMany({
-      where: { id: input.readinessTaskId, status: TaskStatus.DOING, failureReason: input.claimReason },
-      data: { status: TaskStatus.TODO, failureReason: null },
-    });
-    if (held.count !== 1) return false;
-    await tx.task.update({ where: { id: input.regressionTaskId }, data: { status: TaskStatus.TODO, failureReason: null } });
-    // The prior Regression run succeeded; the control plane invalidated its
-    // exact-base evidence after a remote read. This retry is therefore external
-    // compensation, not another attempt charged to the agent. Without the
-    // grant, a requeue at the configured ceiling creates run N+1 with ceiling N
-    // and the runner rejects it before launch -- exactly the stuck state the
-    // readiness transition was supposed to recover.
-    const run = await enqueueTaskRun(tx, input.regressionTaskId, input.now, { budgetGrant: 1 });
-    if (input.recovery) {
-      await tx.mergeRecoveryAttempt.update({ where: { id: input.recovery.aggregateId }, data: {
-        status: MergeRecoveryStatus.REPAIRING,
-        recoveryRunId: run.id,
-        currentBaseSha: input.currentBaseSha,
-        failureReason: null,
-        endedAt: null,
-      } });
-      const body = `Automatic base-drift recovery ${String(input.recovery.attempt)} context carried through readiness requeue`;
-      const metadata = {
-        ...input.recovery,
-        currentBaseSha: input.currentBaseSha,
-        recoveryRunId: run.id,
-      } as Prisma.InputJsonObject;
-      await tx.taskActivity.createMany({ data: [
-        {
-          taskId: input.recovery.integratorTaskId,
-          actorType: "control-plane",
-          body,
-          metadata,
+  claim: ReadinessClaimHandle,
+): Promise<{ applied: boolean; ownership: ReadinessLeaseOwnership }> => db.$transaction(async (tx) => {
+  const settlement = await claim.settle(tx, {
+    kind: "finish",
+    at: input.now,
+    apply: async (client) => {
+      await client.task.update({
+        where: { id: input.readinessTaskId },
+        data: { status: TaskStatus.TODO, failureReason: null },
+      });
+      await client.task.update({
+        where: { id: input.regressionTaskId },
+        data: { status: TaskStatus.TODO, failureReason: null },
+      });
+      // The prior Regression run succeeded; the control plane invalidated its
+      // exact-base evidence after a remote read. This retry is therefore external
+      // compensation, not another attempt charged to the agent. Without the
+      // grant, a requeue at the configured ceiling creates run N+1 with ceiling N
+      // and the runner rejects it before launch -- exactly the stuck state the
+      // readiness transition was supposed to recover.
+      const run = await enqueueTaskRun(client, input.regressionTaskId, input.now, { budgetGrant: 1 });
+      if (input.recovery) {
+        await client.mergeRecoveryAttempt.update({ where: { id: input.recovery.aggregateId }, data: {
+          status: MergeRecoveryStatus.REPAIRING,
+          recoveryRunId: run.id,
+          currentBaseSha: input.currentBaseSha,
+          failureReason: null,
+          endedAt: null,
+        } });
+        const body = `Automatic base-drift recovery ${String(input.recovery.attempt)} context carried through readiness requeue`;
+        const metadata = {
+          ...input.recovery,
+          currentBaseSha: input.currentBaseSha,
+          recoveryRunId: run.id,
+        } as Prisma.InputJsonObject;
+        await client.taskActivity.createMany({ data: [
+          {
+            taskId: input.recovery.integratorTaskId,
+            actorType: "control-plane",
+            body,
+            metadata,
+          },
+          {
+            taskId: input.regressionTaskId,
+            actorType: "control-plane",
+            body,
+            metadata,
+          },
+        ] });
+      }
+      await writeMarker(client, input.regressionTaskId, "readiness", {
+        actorType: "control-plane",
+        body: `Merge readiness returned to regression: ${input.reason}; ${input.staleBaseSha} -> ${input.currentBaseSha}`,
+        metadata: {
+          state: "requeued-regression",
+          reason: input.reason,
+          staleBaseSha: input.staleBaseSha,
+          currentBaseSha: input.currentBaseSha,
         },
-        {
-          taskId: input.regressionTaskId,
-          actorType: "control-plane",
-          body,
-          metadata,
-        },
-      ] });
-    }
-    await writeMarker(tx, input.regressionTaskId, "readiness", {
-      actorType: "control-plane",
-      body: `Merge readiness returned to regression: ${input.reason}; ${input.staleBaseSha} -> ${input.currentBaseSha}`,
-      metadata: {
-        state: "requeued-regression",
-        reason: input.reason,
-        staleBaseSha: input.staleBaseSha,
-        currentBaseSha: input.currentBaseSha,
-      },
-    });
-    return true;
+      });
+      return { value: undefined, ownership: "released" as const };
+    },
+  });
+  if (!settlement.settled) return { applied: false, ownership: settlement.ownership };
+  if (settlement.claim !== "released") throw new Error("Regression requeue retained a finished claim");
+  return { applied: true, ownership: settlement.ownership };
 });
 
 type ClaimedReadiness = {
@@ -343,7 +335,7 @@ type ClaimedReadiness = {
   readiness: ReadinessCandidate;
   regression: ReadinessRegression;
   recovery: RecoveryContext | null;
-  claimReason: string;
+  claim: ReadinessClaimHandle;
   input: ReadinessInput;
 };
 
@@ -378,21 +370,8 @@ const readReadiness = async (
     return { claimed: false, input: { ...context, stage: "regression-pending" } };
   }
 
-  const claimReason = readinessClaim(now);
-  const claimWhere = readiness.status === TaskStatus.TODO
-    ? { id: readiness.id, status: TaskStatus.TODO }
-    : expiredReadinessClaim(readiness.failureReason, now)
-      ? { id: readiness.id, status: TaskStatus.DOING, failureReason: readiness.failureReason }
-      : null;
-  if (!claimWhere) return { claimed: false, input: { ...context, stage: "claim-lost" } };
-  const claimed = await db.$transaction(async (tx) => {
-    await lockTaskMutationRows(tx, readiness.id);
-    return tx.task.updateMany({
-      where: claimWhere,
-      data: { status: TaskStatus.DOING, failureReason: claimReason },
-    });
-  });
-  if (claimed.count !== 1) return { claimed: false, input: { ...context, stage: "claim-lost" } };
+  const claim = await claimReadinessStep(db, readiness.id, now);
+  if (!claim) return { claimed: false, input: { ...context, stage: "claim-lost" } };
 
   let recovery: RecoveryContext | null = null;
   try {
@@ -408,7 +387,7 @@ const readReadiness = async (
       readiness,
       regression,
       recovery,
-      claimReason,
+      claim,
       input,
     });
     if (!regression.stepOutput) {
@@ -437,7 +416,7 @@ const readReadiness = async (
       readiness,
       regression,
       recovery,
-      claimReason,
+      claim,
       input: { ...context, stage: "read-failed", failure: { kind: "unexpected", message } },
     };
   }
@@ -446,50 +425,55 @@ const readReadiness = async (
 const deferReadiness = async (
   db: PrismaClient,
   readinessTaskId: string,
-  claimReason: string,
-): Promise<boolean> => db.$transaction(async (tx) => {
-  await lockTaskMutationRows(tx, readinessTaskId);
-  const deferred = await tx.task.updateMany({
-    where: { id: readinessTaskId, status: TaskStatus.DOING, failureReason: claimReason },
-    data: { status: TaskStatus.TODO, failureReason: null },
+  claim: ReadinessClaimHandle,
+): Promise<{ applied: boolean; ownership: ReadinessLeaseOwnership }> => db.$transaction(async (tx) => {
+  const settlement = await claim.settle(tx, {
+    kind: "finish",
+    at: new Date(),
+    apply: async (client) => {
+      await client.task.update({
+        where: { id: readinessTaskId },
+        data: { status: TaskStatus.TODO, failureReason: null },
+      });
+      return { value: undefined, ownership: "released" as const };
+    },
   });
-  return deferred.count === 1;
+  if (!settlement.settled) return { applied: false, ownership: settlement.ownership };
+  if (settlement.claim !== "released") throw new Error("Readiness defer retained a finished claim");
+  return { applied: true, ownership: settlement.ownership };
 });
 
 const recordLeaseDeferral = async (
   db: PrismaClient,
   input: {
     readinessTaskId: string;
-    claimReason: string;
     chainId: string | null;
     detail: string;
     at: Date;
   },
+  claim: ReadinessClaimHandle,
 ): Promise<boolean> => db.$transaction(async (tx) => {
-  await lockTaskMutationRows(tx, input.readinessTaskId);
-  const held = await tx.task.updateMany({
-    where: {
-      id: input.readinessTaskId,
-      status: TaskStatus.DOING,
-      failureReason: input.claimReason,
-    },
-    data: { failureReason: input.claimReason },
+  const settlement = await claim.settle(tx, {
+    kind: "keep",
+    apply: async (client) => client.taskActivity.create({ data: {
+      taskId: input.readinessTaskId,
+      actorType: "control-plane",
+      body: `Merge lease acquisition deferred: ${input.detail}`,
+      metadata: {
+        kind: MERGE_TAIL_KIND.readiness,
+        state: "lease-acquire-deferred",
+        chainId: input.chainId,
+        detail: input.detail,
+        retryAfter: new Date(input.at.getTime() + READINESS_CLAIM_LEASE_MS).toISOString(),
+      },
+    } }),
   });
-  if (held.count !== 1) return false;
-  await tx.taskActivity.create({ data: {
-    taskId: input.readinessTaskId,
-    actorType: "control-plane",
-    body: `Merge lease acquisition deferred: ${input.detail}`,
-    metadata: {
-      kind: MERGE_TAIL_KIND.readiness,
-      state: "lease-acquire-deferred",
-      chainId: input.chainId,
-      detail: input.detail,
-      retryAfter: new Date(input.at.getTime() + READINESS_CLAIM_LEASE_MS).toISOString(),
-    },
-  } });
-  return true;
+  return settlement.settled;
 });
+
+const leaseDisposition = (ownership: ReadinessLeaseOwnership) => ownership === "released"
+  ? { kind: "release" as const }
+  : { kind: "retain" as const, handoffRunId: ownership.retainFor };
 
 const applyReadinessDecision = async (
   db: PrismaClient,
@@ -500,18 +484,21 @@ const applyReadinessDecision = async (
   runWithMergeLease: WithMergeLease,
   reader: PullRequestReader | null,
 ): Promise<void> => {
-  const { readiness, regression, recovery } = read;
-  let claimReason = read.claimReason;
+  const { readiness, regression, recovery, claim } = read;
+  const target: MergeLeaseTarget | null = readiness.chainId
+    ? { projectId: readiness.projectId, chainId: readiness.chainId }
+    : null;
   const stop = async (reason: string): Promise<boolean> => {
     const stopped = await stopReadiness(db, {
       readinessTaskId: readiness.id,
       regressionTaskId: regression.id,
       reason,
       recovery,
-      claimReason,
-    }, releaseChainLease);
-    if (stopped) result.stopped += 1;
-    return stopped;
+    }, claim);
+    if (!stopped.applied) return false;
+    result.stopped += 1;
+    await releaseChainLease(stopped.leaseToRelease, db);
+    return true;
   };
   const requeue = async (input: {
     staleBaseSha: string;
@@ -524,23 +511,18 @@ const applyReadinessDecision = async (
       ...input,
       now: read.input.now,
       recovery,
-      claimReason,
-    });
-    if (requeued) {
-      result.requeued += 1;
-      const target: MergeLeaseTarget | null = readiness.chainId
-        ? { projectId: readiness.projectId, chainId: readiness.chainId }
-        : null;
-      await releaseChainLease(target, db);
-    }
-    return requeued;
+    }, claim);
+    if (!requeued.applied) return false;
+    result.requeued += 1;
+    await releaseChainLease(target, db);
+    return true;
   };
 
   switch (decision.kind) {
     case "skip":
       return;
     case "defer":
-      await deferReadiness(db, readiness.id, claimReason);
+      await deferReadiness(db, readiness.id, claim);
       return;
     case "stop":
       await stop(decision.evidence);
@@ -553,47 +535,13 @@ const applyReadinessDecision = async (
   }
 
   // From the base this authorization pins to the merge that consumes it,
-  // `main` must not move. The callback makes the sole lawful handoff explicit:
-  // only an authorized mechanical merge retains the Lease.
-  const target: MergeLeaseTarget | null = readiness.chainId
-    ? { projectId: readiness.projectId, chainId: readiness.chainId }
-    : null;
+  // `main` must not move. The Handle records the successor Run before its
+  // transition can return retained Lease ownership.
   const leased = await runWithMergeLease(target, async () => {
-    // The acquire is the only network call outside the GitHub read budget. A
-    // stale worker that lost its claim while taking the Lease must classify the
-    // new owner before choosing release or retain.
-    const renewedClaim = await renewReadinessClaim(db, readiness.id, claimReason);
-    if (!renewedClaim) {
-      const current = await db.task.findUnique({
-        where: { id: readiness.id },
-        select: { status: true, failureReason: true },
-      });
-      const activeSuccessor = current?.status === TaskStatus.DONE
-        || (current?.status === TaskStatus.DOING
-          && current.failureReason?.startsWith(READINESS_CLAIM_PREFIX));
-      const handoff = activeSuccessor && readiness.chainId
-        ? await db.run.findFirst({
-          where: {
-            task: {
-              projectId: readiness.projectId,
-              chainId: readiness.chainId,
-              chainIndex: { gt: readiness.chainIndex ?? -1 },
-            },
-            status: { in: [RunStatus.QUEUED, RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING] },
-          },
-          select: { id: true },
-          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-        })
-        : null;
-      return {
-        disposition: handoff
-          ? { kind: "retain" as const, handoffRunId: handoff.id }
-          : { kind: "release" as const },
-        value: activeSuccessor ? "claim-lost-active" as const : "claim-lost-inactive" as const,
-      };
+    if (!await claim.renew()) {
+      const ownership = await claim.ownershipAfterLoss(db);
+      return { disposition: leaseDisposition(ownership), value: "claim-lost" as const };
     }
-    claimReason = renewedClaim;
-    read.claimReason = renewedClaim;
 
     // Regression evidence is durable before this short Lease window. Repeat
     // the remote decision after acquisition so a base move between the first
@@ -602,19 +550,19 @@ const applyReadinessDecision = async (
     switch (leasedDecision.kind) {
       case "skip":
         return { disposition: { kind: "release" as const }, value: "lease-recheck-skipped" as const };
-      case "defer":
-        await deferReadiness(db, readiness.id, claimReason);
-        return { disposition: { kind: "release" as const }, value: "lease-recheck-deferred" as const };
+      case "defer": {
+        const deferred = await deferReadiness(db, readiness.id, claim);
+        return { disposition: leaseDisposition(deferred.ownership), value: "lease-recheck-deferred" as const };
+      }
       case "stop": {
         const stopped = await stopReadiness(db, {
           readinessTaskId: readiness.id,
           regressionTaskId: regression.id,
           reason: leasedDecision.evidence,
           recovery,
-          claimReason,
-        }, async () => undefined);
-        if (stopped) result.stopped += 1;
-        return { disposition: { kind: "release" as const }, value: "lease-recheck-stopped" as const };
+        }, claim);
+        if (stopped.applied) result.stopped += 1;
+        return { disposition: leaseDisposition(stopped.ownership), value: "lease-recheck-stopped" as const };
       }
       case "requeue-regression": {
         const requeued = await requeueRegression(db, {
@@ -623,175 +571,142 @@ const applyReadinessDecision = async (
           ...leasedDecision,
           now: read.input.now,
           recovery,
-          claimReason,
-        });
-        if (requeued) result.requeued += 1;
-        return { disposition: { kind: "release" as const }, value: "lease-recheck-requeued" as const };
+        }, claim);
+        if (requeued.applied) result.requeued += 1;
+        return { disposition: leaseDisposition(requeued.ownership), value: "lease-recheck-requeued" as const };
       }
       case "authorize":
         break;
     }
 
-    const authorization = await db.$transaction(async (tx) => {
-      await lockTaskMutationRows(tx, readiness.id);
-      const held = await tx.task.updateMany({
-        where: { id: readiness.id, status: TaskStatus.DOING, failureReason: claimReason },
-        data: { status: TaskStatus.DONE, failureReason: null },
-      });
-      if (held.count !== 1) {
-        const current = await tx.task.findUnique({
+    const authorization = await db.$transaction((tx) => claim.settle(tx, {
+      kind: "finish",
+      at: read.input.now,
+      apply: async (client) => {
+        await client.task.update({
           where: { id: readiness.id },
-          select: { status: true, failureReason: true },
+          data: { status: TaskStatus.DONE, failureReason: null },
         });
-        const activeSuccessor = current?.status === TaskStatus.DONE
-          || (current?.status === TaskStatus.DOING
-            && current.failureReason?.startsWith(READINESS_CLAIM_PREFIX));
-        const handoff = activeSuccessor && readiness.chainId
-          ? await tx.run.findFirst({
+        const binding = `mechanical:${readiness.id}:${randomUUID()}`;
+        const payload = {
+          ...leasedDecision.evidence,
+          mergeMethod: AUTHORIZED_MERGE_METHOD,
+          issuedAt: leasedDecision.issuedAt,
+          decision: {
+            channel: "mechanical" as const,
+            inboxDecisionId: binding,
+            inboxMessageId: binding,
+          },
+        };
+        if (recovery) {
+          // Recovery regression merges the current base before it proves the
+          // candidate, so its gated head may legitimately replace the head that
+          // first stopped on base drift. Adopt only the head re-read under the
+          // merge Lease and bind the CAS to the pre-Lease recovery snapshot.
+          const adopted = await client.mergeRecoveryAttempt.updateMany({
             where: {
-              task: {
-                projectId: readiness.projectId,
-                chainId: readiness.chainId,
-                chainIndex: { gt: readiness.chainIndex ?? -1 },
-              },
-              status: { in: [RunStatus.QUEUED, RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING] },
+              id: recovery.aggregateId,
+              status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
+              recoveryRunId: recovery.recoveryRunId,
+              currentBaseSha: recovery.currentBaseSha,
+              authorizedHeadSha: recovery.authorizedHeadSha,
             },
+            data: {
+              currentBaseSha: leasedDecision.evidence.baseSha,
+              authorizedHeadSha: leasedDecision.evidence.headSha,
+            },
+          });
+          if (adopted.count !== 1) {
+            throw new Error("Recovery authorization could not adopt the verified regression head");
+          }
+        }
+        const activity = await client.taskActivity.create({ data: {
+          taskId: readiness.id,
+          actorType: "control-plane",
+          body: `Mechanical merge authorized for PR #${leasedDecision.prNumber} at ${leasedDecision.evidence.headSha}`,
+          metadata: {
+            ...authorizationMetadata(payload),
+            recoverySourceStopId: recovery?.sourceStopId ?? null,
+          } as Prisma.InputJsonObject,
+        } });
+        await client.taskStepOutput.upsert({
+          where: { taskId: readiness.id },
+          create: {
+            taskId: readiness.id,
+            kind: "merge-authorization",
+            body: JSON.stringify({
+              authorizationActivityId: activity.id,
+              headSha: leasedDecision.evidence.headSha,
+            }),
+            commitSha: leasedDecision.evidence.headSha,
+          },
+          update: {
+            kind: "merge-authorization",
+            body: JSON.stringify({
+              authorizationActivityId: activity.id,
+              headSha: leasedDecision.evidence.headSha,
+            }),
+            commitSha: leasedDecision.evidence.headSha,
+          },
+        });
+        await client.task.update({ where: { id: regression.id }, data: { failureReason: null } });
+        if (leasedDecision.auditTriggers.length > 0) {
+          await openDefenseAuditNotice(client, {
+            readinessTaskId: readiness.id,
+            headSha: leasedDecision.headSha,
+            baseSha: leasedDecision.baseSha,
+            triggers: leasedDecision.auditTriggers,
+          });
+        }
+        await writeMarker(client, readiness.id, "readiness", {
+          actorType: "control-plane",
+          body: `Merge readiness authorized exact head ${leasedDecision.evidence.headSha}; merge execution queued`,
+          metadata: {
+            state: "authorized",
+            headSha: leasedDecision.evidence.headSha,
+            authorizationActivityId: activity.id,
+            recoverySourceStopId: recovery?.sourceStopId ?? null,
+          },
+        });
+        const activated = recovery
+          ? await activateRecoveryIntegratorSuccessor(client, {
+            readinessTaskId: readiness.id,
+            integratorTaskId: recovery.integratorTaskId,
+            sourceStopId: recovery.sourceStopId,
+            recoveryRunId: recovery.recoveryRunId,
+            authorizationActivityId: activity.id,
+          }, read.input.now)
+          : await activateChainSuccessor(client, readiness, {}, read.input.now);
+        const handoff = activated.nextTaskId
+          ? await client.run.findFirst({
+            where: { taskId: activated.nextTaskId, status: RunStatus.QUEUED },
             select: { id: true },
-            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+            orderBy: { runNumber: "desc" },
           })
           : null;
         return {
-          kind: activeSuccessor ? "claim-lost-active" as const : "claim-lost-inactive" as const,
-          handoffRunId: handoff?.id ?? null,
+          value: "authorized" as const,
+          ownership: handoff ? { retainFor: handoff.id } : "released" as const,
         };
-      }
-      const binding = `mechanical:${readiness.id}:${randomUUID()}`;
-      const payload = {
-        ...leasedDecision.evidence,
-        mergeMethod: AUTHORIZED_MERGE_METHOD,
-        issuedAt: leasedDecision.issuedAt,
-        decision: {
-          channel: "mechanical" as const,
-          inboxDecisionId: binding,
-          inboxMessageId: binding,
-        },
-      };
-      if (recovery) {
-        // Recovery regression merges the current base before it proves the
-        // candidate, so its gated head may legitimately replace the head that
-        // first stopped on base drift. Adopt only the head re-read under the
-        // merge lease. Bind the CAS to the pre-lease recovery snapshot, then
-        // adopt both exact evidence fields atomically.
-        const adopted = await tx.mergeRecoveryAttempt.updateMany({
-          where: {
-            id: recovery.aggregateId,
-            status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
-            recoveryRunId: recovery.recoveryRunId,
-            currentBaseSha: recovery.currentBaseSha,
-            authorizedHeadSha: recovery.authorizedHeadSha,
-          },
-          data: {
-            currentBaseSha: leasedDecision.evidence.baseSha,
-            authorizedHeadSha: leasedDecision.evidence.headSha,
-          },
-        });
-        if (adopted.count !== 1) {
-          throw new Error("Recovery authorization could not adopt the verified regression head");
-        }
-      }
-      const activity = await tx.taskActivity.create({ data: {
-        taskId: readiness.id,
-        actorType: "control-plane",
-        body: `Mechanical merge authorized for PR #${leasedDecision.prNumber} at ${leasedDecision.evidence.headSha}`,
-        metadata: {
-          ...authorizationMetadata(payload),
-          recoverySourceStopId: recovery?.sourceStopId ?? null,
-        } as Prisma.InputJsonObject,
-      } });
-      await tx.taskStepOutput.upsert({
-        where: { taskId: readiness.id },
-        create: {
-          taskId: readiness.id,
-          kind: "merge-authorization",
-          body: JSON.stringify({
-            authorizationActivityId: activity.id,
-            headSha: leasedDecision.evidence.headSha,
-          }),
-          commitSha: leasedDecision.evidence.headSha,
-        },
-        update: {
-          kind: "merge-authorization",
-          body: JSON.stringify({
-            authorizationActivityId: activity.id,
-            headSha: leasedDecision.evidence.headSha,
-          }),
-          commitSha: leasedDecision.evidence.headSha,
-        },
-      });
-      await tx.task.update({ where: { id: regression.id }, data: { failureReason: null } });
-      // The defence list no longer holds a merge. What it still does is say
-      // which of these paths a human would want to have seen move, so the
-      // merge leaves an audit message behind instead of a review obligation.
-      if (leasedDecision.auditTriggers.length > 0) {
-        await openDefenseAuditNotice(tx, {
-          readinessTaskId: readiness.id,
-          headSha: leasedDecision.headSha,
-          baseSha: leasedDecision.baseSha,
-          triggers: leasedDecision.auditTriggers,
-        });
-      }
-      await writeMarker(tx, readiness.id, "readiness", {
-        actorType: "control-plane",
-        body: `Merge readiness authorized exact head ${leasedDecision.evidence.headSha}; merge execution queued`,
-        metadata: {
-          state: "authorized",
-          headSha: leasedDecision.evidence.headSha,
-          authorizationActivityId: activity.id,
-          recoverySourceStopId: recovery?.sourceStopId ?? null,
-        },
-      });
-      const activated = recovery
-        ? await activateRecoveryIntegratorSuccessor(tx, {
-          readinessTaskId: readiness.id,
-          integratorTaskId: recovery.integratorTaskId,
-          sourceStopId: recovery.sourceStopId,
-          recoveryRunId: recovery.recoveryRunId,
-          authorizationActivityId: activity.id,
-        }, read.input.now)
-        : await activateChainSuccessor(tx, readiness, {}, read.input.now);
-      const handoff = activated.nextTaskId
-        ? await tx.run.findFirst({
-          where: { taskId: activated.nextTaskId, status: RunStatus.QUEUED },
-          select: { id: true },
-          orderBy: { runNumber: "desc" },
-        })
-        : null;
-      if (handoff && readiness.chainId) {
-        await noteLeaseHandoff(tx, { chainId: readiness.chainId, toRunId: handoff.id, at: read.input.now });
-      }
-      return { kind: "authorized" as const, handoffRunId: handoff?.id ?? null };
-    });
-    return {
-      disposition: authorization.handoffRunId
-        ? { kind: "retain" as const, handoffRunId: authorization.handoffRunId }
-        : { kind: "release" as const },
-      value: authorization.kind,
-    };
+      },
+    }));
+    if (!authorization.settled) {
+      return { disposition: leaseDisposition(authorization.ownership), value: "claim-lost" as const };
+    }
+    if (authorization.claim !== "released") throw new Error("Authorization retained a finished claim");
+    return { disposition: leaseDisposition(authorization.ownership), value: authorization.value };
   }, db);
   if (leased.outcome === "contended") return;
   if (leased.outcome === "unreachable") {
     await recordLeaseDeferral(db, {
       readinessTaskId: readiness.id,
-      claimReason,
       chainId: readiness.chainId,
       detail: leased.detail,
       at: read.input.now,
-    });
+    }, claim);
     return;
   }
-  if (leased.value === "authorized") {
-    result.authorized += 1;
-  }
+  if (leased.value === "authorized") result.authorized += 1;
 };
 
 export const readinessTick = async (
@@ -829,14 +744,16 @@ export const readinessTick = async (
         regressionTaskId: read.regression.id,
         reason,
         recovery: read.recovery,
-        claimReason: read.claimReason,
-      }, releaseChainLease);
-      if (stopped) result.stopped += 1;
+      }, read.claim);
+      if (stopped.applied) {
+        result.stopped += 1;
+        await releaseChainLease(stopped.leaseToRelease, db);
+      }
       // A failed release/hold recording can happen after stopMergeTail has
       // already committed its state transition. A second stop then returns
       // false and must not turn that failure into a successful-looking tick.
       // Surface it to the worker caller so the missing evidence is observable.
-      if (!stopped) throw error;
+      if (!stopped.applied) throw error;
     }
   }
   return result;

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -90,7 +90,8 @@ after(async () => { await db.$disconnect(); });
 const HEAD = "a".repeat(40);
 const BASE = "b".repeat(40);
 const BRANCH = "agentos/merge-tail-test";
-const NEWER_CLAIM = "merge-readiness-claim:new-worker|2099-01-01T00:00:00.000Z";
+const NEWER_CLAIM_TOKEN = "new-worker-token";
+const NEWER_CLAIM_EXPIRY = new Date("2099-01-01T00:00:00.000Z");
 const CONFIRMED_RELEASED_AT = new Date("2026-08-27T12:01:02.999Z");
 
 const snapshot = (overrides: Partial<PullRequestSnapshot> = {}): PullRequestSnapshot => ({
@@ -402,7 +403,8 @@ test("an expired orphaned DOING readiness claim is reclaimed after restart", asy
   const seeded = await seedReadiness();
   await db.task.update({ where: { id: seeded.readiness.id }, data: {
     status: TaskStatus.DOING,
-    failureReason: "merge-readiness-claim:dead-worker|2000-01-01T00:00:00.000Z",
+    readinessClaimToken: "dead-worker-token",
+    readinessClaimExpiresAt: new Date("2000-01-01T00:00:00.000Z"),
   } });
   assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 1, requeued: 0, stopped: 0 });
 });
@@ -515,7 +517,11 @@ test("a stale worker cannot stop readiness after a newer worker owns the claim",
   await readStarted;
   await db.task.update({
     where: { id: seeded.readiness.id },
-    data: { status: TaskStatus.DOING, failureReason: NEWER_CLAIM },
+    data: {
+      status: TaskStatus.DOING,
+      readinessClaimToken: NEWER_CLAIM_TOKEN,
+      readinessClaimExpiresAt: NEWER_CLAIM_EXPIRY,
+    },
   });
   finishRead();
 
@@ -525,7 +531,7 @@ test("a stale worker cannot stop readiness after a newer worker owns the claim",
     db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } }),
   ]);
   assert.equal(readiness.status, TaskStatus.DOING);
-  assert.equal(readiness.failureReason, NEWER_CLAIM);
+  assert.equal(readiness.readinessClaimToken, NEWER_CLAIM_TOKEN);
   assert.equal(regression.status, TaskStatus.DONE);
   assert.deepEqual(releasedChainLeases, []);
 });
@@ -548,7 +554,11 @@ test("a stale worker cannot requeue regression after a newer worker owns the cla
   await readStarted;
   await db.task.update({
     where: { id: seeded.readiness.id },
-    data: { status: TaskStatus.DOING, failureReason: NEWER_CLAIM },
+    data: {
+      status: TaskStatus.DOING,
+      readinessClaimToken: NEWER_CLAIM_TOKEN,
+      readinessClaimExpiresAt: NEWER_CLAIM_EXPIRY,
+    },
   });
   finishRead();
 
@@ -567,7 +577,9 @@ test("an unreachable merge lease acquire defers mechanically without spending re
   );
   const readiness = await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } });
   assert.equal(readiness.status, TaskStatus.DOING);
-  assert.match(readiness.failureReason ?? "", /^merge-readiness-claim:/u);
+  assert.notEqual(readiness.readinessClaimToken, null);
+  assert.notEqual(readiness.readinessClaimExpiresAt, null);
+  assert.equal(readiness.failureReason, null);
   const activity = await db.taskActivity.findFirstOrThrow({ where: { taskId: seeded.readiness.id } });
   assert.match(activity.body, /lease acquisition deferred.*ENOENT/ui);
   assert.deepEqual(releasedChainLeases, []);
@@ -609,7 +621,11 @@ test("a worker that acquired then lost its claim releases without a concrete suc
   const loseToWorker: MergeLeaseAcquirer = async () => {
     await db.task.update({
       where: { id: succeeded.readiness.id },
-      data: { status: TaskStatus.DOING, failureReason: NEWER_CLAIM },
+      data: {
+        status: TaskStatus.DOING,
+        readinessClaimToken: NEWER_CLAIM_TOKEN,
+        readinessClaimExpiresAt: NEWER_CLAIM_EXPIRY,
+      },
     });
     return { outcome: "acquired" };
   };
@@ -618,7 +634,10 @@ test("a worker that acquired then lost its claim releases without a concrete suc
     { claimed: 1, authorized: 0, requeued: 0, stopped: 0 },
   );
   assert.deepEqual(releasedChainLeases, [succeeded.readiness.chainId]);
-  assert.equal((await db.task.findUniqueOrThrow({ where: { id: succeeded.readiness.id } })).failureReason, NEWER_CLAIM);
+  assert.equal(
+    (await db.task.findUniqueOrThrow({ where: { id: succeeded.readiness.id } })).readinessClaimToken,
+    NEWER_CLAIM_TOKEN,
+  );
 });
 
 test("a foreign project's active successor cannot receive a claim-loss lease handoff", async () => {

--- a/packages/api/src/readiness-claim.test.ts
+++ b/packages/api/src/readiness-claim.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RunStatus,
+  TaskStatus,
+  type Prisma,
+  type PrismaClient,
+} from "@anneal/db";
+
+import {
+  claimReadinessStep,
+  READINESS_CLAIM_LEASE_MS,
+} from "./readiness-claim.js";
+
+type TaskRow = {
+  id: string;
+  projectId: string;
+  chainId: string | null;
+  chainIndex: number | null;
+  status: TaskStatus;
+  failureReason: string | null;
+  readinessClaimToken: string | null;
+  readinessClaimExpiresAt: Date | null;
+};
+
+type TaskWhere = Partial<TaskRow> & { id: string };
+type TaskWrite = Partial<Pick<
+  TaskRow,
+  "status" | "failureReason" | "readinessClaimToken" | "readinessClaimExpiresAt"
+>>;
+
+const same = (left: unknown, right: unknown): boolean => (
+  left instanceof Date && right instanceof Date
+    ? left.getTime() === right.getTime()
+    : left === right
+);
+
+const fakeDatabase = (overrides: Partial<TaskRow> = {}) => {
+  const task: TaskRow = {
+    id: "readiness-1",
+    projectId: "project-1",
+    chainId: null,
+    chainIndex: 2,
+    status: TaskStatus.TODO,
+    failureReason: "prior human-readable failure",
+    readinessClaimToken: null,
+    readinessClaimExpiresAt: null,
+    ...overrides,
+  };
+  const events: string[] = [];
+  let successor: { id: string; taskId: string; status: RunStatus } | null = null;
+
+  const matches = (where: TaskWhere): boolean => Object.entries(where)
+    .every(([field, value]) => same(task[field as keyof TaskRow], value));
+  const write = (data: TaskWrite): TaskRow => {
+    if (data.readinessClaimToken === null && task.readinessClaimToken !== null) events.push("claim-cleared");
+    Object.assign(task, data);
+    return { ...task };
+  };
+  const tx = {
+    $queryRaw: async (..._input: unknown[]) => [{ id: task.id }],
+    task: {
+      findUnique: async (_input: unknown) => ({ ...task }),
+      findUniqueOrThrow: async (_input: unknown) => ({ ...task }),
+      updateMany: async (input: { where: TaskWhere; data: TaskWrite }) => {
+        if (!matches(input.where)) return { count: 0 };
+        write(input.data);
+        return { count: 1 };
+      },
+      update: async (input: { where: { id: string }; data: TaskWrite }) => {
+        assert.equal(input.where.id, task.id);
+        return write(input.data);
+      },
+    },
+    run: {
+      findFirst: async (_input: unknown) => successor ? { id: successor.id } : null,
+      findUnique: async (input: { where: { id: string } }) => (
+        successor?.id === input.where.id ? { taskId: successor.taskId } : null
+      ),
+    },
+    taskActivity: {
+      create: async (input: { data: { body: string } }) => {
+        if (input.data.body.includes("handed to queued Run")) events.push("handoff-recorded");
+        return { id: "activity-1" };
+      },
+    },
+  };
+  const client = tx as unknown as Prisma.TransactionClient;
+  const db = {
+    ...tx,
+    $transaction: async <T>(operation: (transaction: Prisma.TransactionClient) => Promise<T>): Promise<T> => (
+      operation(client)
+    ),
+  } as unknown as PrismaClient;
+
+  return {
+    db,
+    client,
+    task,
+    events,
+    setSuccessor(run: { id: string; taskId: string; status: RunStatus } | null) {
+      successor = run;
+    },
+  };
+};
+
+const NOW = new Date("2026-08-29T12:00:00.000Z");
+
+test("a Handle acquires, renews, and settles the readiness Step claim", async () => {
+  const fake = fakeDatabase();
+  const handle = await claimReadinessStep(fake.db, fake.task.id, NOW);
+  assert.ok(handle);
+  assert.equal(fake.task.status, TaskStatus.DOING);
+  assert.equal(fake.task.failureReason, null);
+  assert.notEqual(fake.task.readinessClaimToken, null);
+  assert.equal(
+    fake.task.readinessClaimExpiresAt?.getTime(),
+    NOW.getTime() + READINESS_CLAIM_LEASE_MS,
+  );
+
+  const acquiredToken = fake.task.readinessClaimToken;
+  assert.equal(await handle.renew(), true);
+  assert.notEqual(fake.task.readinessClaimToken, acquiredToken);
+
+  const settlement = await fake.db.$transaction((tx) => handle.settle(tx, {
+    kind: "finish",
+    at: NOW,
+    apply: async (client) => {
+      await client.task.update({
+        where: { id: fake.task.id },
+        data: { status: TaskStatus.TODO },
+      });
+      return { value: "deferred" as const, ownership: "released" as const };
+    },
+  }));
+  assert.deepEqual(settlement, {
+    settled: true,
+    claim: "released",
+    value: "deferred",
+    ownership: "released",
+  });
+  assert.equal(fake.task.status, TaskStatus.TODO);
+  assert.equal(fake.task.readinessClaimToken, null);
+  assert.equal(fake.task.readinessClaimExpiresAt, null);
+});
+
+test("only an expired readiness claim can be reclaimed", async () => {
+  const fake = fakeDatabase();
+  const first = await claimReadinessStep(fake.db, fake.task.id, NOW);
+  assert.ok(first);
+  assert.equal(await claimReadinessStep(fake.db, fake.task.id, NOW), null);
+
+  const firstToken = fake.task.readinessClaimToken;
+  const afterExpiry = new Date(NOW.getTime() + READINESS_CLAIM_LEASE_MS + 1);
+  const successor = await claimReadinessStep(fake.db, fake.task.id, afterExpiry);
+  assert.ok(successor);
+  assert.notEqual(fake.task.readinessClaimToken, firstToken);
+  assert.equal(await first.renew(), false);
+  assert.equal(await successor.renew(), true);
+});
+
+test("claim loss classifies a concrete active successor as retained ownership", async () => {
+  const fake = fakeDatabase({ chainId: "chain-1" });
+  const handle = await claimReadinessStep(fake.db, fake.task.id, NOW);
+  assert.ok(handle);
+  fake.task.status = TaskStatus.DONE;
+  fake.task.readinessClaimToken = null;
+  fake.setSuccessor({ id: "run-2", taskId: "integrator-1", status: RunStatus.QUEUED });
+
+  let applied = false;
+  const settlement = await fake.db.$transaction((tx) => handle.settle(tx, {
+    kind: "finish",
+    at: NOW,
+    apply: async () => {
+      applied = true;
+      return { value: undefined, ownership: "released" as const };
+    },
+  }));
+  assert.equal(applied, false);
+  assert.deepEqual(settlement, { settled: false, ownership: { retainFor: "run-2" } });
+  assert.deepEqual(await handle.ownershipAfterLoss(fake.client), { retainFor: "run-2" });
+
+  fake.setSuccessor(null);
+  assert.equal(await handle.ownershipAfterLoss(fake.db), "released");
+});
+
+test("retained settlement records the Run handoff before clearing the claim", async () => {
+  const fake = fakeDatabase({ chainId: "chain-1" });
+  const handle = await claimReadinessStep(fake.db, fake.task.id, NOW);
+  assert.ok(handle);
+  fake.setSuccessor({ id: "run-2", taskId: "integrator-1", status: RunStatus.QUEUED });
+
+  const settlement = await fake.db.$transaction((tx) => handle.settle(tx, {
+    kind: "finish",
+    at: NOW,
+    apply: async (client) => {
+      fake.events.push("transition-applied");
+      await client.task.update({
+        where: { id: fake.task.id },
+        data: { status: TaskStatus.DONE },
+      });
+      return { value: "authorized" as const, ownership: { retainFor: "run-2" } };
+    },
+  }));
+  assert.deepEqual(settlement, {
+    settled: true,
+    claim: "released",
+    value: "authorized",
+    ownership: { retainFor: "run-2" },
+  });
+  assert.deepEqual(fake.events, ["transition-applied", "handoff-recorded", "claim-cleared"]);
+});

--- a/packages/api/src/readiness-claim.ts
+++ b/packages/api/src/readiness-claim.ts
@@ -1,0 +1,216 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  RunStatus,
+  TaskStatus,
+  type Prisma,
+  type PrismaClient,
+} from "@anneal/db";
+
+import { noteLeaseHandoff } from "./merge-lease.js";
+import { lockTaskMutationRows } from "./task-write.js";
+
+export const READINESS_CLAIM_LEASE_MS = 60_000;
+const READINESS_CLAIM_PREFIX = "merge-readiness-claim:";
+
+export type ReadinessLeaseOwnership = "released" | { retainFor: string };
+
+/**
+ * `keep` records work while this Handle remains the Step owner. `finish`
+ * atomically applies the terminal transition, records any successor Run handoff,
+ * and clears the claim before returning its Merge Lease ownership.
+ */
+export type ReadinessClaimTransition<T> =
+  | {
+    kind: "keep";
+    apply: (tx: Prisma.TransactionClient) => Promise<T>;
+  }
+  | {
+    kind: "finish";
+    at: Date;
+    apply: (tx: Prisma.TransactionClient) => Promise<{
+      value: T;
+      ownership: ReadinessLeaseOwnership;
+    }>;
+  };
+
+export type ReadinessClaimSettlement<T> =
+  | { settled: false; ownership: ReadinessLeaseOwnership }
+  | { settled: true; claim: "retained"; value: T }
+  | { settled: true; claim: "released"; value: T; ownership: ReadinessLeaseOwnership };
+
+export interface ReadinessClaimHandle {
+  /** Replaces the opaque CAS token and extends its expiry. False means ownership was lost. */
+  renew(): Promise<boolean>;
+  /** Applies work only while this Handle owns the locked readiness Step. */
+  settle<T>(
+    tx: Prisma.TransactionClient,
+    transition: ReadinessClaimTransition<T>,
+  ): Promise<ReadinessClaimSettlement<T>>;
+  /** Classifies a lost claim; database errors propagate instead of guessing ownership. */
+  ownershipAfterLoss(client: PrismaClient | Prisma.TransactionClient): Promise<ReadinessLeaseOwnership>;
+}
+
+type ClaimState = {
+  token: string;
+  expiresAt: Date;
+};
+
+const newClaimState = (now: Date): ClaimState => ({
+  token: `${READINESS_CLAIM_PREFIX}${randomUUID()}`,
+  expiresAt: new Date(now.getTime() + READINESS_CLAIM_LEASE_MS),
+});
+
+const ownershipAfterLoss = async (
+  client: PrismaClient | Prisma.TransactionClient,
+  taskId: string,
+): Promise<ReadinessLeaseOwnership> => {
+  const current = await client.task.findUnique({
+    where: { id: taskId },
+    select: {
+      status: true,
+      readinessClaimToken: true,
+      projectId: true,
+      chainId: true,
+      chainIndex: true,
+    },
+  });
+  const activeSuccessor = current?.status === TaskStatus.DONE
+    || (current?.status === TaskStatus.DOING && current.readinessClaimToken !== null);
+  if (!activeSuccessor || !current.chainId) return "released";
+
+  const handoff = await client.run.findFirst({
+    where: {
+      task: {
+        projectId: current.projectId,
+        chainId: current.chainId,
+        chainIndex: { gt: current.chainIndex ?? -1 },
+      },
+      status: {
+        in: [RunStatus.QUEUED, RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING],
+      },
+    },
+    select: { id: true },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+  });
+  return handoff ? { retainFor: handoff.id } : "released";
+};
+
+class ReadinessClaim implements ReadinessClaimHandle {
+  constructor(
+    private readonly db: PrismaClient,
+    private readonly taskId: string,
+    private state: ClaimState,
+  ) {}
+
+  async renew(): Promise<boolean> {
+    const renewed = newClaimState(new Date());
+    const held = await this.db.$transaction(async (tx) => {
+      await lockTaskMutationRows(tx, this.taskId);
+      return tx.task.updateMany({
+        where: {
+          id: this.taskId,
+          status: TaskStatus.DOING,
+          readinessClaimToken: this.state.token,
+        },
+        data: {
+          readinessClaimToken: renewed.token,
+          readinessClaimExpiresAt: renewed.expiresAt,
+        },
+      });
+    });
+    if (held.count !== 1) return false;
+    this.state = renewed;
+    return true;
+  }
+
+  async settle<T>(
+    tx: Prisma.TransactionClient,
+    transition: ReadinessClaimTransition<T>,
+  ): Promise<ReadinessClaimSettlement<T>> {
+    await lockTaskMutationRows(tx, this.taskId);
+    const held = await tx.task.findUnique({
+      where: { id: this.taskId },
+      select: { status: true, readinessClaimToken: true, chainId: true },
+    });
+    if (held?.status !== TaskStatus.DOING || held.readinessClaimToken !== this.state.token) {
+      return { settled: false, ownership: await this.ownershipAfterLoss(tx) };
+    }
+
+    if (transition.kind === "keep") {
+      return { settled: true, claim: "retained", value: await transition.apply(tx) };
+    }
+
+    const finished = await transition.apply(tx);
+    if (finished.ownership !== "released") {
+      if (!held.chainId) {
+        throw new Error(`Cannot retain the Merge Lease for readiness Step ${this.taskId} without a Chain`);
+      }
+      await noteLeaseHandoff(tx, {
+        chainId: held.chainId,
+        toRunId: finished.ownership.retainFor,
+        at: transition.at,
+      });
+    }
+    await tx.task.update({
+      where: { id: this.taskId },
+      data: { readinessClaimToken: null, readinessClaimExpiresAt: null },
+    });
+    return {
+      settled: true,
+      claim: "released",
+      value: finished.value,
+      ownership: finished.ownership,
+    };
+  }
+
+  ownershipAfterLoss(
+    client: PrismaClient | Prisma.TransactionClient,
+  ): Promise<ReadinessLeaseOwnership> {
+    return ownershipAfterLoss(client, this.taskId);
+  }
+}
+
+export const claimReadinessStep = async (
+  db: PrismaClient,
+  taskId: string,
+  now: Date,
+): Promise<ReadinessClaimHandle | null> => {
+  const state = newClaimState(now);
+  const claimed = await db.$transaction(async (tx) => {
+    await lockTaskMutationRows(tx, taskId);
+    const current = await tx.task.findUnique({
+      where: { id: taskId },
+      select: {
+        status: true,
+        readinessClaimToken: true,
+        readinessClaimExpiresAt: true,
+      },
+    });
+    const available = current?.status === TaskStatus.TODO
+      || (current?.status === TaskStatus.DOING
+        && current.readinessClaimToken !== null
+        && current.readinessClaimExpiresAt !== null
+        && current.readinessClaimExpiresAt.getTime() <= now.getTime());
+    if (!available) return false;
+
+    const acquired = await tx.task.updateMany({
+      where: current.status === TaskStatus.TODO
+        ? { id: taskId, status: TaskStatus.TODO }
+        : {
+          id: taskId,
+          status: TaskStatus.DOING,
+          readinessClaimToken: current.readinessClaimToken,
+          readinessClaimExpiresAt: current.readinessClaimExpiresAt,
+        },
+      data: {
+        status: TaskStatus.DOING,
+        failureReason: null,
+        readinessClaimToken: state.token,
+        readinessClaimExpiresAt: state.expiresAt,
+      },
+    });
+    return acquired.count === 1;
+  });
+  return claimed ? new ReadinessClaim(db, taskId, state) : null;
+};

--- a/packages/db/prisma/migrations/20260829150000_readiness_claim_handle/migration.sql
+++ b/packages/db/prisma/migrations/20260829150000_readiness_claim_handle/migration.sql
@@ -1,0 +1,9 @@
+-- Merge readiness owns this machine claim independently of the human-readable
+-- Task failure reason. The token is the CAS identity; the timestamp makes
+-- abandoned ownership reclaimable without parsing credentials from prose.
+ALTER TABLE "Task"
+ADD COLUMN "readinessClaimToken" TEXT,
+ADD COLUMN "readinessClaimExpiresAt" TIMESTAMP(3),
+ADD CONSTRAINT "Task_readiness_claim_pair_check" CHECK (
+  ("readinessClaimToken" IS NULL) = ("readinessClaimExpiresAt" IS NULL)
+);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -523,6 +523,8 @@ model Task {
   workingDirectory        String?
   targetBranch            String?
   failureReason           String?
+  readinessClaimToken     String?
+  readinessClaimExpiresAt DateTime?
   status                  TaskStatus           @default(TODO)
   source                  TaskSource           @default(MANUAL)
   archivedAt              DateTime?

--- a/packages/db/src/release-migrate.ts
+++ b/packages/db/src/release-migrate.ts
@@ -74,8 +74,8 @@ export const FILES_PRECHECK_COMMAND = ["npm", "run", "db:files-precheck"] as con
  * match what is on disk.
  */
 export const RELEASE_CANDIDATE_MIGRATIONS = {
-  count: 39,
-  terminal: "20260829120000_task_done_at",
+  count: 40,
+  terminal: "20260829150000_readiness_claim_handle",
 } as const;
 
 /** Stable stop conditions owned by the orchestrator itself. */


### PR DESCRIPTION
## Candidate

Candidate 06: use a Step claim Handle to close the Merge readiness claim lifecycle.

## Changes

| Requested change | Delivered |
| --- | --- |
| 1. Deep claim interface | Added `claimReadinessStep(db, taskId, now) -> Handle | null`; the Handle owns `renew()`, `settle(tx, transition)`, and `ownershipAfterLoss(client)`. |
| 2. Independent persistence | Added only `Task.readinessClaimToken` and `Task.readinessClaimExpiresAt`, plus a migration check requiring the pair to be both null or both present. Updated the canonical release-candidate migration tail to this required migration. No dual write or fallback remains. |
| 3. Handle-owned credential | Token rotation is private to the Handle. The worker no longer threads `claimReason` or writes a renewed token into its read object. |
| 4. One loss classifier | `ownershipAfterLoss` accepts Prisma `db` or `tx`, scopes successor lookup by project and Chain, and returns only `released` or `{ retainFor: runId }`. Query failures propagate. |
| 5. Typed ordering | `keep` and `finish` transitions encode claim retention/settlement. A retained Merge Lease cannot be returned until the Handle records the successor Run handoff in the same transaction; no no-op releaser remains. |
| 6. Direct lifecycle tests | Added non-dbtest tests for acquire, renew, expiry/reclaim, release settlement, ownership loss classification, and retain ordering. Updated the existing readiness DB behavior coverage to assert the independent claim fields. |

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` | PASS |
| `npm run typecheck` | PASS |
| `npm run test -w @anneal/db` | PASS: 262 passed, 0 failed |
| `npm run test -w @anneal/api` | PASS: 645 passed, 0 failed, 1 opt-in skipped |
| `npm run test:db -w @anneal/api -- src/merge-tail-readiness.dbtest.ts` | Local harness stopped before connection because this worktree has no `TEST_DATABASE_URL`; the exact-head full gate below ran the complete DB suite, including this file |
| `grep -rn "merge-readiness-claim" packages/api/src` | PASS: only `readiness-claim.ts` |
| `grep -c "claimReason" packages/api/src/merge-readiness-worker.ts` | PASS: 0 |
| Full merge gate | `MERGE GATE: PASS ec14fe3e7c83d670542f6d906e20fc22edae9447` against baseline `19405ba4db727814dddba4eb886f64fcb2341cad` |

## Lease ownership

| Path | Ownership and ordering | Same as before |
| --- | --- | --- |
| Pre-Lease remote defer | Claim settles to TODO; no Merge Lease was acquired | Yes |
| Pre-Lease stop | Stop transition commits, then its project-scoped Chain Lease target is released | Yes |
| Pre-Lease Regression requeue | Requeue and replacement Run commit, then the Chain Lease target is released | Yes |
| Merge Lease contended | Callback does not run; claim remains until expiry | Yes |
| Merge Lease unreachable | Deferral marker commits under the retained claim; no Merge Lease was acquired | Yes |
| Post-acquire recheck skip/defer | Callback returns `release`; `withMergeLease` releases after callback completion | Yes |
| Post-acquire stop | Handle settles the stop and returns `released`; `withMergeLease` performs the single release after callback completion | Yes |
| Post-acquire Regression requeue | Handle settles the requeue and returns `released`; `withMergeLease` releases after callback completion | Yes |
| Authorization with successor Run | Authorization and Run queueing commit; Handle records handoff, clears claim, then returns `{ retainFor: runId }` | Yes |
| Authorization without successor Run | Authorization commits and Handle returns `released`; callback releases | Yes |
| Claim loss after acquire/at settlement | The one classifier retains only for a concrete active successor Run; otherwise callback releases | Yes |
| Exception stop | Stop commits, then the returned project-scoped target is released; release failures still surface | Yes |

## Out of scope observed

- `packages/api/src/merge-lease.ts` shape is unchanged.
- `packages/db/src/merge-tail.ts` recovery transition table is unchanged.
- `packages/api/src/merge-base-drift-worker.ts` is unchanged.
- No Task claim mechanism outside Merge readiness was generalized.
- The existing contended/unreachable retry policy still relies on claim expiry; this candidate only encapsulates that lifecycle.
