### PR TITLE
docs: tighten README voice and surface trust and traceability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 **You write the specs. It clears the board.**
 
-Anneal is a local control plane for coding agents. Queue tasks in the
-evening, and chains plan, review, implement, verify and merge them
-unattended — on the Codex and Claude subscriptions you are already
-signed in to.
+Anneal runs chains of coding agents on your own Mac. Queue tasks on
+the board, and each one is planned, reviewed, implemented, verified and
+merged unattended, on the Codex and Claude subscriptions you are
+already signed in to.
 
 [![status](https://img.shields.io/badge/status-developer%20preview-orange)](#status)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
@@ -22,25 +22,26 @@ signed in to.
 
 ## The workflow it is built for
 
-During the day you do one thing: write specs. In the evening you queue
-them as tasks on the board. Overnight, a chain picks up each task and
-takes it the whole way — plan, plan review, implementation, two
-independent code reviews, fix application, regression verification, and
-the merge itself. In the morning you read the pull requests that matter,
-open an agent window on the ones you care about, and iterate until you
-are satisfied.
+You do one thing: write specs. Queue them on the board and walk away. A
+chain picks up each task and takes it the whole way through plan, plan
+review, implementation, two independent code reviews, fix application,
+regression verification, and the merge itself. When you come back, you
+read the pull requests that matter, open an agent window on the ones
+you care about, and iterate until you are satisfied.
 
-Between those points nothing needs you. A chain only stops for you when
-an agent asks a question through the Inbox, when a step you marked as
-gated needs a human decision, or when a run escalates. You are not
-sitting in front of it; the board is what you come back to.
+In between, nothing needs you. A chain only stops for you when an agent
+asks a question through the Inbox, when a step you marked as gated
+needs a human decision, or when a run escalates.
 
 ## What you get
 
 - **Spec in, merge out.** A task card becomes a branch, a pull request
-  and a merge behind the merge gate, with every intermediate artifact —
-  plan, review findings, fix dispositions, regression results — recorded
-  and reviewable.
+  and a merge behind the merge gate. Every intermediate artifact (plan,
+  review findings, fix dispositions, regression results) is recorded on
+  your machine, so you can trace any chain step by step afterwards.
+- **Nothing merges on faith.** Two blind code reviews, an independent
+  regression run, and a merge gate stand between an agent's diff and
+  your main branch.
 - **Parallel by default.** Chains for different tasks and different
   repositories run at the same time; throughput comes from how many
   runners you register, not from your hours.
@@ -48,8 +49,6 @@ sitting in front of it; the board is what you come back to.
   CLI, Claude Code and Pi you have already installed and signed in to.
   It holds no credential of its own, runs no proxy, and there is no key
   to paste in.
-- **Review is the product.** Every step's output is the next step's
-  input, and every run record stays on your machine for you to audit.
 
 ## Anneal is built with Anneal
 
@@ -61,14 +60,18 @@ log which commits the chains produced.
 
 ## How it works
 
-A chain instantiates a template of steps. Each step binds an agent role
-— a prompt, a model, a reasoning effort and the runner CLI it executes
-on — and the flagship Full Assurance template covers delivery in twelve
-steps. `Sol` and `Luna` below are the GPT-5.6 variants the Codex CLI
-exposes.
+A chain instantiates a template of steps. Each step binds an agent
+role: a prompt, a model, a reasoning effort and the runner CLI it
+executes on. The flagship Full Assurance template covers delivery in
+twelve steps.
+
+The template is data, not code. Roles, prompts, models and gates are
+all editable, so you can reshape the chain into your own process.
 
 <details>
 <summary><b>The twelve steps in full</b> — role, runner, model and effort for each</summary>
+
+`Sol` and `Luna` below are the GPT-5.6 variants the Codex CLI exposes.
 
 | # | Step | Agent role | What it does | Runner | Model · effort |
 | --- | --- | --- | --- | --- | --- |
@@ -95,11 +98,14 @@ exposes.
 
 </div>
 
-Steps 6 and 7 are parallel siblings: the blind review never sees the
-other's output, and step 8 adjudicates both. Role bindings live in
-[`agents/templates/compound-engineer-workflow/`](agents/templates/compound-engineer-workflow)
-and the models in [`agents/roles/`](agents/roles). Board column
-semantics are defined in the
+The design rule behind the steps: whoever wrote the code never judges
+it. Authorship, review and verification run in separate sessions, the
+two code reviews cannot see each other's findings, and step 8
+adjudicates both. Each session starts clean, with a purpose-built
+prompt and an environment the runner constructs itself: your global
+agent config and skills never leak in as noise. Role bindings live in
+[`agents/templates/compound-engineer-workflow/`](agents/templates/compound-engineer-workflow);
+board column semantics in the
 [task-routing contract](docs/governance/task-routing-v1.md).
 
 ## Quick start
@@ -136,14 +142,12 @@ macOS on Apple Silicon only.
 
 **Read before pointing this at anything you care about:** Anneal
 launches coding CLIs with non-interactive permission bypass, as your
-macOS user, outside a sandbox. Use a disposable repository and a machine
-you are willing to let an agent modify. Details in
+macOS user, outside a sandbox. Use a disposable repository and a
+machine you are willing to let an agent modify. Details in
 [`docs/release/security.md`](docs/release/security.md).
 
-The provider CLIs, their authentication and their plan terms stay
-between you and the provider: Anneal neither reads nor forwards their
-credentials and grants no entitlement. The authoritative support
-statement is
+Provider CLIs, their authentication and their plan terms stay between
+you and the provider; the authoritative support statement is
 [`docs/release/support-matrix.md`](docs/release/support-matrix.md).
 
 ## Documentation
@@ -162,5 +166,5 @@ Five skills from
 [mattpocock/skills](https://github.com/mattpocock/skills) (MIT,
 Copyright (c) 2026 Matt Pocock) supply working text for the chain's
 prompts; see [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). This
-snapshot is licensed under the [MIT License](LICENSE), with its boundary
-defined by [`public-snapshot.json`](public-snapshot.json).
+snapshot is licensed under the [MIT License](LICENSE), with its
+boundary defined by [`public-snapshot.json`](public-snapshot.json).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,9 +4,9 @@
 
 **你只写 spec，它清空看板。**
 
-Anneal 是运行在你本机的 coding agent 控制平面。晚上把任务挂进看板，
-任务链会无人值守地完成计划、评审、实现、验证与合并——全程跑在你已经
-登录的 Codex 与 Claude 订阅上。
+Anneal 在你自己的 Mac 上驱动一条条 coding agent 任务链。把任务挂进
+看板，每个任务都会被无人值守地计划、评审、实现、验证、合并，全程跑在
+你已经登录的 Codex 与 Claude 订阅上。
 
 [![status](https://img.shields.io/badge/status-developer%20preview-orange)](#当前状态)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
@@ -21,27 +21,27 @@ Anneal 是运行在你本机的 coding agent 控制平面。晚上把任务挂�
 
 ## 它服务的工作流
 
-白天你只做一件事：写 spec。晚上把它们作为任务挂进看板。夜里，任务链
-接过每个任务并走完全程——计划、计划评审、实现、两次相互独立的代码评审、
-修复落地、回归验证，直至合并。第二天早上，你只读真正重要的 pull
-request，对在意的那几个开一个 agent 窗口，和 AI 迭代到满意为止。
+你只做一件事：写 spec。把它们挂进看板，然后走开。任务链接过每个任务
+并走完全程：计划、计划评审、实现、两次相互独立的代码评审、修复落地、
+回归验证，直至合并。等你回来，只读真正重要的 pull request，对在意的
+那几个开一个 agent 窗口，和 AI 迭代到满意为止。
 
-在这些节点之间它不需要你。链只在三种情况下停下来等你：agent 通过
-Inbox 向你提问、你标记为 gated 的步骤需要人来决策、或某次运行升级
-（escalate）。你不必守在它前面；看板是你回来时要看的东西。
+中间它不需要你。链只在三种情况下停下来等你：agent 通过 Inbox 向你
+提问、你标记为 gated 的步骤需要人来决策、或某次运行升级（escalate）。
 
 ## 你得到什么
 
 - **Spec 进，merge 出。** 一张任务卡最终成为一个分支、一个 pull
-  request 和一次通过 merge gate 的合并；中间的每个产物——计划、评审
-  发现、修复裁决、回归结果——都被记录、可回看。
+  request 和一次通过 merge gate 的合并。中间的每个产物（计划、评审
+  发现、修复裁决、回归结果）都记录在你的机器上，事后可以逐步回溯
+  整条链。
+- **不靠信任合并。** 两次盲评、一次独立回归验证和一道 merge gate，
+  隔在 agent 的 diff 和你的主分支之间。
 - **默认并行。** 不同任务、不同仓库的链同时在飞；吞吐量取决于你注册了
   多少 runner，而不是你的工时。
 - **用你的订阅，不用 API key。** Anneal 启动的是你已经安装并登录的官方
   Codex CLI、Claude Code 和 Pi。它自己不持有任何凭据，不做代理，也没有
   任何要粘贴的 key。
-- **评审就是产品。** 每一步的输出都是下一步的输入，每次运行的记录都留
-  在你的机器上供你审计。
 
 ## Anneal 由 Anneal 构建
 
@@ -52,12 +52,17 @@ trailer，你可以直接在 git log 里核对哪些提交出自链。
 
 ## 工作原理
 
-链由模板实例化而来。每一步绑定一个 agent 角色——提示词、模型、推理档位
-以及执行它的 runner CLI；旗舰的 Full Assurance 模板用十二步覆盖整条交付
-路径。下表中的 `Sol` 和 `Luna` 是 Codex CLI 暴露的 GPT-5.6 变体。
+链由模板实例化而来。每一步绑定一个 agent 角色：提示词、模型、推理档位
+以及执行它的 runner CLI。旗舰的 Full Assurance 模板用十二步覆盖整条
+交付路径。
+
+模板是数据，不是代码。角色、提示词、模型和 gate 都可以编辑，你可以把
+这条链改造成自己的流程。
 
 <details>
 <summary><b>完整十二步</b>——每一步的角色、runner、模型与档位</summary>
+
+表中的 `Sol` 和 `Luna` 是 Codex CLI 暴露的 GPT-5.6 变体。
 
 | # | 步骤 | Agent 角色 | 做什么 | Runner | 模型 · 档位 |
 | --- | --- | --- | --- | --- | --- |
@@ -84,10 +89,12 @@ trailer，你可以直接在 git log 里核对哪些提交出自链。
 
 </div>
 
-第 6、7 步是并行兄弟：盲评看不到另一路的输出，第 8 步同时裁决两者。
-角色绑定在
-[`agents/templates/compound-engineer-workflow/`](agents/templates/compound-engineer-workflow)，
-模型定义在 [`agents/roles/`](agents/roles)。看板各列的语义见
+这些步骤背后的设计规则是：写代码的一方永远不裁决自己的代码。创作、
+评审与验证在相互独立的会话里进行，两路代码评审看不到彼此的发现，由
+第 8 步统一裁决。每个会话都是干净起步：提示词为该角色专门构造，运行
+环境由 runner 自行构造，你的全局 agent 配置和技能不会作为噪音漏入。角色绑定在
+[`agents/templates/compound-engineer-workflow/`](agents/templates/compound-engineer-workflow)；
+看板各列的语义见
 [task-routing 契约](docs/governance/task-routing-v1.md)。
 
 ## 快速开始
@@ -124,8 +131,8 @@ Developer Preview 4（v0.4.0）：接口与存储数据形态在 preview 之间�
 丢弃的仓库和一台你愿意让 agent 修改的机器。详见
 [`docs/release/security.md`](docs/release/security.md)。
 
-Provider CLI、它们的认证与套餐条款始终在你和 provider 之间：Anneal 不
-读取、不转发它们的凭据，也不授予任何使用权。权威支持声明见
+Provider CLI、它们的认证与套餐条款始终在你和 provider 之间；权威支持
+声明见
 [`docs/release/support-matrix.md`](docs/release/support-matrix.md)。
 
 ## 文档


### PR DESCRIPTION
Second pass on the README rewrite: behavioral one-liner instead of control-plane jargon, time-of-day framing removed, new trust and clean-session points, template-reshaping invitation, traceability wording, and a humanizer pass over the prose. English and Chinese kept in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnQLL2jyVM48vsuEnhUkxF