### PR TITLE
docs: restore the agents view screenshot in How it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ twelve steps.
 The template is data, not code. Roles, prompts, models and gates are
 all editable, so you can reshape the chain into your own process.
 
+<div align="center">
+
+<img src="docs/media/agents.png" alt="Agents view: each agent's role, model, reasoning effort and runner" width="880">
+
+<sub>Agents: a role, a prompt, a model and effort, and the runner it goes to.</sub>
+
+</div>
+
 <details>
 <summary><b>The twelve steps in full</b> — role, runner, model and effort for each</summary>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -59,6 +59,14 @@ trailer，你可以直接在 git log 里核对哪些提交出自链。
 模板是数据，不是代码。角色、提示词、模型和 gate 都可以编辑，你可以把
 这条链改造成自己的流程。
 
+<div align="center">
+
+<img src="docs/media/agents.png" alt="Agents 视图：每个 agent 的角色、模型、推理档位与 runner" width="880">
+
+<sub>Agents：一个角色、一段提示词、一个模型与档位，以及它去往的 runner。</sub>
+
+</div>
+
 <details>
 <summary><b>完整十二步</b>——每一步的角色、runner、模型与档位</summary>
 


### PR DESCRIPTION
Puts docs/media/agents.png back into both READMEs, under the template-is-data paragraph it illustrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnQLL2jyVM48vsuEnhUkxF