### PR TITLE
refactor(api): centralize merge tail recovery state

### DIFF
--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -392,6 +392,39 @@ test("an unexpired readiness claim prevents the recovery fallback transition", a
   assert.equal(readiness.readinessClaimExpiresAt?.getTime(), expiresAt.getTime());
 });
 
+test("a recovery-context read failure after claim is persisted as a readiness stop", async () => {
+  const seeded = await seedIntegratorChain(db, {
+    label: "recovery-context-read-after-claim",
+    shape: "canonical-compound-readiness",
+  });
+  await db.task.update({ where: { id: seeded.readinessTask!.id }, data: { status: TaskStatus.TODO } });
+  const recoveryDelegate = new Proxy(db.mergeRecoveryAttempt, {
+    get(target, property, receiver) {
+      if (property === "findFirst") {
+        return async () => { throw new Error("recovery-context-read-failed"); };
+      }
+      const value = Reflect.get(target, property, receiver) as unknown;
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+  const failingDb = new Proxy(db, {
+    get(target, property, receiver) {
+      if (property === "mergeRecoveryAttempt") return recoveryDelegate;
+      const value = Reflect.get(target, property, receiver) as unknown;
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as PrismaClient;
+
+  const tick = await readinessTick(failingDb, null, new Date(), 5, releaseChainLease, runWithMergeLease);
+
+  assert.deepEqual(tick, { claimed: 1, authorized: 0, requeued: 0, stopped: 1 });
+  const readiness = await db.task.findUniqueOrThrow({ where: { id: seeded.readinessTask!.id } });
+  assert.equal(readiness.status, TaskStatus.REVIEW);
+  assert.equal(readiness.readinessClaimToken, null);
+  assert.equal(readiness.readinessClaimExpiresAt, null);
+  assert.equal(readiness.failureReason, "readiness evaluation failed: recovery-context-read-failed");
+});
+
 test("fresh server-owned readiness authorization alone activates the recovery merge executor", async () => {
   const seeded = await seedStopped("canonical-compound-readiness", "readiness-recovery-activation");
   assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -5,8 +5,11 @@ import { after, before, beforeEach, test } from "node:test";
 import {
   AUTHORIZED_MERGE_METHOD,
   applyInboxDecisionTx,
+  advanceTemplateTask,
   enqueueTaskRun,
+  holdChain,
   MERGE_INTEGRATOR_KIND,
+  MERGE_TAIL_KIND,
   Prisma,
   PrismaClient,
   TaskStatus,
@@ -21,8 +24,14 @@ import {
 
 import { handleRegressionCompletion } from "./merge-tail-actions.js";
 import { baseDriftRecoveryTick } from "./merge-base-drift-worker.js";
+import {
+  awaitAuthorization,
+  ensureRecoveryValidation,
+  enterRepair,
+} from "./merge-tail-state.js";
 import { seedIntegratorChain } from "./merge-integrator-fixture.js";
 import {
+  settleLease,
   withMergeLease,
   type MergeLeaseAcquirer,
   type MergeLeaseReleaser,
@@ -181,8 +190,28 @@ const recordRecoveryPass = async (
     runId: run.id, kind: "regression-verification",
     body: JSON.stringify({ schemaVersion: 1, outcome: "pass", headSha, baseHeadSha: baseSha, gateVerdict: "PASS" }), commitSha: headSha,
   } });
-  await db.task.update({ where: { id: seeded.gateTask.id }, data: { status: TaskStatus.DONE } });
-  return run;
+  const completion = await db.$transaction(async (tx) => {
+    const outcome = await handleRegressionCompletion(tx, {
+      task: seeded.gateTask,
+      run: {
+        id: run.id,
+        agentId: run.agentId,
+        branch: run.branch,
+        headSha,
+        sessionId: seeded.gateSession.id,
+      },
+      now: new Date(),
+    });
+    if (outcome === "advance") {
+      await advanceTemplateTask(tx, seeded.gateTask.id, run.id, null);
+    }
+    const lease = await settleLease(tx, {
+      taskId: seeded.gateTask.id,
+      outcome: outcome === "advance" ? "continue" : "stop",
+    });
+    return { outcome, lease };
+  });
+  return { run, ...completion };
 };
 
 const finishRecoveryPass = async (
@@ -230,6 +259,137 @@ test("queued recovery keeps generic PATCH, retry, and enqueue blocked until read
   await assertIntegratorGuarded(seeded.integratorTask!.id);
   assert.equal(await db.run.count({ where: { taskId: seeded.integratorTask!.id } }), 1);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.integratorTask!.id } })).status, TaskStatus.REVIEW);
+});
+
+test("a recovery pass delegates activation to the held-Chain seam and retains the Lease", async () => {
+  const seeded = await seedStopped("canonical-compound-readiness", "recovery-pass-held-chain");
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  const held = await db.$transaction((tx) => holdChain(tx, {
+    projectId: seeded.project.id,
+    chainId: seeded.chainId,
+    taskId: seeded.gateTask.id,
+    requestId: "hold-recovery-pass",
+  }));
+  assert.equal("message" in held, false);
+
+  const completion = await recordRecoveryPass(seeded, BASE_2);
+
+  assert.equal(completion.outcome, "advance");
+  assert.deepEqual(completion.lease, { disposition: "retain", leaseToRelease: null });
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.gateTask.id } })).status, TaskStatus.DONE);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readinessTask!.id } })).status, TaskStatus.TODO);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: seeded.readinessTask!.id,
+    metadata: { path: ["sourceRunId"], equals: completion.run.id },
+  } }), 0, "the held Chain did not activate readiness");
+  assert.equal((await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  })).status, "AWAITING_AUTHORIZATION");
+});
+
+test("enterRepair directly owns both declared repair edges", async () => {
+  const seeded = await seedStopped("canonical-compound-readiness", "direct-enter-repair-edges");
+  const stop = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: seeded.integratorTask!.id,
+    metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.result },
+  }, orderBy: { createdAt: "desc" } });
+  const source = await db.taskStepOutput.findUniqueOrThrow({ where: { taskId: seeded.integratorTask!.id } });
+  const authorization = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: seeded.readinessTask!.id,
+    metadata: { path: ["kind"], equals: MERGE_INTEGRATOR_KIND.authorization },
+  }, orderBy: { createdAt: "desc" } });
+  const attempt = await db.$transaction((tx) => ensureRecoveryValidation(tx, {
+    integratorTaskId: seeded.integratorTask!.id,
+    sourceStopId: stop.id,
+    identity: {
+      sourceRunId: source.runId!,
+      authorizationActivityId: authorization.id,
+      readinessTaskId: seeded.readinessTask!.id,
+      regressionTaskId: seeded.gateTask.id,
+      repository: "acme/widgets",
+      prNumber: 123,
+      targetBranch: "master",
+      authorizedHeadSha: HEAD,
+      authorizedBaseSha: BASE,
+      observedBaseSha: BASE_2,
+    },
+  }));
+
+  const first = await db.$transaction((tx) => enterRepair(tx, {
+    aggregateId: attempt.id,
+    currentBaseSha: BASE_2,
+    now: new Date(),
+  }));
+  assert.equal((await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: attempt.id } })).status, "REPAIRING");
+
+  await db.run.update({ where: { id: first.recoveryRunId }, data: { status: "SUCCEEDED" } });
+  await db.task.update({ where: { id: seeded.gateTask.id }, data: { status: TaskStatus.DONE } });
+  const context = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: attempt.id } });
+  await db.$transaction((tx) => awaitAuthorization(tx, {
+    aggregateId: context.id,
+    attempt: context.attempt,
+    sourceStopId: context.sourceStopId,
+    sourceRunId: context.boundSourceRunId!,
+    authorizationActivityId: context.authorizationActivityId!,
+    repository: context.repository!,
+    prNumber: context.prNumber!,
+    targetBranch: context.targetBranch!,
+    authorizedHeadSha: context.authorizedHeadSha!,
+    authorizedBaseSha: context.authorizedBaseSha!,
+    observedBaseSha: context.observedBaseSha!,
+    currentBaseSha: context.currentBaseSha!,
+    readinessTaskId: context.readinessTaskId!,
+    regressionTaskId: context.regressionTaskId!,
+    integratorTaskId: context.integratorTaskId,
+    recoveryRunId: context.recoveryRunId!,
+  }));
+  await db.$transaction((tx) => enterRepair(tx, {
+    aggregateId: attempt.id,
+    currentBaseSha: BASE_3,
+    now: new Date(),
+    readinessRequeue: { staleBaseSha: BASE_2, reason: "base advanced" },
+  }));
+  assert.equal((await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: attempt.id } })).status, "REPAIRING");
+});
+
+test("an unexpired readiness claim prevents the recovery fallback transition", async () => {
+  const seeded = await seedStopped("canonical-compound-readiness", "recovery-readiness-claim-order");
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  const run = await db.run.findFirstOrThrow({
+    where: { taskId: seeded.gateTask.id },
+    orderBy: { runNumber: "desc" },
+  });
+  await db.run.update({ where: { id: run.id }, data: { status: "SUCCEEDED", headSha: HEAD } });
+  await db.taskStepOutput.upsert({ where: { taskId: seeded.gateTask.id }, create: {
+    taskId: seeded.gateTask.id,
+    runId: run.id,
+    kind: "regression-verification",
+    body: JSON.stringify({ schemaVersion: 1, outcome: "pass", headSha: HEAD, baseHeadSha: BASE_2, gateVerdict: "PASS" }),
+    commitSha: HEAD,
+  }, update: {
+    runId: run.id,
+    body: JSON.stringify({ schemaVersion: 1, outcome: "pass", headSha: HEAD, baseHeadSha: BASE_2, gateVerdict: "PASS" }),
+    commitSha: HEAD,
+  } });
+  await db.task.update({ where: { id: seeded.gateTask.id }, data: { status: TaskStatus.DONE } });
+  const foreignToken = "merge-readiness-claim:foreign-owner";
+  const expiresAt = new Date(Date.now() + 60_000);
+  await db.task.update({ where: { id: seeded.readinessTask!.id }, data: {
+    status: TaskStatus.DOING,
+    readinessClaimToken: foreignToken,
+    readinessClaimExpiresAt: expiresAt,
+  } });
+
+  const tick = await readinessTick(db, reader(snapshot(BASE_2)), new Date(), 5, releaseChainLease, runWithMergeLease);
+
+  assert.equal(tick.claimed, 0);
+  assert.equal((await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  })).status, "REPAIRING");
+  const readiness = await db.task.findUniqueOrThrow({ where: { id: seeded.readinessTask!.id } });
+  assert.equal(readiness.status, TaskStatus.DOING);
+  assert.equal(readiness.readinessClaimToken, foreignToken);
+  assert.equal(readiness.readinessClaimExpiresAt?.getTime(), expiresAt.getTime());
 });
 
 test("fresh server-owned readiness authorization alone activates the recovery merge executor", async () => {
@@ -472,7 +632,29 @@ test("recovery freshness requeue preserves the run binding through fresh authori
   const seeded = await seedStopped("canonical-compound-readiness", "readiness-recovery-second-freshness");
   assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
 
-  const firstRecoveryRun = await recordRecoveryPass(seeded, BASE_2);
+  const { run: firstRecoveryRun } = await recordRecoveryPass(seeded, BASE_2);
+  const regressionOutput = await db.taskStepOutput.findUniqueOrThrow({ where: { taskId: seeded.gateTask.id } });
+  const readinessOutput = await db.taskStepOutput.create({ data: {
+    taskId: seeded.readinessTask!.id,
+    kind: "merge-authorization",
+    body: "stale readiness output retained until replacement",
+    commitSha: HEAD,
+  } });
+  const question = await db.inboxMessage.create({ data: {
+    from: "AGENT",
+    taskId: seeded.integratorTask!.id,
+    kind: "MULTIPLE_CHOICE",
+    status: "OPEN",
+    body: "operator question must survive readiness requeue",
+    choices: [{ id: "continue", label: "Continue" }],
+    dedupeKey: `requeue-side-effects:${seeded.integratorTask!.id}`,
+  } });
+  const integratorTimestamp = new Date("2026-08-01T00:00:00.000Z");
+  const integratorFailure = "initial recovery remains operator-visible";
+  await db.task.update({ where: { id: seeded.integratorTask!.id }, data: {
+    failureReason: integratorFailure,
+    updatedAt: integratorTimestamp,
+  } });
 
   assert.equal((await readinessTick(db, reader(snapshot(BASE_3)), new Date(), 5, releaseChainLease, runWithMergeLease)).requeued, 1);
   const secondRecoveryRun = await db.run.findFirstOrThrow({
@@ -484,6 +666,12 @@ test("recovery freshness requeue preserves the run binding through fresh authori
   assert.equal(aggregate.status, "REPAIRING");
   assert.equal(aggregate.recoveryRunId, secondRecoveryRun.id);
   assert.equal(aggregate.currentBaseSha, BASE_3);
+  assert.equal((await db.taskStepOutput.findUniqueOrThrow({ where: { taskId: seeded.gateTask.id } })).id, regressionOutput.id);
+  assert.equal((await db.taskStepOutput.findUniqueOrThrow({ where: { taskId: seeded.readinessTask!.id } })).id, readinessOutput.id);
+  assert.equal((await db.inboxMessage.findUniqueOrThrow({ where: { id: question.id } })).status, "OPEN");
+  const integrator = await db.task.findUniqueOrThrow({ where: { id: seeded.integratorTask!.id } });
+  assert.equal(integrator.failureReason, integratorFailure);
+  assert.equal(integrator.updatedAt.getTime(), integratorTimestamp.getTime());
   const integratorBinding = await db.taskActivity.findFirst({
     where: {
       taskId: seeded.integratorTask!.id,
@@ -548,7 +736,7 @@ test("eligible direct and compound stops recover once under duplicate ticks and 
       (await readMarkerHistory(db, seeded.integratorTask!.id))
         .filter((entry) => entry.kind === "baseDriftRecovery")
         .map((entry) => entry.state),
-      ["awaiting-authorization", "queued"],
+      ["queued"],
     );
   }
 });
@@ -883,6 +1071,42 @@ test("a transient reader outage is retried and later recovers", async () => {
   assert.equal(await db.run.count({ where: { taskId: seeded.gateTask.id } }), 2);
 });
 
+test("a chain-active retry fills its existing VALIDATING identity before later repair", async () => {
+  const seeded = await seedStopped("canonical-compound-readiness", "chain-active-identity-fill");
+  const active = await db.run.create({ data: {
+    projectId: seeded.project.id,
+    taskId: seeded.gateTask.id,
+    agentId: seeded.agent.id,
+    repoId: seeded.repo.id,
+    runNumber: 2,
+    dedupeKey: `task:${seeded.gateTask.id}:run:2`,
+    runner: "CLAUDE",
+    model: seeded.agent.model,
+    promptHash: "chain-active",
+    status: "RUNNING",
+  } });
+
+  assert.deepEqual(await baseDriftRecoveryTick(db, reader(snapshot(BASE_2))), {
+    examined: 1, recovered: 0, exhausted: 0, ineligible: 0,
+  });
+  const validating = await db.mergeRecoveryAttempt.findFirstOrThrow({
+    where: { integratorTaskId: seeded.integratorTask!.id },
+  });
+  assert.equal(validating.status, "VALIDATING");
+  assert.equal(validating.boundSourceRunId, null);
+  assert.equal(validating.readinessTaskId, null);
+  assert.equal(validating.validationAttempts, 1);
+
+  await db.run.update({ where: { id: active.id }, data: { status: "SUCCEEDED" } });
+  assert.equal((await baseDriftRecoveryTick(db, reader(snapshot(BASE_2)))).recovered, 1);
+  const repaired = await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: validating.id } });
+  assert.equal(repaired.status, "REPAIRING");
+  assert.equal(repaired.boundSourceRunId !== null, true);
+  assert.equal(repaired.readinessTaskId, seeded.readinessTask!.id);
+  assert.equal(repaired.regressionTaskId, seeded.gateTask.id);
+  assert.equal(repaired.recoveryRunId !== null, true);
+});
+
 test("older irrelevant REVIEW integrators cannot starve a later eligible stop", async () => {
   const prefix = await seedIntegratorChain(db, { label: "starvation-prefix", shape: "canonical-compound-readiness" });
   await db.task.createMany({ data: Array.from({ length: 55 }, (_, index) => ({
@@ -996,6 +1220,63 @@ test("operator-authored recovery metadata cannot suppress an ordinary gate repai
   assert.equal(await db.inboxMessage.count({ where: {
     dedupeKey: { startsWith: "merge-base-drift-recovery-tail-stop:" },
   } }), 0);
+});
+
+test("a repair attempt beyond the recent marker window still prevents a free retry", async () => {
+  const seeded = await seedIntegratorChain(db, {
+    label: "repair-attempt-full-history",
+    shape: "canonical-compound-readiness",
+  });
+  await db.agent.update({ where: { id: seeded.agent.id }, data: { name: "senior-dev" } });
+  await db.run.update({ where: { id: seeded.gateRun.id }, data: { headSha: HEAD } });
+  const verdict = JSON.stringify({
+    schemaVersion: 1,
+    outcome: "gate-fail",
+    headSha: HEAD,
+    baseHeadSha: BASE,
+    gateVerdict: "FAIL",
+    summary: "gate failed",
+  });
+  await db.taskStepOutput.create({ data: {
+    taskId: seeded.gateTask.id,
+    runId: seeded.gateRun.id,
+    kind: "regression-verification",
+    body: verdict,
+    commitSha: HEAD,
+  } });
+  const completion = {
+    task: seeded.gateTask,
+    run: {
+      id: seeded.gateRun.id,
+      agentId: seeded.agent.id,
+      branch: "agentos/chain/demo",
+      headSha: HEAD,
+      sessionId: seeded.gateSession.id,
+    },
+    now: new Date(),
+  };
+  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, completion)), "handled");
+  assert.equal(await db.task.count({ where: { name: "Autonomous merge tail: gate-fix" } }), 1);
+
+  for (let index = 0; index < 25; index += 1) {
+    await writeMarker(db, seeded.gateTask.id, "regression", {
+      actorType: "control-plane",
+      body: `later regression activity ${String(index)}`,
+      metadata: { outcome: "pass", headSha: HEAD, baseHeadSha: BASE },
+    });
+  }
+  const recent = await db.taskActivity.findMany({
+    where: { taskId: seeded.gateTask.id },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: 20,
+    select: { metadata: true },
+  });
+  assert.equal(recent.some(({ metadata }) => (
+    (metadata as Record<string, unknown>).kind === MERGE_TAIL_KIND.repairAttempt
+  )), false, "the first attempt is outside the recent-state window");
+
+  assert.equal(await db.$transaction((tx) => handleRegressionCompletion(tx, completion)), "handled");
+  assert.equal(await db.task.count({ where: { name: "Autonomous merge tail: gate-fix" } }), 1);
 });
 
 test("a recovery regression conflict, semantic failure, or gate failure stops without an auxiliary repair task", async () => {

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -544,10 +544,11 @@ test("eligible direct and compound stops recover once under duplicate ticks and 
       assert.equal(parsed.payload.baseSha, BASE_2);
     }
     assert.equal(await db.run.count({ where: { taskId: seeded.integratorTask!.id } }), 2);
-    assert.equal(
+    assert.deepEqual(
       (await readMarkerHistory(db, seeded.integratorTask!.id))
-        .filter((entry) => entry.kind === "baseDriftRecovery").length,
-      1,
+        .filter((entry) => entry.kind === "baseDriftRecovery")
+        .map((entry) => entry.state),
+      ["awaiting-authorization", "queued"],
     );
   }
 });

--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -8,8 +8,6 @@ import {
   Prisma,
   TaskStatus,
   asJsonObject,
-  closeIntegratorQuestions,
-  enqueueTaskRun,
   isMergeReadinessStep,
   latestRecordedStop,
   lockChainRows,
@@ -19,7 +17,6 @@ import {
   resolveChainTarget,
   selectAuthorization,
   taskIsIntegratorStep,
-  writeMarker,
   type CardRow,
   type CandidateActivity,
   type DecisionRow,
@@ -41,46 +38,17 @@ import {
   type Retry,
 } from "./base-drift-recovery-decision.js";
 import { stopMergeTail } from "./merge-tail-actions.js";
+import {
+  ensureRecoveryValidation,
+  enterRepair,
+  recordValidationRetry,
+  recoveryIsReopenableLegacyRefusal,
+  retireLegacyRefusal,
+} from "./merge-tail-state.js";
 
 type DbReader = PrismaClient | Prisma.TransactionClient;
 
 const SHA = /^[0-9a-f]{40}$/u;
-const LEGACY_PRE_INTENT_REFUSAL = "source executor run does not have exactly one server-bound merge intent";
-const LEGACY_TARGET_BRANCH_REFUSAL = "authorized target ref differs from the chain target branch";
-
-const isLegacyPreIntentRefusal = (attempt: MergeRecoveryAttempt): boolean => (
-  attempt.status === MergeRecoveryStatus.FAILED
-  && attempt.failureReason === LEGACY_PRE_INTENT_REFUSAL
-  && attempt.boundSourceRunId === null
-  && attempt.authorizationActivityId === null
-  && attempt.recoveryRunId === null
-);
-
-const isLegacyTargetBranchRefusal = (attempt: MergeRecoveryAttempt): boolean => (
-  attempt.status === MergeRecoveryStatus.FAILED
-  && attempt.failureReason === LEGACY_TARGET_BRANCH_REFUSAL
-  && attempt.boundSourceRunId === null
-  && attempt.authorizationActivityId === null
-  && attempt.recoveryRunId === null
-  && attempt.readinessTaskId === null
-  && attempt.regressionTaskId === null
-  && attempt.repository === null
-  && attempt.prNumber === null
-  && attempt.targetBranch === null
-  && attempt.authorizedHeadSha === null
-  && attempt.authorizedBaseSha === null
-  && attempt.observedBaseSha === null
-  && attempt.currentBaseSha === null
-);
-
-const isReopenableLegacyRefusal = (attempt: MergeRecoveryAttempt): boolean => (
-  isLegacyPreIntentRefusal(attempt) || isLegacyTargetBranchRefusal(attempt)
-);
-
-const retiredLegacyRefusalReason = (reason: string): string => (
-  `Historical base-drift recovery refusal retired after current validation: ${reason}`
-);
-
 export const baseDriftRecoveryPollIntervalMs = (): number => {
   const raw = Number(process.env.MERGE_BASE_DRIFT_RECOVERY_POLL_INTERVAL_MS);
   return Number.isFinite(raw) && raw >= 250 ? Math.floor(raw) : 2_000;
@@ -94,47 +62,6 @@ const recoveryAttemptFor = async (
   where: { integratorTaskId, sourceStopId },
   orderBy: [{ attempt: "desc" }, { id: "desc" }],
 });
-
-const ensureValidationAttemptLocked = async (
-  tx: Prisma.TransactionClient,
-  integratorTaskId: string,
-  sourceStopId: string,
-  candidate?: RecoveryCandidate,
-): Promise<MergeRecoveryAttempt> => {
-  const existing = await recoveryAttemptFor(tx, integratorTaskId, sourceStopId);
-  const candidateData = candidate ? {
-    boundSourceRunId: candidate.sourceRunId,
-    authorizationActivityId: candidate.authorizationActivityId,
-    readinessTaskId: candidate.readinessTaskId,
-    regressionTaskId: candidate.regressionTaskId,
-    repository: candidate.repository,
-    prNumber: candidate.prNumber,
-    targetBranch: candidate.targetBranch,
-    authorizedHeadSha: candidate.authorizedHeadSha,
-    authorizedBaseSha: candidate.authorizedBaseSha,
-    observedBaseSha: candidate.observedBaseSha,
-  } : {};
-  if (existing) {
-    if (!candidate || !isReopenableLegacyRefusal(existing)) return existing;
-    return tx.mergeRecoveryAttempt.update({ where: { id: existing.id }, data: {
-      status: MergeRecoveryStatus.VALIDATING,
-      failureReason: null,
-      endedAt: null,
-      ...candidateData,
-    } });
-  }
-  const latest = await tx.mergeRecoveryAttempt.aggregate({
-    where: { integratorTaskId },
-    _max: { attempt: true },
-  });
-  return tx.mergeRecoveryAttempt.create({ data: {
-    integratorTaskId,
-    sourceStopId,
-    attempt: (latest._max.attempt ?? 0) + 1,
-    status: MergeRecoveryStatus.VALIDATING,
-    ...candidateData,
-  } });
-};
 
 const parseBaseDriftEvidence = (evidence: string): { observed: string; authorized: string } | null => {
   let value: unknown;
@@ -179,7 +106,7 @@ const loadCandidate = async (db: DbReader, integratorTaskId: string): Promise<Ca
   const existingAttempt = await recoveryAttemptFor(db, task.id, stop.stopId);
   if (existingAttempt
     && existingAttempt.status !== MergeRecoveryStatus.VALIDATING
-    && !isReopenableLegacyRefusal(existingAttempt)) return { kind: "skip" };
+    && !recoveryIsReopenableLegacyRefusal(existingAttempt)) return { kind: "skip" };
   const refuse = (code: CandidateRefusalCode, detail?: string): CandidateLoad => ({
     kind: "refused", code, stopId: stop.stopId, ...(detail ? { detail } : {}),
   });
@@ -327,7 +254,7 @@ const settleIneligibleLocked = async (
   reason: string,
   identity?: Partial<RecoveryIdentity>,
 ): Promise<void> => {
-  const attempt = await ensureValidationAttemptLocked(tx, integratorTaskId, stopId);
+  const attempt = await ensureRecoveryValidation(tx, { integratorTaskId, sourceStopId: stopId });
   await stopMergeTail(tx, {
     phase: "recovery-validation",
     aggregateId: attempt.id,
@@ -361,26 +288,14 @@ const settleIneligible = async (
   if (currentStop?.stopId !== stopId) return false;
   const existing = await recoveryAttemptFor(tx, integratorTaskId, stopId);
   if (existing && existing.status !== MergeRecoveryStatus.VALIDATING) {
-    if (!isReopenableLegacyRefusal(existing)) return false;
-    const retiredReason = retiredLegacyRefusalReason(reason);
-    await tx.mergeRecoveryAttempt.update({ where: { id: existing.id }, data: {
-      failureReason: retiredReason,
-      endedAt: new Date(),
-    } });
-    await tx.task.update({ where: { id: integratorTaskId }, data: {
-      status: TaskStatus.REVIEW,
-      failureReason: `Automatic base-drift recovery refused: ${reason}`,
-    } });
-    await writeMarker(tx, integratorTaskId, "baseDriftRecovery", {
-      actorType: "control-plane",
-      body: retiredReason,
-      metadata: {
-        state: "legacy-refusal-retired",
-        integratorTaskId,
-        sourceStopId: stopId,
-        priorReason: existing.failureReason,
-        reason,
-      },
+    if (!recoveryIsReopenableLegacyRefusal(existing)) return false;
+    await retireLegacyRefusal(tx, {
+      aggregateId: existing.id,
+      integratorTaskId,
+      sourceStopId: stopId,
+      priorReason: existing.failureReason,
+      reason,
+      at: new Date(),
     });
     await openAbandonQuestion(tx, integratorTaskId, stopId);
     return true;
@@ -398,7 +313,7 @@ const recordClassificationRetry = async (
   if (!await lockRecoveryChain(tx, integratorTaskId)) return "skipped";
   const currentStop = await latestRecordedStop(tx, integratorTaskId);
   if (currentStop?.stopId !== stopId) return "skipped";
-  const attempt = await ensureValidationAttemptLocked(tx, integratorTaskId, stopId);
+  const attempt = await ensureRecoveryValidation(tx, { integratorTaskId, sourceStopId: stopId });
   if (attempt.status !== MergeRecoveryStatus.VALIDATING) return "skipped";
   const decision = classifyRetryBudget({
     reason,
@@ -418,20 +333,13 @@ const recordClassificationRetry = async (
       break;
   }
   const classificationAttempt = decision.classificationAttempt;
-  await tx.mergeRecoveryAttempt.update({
-    where: { id: attempt.id },
-    data: { validationAttempts: classificationAttempt, failureReason: reason },
-  });
-  await writeMarker(tx, integratorTaskId, "baseDriftRecovery", {
-    actorType: "control-plane",
-    body: `Automatic pre-merge base-drift classification deferred (${classificationAttempt}/${MAX_BASE_DRIFT_CLASSIFICATION_RETRIES}): ${reason}`,
-    metadata: {
-      state: "classification-retry",
-      integratorTaskId,
-      sourceStopId: stopId,
-      classificationAttempt,
-      reason,
-    },
+  await recordValidationRetry(tx, {
+    aggregateId: attempt.id,
+    integratorTaskId,
+    sourceStopId: stopId,
+    classificationAttempt,
+    maxAttempts: MAX_BASE_DRIFT_CLASSIFICATION_RETRIES,
+    reason,
   });
   return "retryable";
 });
@@ -450,7 +358,11 @@ const queueRecovery = async (
   now: Date,
 ): Promise<QueueRecoveryResult> => db.$transaction(async (tx) => {
   if (!await lockRecoveryChain(tx, expected.integratorTaskId)) return { kind: "skip" };
-  const aggregate = await ensureValidationAttemptLocked(tx, expected.integratorTaskId, expected.stopId, expected);
+  const aggregate = await ensureRecoveryValidation(tx, {
+    integratorTaskId: expected.integratorTaskId,
+    sourceStopId: expected.stopId,
+    identity: expected,
+  });
   const loaded = await loadCandidate(tx, expected.integratorTaskId);
 
   // A recovery spends an attempt only once it owns a fresh regression Run.
@@ -533,42 +445,7 @@ const queueRecovery = async (
       break;
   }
 
-  await closeIntegratorQuestions(tx, expected.integratorTaskId);
-  await tx.task.update({ where: { id: expected.regressionTaskId }, data: { status: TaskStatus.TODO, failureReason: null } });
-  await tx.task.update({ where: { id: expected.readinessTaskId }, data: { status: TaskStatus.TODO, failureReason: null } });
-  await tx.task.update({ where: { id: expected.integratorTaskId }, data: {
-    status: TaskStatus.REVIEW,
-    failureReason: `Automatic base-drift recovery ${attempt} queued from stop ${expected.stopId}`,
-  } });
-  const run = await enqueueTaskRun(tx, expected.regressionTaskId, now);
-  await tx.mergeRecoveryAttempt.update({ where: { id: aggregate.id }, data: {
-    status: MergeRecoveryStatus.REPAIRING,
-    failureReason: null,
-    endedAt: null,
-    boundSourceRunId: expected.sourceRunId,
-    authorizationActivityId: expected.authorizationActivityId,
-    recoveryRunId: run.id,
-    readinessTaskId: expected.readinessTaskId,
-    regressionTaskId: expected.regressionTaskId,
-    repository: expected.repository,
-    prNumber: expected.prNumber,
-    targetBranch: expected.targetBranch,
-    authorizedHeadSha: expected.authorizedHeadSha,
-    authorizedBaseSha: expected.authorizedBaseSha,
-    observedBaseSha: expected.observedBaseSha,
-    currentBaseSha,
-  } });
-  const metadata = { ...common, state: "queued", recoveryRunId: run.id };
-  await writeMarker(tx, expected.integratorTaskId, "baseDriftRecovery", {
-    actorType: "control-plane",
-    body: `Automatic base-drift recovery ${attempt} parked stop ${expected.stopId} and queued fresh regression`,
-    metadata,
-  });
-  await writeMarker(tx, expected.regressionTaskId, "baseDriftRecovery", {
-    actorType: "control-plane",
-    body: `Automatic base-drift recovery ${attempt} verifies ${expected.authorizedHeadSha} against current base ${currentBaseSha}`,
-    metadata,
-  });
+  await enterRepair(tx, { aggregateId: aggregate.id, currentBaseSha, now });
   return { kind: "recovered" };
 });
 
@@ -668,7 +545,11 @@ export const baseDriftRecoveryTick = async (
       const settlementTask = { id: task.id, identity: candidate };
       const validation = await db.$transaction(async (tx) => {
         if (!await lockRecoveryChain(tx, candidate.integratorTaskId)) return false;
-        const attempt = await ensureValidationAttemptLocked(tx, candidate.integratorTaskId, candidate.stopId, candidate);
+        const attempt = await ensureRecoveryValidation(tx, {
+          integratorTaskId: candidate.integratorTaskId,
+          sourceStopId: candidate.stopId,
+          identity: candidate,
+        });
         return attempt.status === MergeRecoveryStatus.VALIDATING;
       });
       if (!validation) continue;

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -320,24 +320,13 @@ const readReadiness = async (
     return { claimed: false, input: { ...context, stage: "regression-pending" } };
   }
 
-  let recovery: RecoveryContext | null = null;
-  let recoveryStatus: MergeRecoveryStatus | null = null;
-  try {
-    const recoveryRead = await recoveryContextFor(db, regression.id, readiness.id, regression.runs[0]?.id ?? null);
-    recovery = recoveryRead?.context ?? null;
-    recoveryStatus = recoveryRead?.status ?? null;
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    return {
-      claimed: false,
-      input: { ...context, stage: "read-failed", failure: { kind: "unexpected", message } },
-    };
-  }
-
   const claim = await claimReadinessStep(db, readiness.id, now);
   if (!claim) return { claimed: false, input: { ...context, stage: "claim-lost" } };
 
+  let recovery: RecoveryContext | null = null;
   try {
+    const recoveryRead = await recoveryContextFor(db, regression.id, readiness.id, regression.runs[0]?.id ?? null);
+    recovery = recoveryRead?.context ?? null;
     const claimedRead = (input: ReadinessInput): ClaimedReadiness => ({
       claimed: true,
       readiness,
@@ -346,7 +335,7 @@ const readReadiness = async (
       claim,
       input,
     });
-    if (recovery && recoveryStatus === MergeRecoveryStatus.REPAIRING) {
+    if (recovery && recoveryRead?.status === MergeRecoveryStatus.REPAIRING) {
       const transition = await db.$transaction((tx) => claim.settle(tx, {
         kind: "keep",
         apply: async (client) => awaitAuthorization(client, recovery!),

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -24,6 +24,12 @@ import {
 
 import { lockTaskMutationRows } from "./task-write.js";
 import { openDefenseAuditNotice, stopMergeTail } from "./merge-tail-actions.js";
+import {
+  adoptRecoveryHead,
+  awaitAuthorization,
+  enterRepair,
+  reopenAfterHeadAdoption,
+} from "./merge-tail-state.js";
 import { createGitHubReader, type PullRequestReader } from "./github-read.js";
 import {
   evaluateReadiness,
@@ -123,45 +129,9 @@ export const reopenRecoveryHeadAdoptionFailures = async (
         || stop?.stopId !== attempt.sourceStopId
         || stop.sourceRunId !== context.sourceRunId) return false;
 
-      const updated = await tx.mergeRecoveryAttempt.updateMany({
-        where: {
-          id: attempt.id,
-          status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
-          failureReason: attempt.failureReason,
-          boundSourceRunId: context.sourceRunId,
-          authorizationActivityId: context.authorizationActivityId,
-          recoveryRunId: context.recoveryRunId,
-          readinessTaskId: context.readinessTaskId,
-          regressionTaskId: context.regressionTaskId,
-          repository: context.repository,
-          prNumber: context.prNumber,
-          targetBranch: context.targetBranch,
-          authorizedHeadSha: context.authorizedHeadSha,
-          authorizedBaseSha: context.authorizedBaseSha,
-          observedBaseSha: context.observedBaseSha,
-          currentBaseSha: context.currentBaseSha,
-        },
-        data: { status: MergeRecoveryStatus.REPAIRING, failureReason: null, endedAt: null },
-      });
-      if (updated.count !== 1) return false;
-      await tx.task.update({ where: { id: candidate.regressionTaskId! }, data: { status: TaskStatus.DONE, failureReason: null } });
-      await tx.task.update({ where: { id: candidate.readinessTaskId! }, data: { status: TaskStatus.TODO, failureReason: null } });
-      await tx.task.update({ where: { id: candidate.integratorTaskId }, data: {
-        status: TaskStatus.REVIEW,
-        failureReason: `Automatic base-drift recovery ${candidate.attempt} resumed after verified regression head adoption`,
-      } });
-      const body = `Automatic base-drift recovery ${candidate.attempt} reopened the verified Regression result for fresh readiness authorization`;
-      const metadata = {
-        aggregateId: candidate.id,
-        sourceStopId: candidate.sourceStopId,
-        recoveryRunId: candidate.recoveryRunId,
-        state: "reopened-head-adoption",
-      };
-      await writeMarker(tx, candidate.integratorTaskId, "baseDriftRecovery", {
-        actorType: "control-plane", body, metadata,
-      });
-      await writeMarker(tx, candidate.regressionTaskId!, "baseDriftRecovery", {
-        actorType: "control-plane", body, metadata,
+      await reopenAfterHeadAdoption(tx, {
+        recovery: context,
+        expectedFailureReason: attempt.failureReason,
       });
       return true;
     });
@@ -198,7 +168,7 @@ const recoveryContextFor = async (
   regressionTaskId: string,
   readinessTaskId: string,
   recoveryRunId: string | null,
-): Promise<RecoveryContext | null> => {
+): Promise<{ context: RecoveryContext; status: MergeRecoveryStatus } | null> => {
   if (!recoveryRunId) return null;
   const row = await db.mergeRecoveryAttempt.findFirst({ where: {
     regressionTaskId,
@@ -206,7 +176,8 @@ const recoveryContextFor = async (
     recoveryRunId,
     status: { in: [MergeRecoveryStatus.REPAIRING, MergeRecoveryStatus.AWAITING_AUTHORIZATION] },
   }, orderBy: [{ attempt: "desc" }, { id: "desc" }] });
-  return recoveryContext(row);
+  const context = recoveryContext(row);
+  return row && context ? { context, status: row.status } : null;
 };
 
 const stopReadiness = async (
@@ -268,60 +239,40 @@ const requeueRegression = async (
     kind: "finish",
     at: input.now,
     apply: async (client) => {
-      await client.task.update({
-        where: { id: input.readinessTaskId },
-        data: { status: TaskStatus.TODO, failureReason: null },
-      });
-      await client.task.update({
-        where: { id: input.regressionTaskId },
-        data: { status: TaskStatus.TODO, failureReason: null },
-      });
       // The prior Regression run succeeded; the control plane invalidated its
       // exact-base evidence after a remote read. This retry is therefore external
       // compensation, not another attempt charged to the agent. Without the
       // grant, a requeue at the configured ceiling creates run N+1 with ceiling N
       // and the runner rejects it before launch -- exactly the stuck state the
       // readiness transition was supposed to recover.
-      const run = await enqueueTaskRun(client, input.regressionTaskId, input.now, { budgetGrant: 1 });
       if (input.recovery) {
-        await client.mergeRecoveryAttempt.update({ where: { id: input.recovery.aggregateId }, data: {
-          status: MergeRecoveryStatus.REPAIRING,
-          recoveryRunId: run.id,
+        await enterRepair(client, {
+          aggregateId: input.recovery.aggregateId,
           currentBaseSha: input.currentBaseSha,
-          failureReason: null,
-          endedAt: null,
-        } });
-        const body = `Automatic base-drift recovery ${String(input.recovery.attempt)} context carried through readiness requeue`;
-        const metadata = {
-          ...input.recovery,
-          currentBaseSha: input.currentBaseSha,
-          recoveryRunId: run.id,
-        } as Prisma.InputJsonObject;
-        await client.taskActivity.createMany({ data: [
-          {
-            taskId: input.recovery.integratorTaskId,
-            actorType: "control-plane",
-            body,
-            metadata,
+          now: input.now,
+          readinessRequeue: { staleBaseSha: input.staleBaseSha, reason: input.reason },
+        });
+      } else {
+        await client.task.update({
+          where: { id: input.readinessTaskId },
+          data: { status: TaskStatus.TODO, failureReason: null },
+        });
+        await client.task.update({
+          where: { id: input.regressionTaskId },
+          data: { status: TaskStatus.TODO, failureReason: null },
+        });
+        await enqueueTaskRun(client, input.regressionTaskId, input.now, { budgetGrant: 1 });
+        await writeMarker(client, input.regressionTaskId, "readiness", {
+          actorType: "control-plane",
+          body: `Merge readiness returned to regression: ${input.reason}; ${input.staleBaseSha} -> ${input.currentBaseSha}`,
+          metadata: {
+            state: "requeued-regression",
+            reason: input.reason,
+            staleBaseSha: input.staleBaseSha,
+            currentBaseSha: input.currentBaseSha,
           },
-          {
-            taskId: input.regressionTaskId,
-            actorType: "control-plane",
-            body,
-            metadata,
-          },
-        ] });
+        });
       }
-      await writeMarker(client, input.regressionTaskId, "readiness", {
-        actorType: "control-plane",
-        body: `Merge readiness returned to regression: ${input.reason}; ${input.staleBaseSha} -> ${input.currentBaseSha}`,
-        metadata: {
-          state: "requeued-regression",
-          reason: input.reason,
-          staleBaseSha: input.staleBaseSha,
-          currentBaseSha: input.currentBaseSha,
-        },
-      });
       return { value: undefined, ownership: "released" as const };
     },
   });
@@ -370,18 +321,25 @@ const readReadiness = async (
     return { claimed: false, input: { ...context, stage: "regression-pending" } };
   }
 
+  let recovery: RecoveryContext | null = null;
+  try {
+    const recoveryRead = await recoveryContextFor(db, regression.id, readiness.id, regression.runs[0]?.id ?? null);
+    recovery = recoveryRead?.context ?? null;
+    if (recovery && recoveryRead?.status === MergeRecoveryStatus.REPAIRING) {
+      await db.$transaction((tx) => awaitAuthorization(tx, recovery!));
+    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      claimed: false,
+      input: { ...context, stage: "read-failed", failure: { kind: "unexpected", message } },
+    };
+  }
+
   const claim = await claimReadinessStep(db, readiness.id, now);
   if (!claim) return { claimed: false, input: { ...context, stage: "claim-lost" } };
 
-  let recovery: RecoveryContext | null = null;
   try {
-    recovery = await recoveryContextFor(db, regression.id, readiness.id, regression.runs[0]?.id ?? null);
-    if (recovery) {
-      await db.mergeRecoveryAttempt.update({ where: { id: recovery.aggregateId }, data: {
-        status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
-        failureReason: null,
-      } });
-    }
     const claimedRead = (input: ReadinessInput): ClaimedReadiness => ({
       claimed: true,
       readiness,
@@ -603,22 +561,11 @@ const applyReadinessDecision = async (
           // candidate, so its gated head may legitimately replace the head that
           // first stopped on base drift. Adopt only the head re-read under the
           // merge Lease and bind the CAS to the pre-Lease recovery snapshot.
-          const adopted = await client.mergeRecoveryAttempt.updateMany({
-            where: {
-              id: recovery.aggregateId,
-              status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
-              recoveryRunId: recovery.recoveryRunId,
-              currentBaseSha: recovery.currentBaseSha,
-              authorizedHeadSha: recovery.authorizedHeadSha,
-            },
-            data: {
-              currentBaseSha: leasedDecision.evidence.baseSha,
-              authorizedHeadSha: leasedDecision.evidence.headSha,
-            },
+          await adoptRecoveryHead(client, {
+            recovery,
+            currentBaseSha: leasedDecision.evidence.baseSha,
+            authorizedHeadSha: leasedDecision.evidence.headSha,
           });
-          if (adopted.count !== 1) {
-            throw new Error("Recovery authorization could not adopt the verified regression head");
-          }
         }
         const activity = await client.taskActivity.create({ data: {
           taskId: readiness.id,

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -129,11 +129,10 @@ export const reopenRecoveryHeadAdoptionFailures = async (
         || stop?.stopId !== attempt.sourceStopId
         || stop.sourceRunId !== context.sourceRunId) return false;
 
-      await reopenAfterHeadAdoption(tx, {
+      return reopenAfterHeadAdoption(tx, {
         recovery: context,
         expectedFailureReason: attempt.failureReason,
       });
-      return true;
     });
     if (applied) reopened += 1;
   }
@@ -322,12 +321,11 @@ const readReadiness = async (
   }
 
   let recovery: RecoveryContext | null = null;
+  let recoveryStatus: MergeRecoveryStatus | null = null;
   try {
     const recoveryRead = await recoveryContextFor(db, regression.id, readiness.id, regression.runs[0]?.id ?? null);
     recovery = recoveryRead?.context ?? null;
-    if (recovery && recoveryRead?.status === MergeRecoveryStatus.REPAIRING) {
-      await db.$transaction((tx) => awaitAuthorization(tx, recovery!));
-    }
+    recoveryStatus = recoveryRead?.status ?? null;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     return {
@@ -348,6 +346,15 @@ const readReadiness = async (
       claim,
       input,
     });
+    if (recovery && recoveryStatus === MergeRecoveryStatus.REPAIRING) {
+      const transition = await db.$transaction((tx) => claim.settle(tx, {
+        kind: "keep",
+        apply: async (client) => awaitAuthorization(client, recovery!),
+      }));
+      if (!transition.settled) {
+        return { claimed: false, input: { ...context, stage: "claim-lost" } };
+      }
+    }
     if (!regression.stepOutput) {
       return claimedRead({ ...context, stage: "missing-regression-evidence" });
     }

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -217,7 +217,7 @@ export const baseDriftRecoveryContext = async (
   return recoveryContext(row);
 };
 
-type RecoveryStopData = Prisma.MergeRecoveryAttemptUpdateInput;
+type RecoveryStopData = Prisma.MergeRecoveryAttemptUpdateManyMutationInput;
 
 export type StopMergeTailInput =
   | {
@@ -706,7 +706,6 @@ export const handleRegressionCompletion = async (
     await recordVerdict();
     if (recovery) {
       await awaitAuthorization(tx, recovery);
-      return "handled";
     }
     return "advance";
   }

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -9,7 +9,6 @@ import {
   MAX_MERGE_TAIL_REPAIR_ATTEMPTS,
   MERGE_TAIL_KIND,
   MERGE_TAIL_SCHEMA_VERSION,
-  mergeRecoveryTransitionAllowed,
   MergeRecoveryStatus,
   type Marker,
   parseResolverResult,
@@ -27,6 +26,7 @@ import { FAILURE_REASON_LIMIT, truncateFailureReason } from "./failure-reason.js
 import { canonicalOutputRefusal } from "./canonical-task-output.js";
 import { settleLease, type LeaseSettlementOutcome } from "./merge-lease.js";
 import type { MergeLeaseTarget } from "./merge-lease-hold.js";
+import { awaitAuthorization, blockDownstream, exhaust } from "./merge-tail-state.js";
 
 /**
  * The autonomous merge tail's own actions: the base-drift recovery aggregate,
@@ -267,26 +267,6 @@ export type StopMergeTailResult = { leaseToRelease: MergeLeaseTarget | null };
 type ReadinessStopMergeTailInput = Extract<StopMergeTailInput, { phase: "readiness" }>;
 type CompletionOwnedStopMergeTailInput = Exclude<StopMergeTailInput, ReadinessStopMergeTailInput>;
 
-const transitionRecovery = async (
-  tx: DbTx,
-  aggregateId: string,
-  target: MergeRecoveryStatus,
-  data: RecoveryStopData,
-): Promise<void> => {
-  const aggregate = await tx.mergeRecoveryAttempt.findUnique({
-    where: { id: aggregateId },
-    select: { status: true },
-  });
-  if (!aggregate) throw new Error(`Merge recovery aggregate ${aggregateId} is absent`);
-  if (!mergeRecoveryTransitionAllowed(aggregate.status, target)) {
-    throw new Error(`Illegal merge recovery transition ${aggregate.status} -> ${target} for ${aggregateId}`);
-  }
-  await tx.mergeRecoveryAttempt.update({
-    where: { id: aggregateId },
-    data: { ...data, status: target },
-  });
-};
-
 const stopNotice = async (
   tx: DbTx,
   input: { taskId: string; body: string; dedupeKey: string; agentId?: string; sessionId?: string },
@@ -327,31 +307,7 @@ export async function stopMergeTail(
         ? `Autonomous merge readiness stopped: ${input.reason}`
         : `Autonomous merge tail stopped: ${input.reason}`;
     if (recovery) {
-      await transitionRecovery(tx, recovery.aggregateId, MergeRecoveryStatus.BLOCKED_DOWNSTREAM, {
-        failureReason: input.reason,
-        endedAt: input.at,
-      });
-      if (input.phase === "regression") {
-        await tx.task.updateMany({
-          where: { id: { in: [recovery.regressionTaskId, recovery.readinessTaskId, recovery.integratorTaskId] } },
-          data: { status: TaskStatus.REVIEW, failureReason: body },
-        });
-      } else {
-        await tx.task.updateMany({
-          where: { id: { in: [input.readinessTaskId, input.regressionTaskId] } },
-          data: { status: TaskStatus.REVIEW, failureReason: input.reason },
-        });
-        await tx.task.update({
-          where: { id: recovery.integratorTaskId },
-          data: { status: TaskStatus.REVIEW, failureReason: body },
-        });
-      }
-      const dedupeKey = `merge-base-drift-recovery-tail-stop:${recovery.sourceStopId}:${input.phase}`;
-      const metadata = { ...recovery, state: "tail-stopped", phase: input.phase, reason: input.reason, dedupeKey };
-      for (const taskId of [recovery.integratorTaskId, recovery.regressionTaskId]) {
-        await writeMarker(tx, taskId, "baseDriftRecovery", { actorType: "control-plane", body, metadata });
-      }
-      await stopNotice(tx, { taskId: input.regressionTaskId, body, dedupeKey });
+      await blockDownstream(tx, { recovery, phase: input.phase, reason: input.reason, at: input.at });
     } else if (input.phase === "readiness") {
       await tx.task.updateMany({
         where: { id: { in: [input.readinessTaskId, input.regressionTaskId] } },
@@ -420,38 +376,18 @@ export async function stopMergeTail(
     return;
   }
 
-  await transitionRecovery(tx, input.aggregateId, MergeRecoveryStatus.FAILED, {
-    ...input.recoveryData,
-    failureReason: input.reason,
-    endedAt: input.at,
-  });
   const state = input.phase === "recovery-validation" ? "ineligible" : "exhausted";
-  const body = input.phase === "recovery-validation"
-    ? `Automatic pre-merge base-drift recovery refused: ${input.reason}`
-    : `Automatic pre-merge base-drift recovery exhausted at attempt ${input.attempt}`;
-  await writeMarker(tx, input.integratorTaskId, "baseDriftRecovery", {
-    actorType: "control-plane",
-    body,
-    metadata: {
-      state,
-      ...input.markerMetadata,
-      integratorTaskId: input.integratorTaskId,
-      sourceStopId: input.sourceStopId,
-      reason: input.reason,
-    },
+  await exhaust(tx, {
+    aggregateId: input.aggregateId,
+    integratorTaskId: input.integratorTaskId,
+    sourceStopId: input.sourceStopId,
+    reason: input.reason,
+    at: input.at,
+    attempt: input.attempt,
+    state,
+    recoveryData: input.recoveryData,
+    markerMetadata: input.markerMetadata,
   });
-  const dedupeKey = `merge-base-drift-recovery:${state}:${input.sourceStopId}`;
-  await stopNotice(tx, {
-    taskId: input.integratorTaskId,
-    body: `Automatic pre-merge base-drift recovery ${state} for stop ${input.sourceStopId}: ${input.reason}. No regression run or re-authorization was created.`,
-    dedupeKey,
-  });
-  await tx.task.update({ where: { id: input.integratorTaskId }, data: {
-    status: TaskStatus.REVIEW,
-    failureReason: input.phase === "recovery-validation"
-      ? `Automatic base-drift recovery refused: ${input.reason}`
-      : input.reason,
-  } });
 }
 
 type MergeTailCompletionTask = {
@@ -769,10 +705,8 @@ export const handleRegressionCompletion = async (
   if (verdict.outcome === "pass") {
     await recordVerdict();
     if (recovery) {
-      await tx.mergeRecoveryAttempt.update({ where: { id: recovery.aggregateId }, data: {
-        status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
-        failureReason: null,
-      } });
+      await awaitAuthorization(tx, recovery);
+      return "handled";
     }
     return "advance";
   }

--- a/packages/api/src/merge-tail-state.test.ts
+++ b/packages/api/src/merge-tail-state.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MergeRecoveryStatus,
+  Prisma,
+  TaskStatus,
+  type RecoveryContext,
+} from "@anneal/db";
+
+import {
+  awaitAuthorization,
+  blockDownstream,
+  exhaust,
+  reopenAfterHeadAdoption,
+} from "./merge-tail-state.js";
+
+const recovery: RecoveryContext = {
+  aggregateId: "aggregate-1",
+  attempt: 2,
+  sourceStopId: "stop-1",
+  sourceRunId: "source-run-1",
+  authorizationActivityId: "authorization-1",
+  repository: "acme/widgets",
+  prNumber: 42,
+  targetBranch: "main",
+  authorizedHeadSha: "a".repeat(40),
+  authorizedBaseSha: "b".repeat(40),
+  observedBaseSha: "c".repeat(40),
+  currentBaseSha: "d".repeat(40),
+  readinessTaskId: "readiness-1",
+  regressionTaskId: "regression-1",
+  integratorTaskId: "integrator-1",
+  recoveryRunId: "recovery-run-1",
+};
+
+const stateTx = (status: MergeRecoveryStatus, failureReason = "head adoption failed") => {
+  const recoveryUpdates: Array<Record<string, any>> = [];
+  const taskUpdates: Array<Record<string, any>> = [];
+  const outputDeletes: Array<Record<string, any>> = [];
+  const activities: Array<Record<string, any>> = [];
+  const notices: Array<Record<string, any>> = [];
+  const tx = {
+    mergeRecoveryAttempt: {
+      findUnique: async (args: Record<string, any>) => (
+        args.select?.failureReason ? { failureReason } : { status }
+      ),
+      update: async (args: Record<string, any>) => {
+        recoveryUpdates.push(args);
+        return { id: recovery.aggregateId, status: args.data.status };
+      },
+    },
+    task: {
+      update: async (args: Record<string, any>) => {
+        taskUpdates.push(args);
+        return {};
+      },
+    },
+    taskStepOutput: {
+      deleteMany: async (args: Record<string, any>) => {
+        outputDeletes.push(args);
+        return { count: 1 };
+      },
+    },
+    taskActivity: {
+      create: async ({ data }: { data: Record<string, any> }) => {
+        activities.push(data);
+        return data;
+      },
+    },
+    inboxMessage: {
+      upsert: async (args: Record<string, any>) => {
+        notices.push(args);
+        return {};
+      },
+    },
+  } as unknown as Prisma.TransactionClient;
+  return { tx, recoveryUpdates, taskUpdates, outputDeletes, activities, notices };
+};
+
+test("awaitAuthorization atomically owns the recovery Task tuple and marker", async () => {
+  const observed = stateTx(MergeRecoveryStatus.REPAIRING);
+
+  await awaitAuthorization(observed.tx, recovery);
+
+  assert.equal(observed.recoveryUpdates[0]?.data.status, MergeRecoveryStatus.AWAITING_AUTHORIZATION);
+  assert.deepEqual(observed.taskUpdates, [
+    { where: { id: recovery.regressionTaskId }, data: { status: TaskStatus.DONE, failureReason: null } },
+    { where: { id: recovery.readinessTaskId }, data: { status: TaskStatus.TODO, failureReason: null } },
+    { where: { id: recovery.integratorTaskId }, data: { status: TaskStatus.REVIEW } },
+  ]);
+  assert.deepEqual(
+    observed.activities.map((activity) => activity.metadata.state),
+    ["awaiting-authorization", "awaiting-authorization", "queued"],
+  );
+});
+
+test("blockDownstream atomically parks all three Tasks and writes its deduped marker", async () => {
+  const observed = stateTx(MergeRecoveryStatus.AWAITING_AUTHORIZATION);
+  const at = new Date("2026-08-29T12:00:00.000Z");
+
+  await blockDownstream(observed.tx, {
+    recovery,
+    phase: "readiness",
+    reason: "verified head moved",
+    at,
+  });
+
+  assert.equal(observed.recoveryUpdates[0]?.data.status, MergeRecoveryStatus.BLOCKED_DOWNSTREAM);
+  assert.deepEqual(
+    observed.taskUpdates.map((update) => [update.where.id, update.data.status]),
+    [
+      [recovery.regressionTaskId, TaskStatus.REVIEW],
+      [recovery.readinessTaskId, TaskStatus.REVIEW],
+      [recovery.integratorTaskId, TaskStatus.REVIEW],
+    ],
+  );
+  assert.deepEqual(observed.activities.map((activity) => activity.metadata.state), ["tail-stopped", "tail-stopped"]);
+  assert.equal(
+    observed.notices[0]?.where.dedupeKey,
+    `merge-base-drift-recovery-tail-stop:${recovery.sourceStopId}:readiness`,
+  );
+});
+
+test("reopenAfterHeadAdoption takes the declared BLOCKED_DOWNSTREAM reopen edge", async () => {
+  const observed = stateTx(MergeRecoveryStatus.BLOCKED_DOWNSTREAM);
+
+  await reopenAfterHeadAdoption(observed.tx, {
+    recovery,
+    expectedFailureReason: "head adoption failed",
+  });
+
+  assert.equal(observed.recoveryUpdates[0]?.data.status, MergeRecoveryStatus.REPAIRING);
+  assert.deepEqual(
+    observed.taskUpdates.map((update) => [update.where.id, update.data.status]),
+    [
+      [recovery.regressionTaskId, TaskStatus.DONE],
+      [recovery.readinessTaskId, TaskStatus.TODO],
+      [recovery.integratorTaskId, TaskStatus.REVIEW],
+    ],
+  );
+  assert.deepEqual(observed.outputDeletes, [{ where: { taskId: recovery.readinessTaskId } }]);
+  assert.deepEqual(observed.activities.map((activity) => activity.metadata.state), [
+    "reopened-head-adoption",
+    "reopened-head-adoption",
+  ]);
+});
+
+test("exhaust atomically fails validation and parks the integrator", async () => {
+  const observed = stateTx(MergeRecoveryStatus.VALIDATING);
+
+  await exhaust(observed.tx, {
+    aggregateId: recovery.aggregateId,
+    integratorTaskId: recovery.integratorTaskId,
+    sourceStopId: recovery.sourceStopId,
+    reason: "recovery budget exhausted",
+    at: new Date("2026-08-29T12:00:00.000Z"),
+    attempt: recovery.attempt,
+    state: "exhausted",
+    recoveryData: {},
+    markerMetadata: {},
+  });
+
+  assert.equal(observed.recoveryUpdates[0]?.data.status, MergeRecoveryStatus.FAILED);
+  assert.deepEqual(observed.taskUpdates, [{
+    where: { id: recovery.integratorTaskId },
+    data: { status: TaskStatus.REVIEW, failureReason: "recovery budget exhausted" },
+  }]);
+  assert.equal(observed.activities[0]?.metadata.state, "exhausted");
+  assert.equal(observed.notices.length, 1);
+});
+
+test("named migrations reject undeclared recovery edges before Task or marker writes", async () => {
+  const observed = stateTx(MergeRecoveryStatus.FAILED);
+
+  await assert.rejects(
+    awaitAuthorization(observed.tx, recovery),
+    /Illegal merge recovery transition FAILED -> AWAITING_AUTHORIZATION/u,
+  );
+
+  assert.deepEqual(observed.recoveryUpdates, []);
+  assert.deepEqual(observed.taskUpdates, []);
+  assert.deepEqual(observed.activities, []);
+});

--- a/packages/api/src/merge-tail-state.test.ts
+++ b/packages/api/src/merge-tail-state.test.ts
@@ -151,14 +151,16 @@ test("reopenAfterHeadAdoption takes the declared BLOCKED_DOWNSTREAM reopen edge"
 });
 
 test("reopenAfterHeadAdoption skips a stale full-snapshot CAS without touching Tasks", async () => {
-  const observed = stateTx(MergeRecoveryStatus.FAILED, "head adoption failed", 0);
+  const observed = stateTx(MergeRecoveryStatus.BLOCKED_DOWNSTREAM, "head adoption failed", 0);
 
   assert.equal(await reopenAfterHeadAdoption(observed.tx, {
     recovery,
     expectedFailureReason: "head adoption failed",
   }), false);
 
-  assert.equal(observed.recoveryUpdates.length, 0);
+  assert.equal(observed.recoveryUpdates.length, 1);
+  assert.equal(observed.recoveryUpdates[0]?.data.status, MergeRecoveryStatus.REPAIRING);
+  assert.equal(observed.recoveryUpdates[0]?.where.AND[1].failureReason, "head adoption failed");
   assert.deepEqual(observed.taskUpdates, []);
   assert.deepEqual(observed.outputDeletes, []);
   assert.deepEqual(observed.activities, []);

--- a/packages/api/src/merge-tail-state.test.ts
+++ b/packages/api/src/merge-tail-state.test.ts
@@ -5,12 +5,14 @@ import {
   MergeRecoveryStatus,
   Prisma,
   TaskStatus,
+  type MergeRecoveryAttempt,
   type RecoveryContext,
 } from "@anneal/db";
 
 import {
   awaitAuthorization,
   blockDownstream,
+  ensureRecoveryValidation,
   exhaust,
   reopenAfterHeadAdoption,
 } from "./merge-tail-state.js";
@@ -34,7 +36,11 @@ const recovery: RecoveryContext = {
   recoveryRunId: "recovery-run-1",
 };
 
-const stateTx = (status: MergeRecoveryStatus, failureReason = "head adoption failed") => {
+const stateTx = (
+  status: MergeRecoveryStatus,
+  failureReason = "head adoption failed",
+  casCount = 1,
+) => {
   const recoveryUpdates: Array<Record<string, any>> = [];
   const taskUpdates: Array<Record<string, any>> = [];
   const outputDeletes: Array<Record<string, any>> = [];
@@ -49,6 +55,11 @@ const stateTx = (status: MergeRecoveryStatus, failureReason = "head adoption fai
         recoveryUpdates.push(args);
         return { id: recovery.aggregateId, status: args.data.status };
       },
+      updateMany: async (args: Record<string, any>) => {
+        recoveryUpdates.push(args);
+        return { count: casCount };
+      },
+      findUniqueOrThrow: async () => ({ id: recovery.aggregateId, status: MergeRecoveryStatus.REPAIRING }),
     },
     task: {
       update: async (args: Record<string, any>) => {
@@ -78,21 +89,14 @@ const stateTx = (status: MergeRecoveryStatus, failureReason = "head adoption fai
   return { tx, recoveryUpdates, taskUpdates, outputDeletes, activities, notices };
 };
 
-test("awaitAuthorization atomically owns the recovery Task tuple and marker", async () => {
+test("awaitAuthorization changes only aggregate authority before the activation seam runs", async () => {
   const observed = stateTx(MergeRecoveryStatus.REPAIRING);
 
   await awaitAuthorization(observed.tx, recovery);
 
   assert.equal(observed.recoveryUpdates[0]?.data.status, MergeRecoveryStatus.AWAITING_AUTHORIZATION);
-  assert.deepEqual(observed.taskUpdates, [
-    { where: { id: recovery.regressionTaskId }, data: { status: TaskStatus.DONE, failureReason: null } },
-    { where: { id: recovery.readinessTaskId }, data: { status: TaskStatus.TODO, failureReason: null } },
-    { where: { id: recovery.integratorTaskId }, data: { status: TaskStatus.REVIEW } },
-  ]);
-  assert.deepEqual(
-    observed.activities.map((activity) => activity.metadata.state),
-    ["awaiting-authorization", "awaiting-authorization", "queued"],
-  );
+  assert.deepEqual(observed.taskUpdates, []);
+  assert.deepEqual(observed.activities, []);
 });
 
 test("blockDownstream atomically parks all three Tasks and writes its deduped marker", async () => {
@@ -125,10 +129,10 @@ test("blockDownstream atomically parks all three Tasks and writes its deduped ma
 test("reopenAfterHeadAdoption takes the declared BLOCKED_DOWNSTREAM reopen edge", async () => {
   const observed = stateTx(MergeRecoveryStatus.BLOCKED_DOWNSTREAM);
 
-  await reopenAfterHeadAdoption(observed.tx, {
+  assert.equal(await reopenAfterHeadAdoption(observed.tx, {
     recovery,
     expectedFailureReason: "head adoption failed",
-  });
+  }), true);
 
   assert.equal(observed.recoveryUpdates[0]?.data.status, MergeRecoveryStatus.REPAIRING);
   assert.deepEqual(
@@ -144,6 +148,114 @@ test("reopenAfterHeadAdoption takes the declared BLOCKED_DOWNSTREAM reopen edge"
     "reopened-head-adoption",
     "reopened-head-adoption",
   ]);
+});
+
+test("reopenAfterHeadAdoption skips a stale full-snapshot CAS without touching Tasks", async () => {
+  const observed = stateTx(MergeRecoveryStatus.FAILED, "head adoption failed", 0);
+
+  assert.equal(await reopenAfterHeadAdoption(observed.tx, {
+    recovery,
+    expectedFailureReason: "head adoption failed",
+  }), false);
+
+  assert.equal(observed.recoveryUpdates.length, 0);
+  assert.deepEqual(observed.taskUpdates, []);
+  assert.deepEqual(observed.outputDeletes, []);
+  assert.deepEqual(observed.activities, []);
+});
+
+test("ensureRecoveryValidation owns the declared FAILED legacy reopen edge", async () => {
+  const legacy = {
+    id: recovery.aggregateId,
+    integratorTaskId: recovery.integratorTaskId,
+    sourceStopId: recovery.sourceStopId,
+    attempt: recovery.attempt,
+    status: MergeRecoveryStatus.FAILED,
+    failureReason: "source executor run does not have exactly one server-bound merge intent",
+    boundSourceRunId: null,
+    authorizationActivityId: null,
+    recoveryRunId: null,
+    readinessTaskId: null,
+    regressionTaskId: null,
+    repository: null,
+    prNumber: null,
+    targetBranch: null,
+    authorizedHeadSha: null,
+    authorizedBaseSha: null,
+    observedBaseSha: null,
+    currentBaseSha: null,
+  } as MergeRecoveryAttempt;
+  const observed = stateTx(MergeRecoveryStatus.FAILED);
+  const tx = observed.tx as unknown as {
+    mergeRecoveryAttempt: { findFirst: (args: unknown) => Promise<MergeRecoveryAttempt | null> };
+  };
+  tx.mergeRecoveryAttempt.findFirst = async () => legacy;
+
+  await ensureRecoveryValidation(observed.tx, {
+    integratorTaskId: recovery.integratorTaskId,
+    sourceStopId: recovery.sourceStopId,
+    identity: {
+      sourceRunId: recovery.sourceRunId,
+      authorizationActivityId: recovery.authorizationActivityId,
+      readinessTaskId: recovery.readinessTaskId,
+      regressionTaskId: recovery.regressionTaskId,
+      repository: recovery.repository,
+      prNumber: recovery.prNumber,
+      targetBranch: recovery.targetBranch,
+      authorizedHeadSha: recovery.authorizedHeadSha,
+      authorizedBaseSha: recovery.authorizedBaseSha,
+      observedBaseSha: recovery.observedBaseSha,
+    },
+  });
+
+  assert.equal(observed.recoveryUpdates[0]?.data.status, MergeRecoveryStatus.VALIDATING);
+  assert.equal(observed.activities[0]?.metadata.state, "legacy-validation-reopened");
+});
+
+test("ensureRecoveryValidation fails loudly instead of overwriting conflicting VALIDATING identity", async () => {
+  const validating = {
+    id: recovery.aggregateId,
+    integratorTaskId: recovery.integratorTaskId,
+    sourceStopId: recovery.sourceStopId,
+    attempt: recovery.attempt,
+    status: MergeRecoveryStatus.VALIDATING,
+    boundSourceRunId: "different-source-run",
+    authorizationActivityId: null,
+    recoveryRunId: null,
+    readinessTaskId: null,
+    regressionTaskId: null,
+    repository: null,
+    prNumber: null,
+    targetBranch: null,
+    authorizedHeadSha: null,
+    authorizedBaseSha: null,
+    observedBaseSha: null,
+    currentBaseSha: null,
+  } as MergeRecoveryAttempt;
+  const observed = stateTx(MergeRecoveryStatus.VALIDATING);
+  const tx = observed.tx as unknown as {
+    mergeRecoveryAttempt: { findFirst: (args: unknown) => Promise<MergeRecoveryAttempt | null> };
+  };
+  tx.mergeRecoveryAttempt.findFirst = async () => validating;
+
+  await assert.rejects(ensureRecoveryValidation(observed.tx, {
+    integratorTaskId: recovery.integratorTaskId,
+    sourceStopId: recovery.sourceStopId,
+    identity: {
+      sourceRunId: recovery.sourceRunId,
+      authorizationActivityId: recovery.authorizationActivityId,
+      readinessTaskId: recovery.readinessTaskId,
+      regressionTaskId: recovery.regressionTaskId,
+      repository: recovery.repository,
+      prNumber: recovery.prNumber,
+      targetBranch: recovery.targetBranch,
+      authorizedHeadSha: recovery.authorizedHeadSha,
+      authorizedBaseSha: recovery.authorizedBaseSha,
+      observedBaseSha: recovery.observedBaseSha,
+    },
+  }), /boundSourceRunId conflicts with the validated tail identity/u);
+
+  assert.deepEqual(observed.recoveryUpdates, []);
 });
 
 test("exhaust atomically fails validation and parks the integrator", async () => {

--- a/packages/api/src/merge-tail-state.ts
+++ b/packages/api/src/merge-tail-state.ts
@@ -1,0 +1,510 @@
+import {
+  closeIntegratorQuestions,
+  enqueueTaskRun,
+  MergeRecoveryStatus,
+  Prisma,
+  TaskStatus,
+  transitionMergeRecovery,
+  writeMarker,
+  type MergeRecoveryAttempt,
+  type MergeRecoveryTransitionData,
+  type RecoveryContext,
+} from "@anneal/db";
+
+type DbTx = Prisma.TransactionClient;
+
+const LEGACY_PRE_INTENT_REFUSAL = "source executor run does not have exactly one server-bound merge intent";
+const LEGACY_TARGET_BRANCH_REFUSAL = "authorized target ref differs from the chain target branch";
+
+export type RecoveryValidationIdentity = {
+  sourceRunId: string;
+  authorizationActivityId: string;
+  readinessTaskId: string;
+  regressionTaskId: string;
+  repository: string;
+  prNumber: number;
+  targetBranch: string;
+  authorizedHeadSha: string;
+  authorizedBaseSha: string;
+  observedBaseSha: string;
+};
+
+type RecoveryValidationData = {
+  boundSourceRunId: string;
+  authorizationActivityId: string;
+  readinessTaskId: string;
+  regressionTaskId: string;
+  repository: string;
+  prNumber: number;
+  targetBranch: string;
+  authorizedHeadSha: string;
+  authorizedBaseSha: string;
+  observedBaseSha: string;
+};
+
+const validationData = (identity: RecoveryValidationIdentity): RecoveryValidationData => ({
+  boundSourceRunId: identity.sourceRunId,
+  authorizationActivityId: identity.authorizationActivityId,
+  readinessTaskId: identity.readinessTaskId,
+  regressionTaskId: identity.regressionTaskId,
+  repository: identity.repository,
+  prNumber: identity.prNumber,
+  targetBranch: identity.targetBranch,
+  authorizedHeadSha: identity.authorizedHeadSha,
+  authorizedBaseSha: identity.authorizedBaseSha,
+  observedBaseSha: identity.observedBaseSha,
+});
+
+export const recoveryIsReopenableLegacyRefusal = (attempt: MergeRecoveryAttempt): boolean => (
+  (attempt.status === MergeRecoveryStatus.FAILED
+    && attempt.failureReason === LEGACY_PRE_INTENT_REFUSAL
+    && attempt.boundSourceRunId === null
+    && attempt.authorizationActivityId === null
+    && attempt.recoveryRunId === null)
+  || (attempt.status === MergeRecoveryStatus.FAILED
+    && attempt.failureReason === LEGACY_TARGET_BRANCH_REFUSAL
+    && attempt.boundSourceRunId === null
+    && attempt.authorizationActivityId === null
+    && attempt.recoveryRunId === null
+    && attempt.readinessTaskId === null
+    && attempt.regressionTaskId === null
+    && attempt.repository === null
+    && attempt.prNumber === null
+    && attempt.targetBranch === null
+    && attempt.authorizedHeadSha === null
+    && attempt.authorizedBaseSha === null
+    && attempt.observedBaseSha === null
+    && attempt.currentBaseSha === null)
+);
+
+/** Opens the initial VALIDATING state or the two explicitly supported legacy reopen shapes. */
+export const ensureRecoveryValidation = async (
+  tx: DbTx,
+  input: {
+    integratorTaskId: string;
+    sourceStopId: string;
+    identity?: RecoveryValidationIdentity;
+  },
+): Promise<MergeRecoveryAttempt> => {
+  const existing = await tx.mergeRecoveryAttempt.findFirst({
+    where: { integratorTaskId: input.integratorTaskId, sourceStopId: input.sourceStopId },
+    orderBy: [{ attempt: "desc" }, { id: "desc" }],
+  });
+  if (existing) {
+    if (!input.identity || !recoveryIsReopenableLegacyRefusal(existing)) return existing;
+    const reopened = await transitionMergeRecovery(tx, existing.id, MergeRecoveryStatus.VALIDATING, {
+      failureReason: null,
+      endedAt: null,
+      ...validationData(input.identity),
+    });
+    await writeMarker(tx, input.integratorTaskId, "baseDriftRecovery", {
+      actorType: "control-plane",
+      body: `Automatic pre-merge base-drift validation reopened legacy refusal for stop ${input.sourceStopId}`,
+      metadata: {
+        state: "legacy-validation-reopened",
+        aggregateId: existing.id,
+        sourceStopId: input.sourceStopId,
+      },
+    });
+    return reopened;
+  }
+  const latest = await tx.mergeRecoveryAttempt.aggregate({
+    where: { integratorTaskId: input.integratorTaskId },
+    _max: { attempt: true },
+  });
+  return tx.mergeRecoveryAttempt.create({ data: {
+    integratorTaskId: input.integratorTaskId,
+    sourceStopId: input.sourceStopId,
+    attempt: (latest._max.attempt ?? 0) + 1,
+    status: MergeRecoveryStatus.VALIDATING,
+    ...(input.identity ? validationData(input.identity) : {}),
+  } });
+};
+
+type RecoveryRepairIdentity = Omit<RecoveryContext, "currentBaseSha" | "recoveryRunId">;
+
+const requireRecoveryRepairIdentity = async (
+  tx: DbTx,
+  aggregateId: string,
+): Promise<RecoveryRepairIdentity> => {
+  const aggregate = await tx.mergeRecoveryAttempt.findUnique({ where: { id: aggregateId } });
+  if (!aggregate?.boundSourceRunId || !aggregate.authorizationActivityId
+    || !aggregate.readinessTaskId || !aggregate.regressionTaskId || !aggregate.repository
+    || aggregate.prNumber === null || !aggregate.targetBranch || !aggregate.authorizedHeadSha
+    || !aggregate.authorizedBaseSha || !aggregate.observedBaseSha) {
+    throw new Error(`Merge recovery aggregate ${aggregateId} has incomplete tail identity`);
+  }
+  return {
+    aggregateId: aggregate.id,
+    attempt: aggregate.attempt,
+    sourceStopId: aggregate.sourceStopId,
+    sourceRunId: aggregate.boundSourceRunId,
+    authorizationActivityId: aggregate.authorizationActivityId,
+    repository: aggregate.repository,
+    prNumber: aggregate.prNumber,
+    targetBranch: aggregate.targetBranch,
+    authorizedHeadSha: aggregate.authorizedHeadSha,
+    authorizedBaseSha: aggregate.authorizedBaseSha,
+    observedBaseSha: aggregate.observedBaseSha,
+    readinessTaskId: aggregate.readinessTaskId,
+    regressionTaskId: aggregate.regressionTaskId,
+    integratorTaskId: aggregate.integratorTaskId,
+  };
+};
+
+const stopNotice = async (
+  tx: DbTx,
+  input: { taskId: string; body: string; dedupeKey: string },
+): Promise<void> => {
+  await tx.inboxMessage.upsert({ where: { dedupeKey: input.dedupeKey }, create: {
+    from: "AGENT",
+    taskId: input.taskId,
+    kind: "TEXT",
+    body: input.body,
+    dedupeKey: input.dedupeKey,
+  }, update: {} });
+};
+
+export const enterRepair = async (
+  tx: DbTx,
+  input: {
+    aggregateId: string;
+    currentBaseSha: string;
+    now: Date;
+    readinessRequeue?: { staleBaseSha: string; reason: string };
+  },
+): Promise<{ recoveryRunId: string }> => {
+  const context = await requireRecoveryRepairIdentity(tx, input.aggregateId);
+  const aggregate = await tx.mergeRecoveryAttempt.findUniqueOrThrow({
+    where: { id: input.aggregateId },
+    select: { status: true },
+  });
+  const requeue = input.readinessRequeue;
+  if ((aggregate.status === MergeRecoveryStatus.AWAITING_AUTHORIZATION) !== Boolean(requeue)) {
+    throw new Error(`Merge recovery ${input.aggregateId} repair intent does not match ${aggregate.status}`);
+  }
+
+  await closeIntegratorQuestions(tx, context.integratorTaskId);
+  await tx.taskStepOutput.deleteMany({
+    where: { taskId: { in: [context.regressionTaskId, context.readinessTaskId] } },
+  });
+  await tx.task.update({
+    where: { id: context.regressionTaskId },
+    data: { status: TaskStatus.TODO, failureReason: null },
+  });
+  await tx.task.update({
+    where: { id: context.readinessTaskId },
+    data: { status: TaskStatus.TODO, failureReason: null },
+  });
+  await tx.task.update({
+    where: { id: context.integratorTaskId },
+    data: requeue
+      ? { status: TaskStatus.REVIEW }
+      : {
+          status: TaskStatus.REVIEW,
+          failureReason: `Automatic base-drift recovery ${String(context.attempt)} queued from stop ${context.sourceStopId}`,
+        },
+  });
+  const run = await enqueueTaskRun(
+    tx,
+    context.regressionTaskId,
+    input.now,
+    requeue ? { budgetGrant: 1 } : {},
+  );
+  await transitionMergeRecovery(tx, input.aggregateId, MergeRecoveryStatus.REPAIRING, {
+    recoveryRunId: run.id,
+    currentBaseSha: input.currentBaseSha,
+    failureReason: null,
+    endedAt: null,
+  });
+
+  const body = requeue
+    ? `Automatic base-drift recovery ${String(context.attempt)} context carried through readiness requeue`
+    : `Automatic base-drift recovery ${String(context.attempt)} parked stop ${context.sourceStopId} and queued fresh regression`;
+  const metadata = {
+    ...context,
+    currentBaseSha: input.currentBaseSha,
+    recoveryRunId: run.id,
+    state: requeue ? "readiness-requeued" : "queued",
+  };
+  await writeMarker(tx, context.integratorTaskId, "baseDriftRecovery", {
+    actorType: "control-plane",
+    body,
+    metadata,
+  });
+  await writeMarker(tx, context.regressionTaskId, "baseDriftRecovery", {
+    actorType: "control-plane",
+    body: requeue
+      ? body
+      : `Automatic base-drift recovery ${String(context.attempt)} verifies ${context.authorizedHeadSha} against current base ${input.currentBaseSha}`,
+    metadata,
+  });
+  if (requeue) {
+    await writeMarker(tx, context.regressionTaskId, "readiness", {
+      actorType: "control-plane",
+      body: `Merge readiness returned to regression: ${requeue.reason}; ${requeue.staleBaseSha} -> ${input.currentBaseSha}`,
+      metadata: {
+        state: "requeued-regression",
+        reason: requeue.reason,
+        staleBaseSha: requeue.staleBaseSha,
+        currentBaseSha: input.currentBaseSha,
+      },
+    });
+  }
+  return { recoveryRunId: run.id };
+};
+
+export const awaitAuthorization = async (
+  tx: DbTx,
+  recovery: RecoveryContext,
+): Promise<void> => {
+  await transitionMergeRecovery(
+    tx,
+    recovery.aggregateId,
+    MergeRecoveryStatus.AWAITING_AUTHORIZATION,
+    { failureReason: null },
+  );
+  await tx.task.update({
+    where: { id: recovery.regressionTaskId },
+    data: { status: TaskStatus.DONE, failureReason: null },
+  });
+  await tx.task.update({
+    where: { id: recovery.readinessTaskId },
+    data: { status: TaskStatus.TODO, failureReason: null },
+  });
+  await tx.task.update({
+    where: { id: recovery.integratorTaskId },
+    data: { status: TaskStatus.REVIEW },
+  });
+  const body = `Automatic base-drift recovery ${String(recovery.attempt)} awaits fresh readiness authorization`;
+  const metadata = { ...recovery, state: "awaiting-authorization" };
+  await writeMarker(tx, recovery.integratorTaskId, "baseDriftRecovery", {
+    actorType: "control-plane", body, metadata,
+  });
+  await writeMarker(tx, recovery.regressionTaskId, "baseDriftRecovery", {
+    actorType: "control-plane", body, metadata,
+  });
+  await writeMarker(tx, recovery.readinessTaskId, "readiness", {
+    actorType: "control-plane",
+    body: "Predecessor layer completed; server-side merge readiness queued",
+    metadata: { state: "queued", sourceRunId: recovery.recoveryRunId },
+  });
+};
+
+export const blockDownstream = async (
+  tx: DbTx,
+  input: {
+    recovery: RecoveryContext;
+    phase: "regression" | "readiness";
+    reason: string;
+    at: Date;
+  },
+): Promise<void> => {
+  const { recovery } = input;
+  const body = `Automatic base-drift recovery ${String(recovery.attempt)} stopped at ${input.phase}: ${input.reason}`;
+  await transitionMergeRecovery(tx, recovery.aggregateId, MergeRecoveryStatus.BLOCKED_DOWNSTREAM, {
+    failureReason: input.reason,
+    endedAt: input.at,
+  });
+  await tx.task.update({
+    where: { id: recovery.regressionTaskId },
+    data: {
+      status: TaskStatus.REVIEW,
+      failureReason: input.phase === "regression" ? body : input.reason,
+    },
+  });
+  await tx.task.update({
+    where: { id: recovery.readinessTaskId },
+    data: {
+      status: TaskStatus.REVIEW,
+      failureReason: input.phase === "regression" ? body : input.reason,
+    },
+  });
+  await tx.task.update({
+    where: { id: recovery.integratorTaskId },
+    data: { status: TaskStatus.REVIEW, failureReason: body },
+  });
+  const dedupeKey = `merge-base-drift-recovery-tail-stop:${recovery.sourceStopId}:${input.phase}`;
+  const metadata = { ...recovery, state: "tail-stopped", phase: input.phase, reason: input.reason, dedupeKey };
+  for (const taskId of [recovery.integratorTaskId, recovery.regressionTaskId]) {
+    await writeMarker(tx, taskId, "baseDriftRecovery", { actorType: "control-plane", body, metadata });
+  }
+  await stopNotice(tx, { taskId: recovery.regressionTaskId, body, dedupeKey });
+};
+
+export const reopenAfterHeadAdoption = async (
+  tx: DbTx,
+  input: { recovery: RecoveryContext; expectedFailureReason: string },
+): Promise<void> => {
+  const aggregate = await tx.mergeRecoveryAttempt.findUnique({
+    where: { id: input.recovery.aggregateId },
+    select: { failureReason: true },
+  });
+  if (aggregate?.failureReason !== input.expectedFailureReason) {
+    throw new Error(`Merge recovery ${input.recovery.aggregateId} head-adoption failure changed before reopen`);
+  }
+  await transitionMergeRecovery(tx, input.recovery.aggregateId, MergeRecoveryStatus.REPAIRING, {
+    failureReason: null,
+    endedAt: null,
+  });
+  await tx.taskStepOutput.deleteMany({ where: { taskId: input.recovery.readinessTaskId } });
+  await tx.task.update({
+    where: { id: input.recovery.regressionTaskId },
+    data: { status: TaskStatus.DONE, failureReason: null },
+  });
+  await tx.task.update({
+    where: { id: input.recovery.readinessTaskId },
+    data: { status: TaskStatus.TODO, failureReason: null },
+  });
+  await tx.task.update({
+    where: { id: input.recovery.integratorTaskId },
+    data: {
+      status: TaskStatus.REVIEW,
+      failureReason: `Automatic base-drift recovery ${String(input.recovery.attempt)} resumed after verified regression head adoption`,
+    },
+  });
+  const body = `Automatic base-drift recovery ${String(input.recovery.attempt)} reopened the verified Regression result for fresh readiness authorization`;
+  const metadata = {
+    aggregateId: input.recovery.aggregateId,
+    sourceStopId: input.recovery.sourceStopId,
+    recoveryRunId: input.recovery.recoveryRunId,
+    state: "reopened-head-adoption",
+  };
+  for (const taskId of [input.recovery.integratorTaskId, input.recovery.regressionTaskId]) {
+    await writeMarker(tx, taskId, "baseDriftRecovery", { actorType: "control-plane", body, metadata });
+  }
+};
+
+export const exhaust = async (
+  tx: DbTx,
+  input: {
+    aggregateId: string;
+    integratorTaskId: string;
+    sourceStopId: string;
+    reason: string;
+    at: Date;
+    attempt: number;
+    state: "ineligible" | "exhausted";
+    recoveryData: MergeRecoveryTransitionData;
+    markerMetadata: Record<string, unknown>;
+  },
+): Promise<void> => {
+  await transitionMergeRecovery(tx, input.aggregateId, MergeRecoveryStatus.FAILED, {
+    ...input.recoveryData,
+    failureReason: input.reason,
+    endedAt: input.at,
+  });
+  const body = input.state === "ineligible"
+    ? `Automatic pre-merge base-drift recovery refused: ${input.reason}`
+    : `Automatic pre-merge base-drift recovery exhausted at attempt ${String(input.attempt)}`;
+  await tx.task.update({ where: { id: input.integratorTaskId }, data: {
+    status: TaskStatus.REVIEW,
+    failureReason: input.state === "ineligible"
+      ? `Automatic base-drift recovery refused: ${input.reason}`
+      : input.reason,
+  } });
+  await writeMarker(tx, input.integratorTaskId, "baseDriftRecovery", {
+    actorType: "control-plane",
+    body,
+    metadata: {
+      state: input.state,
+      ...input.markerMetadata,
+      integratorTaskId: input.integratorTaskId,
+      sourceStopId: input.sourceStopId,
+      reason: input.reason,
+    },
+  });
+  const dedupeKey = `merge-base-drift-recovery:${input.state}:${input.sourceStopId}`;
+  await stopNotice(tx, {
+    taskId: input.integratorTaskId,
+    body: `Automatic pre-merge base-drift recovery ${input.state} for stop ${input.sourceStopId}: ${input.reason}. No regression run or re-authorization was created.`,
+    dedupeKey,
+  });
+};
+
+export const recordValidationRetry = async (
+  tx: DbTx,
+  input: {
+    aggregateId: string;
+    integratorTaskId: string;
+    sourceStopId: string;
+    classificationAttempt: number;
+    maxAttempts: number;
+    reason: string;
+  },
+): Promise<void> => {
+  await tx.mergeRecoveryAttempt.update({
+    where: { id: input.aggregateId },
+    data: { validationAttempts: input.classificationAttempt, failureReason: input.reason },
+  });
+  await writeMarker(tx, input.integratorTaskId, "baseDriftRecovery", {
+    actorType: "control-plane",
+    body: `Automatic pre-merge base-drift classification deferred (${String(input.classificationAttempt)}/${String(input.maxAttempts)}): ${input.reason}`,
+    metadata: {
+      state: "classification-retry",
+      integratorTaskId: input.integratorTaskId,
+      sourceStopId: input.sourceStopId,
+      classificationAttempt: input.classificationAttempt,
+      reason: input.reason,
+    },
+  });
+};
+
+export const retireLegacyRefusal = async (
+  tx: DbTx,
+  input: {
+    aggregateId: string;
+    integratorTaskId: string;
+    sourceStopId: string;
+    priorReason: string | null;
+    reason: string;
+    at: Date;
+  },
+): Promise<void> => {
+  const retiredReason = `Historical base-drift recovery refusal retired after current validation: ${input.reason}`;
+  await tx.mergeRecoveryAttempt.update({
+    where: { id: input.aggregateId },
+    data: { failureReason: retiredReason, endedAt: input.at },
+  });
+  await tx.task.update({ where: { id: input.integratorTaskId }, data: {
+    status: TaskStatus.REVIEW,
+    failureReason: `Automatic base-drift recovery refused: ${input.reason}`,
+  } });
+  await writeMarker(tx, input.integratorTaskId, "baseDriftRecovery", {
+    actorType: "control-plane",
+    body: retiredReason,
+    metadata: {
+      state: "legacy-refusal-retired",
+      integratorTaskId: input.integratorTaskId,
+      sourceStopId: input.sourceStopId,
+      priorReason: input.priorReason,
+      reason: input.reason,
+    },
+  });
+};
+
+export const adoptRecoveryHead = async (
+  tx: DbTx,
+  input: {
+    recovery: RecoveryContext;
+    currentBaseSha: string;
+    authorizedHeadSha: string;
+  },
+): Promise<void> => {
+  const adopted = await tx.mergeRecoveryAttempt.updateMany({
+    where: {
+      id: input.recovery.aggregateId,
+      status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
+      recoveryRunId: input.recovery.recoveryRunId,
+      currentBaseSha: input.recovery.currentBaseSha,
+      authorizedHeadSha: input.recovery.authorizedHeadSha,
+    },
+    data: {
+      currentBaseSha: input.currentBaseSha,
+      authorizedHeadSha: input.authorizedHeadSha,
+    },
+  });
+  if (adopted.count !== 1) {
+    throw new Error("Recovery authorization could not adopt the verified regression head");
+  }
+};

--- a/packages/api/src/merge-tail-state.ts
+++ b/packages/api/src/merge-tail-state.ts
@@ -55,6 +55,25 @@ const validationData = (identity: RecoveryValidationIdentity): RecoveryValidatio
   observedBaseSha: identity.observedBaseSha,
 });
 
+const fillValidationIdentity = async (
+  tx: DbTx,
+  attempt: MergeRecoveryAttempt,
+  identity: RecoveryValidationIdentity,
+): Promise<MergeRecoveryAttempt> => {
+  const supplied = validationData(identity);
+  const missing: Partial<RecoveryValidationData> = {};
+  for (const key of Object.keys(supplied) as Array<keyof RecoveryValidationData>) {
+    const current = attempt[key];
+    if (current !== null && current !== supplied[key]) {
+      throw new Error(`Merge recovery ${attempt.id} ${key} conflicts with the validated tail identity`);
+    }
+    if (current === null) Object.assign(missing, { [key]: supplied[key] });
+  }
+  return Object.keys(missing).length === 0
+    ? attempt
+    : tx.mergeRecoveryAttempt.update({ where: { id: attempt.id }, data: missing });
+};
+
 export const recoveryIsReopenableLegacyRefusal = (attempt: MergeRecoveryAttempt): boolean => (
   (attempt.status === MergeRecoveryStatus.FAILED
     && attempt.failureReason === LEGACY_PRE_INTENT_REFUSAL
@@ -91,6 +110,9 @@ export const ensureRecoveryValidation = async (
     orderBy: [{ attempt: "desc" }, { id: "desc" }],
   });
   if (existing) {
+    if (existing.status === MergeRecoveryStatus.VALIDATING && input.identity) {
+      return fillValidationIdentity(tx, existing, input.identity);
+    }
     if (!input.identity || !recoveryIsReopenableLegacyRefusal(existing)) return existing;
     const reopened = await transitionMergeRecovery(tx, existing.id, MergeRecoveryStatus.VALIDATING, {
       failureReason: null,
@@ -184,10 +206,12 @@ export const enterRepair = async (
     throw new Error(`Merge recovery ${input.aggregateId} repair intent does not match ${aggregate.status}`);
   }
 
-  await closeIntegratorQuestions(tx, context.integratorTaskId);
-  await tx.taskStepOutput.deleteMany({
-    where: { taskId: { in: [context.regressionTaskId, context.readinessTaskId] } },
-  });
+  if (!requeue) {
+    await closeIntegratorQuestions(tx, context.integratorTaskId);
+    await tx.taskStepOutput.deleteMany({
+      where: { taskId: { in: [context.regressionTaskId, context.readinessTaskId] } },
+    });
+  }
   await tx.task.update({
     where: { id: context.regressionTaskId },
     data: { status: TaskStatus.TODO, failureReason: null },
@@ -196,15 +220,15 @@ export const enterRepair = async (
     where: { id: context.readinessTaskId },
     data: { status: TaskStatus.TODO, failureReason: null },
   });
-  await tx.task.update({
-    where: { id: context.integratorTaskId },
-    data: requeue
-      ? { status: TaskStatus.REVIEW }
-      : {
-          status: TaskStatus.REVIEW,
-          failureReason: `Automatic base-drift recovery ${String(context.attempt)} queued from stop ${context.sourceStopId}`,
-        },
-  });
+  if (!requeue) {
+    await tx.task.update({
+      where: { id: context.integratorTaskId },
+      data: {
+        status: TaskStatus.REVIEW,
+        failureReason: `Automatic base-drift recovery ${String(context.attempt)} queued from stop ${context.sourceStopId}`,
+      },
+    });
+  }
   const run = await enqueueTaskRun(
     tx,
     context.regressionTaskId,
@@ -227,19 +251,16 @@ export const enterRepair = async (
     recoveryRunId: run.id,
     state: requeue ? "readiness-requeued" : "queued",
   };
-  await writeMarker(tx, context.integratorTaskId, "baseDriftRecovery", {
-    actorType: "control-plane",
-    body,
-    metadata,
-  });
-  await writeMarker(tx, context.regressionTaskId, "baseDriftRecovery", {
-    actorType: "control-plane",
-    body: requeue
-      ? body
-      : `Automatic base-drift recovery ${String(context.attempt)} verifies ${context.authorizedHeadSha} against current base ${input.currentBaseSha}`,
-    metadata,
-  });
   if (requeue) {
+    const requeueMetadata = {
+      ...context,
+      currentBaseSha: input.currentBaseSha,
+      recoveryRunId: run.id,
+    } as Prisma.InputJsonObject;
+    await tx.taskActivity.createMany({ data: [
+      { taskId: context.integratorTaskId, actorType: "control-plane", body, metadata: requeueMetadata },
+      { taskId: context.regressionTaskId, actorType: "control-plane", body, metadata: requeueMetadata },
+    ] });
     await writeMarker(tx, context.regressionTaskId, "readiness", {
       actorType: "control-plane",
       body: `Merge readiness returned to regression: ${requeue.reason}; ${requeue.staleBaseSha} -> ${input.currentBaseSha}`,
@@ -249,6 +270,17 @@ export const enterRepair = async (
         staleBaseSha: requeue.staleBaseSha,
         currentBaseSha: input.currentBaseSha,
       },
+    });
+  } else {
+    await writeMarker(tx, context.integratorTaskId, "baseDriftRecovery", {
+      actorType: "control-plane",
+      body,
+      metadata,
+    });
+    await writeMarker(tx, context.regressionTaskId, "baseDriftRecovery", {
+      actorType: "control-plane",
+      body: `Automatic base-drift recovery ${String(context.attempt)} verifies ${context.authorizedHeadSha} against current base ${input.currentBaseSha}`,
+      metadata,
     });
   }
   return { recoveryRunId: run.id };
@@ -264,31 +296,6 @@ export const awaitAuthorization = async (
     MergeRecoveryStatus.AWAITING_AUTHORIZATION,
     { failureReason: null },
   );
-  await tx.task.update({
-    where: { id: recovery.regressionTaskId },
-    data: { status: TaskStatus.DONE, failureReason: null },
-  });
-  await tx.task.update({
-    where: { id: recovery.readinessTaskId },
-    data: { status: TaskStatus.TODO, failureReason: null },
-  });
-  await tx.task.update({
-    where: { id: recovery.integratorTaskId },
-    data: { status: TaskStatus.REVIEW },
-  });
-  const body = `Automatic base-drift recovery ${String(recovery.attempt)} awaits fresh readiness authorization`;
-  const metadata = { ...recovery, state: "awaiting-authorization" };
-  await writeMarker(tx, recovery.integratorTaskId, "baseDriftRecovery", {
-    actorType: "control-plane", body, metadata,
-  });
-  await writeMarker(tx, recovery.regressionTaskId, "baseDriftRecovery", {
-    actorType: "control-plane", body, metadata,
-  });
-  await writeMarker(tx, recovery.readinessTaskId, "readiness", {
-    actorType: "control-plane",
-    body: "Predecessor layer completed; server-side merge readiness queued",
-    metadata: { state: "queued", sourceRunId: recovery.recoveryRunId },
-  });
 };
 
 export const blockDownstream = async (
@@ -335,18 +342,27 @@ export const blockDownstream = async (
 export const reopenAfterHeadAdoption = async (
   tx: DbTx,
   input: { recovery: RecoveryContext; expectedFailureReason: string },
-): Promise<void> => {
-  const aggregate = await tx.mergeRecoveryAttempt.findUnique({
-    where: { id: input.recovery.aggregateId },
-    select: { failureReason: true },
-  });
-  if (aggregate?.failureReason !== input.expectedFailureReason) {
-    throw new Error(`Merge recovery ${input.recovery.aggregateId} head-adoption failure changed before reopen`);
-  }
-  await transitionMergeRecovery(tx, input.recovery.aggregateId, MergeRecoveryStatus.REPAIRING, {
+): Promise<boolean> => {
+  const transitioned = await transitionMergeRecovery(tx, input.recovery.aggregateId, MergeRecoveryStatus.REPAIRING, {
     failureReason: null,
     endedAt: null,
+  }, {
+    status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
+    failureReason: input.expectedFailureReason,
+    boundSourceRunId: input.recovery.sourceRunId,
+    authorizationActivityId: input.recovery.authorizationActivityId,
+    recoveryRunId: input.recovery.recoveryRunId,
+    readinessTaskId: input.recovery.readinessTaskId,
+    regressionTaskId: input.recovery.regressionTaskId,
+    repository: input.recovery.repository,
+    prNumber: input.recovery.prNumber,
+    targetBranch: input.recovery.targetBranch,
+    authorizedHeadSha: input.recovery.authorizedHeadSha,
+    authorizedBaseSha: input.recovery.authorizedBaseSha,
+    observedBaseSha: input.recovery.observedBaseSha,
+    currentBaseSha: input.recovery.currentBaseSha,
   });
+  if (!transitioned) return false;
   await tx.taskStepOutput.deleteMany({ where: { taskId: input.recovery.readinessTaskId } });
   await tx.task.update({
     where: { id: input.recovery.regressionTaskId },
@@ -373,6 +389,7 @@ export const reopenAfterHeadAdoption = async (
   for (const taskId of [input.recovery.integratorTaskId, input.recovery.regressionTaskId]) {
     await writeMarker(tx, taskId, "baseDriftRecovery", { actorType: "control-plane", body, metadata });
   }
+  return true;
 };
 
 export const exhaust = async (

--- a/packages/db/src/chain-activation.ts
+++ b/packages/db/src/chain-activation.ts
@@ -14,6 +14,7 @@ import {
   isMergeReadinessStep,
   isRegressionVerificationOutputKind,
   MERGE_TAIL_KIND,
+  transitionMergeRecovery,
 } from "./merge-tail.js";
 import {
   ArchivedAssigneeError,
@@ -974,12 +975,11 @@ export const activateRecoveryIntegratorSuccessor = async (
   if (activated.nextTaskId !== input.integratorTaskId) {
     throw new Error("Recovery activation did not resolve the expected merge-integrator successor");
   }
-  await tx.mergeRecoveryAttempt.update({ where: { id: recovery.id }, data: {
-    status: MergeRecoveryStatus.SUCCEEDED,
+  await transitionMergeRecovery(tx, recovery.id, MergeRecoveryStatus.SUCCEEDED, {
     authorizationActivityId: authorization.id,
     failureReason: null,
     endedAt: now,
-  } });
+  });
   return activated;
 };
 

--- a/packages/db/src/merge-tail.test.ts
+++ b/packages/db/src/merge-tail.test.ts
@@ -11,6 +11,7 @@ import {
   isMergeReadinessStep,
   mergeRecoveryPhase,
   mergeRecoveryTransitionAllowed,
+  RECOVERY_TRANSITIONS,
   parseResolverResult,
   parseRegressionVerdict,
 } from "./merge-tail.js";
@@ -19,13 +20,30 @@ const A = "a".repeat(40);
 const B = "b".repeat(40);
 
 test("merge recovery state transitions and operator phases are explicit", () => {
-  assert.equal(mergeRecoveryTransitionAllowed(MergeRecoveryStatus.VALIDATING, MergeRecoveryStatus.REPAIRING), true);
-  assert.equal(mergeRecoveryTransitionAllowed(MergeRecoveryStatus.VALIDATING, MergeRecoveryStatus.FAILED), true);
-  assert.equal(mergeRecoveryTransitionAllowed(MergeRecoveryStatus.REPAIRING, MergeRecoveryStatus.AWAITING_AUTHORIZATION), true);
-  assert.equal(mergeRecoveryTransitionAllowed(MergeRecoveryStatus.AWAITING_AUTHORIZATION, MergeRecoveryStatus.REPAIRING), true);
-  assert.equal(mergeRecoveryTransitionAllowed(MergeRecoveryStatus.AWAITING_AUTHORIZATION, MergeRecoveryStatus.SUCCEEDED), true);
-  assert.equal(mergeRecoveryTransitionAllowed(MergeRecoveryStatus.SUCCEEDED, MergeRecoveryStatus.REPAIRING), false);
-  assert.equal(mergeRecoveryTransitionAllowed(MergeRecoveryStatus.FAILED, MergeRecoveryStatus.VALIDATING), false);
+  const statuses = Object.values(MergeRecoveryStatus);
+  const declaredEdges = statuses.flatMap((from) => (
+    [...RECOVERY_TRANSITIONS[from]].map((to) => `${from}->${to}`)
+  ));
+  assert.deepEqual(declaredEdges, [
+    "VALIDATING->REPAIRING",
+    "VALIDATING->FAILED",
+    "REPAIRING->AWAITING_AUTHORIZATION",
+    "REPAIRING->BLOCKED_DOWNSTREAM",
+    "AWAITING_AUTHORIZATION->REPAIRING",
+    "AWAITING_AUTHORIZATION->BLOCKED_DOWNSTREAM",
+    "AWAITING_AUTHORIZATION->SUCCEEDED",
+    "BLOCKED_DOWNSTREAM->REPAIRING",
+    "FAILED->VALIDATING",
+  ]);
+  for (const from of statuses) {
+    for (const to of statuses) {
+      assert.equal(
+        mergeRecoveryTransitionAllowed(from, to),
+        from === to || RECOVERY_TRANSITIONS[from].has(to),
+        `${from} -> ${to}`,
+      );
+    }
+  }
   assert.deepEqual(Object.values(MergeRecoveryStatus).map((status) => mergeRecoveryPhase(status)), [
     "validation",
     "repair",

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -1,4 +1,4 @@
-import { MergeRecoveryStatus, type Prisma } from "@prisma/client";
+import { MergeRecoveryStatus, type MergeRecoveryAttempt, type Prisma } from "@prisma/client";
 
 import { stepRole } from "./step-role.js";
 
@@ -71,7 +71,9 @@ export const mergeRecoveryTransitionAllowed = (
   to: MergeRecoveryStatus,
 ): boolean => from === to || RECOVERY_TRANSITIONS[from].has(to);
 
-export type MergeRecoveryTransitionData = Omit<Prisma.MergeRecoveryAttemptUpdateInput, "status">;
+export type MergeRecoveryTransitionData = Omit<Prisma.MergeRecoveryAttemptUpdateManyMutationInput, "status">;
+
+export type MergeRecoveryTransitionGuard = Prisma.MergeRecoveryAttemptWhereInput;
 
 /**
  * The fail-loud persistence primitive for every recovery status change. Named
@@ -79,17 +81,48 @@ export type MergeRecoveryTransitionData = Omit<Prisma.MergeRecoveryAttemptUpdate
  * activation module also uses this primitive for its authorization-bound
  * terminal success.
  */
-export const transitionMergeRecovery = async (
+export function transitionMergeRecovery(
+  tx: Prisma.TransactionClient,
+  aggregateId: string,
+  target: MergeRecoveryStatus,
+  data?: MergeRecoveryTransitionData,
+): Promise<MergeRecoveryAttempt>;
+export function transitionMergeRecovery(
+  tx: Prisma.TransactionClient,
+  aggregateId: string,
+  target: MergeRecoveryStatus,
+  data: MergeRecoveryTransitionData,
+  expected: MergeRecoveryTransitionGuard,
+): Promise<MergeRecoveryAttempt | null>;
+export async function transitionMergeRecovery(
   tx: Prisma.TransactionClient,
   aggregateId: string,
   target: MergeRecoveryStatus,
   data: MergeRecoveryTransitionData = {},
-) => {
+  expected?: MergeRecoveryTransitionGuard,
+): Promise<MergeRecoveryAttempt | null> {
   const aggregate = await tx.mergeRecoveryAttempt.findUnique({
     where: { id: aggregateId },
     select: { status: true },
   });
-  if (!aggregate) throw new Error(`Merge recovery aggregate ${aggregateId} is absent`);
+  if (!aggregate) {
+    if (expected) return null;
+    throw new Error(`Merge recovery aggregate ${aggregateId} is absent`);
+  }
+  if (expected) {
+    const guardedFrom = typeof expected.status === "string" ? expected.status : aggregate.status;
+    if (!mergeRecoveryTransitionAllowed(guardedFrom, target)) {
+      throw new Error(`Illegal merge recovery transition ${guardedFrom} -> ${target} for ${aggregateId}`);
+    }
+    if (aggregate.status !== guardedFrom) return null;
+    const updated = await tx.mergeRecoveryAttempt.updateMany({
+      where: { AND: [{ id: aggregateId, status: aggregate.status }, expected] },
+      data: { ...data, status: target },
+    });
+    return updated.count === 1
+      ? tx.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: aggregateId } })
+      : null;
+  }
   if (!mergeRecoveryTransitionAllowed(aggregate.status, target)) {
     throw new Error(`Illegal merge recovery transition ${aggregate.status} -> ${target} for ${aggregateId}`);
   }
@@ -97,7 +130,7 @@ export const transitionMergeRecovery = async (
     where: { id: aggregateId },
     data: { ...data, status: target },
   });
-};
+}
 
 export const mergeRecoveryPhase = (status: MergeRecoveryStatus): MergeRecoveryPhase => (
   status === MergeRecoveryStatus.VALIDATING ? "validation"

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -50,7 +50,7 @@ export type MergeRecoveryPhase =
   | "succeeded"
   | "actual-failure";
 
-const RECOVERY_TRANSITIONS: Record<MergeRecoveryStatus, ReadonlySet<MergeRecoveryStatus>> = {
+export const RECOVERY_TRANSITIONS: Record<MergeRecoveryStatus, ReadonlySet<MergeRecoveryStatus>> = {
   [MergeRecoveryStatus.VALIDATING]: new Set([MergeRecoveryStatus.REPAIRING, MergeRecoveryStatus.FAILED]),
   [MergeRecoveryStatus.REPAIRING]: new Set([
     MergeRecoveryStatus.AWAITING_AUTHORIZATION,
@@ -61,15 +61,43 @@ const RECOVERY_TRANSITIONS: Record<MergeRecoveryStatus, ReadonlySet<MergeRecover
     MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
     MergeRecoveryStatus.SUCCEEDED,
   ]),
-  [MergeRecoveryStatus.BLOCKED_DOWNSTREAM]: new Set(),
+  [MergeRecoveryStatus.BLOCKED_DOWNSTREAM]: new Set([MergeRecoveryStatus.REPAIRING]),
   [MergeRecoveryStatus.SUCCEEDED]: new Set(),
-  [MergeRecoveryStatus.FAILED]: new Set(),
+  [MergeRecoveryStatus.FAILED]: new Set([MergeRecoveryStatus.VALIDATING]),
 };
 
 export const mergeRecoveryTransitionAllowed = (
   from: MergeRecoveryStatus,
   to: MergeRecoveryStatus,
 ): boolean => from === to || RECOVERY_TRANSITIONS[from].has(to);
+
+export type MergeRecoveryTransitionData = Omit<Prisma.MergeRecoveryAttemptUpdateInput, "status">;
+
+/**
+ * The fail-loud persistence primitive for every recovery status change. Named
+ * merge-tail operations own the surrounding Task and marker writes; the
+ * activation module also uses this primitive for its authorization-bound
+ * terminal success.
+ */
+export const transitionMergeRecovery = async (
+  tx: Prisma.TransactionClient,
+  aggregateId: string,
+  target: MergeRecoveryStatus,
+  data: MergeRecoveryTransitionData = {},
+) => {
+  const aggregate = await tx.mergeRecoveryAttempt.findUnique({
+    where: { id: aggregateId },
+    select: { status: true },
+  });
+  if (!aggregate) throw new Error(`Merge recovery aggregate ${aggregateId} is absent`);
+  if (!mergeRecoveryTransitionAllowed(aggregate.status, target)) {
+    throw new Error(`Illegal merge recovery transition ${aggregate.status} -> ${target} for ${aggregateId}`);
+  }
+  return tx.mergeRecoveryAttempt.update({
+    where: { id: aggregateId },
+    data: { ...data, status: target },
+  });
+};
 
 export const mergeRecoveryPhase = (status: MergeRecoveryStatus): MergeRecoveryPhase => (
   status === MergeRecoveryStatus.VALIDATING ? "validation"


### PR DESCRIPTION
## Candidate

Candidate 05 — merge-tail state owner

Exact head: `eadb9ce1873d9f5964f37990e5acf62599b9a3fe`

## Changes

1. Added `packages/api/src/merge-tail-state.ts` as the deep module that owns merge-tail recovery mutations and exposes `enterRepair`, `awaitAuthorization`, `blockDownstream`, `reopenAfterHeadAdoption`, and `exhaust`.
2. Added the fail-loud `transitionMergeRecovery` primitive and made `RECOVERY_TRANSITIONS` authoritative, including `BLOCKED_DOWNSTREAM -> REPAIRING` and `FAILED -> VALIDATING`.
3. Replaced recovery/status write protocols in `merge-readiness-worker.ts`, `merge-base-drift-worker.ts`, and `merge-tail-actions.ts` with intent-level calls to the owner. Successor activation delegates to the existing authoritative activation seam.
4. Kept retry budgeting on complete durable history rather than the recent 20-row activity window; no compatibility double-write or new persistence model was introduced.
5. Added exhaustive transition-table tests, direct named-operation tests, and DB regressions for activation, claims, requeue side effects, marker-window history, identity fill, and reopen CAS behavior.

## Blind review F1–F8 closure

- F1: recovery Regression pass again returns `advance`; `run-completion.ts` therefore invokes `advanceTemplateTask` and preserves Lease `continue`. A held-Chain DB test proves readiness activation is withheld and the Lease is retained.
- F2: an existing `VALIDATING` aggregate now fills missing identity under the caller's Chain lock and throws on any populated-field conflict. The `chain-active retry -> later candidate -> enter repair` regression passes.
- F3: readiness claims the Step before reading recovery context. Recovery mutation remains inside `ReadinessClaimHandle.settle({ kind: "keep" })`; an unexpired foreign claim leaves both Task and aggregate untouched, while a post-claim recovery-read failure is persisted as a readiness stop.
- F4: readiness requeue preserves the old side effects: it does not close Integrator questions, delete Regression/Readiness outputs, or rewrite Integrator status/failure/timestamp.
- F5/F6: the three redundant `awaitAuthorization` markers were removed; requeue binding activities retain their prior non-marker shape. A real DB regression pushes the first repair attempt beyond 20 recent rows and proves the full-history read prevents a free retry.
- F7: direct coverage now exercises both `enterRepair` edges and the `FAILED -> VALIDATING` legacy reopen operation, while the exhaustive table test remains intact.
- F8: reopen uses a guarded full-snapshot CAS through the transition primitive and returns `false` for stale status/data without touching Tasks or aborting the readiness tick. The direct test now starts in `BLOCKED_DOWNSTREAM`, reaches guarded `updateMany`, and forces a count-zero snapshot miss.

## Migration matrix

| Migration | Recovery status | Regression Task | Readiness Task | Integrator Task | Output / activity / Inbox ownership |
| --- | --- | --- | --- | --- | --- |
| `enterRepair` initial | `VALIDATING -> REPAIRING` | `TODO`, failure cleared, fresh Run queued | `TODO`, failure cleared | `REVIEW` with the operator-visible recovery reason | closes Integrator questions; deletes stale Regression/Readiness outputs; writes Integrator and Regression `baseDriftRecovery` markers |
| `enterRepair` readiness requeue | `AWAITING_AUTHORIZATION -> REPAIRING` | `TODO`, failure cleared, compensated Run queued | `TODO`, failure cleared | unchanged | preserves questions and outputs; preserves the two prior binding activities and the Regression `readiness` marker; grants the existing one-run retry budget |
| `awaitAuthorization` | `REPAIRING -> AWAITING_AUTHORIZATION` | completed by `advanceTemplateTask` | activated only through `advanceTemplateTask`, subject to Chain Hold/join/assignee/dispatch rules | unchanged | the Regression verdict marker is written before the transition; the readiness `queued` marker is owned by successful chain activation, not duplicated by the state owner |
| `blockDownstream` | `REPAIRING/AWAITING_AUTHORIZATION -> BLOCKED_DOWNSTREAM` | `REVIEW` with phase-appropriate failure | `REVIEW` with phase-appropriate failure | `REVIEW` with operator-visible tail-stop failure | writes Integrator and Regression `baseDriftRecovery` markers and a deduplicated stop Inbox message |
| `reopenAfterHeadAdoption` | guarded `BLOCKED_DOWNSTREAM -> REPAIRING` | `DONE`, failure cleared | `TODO`, failure cleared | `REVIEW` with operator-visible resume reason | full-snapshot CAS first; then deletes stale Readiness output and writes Integrator/Regression reopen markers; stale candidates return `false` with no side effects |
| `exhaust` | `VALIDATING -> FAILED` | unchanged when validation ends before a recovery tail is bound | unchanged when validation ends before a recovery tail is bound | `REVIEW` with operator-visible refusal/exhaustion reason | writes Integrator refusal/exhaustion marker and deduplicated Inbox message; creates no Run or authorization |

The same authority models `FAILED -> VALIDATING` in `ensureRecoveryValidation` for the two explicit legacy-refusal shapes. Existing `VALIDATING` rows accept only missing identity fields and reject conflicts. `activateRecoveryIntegratorSuccessor` owns `AWAITING_AUTHORIZATION -> SUCCEEDED` and delegates its status write to `transitionMergeRecovery` while preserving its chain activation contract.

## Direct-write evidence

Command:

```text
rg -n 'mergeRecoveryAttempt\.(create|update|updateMany)|status:\s*MergeRecoveryStatus' packages/api/src/merge-readiness-worker.ts packages/api/src/merge-base-drift-worker.ts packages/api/src/merge-tail-actions.ts packages/api/src/merge-tail-state.ts packages/db/src/chain-activation.ts packages/db/src/merge-tail.ts
```

Result:

```text
packages/api/src/merge-readiness-worker.ts:83:      status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
packages/api/src/merge-readiness-worker.ts:170:): Promise<{ context: RecoveryContext; status: MergeRecoveryStatus } | null> => {
packages/db/src/chain-activation.ts:899:        status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
packages/api/src/merge-tail-state.ts:74:    : tx.mergeRecoveryAttempt.update({ where: { id: attempt.id }, data: missing });
packages/api/src/merge-tail-state.ts:137:  return tx.mergeRecoveryAttempt.create({ data: {
packages/api/src/merge-tail-state.ts:141:    status: MergeRecoveryStatus.VALIDATING,
packages/api/src/merge-tail-state.ts:350:    status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
packages/api/src/merge-tail-state.ts:453:  await tx.mergeRecoveryAttempt.update({
packages/api/src/merge-tail-state.ts:482:  await tx.mergeRecoveryAttempt.update({
packages/api/src/merge-tail-state.ts:511:  const adopted = await tx.mergeRecoveryAttempt.updateMany({
packages/api/src/merge-tail-state.ts:514:      status: MergeRecoveryStatus.AWAITING_AUTHORIZATION,
packages/db/src/merge-tail.ts:118:    const updated = await tx.mergeRecoveryAttempt.updateMany({
packages/db/src/merge-tail.ts:129:  return tx.mergeRecoveryAttempt.update({
packages/db/src/merge-tail.ts:135:export const mergeRecoveryPhase = (status: MergeRecoveryStatus): MergeRecoveryPhase => (
```

Remaining hits, one by one:

- `merge-readiness-worker.ts:83` is a query predicate; line 170 is a return type.
- `chain-activation.ts:899` is the success-activation predicate; its status write calls the transition primitive.
- `merge-tail-state.ts:74` fills only missing identity fields on an existing `VALIDATING` row and does not change status.
- `merge-tail-state.ts:137/141` is initial aggregate creation in the owner, not a transition bypass.
- `merge-tail-state.ts:350` is the reopen CAS guard predicate.
- `merge-tail-state.ts:453` records validation-attempt metadata without changing status.
- `merge-tail-state.ts:482` retires legacy-refusal metadata without changing status.
- `merge-tail-state.ts:511/514` is the authorization head-adoption CAS; status is a predicate and the update changes only the authorized head/current base.
- `merge-tail.ts:118/129` are the guarded and fail-loud forms of the sole status-writing transition primitive; line 135 is a pure phase projection.
- `merge-base-drift-worker.ts` and `merge-tail-actions.ts` have no remaining hits.

Named-operation caller inventory:

```text
packages/api/src/merge-base-drift-worker.ts:448:  await enterRepair(tx, { aggregateId: aggregate.id, currentBaseSha, now });
packages/api/src/merge-tail-actions.ts:310:      await blockDownstream(tx, { recovery, phase: input.phase, reason: input.reason, at: input.at });
packages/api/src/merge-tail-actions.ts:380:  await exhaust(tx, {
packages/api/src/merge-tail-actions.ts:708:      await awaitAuthorization(tx, recovery);
packages/api/src/merge-readiness-worker.ts:132:      return reopenAfterHeadAdoption(tx, {
packages/api/src/merge-readiness-worker.ts:248:        await enterRepair(client, {
packages/api/src/merge-readiness-worker.ts:352:        apply: async (client) => awaitAuthorization(client, recovery!),
```

## Validation

- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `node --import tsx --test src/merge-tail.test.ts` from `packages/db` — PASS, 8/8
- `node --import tsx --test src/merge-tail-actions.test.ts src/merge-tail-state.test.ts` from `packages/api` — PASS, 16/16
- `npm run test:db -w @anneal/api -- src/merge-base-drift-recovery.dbtest.ts src/merge-stop-state.dbtest.ts` with isolated `RUNNER_WORKSPACE_ROOT`, non-public scratch schema, and throwaway PostgreSQL — PASS, 53/53
- `git diff --check` — PASS

## Out of scope observed

- Five-storage read-model consolidation is not included. Authorization selection, stop history, board/read projections, Task output/activity, and Inbox reads cannot move behind this module without expanding interfaces and the mechanically covered surface. The strong write-owner line is complete; read-model consolidation remains a separate candidate.
- No adjacent dead code was removed.


