### PR TITLE
refactor(api): centralize merge lease outcomes

### DIFF
--- a/packages/api/src/active-run-cancellation.dbtest.ts
+++ b/packages/api/src/active-run-cancellation.dbtest.ts
@@ -4,8 +4,12 @@ import { after, before, beforeEach, test } from "node:test";
 import { PrismaClient, RunStatus, SessionExecutionStatus, TaskStatus } from "@anneal/db";
 
 import { suspendForInbox } from "./inbox.js";
+import type { ReleaseMergeLease } from "./merge-lease.js";
 import { reconcileDatabaseRuns } from "./reconcile.js";
-import { acknowledgeCancellation, cancelRun } from "./run-cancel.js";
+import {
+  acknowledgeCancellation as acknowledgeCancellationWithLease,
+  cancelRun as cancelRunWithLease,
+} from "./run-cancel.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
@@ -17,6 +21,17 @@ after(async () => { await db.$disconnect(); });
 const OPERATOR = "active-cancel-operator";
 const RUNNER = "active-cancel-runner-token";
 const RUNNER_ID = "active-cancel-runner";
+const noOpReleaseMergeLease: ReleaseMergeLease = async () => {};
+const cancelRun = (
+  client: PrismaClient,
+  runId: string,
+  body: Parameters<typeof cancelRunWithLease>[2],
+) => cancelRunWithLease(client, runId, body, noOpReleaseMergeLease);
+const acknowledgeCancellation = (
+  client: PrismaClient,
+  runId: string,
+  body: Parameters<typeof acknowledgeCancellationWithLease>[2],
+) => acknowledgeCancellationWithLease(client, runId, body, noOpReleaseMergeLease);
 
 const call = async (method: string, path: string, token: string, body?: unknown, client: PrismaClient = db) => {
   const priorOperator = process.env.OPERATOR_TOKEN;

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -916,7 +916,9 @@ test("startup reconciliation spares a run whose runner is still heartbeating", a
       create: async () => ({}),
     },
     $transaction: async (operation: (value: unknown) => Promise<unknown>) => operation({
-      $queryRaw: async () => [{ id: "task-2", archivedAt: null }],
+      $queryRaw: async (query: TemplateStringsArray) => query.join("").includes('FROM "TaskActivity" AS pending')
+        ? []
+        : [{ id: "task-2", archivedAt: null }],
       run: {
         findFirst: async () => ({ cancelRequestId: null, cancelReason: null, cancelRequestedAt: null }),
         updateMany: async ({ where }: { where: { id: string } }) => { lost.push(where.id); return { count: 1 }; },
@@ -1731,6 +1733,7 @@ test("claim query filters archived agents before take so active work cannot star
           claimQuery = sql;
           return [{ id: "active" }];
         }
+        if (sql.includes('FROM "TaskActivity" AS pending')) return [];
         return [{ granted: true }];
       },
       // The claim loop brackets every candidate in a savepoint.
@@ -1797,7 +1800,9 @@ test("claim polling throttles the archived-run audit sweep per API process", asy
           const sql = Array.isArray(query)
             ? query.join("?")
             : (query as { strings?: string[] }).strings?.join("?") ?? "";
-          return sql.includes('SELECT candidate."id"') ? [] : [{ granted: true }];
+          if (sql.includes('SELECT candidate."id"')) return [];
+          if (sql.includes('FROM "TaskActivity" AS pending')) return [];
+          return [{ granted: true }];
         },
         run: { findMany: async () => [] },
         taskActivity: { findMany: async () => [] },

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -916,7 +916,7 @@ test("startup reconciliation spares a run whose runner is still heartbeating", a
       create: async () => ({}),
     },
     $transaction: async (operation: (value: unknown) => Promise<unknown>) => operation({
-      $queryRaw: async (query: TemplateStringsArray) => query.join("").includes('FROM "TaskActivity" AS pending')
+      $queryRaw: async (query: TemplateStringsArray) => query.join("").includes('FROM "TaskActivity" AS activity')
         ? []
         : [{ id: "task-2", archivedAt: null }],
       run: {
@@ -1733,7 +1733,7 @@ test("claim query filters archived agents before take so active work cannot star
           claimQuery = sql;
           return [{ id: "active" }];
         }
-        if (sql.includes('FROM "TaskActivity" AS pending')) return [];
+        if (sql.includes('FROM "TaskActivity" AS activity')) return [];
         return [{ granted: true }];
       },
       // The claim loop brackets every candidate in a savepoint.
@@ -1801,7 +1801,7 @@ test("claim polling throttles the archived-run audit sweep per API process", asy
             ? query.join("?")
             : (query as { strings?: string[] }).strings?.join("?") ?? "";
           if (sql.includes('SELECT candidate."id"')) return [];
-          if (sql.includes('FROM "TaskActivity" AS pending')) return [];
+          if (sql.includes('FROM "TaskActivity" AS activity')) return [];
           return [{ granted: true }];
         },
         run: { findMany: async () => [] },

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -916,10 +916,15 @@ test("startup reconciliation spares a run whose runner is still heartbeating", a
       create: async () => ({}),
     },
     $transaction: async (operation: (value: unknown) => Promise<unknown>) => operation({
-      $queryRaw: async (query: TemplateStringsArray) => query.join("").includes('FROM "TaskActivity" AS activity')
-        || query.join("").includes('FROM "TaskActivity" AS deferred')
-        ? []
-        : [{ id: "task-2", archivedAt: null }],
+      $queryRaw: async (query: TemplateStringsArray | Prisma.Sql, ...parameters: unknown[]) => {
+        const sql = "sql" in query ? query.sql : query.join("");
+        const values = "values" in query ? query.values : parameters;
+        if (sql.includes('FROM "TaskActivity" AS deferred')) {
+          assert.deepEqual(values, [100]);
+          return [];
+        }
+        return sql.includes('FROM "TaskActivity" AS activity') ? [] : [{ id: "task-2", archivedAt: null }];
+      },
       run: {
         findFirst: async () => ({ cancelRequestId: null, cancelReason: null, cancelRequestedAt: null }),
         updateMany: async ({ where }: { where: { id: string } }) => { lost.push(where.id); return { count: 1 }; },

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -917,6 +917,7 @@ test("startup reconciliation spares a run whose runner is still heartbeating", a
     },
     $transaction: async (operation: (value: unknown) => Promise<unknown>) => operation({
       $queryRaw: async (query: TemplateStringsArray) => query.join("").includes('FROM "TaskActivity" AS activity')
+        || query.join("").includes('FROM "TaskActivity" AS deferred')
         ? []
         : [{ id: "task-2", archivedAt: null }],
       run: {
@@ -1734,6 +1735,7 @@ test("claim query filters archived agents before take so active work cannot star
           return [{ id: "active" }];
         }
         if (sql.includes('FROM "TaskActivity" AS activity')) return [];
+        if (sql.includes('FROM "TaskActivity" AS deferred')) return [];
         return [{ granted: true }];
       },
       // The claim loop brackets every candidate in a savepoint.
@@ -1802,6 +1804,7 @@ test("claim polling throttles the archived-run audit sweep per API process", asy
             : (query as { strings?: string[] }).strings?.join("?") ?? "";
           if (sql.includes('SELECT candidate."id"')) return [];
           if (sql.includes('FROM "TaskActivity" AS activity')) return [];
+          if (sql.includes('FROM "TaskActivity" AS deferred')) return [];
           return [{ granted: true }];
         },
         run: { findMany: async () => [] },

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -3306,14 +3306,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/runner/runs/:runId/cancel/acknowledge", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, cancelAcknowledgeInput);
-    const result = await acknowledgeCancellation(db, runId, body);
+    const result = await acknowledgeCancellation(db, runId, body, releaseChainLease);
     if ("message" in result) return refusalJson(context, result);
-    const { releaseMergeLeaseTask, ...settlement } = result;
-    // Cancellation is a terminal write. The lease target is deliberately
-    // released only after that transaction commits, when the release adapter
-    // can also record the confirmed deletion and its hold window.
-    await releaseChainLease(releaseMergeLeaseTask, db);
-    return context.json(settlement);
+    return context.json(result);
   });
 
   // Publication is a separate durable fact from terminal completion. Persist
@@ -3954,14 +3949,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/runs/:runId/cancel", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, cancelRunInput);
-    const result = await cancelRun(db, runId, body);
+    const result = await cancelRun(db, runId, body, releaseChainLease);
     if ("message" in result) return refusalJson(context, result);
-    const { releaseMergeLeaseTask, ...cancellation } = result;
-    // A queued cancellation is the final consumer when no runner ever claims
-    // the Run. Keep the release post-commit so a rollback cannot free a lease
-    // whose cancellation state was not durably written.
-    await releaseChainLease(releaseMergeLeaseTask, db);
-    return context.json(cancellation);
+    return context.json(result);
   });
 
   app.get("/runs/:runId/events", async (context) => {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -130,7 +130,12 @@ import {
   jsonValue,
   normalizeSessionEventValue,
 } from "./execution.js";
-import { createArchivedRunNoticeScheduler, noteArchivedQueuedRuns, reconcileDatabaseRuns } from "./reconcile.js";
+import {
+  createArchivedRunNoticeScheduler,
+  noteArchivedQueuedRuns,
+  reconcileDatabaseRuns,
+  ReconciliationMaintenanceError,
+} from "./reconcile.js";
 import {
   type Refusal,
   type RefusalDetail,
@@ -3173,7 +3178,19 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const now = new Date();
     runners.note(body.runnerId, body, now);
     await options.ownership.assertHeld();
-    await reconcileDatabaseRuns(db, now, releaseChainLease);
+    try {
+      await reconcileDatabaseRuns(db, now, releaseChainLease);
+    } catch (error: unknown) {
+      if (!(error instanceof ReconciliationMaintenanceError)) throw error;
+      console.error("Runner claim reconciliation maintenance failed after commit", {
+        reconciledAt: error.reconciledAt.toISOString(),
+        failures: error.failures.map((failure) => ({
+          target: failure.target,
+          phase: failure.phase,
+          error: failure.error instanceof Error ? failure.error.message : String(failure.error),
+        })),
+      });
+    }
     await noteArchivedQueuedRunsOnClaim(now).catch((error: unknown) => console.error("Archived-run notice failed", error));
     const claimed = await claimRun(db, {
       body,

--- a/packages/api/src/merge-base-drift-recovery.dbtest.ts
+++ b/packages/api/src/merge-base-drift-recovery.dbtest.ts
@@ -31,7 +31,7 @@ import {
 } from "./merge-tail-state.js";
 import { seedIntegratorChain } from "./merge-integrator-fixture.js";
 import {
-  settleLease,
+  commitWithLeaseOutcome,
   withMergeLease,
   type MergeLeaseAcquirer,
   type MergeLeaseReleaser,
@@ -190,7 +190,7 @@ const recordRecoveryPass = async (
     runId: run.id, kind: "regression-verification",
     body: JSON.stringify({ schemaVersion: 1, outcome: "pass", headSha, baseHeadSha: baseSha, gateVerdict: "PASS" }), commitSha: headSha,
   } });
-  const completion = await db.$transaction(async (tx) => {
+  const completion = await commitWithLeaseOutcome(db, async (tx) => {
     const outcome = await handleRegressionCompletion(tx, {
       task: seeded.gateTask,
       run: {
@@ -205,12 +205,14 @@ const recordRecoveryPass = async (
     if (outcome === "advance") {
       await advanceTemplateTask(tx, seeded.gateTask.id, run.id, null);
     }
-    const lease = await settleLease(tx, {
-      taskId: seeded.gateTask.id,
-      outcome: outcome === "advance" ? "continue" : "stop",
-    });
-    return { outcome, lease };
-  });
+    return {
+      value: { outcome },
+      leaseOutcome: outcome === "advance"
+        ? { kind: "continue" }
+        : { kind: "stop", taskId: seeded.gateTask.id },
+    };
+  }, { release: releaseChainLease });
+  if (!completion) throw new Error("Recovery pass completion returned no result");
   return { run, ...completion };
 };
 
@@ -275,7 +277,6 @@ test("a recovery pass delegates activation to the held-Chain seam and retains th
   const completion = await recordRecoveryPass(seeded, BASE_2);
 
   assert.equal(completion.outcome, "advance");
-  assert.deepEqual(completion.lease, { disposition: "retain", leaseToRelease: null });
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.gateTask.id } })).status, TaskStatus.DONE);
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readinessTask!.id } })).status, TaskStatus.TODO);
   assert.equal(await db.taskActivity.count({ where: {

--- a/packages/api/src/merge-lease-cancel-release.dbtest.ts
+++ b/packages/api/src/merge-lease-cancel-release.dbtest.ts
@@ -31,7 +31,7 @@ import {
 
 import type { ReleaseMergeLease } from "./merge-lease.js";
 import { recordMergeLeaseHold } from "./merge-lease-hold.js";
-import { reconcileDatabaseRuns } from "./reconcile.js";
+import { ReconciliationMaintenanceError, reconcileDatabaseRuns } from "./reconcile.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
@@ -113,15 +113,24 @@ const seedChain = async (options: { outputKind?: string; chainId?: string; chain
   const environment = await db.environment.create({ data: { projectId: project.id, name: "local", allowedHosts: [] } });
   const mechanical = options.outputKind === "merge-result";
   const agent = await db.agent.create({ data: {
-    projectId: project.id, environmentId: environment.id,
+    projectId: project.id,
+    environmentId: environment.id,
     name: mechanical ? INTEGRATOR_AGENT_NAME : `agent-${suffix}`,
     title: mechanical ? "Merge Integrator" : "Agent",
     model: mechanical ? INTEGRATOR_SENTINEL_MODEL : "claude-opus-5:high",
-    foundationalPrompt: "foundation", rolePrompt: "role",
+    foundationalPrompt: "foundation",
+    rolePrompt: "role",
   } });
   const repo = await db.repo.create({ data: {
     projectId: project.id, name: "repo", remoteUrl: "https://github.com/acme/widgets.git",
     mountPath: "/repo", defaultBranch: "master",
+  } });
+  await db.agentRepoAccess.create({ data: {
+    projectId: project.id,
+    agentId: agent.id,
+    repoId: repo.id,
+    mountPath: "/repo",
+    permissions: "GIT_WRITE",
   } });
   const template = await db.taskTemplate.create({ data: {
     projectId: project.id, name: DIRECT_TEMPLATE_NAME, description: "cancel fixture", variables: [],
@@ -168,6 +177,8 @@ const seedRun = async (
     leaseExpiresAt?: Date | null;
     heartbeatAt?: Date | null;
     claimed?: boolean;
+    createdAt?: Date;
+    readyAt?: Date;
   } = {},
 ) => {
   const status = options.status ?? RunStatus.RUNNING;
@@ -179,6 +190,8 @@ const seedRun = async (
     runNumber, dedupeKey: `task:${taskId}:run:${runNumber}`, status,
     runner: "CLAUDE", model: chain.agent.model, promptHash: "hash", branch: `claude/${chain.suffix}-${runNumber}`,
     targetBranch: "master", maxRunsPerTask: options.maxRunsPerTask ?? 5,
+    ...(options.createdAt ? { createdAt: options.createdAt } : {}),
+    ...(options.readyAt ? { readyAt: options.readyAt } : {}),
     ...(claimed ? {
       runnerId: RUNNER_ID,
       fencingToken: `fence-${chain.suffix}-${runNumber}`,
@@ -289,7 +302,7 @@ test("reconciliation terminalizing a cancellation after runner loss releases the
   await assertConfirmedHold(chain.task.id);
 });
 
-test("a lost mechanical run hands the lease to its retry until orphan cleanup", async () => {
+test("a lost mechanical run that still has an attempt left keeps the lease for its retry", async () => {
   const now = new Date();
   const chain = await seedChain({ outputKind: "merge-result", chainIndex: 7 });
   const run = await seedRun(chain, {
@@ -300,19 +313,14 @@ test("a lost mechanical run hands the lease to its retry until orphan cleanup", 
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: run.id } })).status, RunStatus.LOST);
   const retry = await db.run.findFirst({ where: { taskId: chain.task.id, runNumber: 2 } });
   assert.ok(retry, "the lost run bought a retry");
-  const pending = await db.taskActivity.findFirstOrThrow({ where: {
-    taskId: chain.task.id,
-    metadata: { path: ["state"], equals: "pending" },
-  } });
-  assert.equal((pending.metadata as Record<string, unknown>).toRunId, retry.id);
-  assert.equal((pending.metadata as Record<string, unknown>).consumerReadyAt, retry.readyAt.toISOString());
+  // This retry inherits the already-held Lease. Only readiness authorization
+  // creates a recoverable handoff marker; retry scheduling does not shorten
+  // the original mechanical holding window.
   assert.deepEqual(releasedChainLeases, []);
-
-  assert.equal(
-    await reconcileDatabaseRuns(db, new Date(retry.readyAt.getTime() + 61_000), collectRelease),
-    1,
-  );
-  assert.deepEqual(releasedChainLeases, [chain.chainId]);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: chain.task.id,
+    metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.leaseHandoff },
+  } }), 0);
 });
 
 test("a lost merge-tail run with no attempts left releases the lease", async () => {
@@ -374,7 +382,8 @@ test("a lost ordinary step with no attempts left never touches the lease", async
 test("a stranded queued handoff releases once and records settlement after release", async () => {
   const now = new Date();
   const chain = await seedChain();
-  const run = await seedRun(chain, { status: RunStatus.QUEUED });
+  const stale = new Date(now.getTime() - 180_000);
+  const run = await seedRun(chain, { status: RunStatus.QUEUED, createdAt: stale, readyAt: stale });
   await db.taskActivity.create({ data: {
     taskId: chain.task.id,
     actorType: "control-plane",
@@ -421,6 +430,8 @@ test("handoff recovery drains its bounded page oldest-first", async () => {
     promptHash: "hash",
     branch: `claude/${chain.suffix}-lease-page-${index}`,
     targetBranch: "master",
+    createdAt: new Date(now.getTime() - 180_000),
+    readyAt: new Date(now.getTime() - 180_000),
   })) });
   const handedOffAt = new Date(now.getTime() - 120_000).toISOString();
   await db.taskActivity.createMany({ data: runIds.map((toRunId, index) => ({
@@ -456,7 +467,8 @@ test("handoff recovery drains its bounded page oldest-first", async () => {
 test("duplicate pending handoffs for one Run settle once", async () => {
   const now = new Date();
   const chain = await seedChain();
-  const run = await seedRun(chain, { status: RunStatus.QUEUED });
+  const stale = new Date(now.getTime() - 180_000);
+  const run = await seedRun(chain, { status: RunStatus.QUEUED, createdAt: stale, readyAt: stale });
   const handedOffAt = new Date(now.getTime() - 120_000).toISOString();
   await db.taskActivity.createMany({ data: Array.from({ length: 2 }, (_, index) => ({
     taskId: chain.task.id,
@@ -486,7 +498,8 @@ test("duplicate pending handoffs for one Run settle once", async () => {
 test("a released marker older than a new pending handoff does not suppress recovery", async () => {
   const now = new Date();
   const chain = await seedChain();
-  const run = await seedRun(chain, { status: RunStatus.QUEUED });
+  const runFloor = new Date(now.getTime() - 240_000);
+  const run = await seedRun(chain, { status: RunStatus.QUEUED, createdAt: runFloor, readyAt: runFloor });
   await db.taskActivity.createMany({ data: [
     {
       taskId: chain.task.id,
@@ -526,12 +539,160 @@ test("a released marker older than a new pending handoff does not suppress recov
   } }), 2);
 });
 
+test("an old active handoff remains discoverable while released and claimed consumers stay excluded", async () => {
+  const now = new Date();
+  const old = await seedChain();
+  const released = await seedChain();
+  const claimed = await seedChain();
+  const nineDaysAgo = new Date(now.getTime() - (9 * 24 * 60 * 60 * 1_000));
+  const eightDaysAgo = new Date(now.getTime() - (8 * 24 * 60 * 60 * 1_000));
+  const stale = new Date(now.getTime() - 180_000);
+  const oldRun = await seedRun(old, {
+    status: RunStatus.QUEUED, createdAt: nineDaysAgo, readyAt: nineDaysAgo,
+  });
+  const releasedRun = await seedRun(released, {
+    status: RunStatus.QUEUED, createdAt: stale, readyAt: stale,
+  });
+  const claimedRun = await seedRun(claimed, {
+    status: RunStatus.CLAIMED, createdAt: stale, readyAt: stale,
+  });
+  const pending = (chain: typeof old, runId: string, createdAt: Date) => ({
+    taskId: chain.task.id,
+    actorType: "control-plane",
+    body: `Chain Lease handed to queued Run ${runId}`,
+    createdAt,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "pending",
+      chainId: chain.chainId,
+      toRunId: runId,
+      handedOffAt: createdAt.toISOString(),
+    },
+  });
+  await db.taskActivity.create({ data: pending(old, oldRun.id, eightDaysAgo) });
+  await db.taskActivity.create({ data: pending(released, releasedRun.id, new Date(now.getTime() - 120_000)) });
+  await db.taskActivity.create({ data: {
+    taskId: released.task.id,
+    actorType: "control-plane",
+    body: "Queued handoff already released",
+    createdAt: new Date(now.getTime() - 90_000),
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "released",
+      chainId: released.chainId,
+      toRunId: releasedRun.id,
+      releasedAt: new Date(now.getTime() - 90_000).toISOString(),
+    },
+  } });
+  await db.taskActivity.create({ data: pending(claimed, claimedRun.id, new Date(now.getTime() - 120_000)) });
+
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 1);
+  assert.deepEqual(releasedLeaseTargets, [{ chainId: old.chainId, projectId: old.project.id }]);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: old.task.id,
+    metadata: { path: ["state"], equals: "released" },
+  } }), 1);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: claimed.task.id,
+    metadata: { path: ["state"], equals: "released" },
+  } }), 0);
+});
+
+test("a malformed handoff is durably invalidated without blocking a valid batch sibling", async () => {
+  const now = new Date();
+  const valid = await seedChain();
+  const malformed = await seedChain({ outputKind: "implementation" });
+  const stale = new Date(now.getTime() - 180_000);
+  const validRun = await seedRun(valid, { status: RunStatus.QUEUED, createdAt: stale, readyAt: stale });
+  const malformedRun = await seedRun(malformed, { status: RunStatus.QUEUED, createdAt: stale, readyAt: stale });
+  for (const [chain, run] of [[valid, validRun], [malformed, malformedRun]] as const) {
+    await db.taskActivity.create({ data: {
+      taskId: chain.task.id,
+      actorType: "control-plane",
+      body: `Chain Lease handed to queued Run ${run.id}`,
+      metadata: {
+        kind: MERGE_TAIL_KIND.leaseHandoff,
+        schemaVersion: 1,
+        state: "pending",
+        chainId: chain.chainId,
+        toRunId: run.id,
+        handedOffAt: new Date(now.getTime() - 120_000).toISOString(),
+      },
+    } });
+  }
+
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 2);
+  assert.deepEqual(releasedLeaseTargets, [{ chainId: valid.chainId, projectId: valid.project.id }]);
+  const invalid = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: malformed.task.id,
+    metadata: { path: ["state"], equals: "invalid" },
+  } });
+  assert.match(invalid.body, /does not resolve to a Merge Lease holder/u);
+  assert.equal((invalid.metadata as Record<string, unknown>).toRunId, malformedRun.id);
+  assert.equal(await reconcileDatabaseRuns(db, new Date(now.getTime() + 1_000), collectRelease), 0);
+});
+
+test("runner claim reports post-commit reconciliation maintenance failure and still claims", async (t) => {
+  const now = new Date();
+  const chain = await seedChain();
+  const stale = new Date(now.getTime() - 180_000);
+  const run = await seedRun(chain, { status: RunStatus.QUEUED, createdAt: stale, readyAt: stale });
+  await db.taskActivity.create({ data: {
+    taskId: chain.task.id,
+    actorType: "control-plane",
+    body: `Chain Lease handed to queued Run ${run.id}`,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "pending",
+      chainId: chain.chainId,
+      toRunId: run.id,
+      handedOffAt: new Date(now.getTime() - 120_000).toISOString(),
+    },
+  } });
+  const failure = new Error("release helper unavailable after reconciliation commit");
+  const reports: unknown[][] = [];
+  t.mock.method(console, "error", (...args: unknown[]) => { reports.push(args); });
+  const priorRunnerToken = process.env.RUNNER_TOKEN;
+  process.env.RUNNER_TOKEN = RUNNER;
+  try {
+    const response = await createApp(db, {
+      releaseMergeLease: async () => { throw failure; },
+    }).request("/runner/tasks/claim", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${RUNNER}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ runnerId: "claim-after-maintenance-failure", leaseSeconds: 60 }),
+    });
+    const responseText = await response.text();
+    assert.equal(response.status, 200, responseText);
+    assert.equal((JSON.parse(responseText) as { run: { id: string } }).run.id, run.id);
+  } finally {
+    if (priorRunnerToken === undefined) delete process.env.RUNNER_TOKEN;
+    else process.env.RUNNER_TOKEN = priorRunnerToken;
+  }
+  const report = reports.find(([message]) => message === "Runner claim reconciliation maintenance failed after commit");
+  assert.ok(report, "the typed maintenance failure is reported at the claim boundary");
+  const context = report[1] as {
+    reconciledAt: string;
+    failures: Array<{ target: { chainId: string; projectId: string }; phase: string; error: string }>;
+  };
+  assert.match(context.reconciledAt, /^\d{4}-/u);
+  assert.deepEqual(context.failures, [{
+    target: { chainId: chain.chainId, projectId: chain.project.id },
+    phase: "release",
+    error: failure.message,
+  }]);
+});
+
 test("one hold-recording failure does not block other stranded lease releases or settlements", async () => {
   const now = new Date();
   const first = await seedChain();
   const second = await seedChain();
-  const firstRun = await seedRun(first, { status: RunStatus.QUEUED });
-  const secondRun = await seedRun(second, { status: RunStatus.QUEUED });
+  const stale = new Date(now.getTime() - 180_000);
+  const firstRun = await seedRun(first, { status: RunStatus.QUEUED, createdAt: stale, readyAt: stale });
+  const secondRun = await seedRun(second, { status: RunStatus.QUEUED, createdAt: stale, readyAt: stale });
   for (const [chain, run] of [[first, firstRun], [second, secondRun]] as const) {
     await db.taskActivity.create({ data: {
       taskId: chain.task.id,
@@ -558,7 +719,8 @@ test("one hold-recording failure does not block other stranded lease releases or
 
   await assert.rejects(
     reconcileDatabaseRuns(db, now, releaseAll),
-    (error: unknown) => error instanceof AggregateError && error.errors.includes(recordingFailure),
+    (error: unknown) => error instanceof ReconciliationMaintenanceError
+      && error.failures.some((failure) => failure.phase === "release" && failure.error === recordingFailure),
   );
   assert.deepEqual(new Set(attempted), new Set([first.project.id, second.project.id]));
   assert.equal(await db.taskActivity.count({ where: {

--- a/packages/api/src/merge-lease-cancel-release.dbtest.ts
+++ b/packages/api/src/merge-lease-cancel-release.dbtest.ts
@@ -495,6 +495,102 @@ test("duplicate pending handoffs for one Run settle once", async () => {
   } }), 1);
 });
 
+test("an old queued Run with a fresh handoff waits for the handoff grace clock", async () => {
+  const now = new Date();
+  const chain = await seedChain();
+  const old = new Date(now.getTime() - (9 * 24 * 60 * 60 * 1_000));
+  const freshHandoff = new Date(now.getTime() - 30_000);
+  const run = await seedRun(chain, { status: RunStatus.QUEUED, createdAt: old, readyAt: old });
+  await db.taskActivity.create({ data: {
+    taskId: chain.task.id,
+    actorType: "control-plane",
+    body: `Fresh Chain Lease handoff to old Run ${run.id}`,
+    createdAt: freshHandoff,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "pending",
+      chainId: chain.chainId,
+      toRunId: run.id,
+      handedOffAt: freshHandoff.toISOString(),
+    },
+  } });
+
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 0);
+  assert.deepEqual(releasedChainLeases, []);
+  assert.equal(await reconcileDatabaseRuns(db, new Date(freshHandoff.getTime() + 61_000), collectRelease), 1);
+  assert.deepEqual(releasedChainLeases, [chain.chainId]);
+});
+
+test("unrelated stale queued Runs cannot hide a matching handoff from the bounded driver", async () => {
+  const now = new Date();
+  const chain = await seedChain();
+  const unrelatedAt = new Date(now.getTime() - 300_000);
+  const matchingAt = new Date(now.getTime() - 180_000);
+  const matching = await seedRun(chain, {
+    status: RunStatus.QUEUED,
+    createdAt: matchingAt,
+    readyAt: matchingAt,
+  });
+  const unrelatedIds = Array.from({ length: 101 }, (_, index) => `unrelated-stale-${chain.suffix}-${index}`);
+  await db.run.createMany({ data: unrelatedIds.map((id, index) => ({
+    id,
+    projectId: chain.project.id,
+    taskId: chain.task.id,
+    agentId: chain.agent.id,
+    repoId: chain.repo.id,
+    runNumber: index + 2,
+    dedupeKey: `task:${chain.task.id}:unrelated-stale:${index}`,
+    status: RunStatus.QUEUED,
+    runner: "CLAUDE" as const,
+    model: chain.agent.model,
+    promptHash: "hash",
+    branch: `claude/${chain.suffix}-unrelated-${index}`,
+    targetBranch: "master",
+    createdAt: unrelatedAt,
+    readyAt: unrelatedAt,
+  })) });
+  await db.taskActivity.createMany({ data: unrelatedIds.map((toRunId, index) => ({
+    taskId: chain.task.id,
+    actorType: "control-plane",
+    body: `Malformed unrelated handoff ${index}`,
+    createdAt: new Date(now.getTime() - 240_000),
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "pending",
+      toRunId,
+      handedOffAt: new Date(now.getTime() - 240_000).toISOString(),
+    },
+  })) });
+  const handedOffAt = new Date(now.getTime() - 120_000);
+  await db.taskActivity.create({ data: {
+    taskId: chain.task.id,
+    actorType: "control-plane",
+    body: `Only matching Chain Lease handoff ${matching.id}`,
+    createdAt: handedOffAt,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "pending",
+      chainId: chain.chainId,
+      toRunId: matching.id,
+      handedOffAt: handedOffAt.toISOString(),
+    },
+  } });
+
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 1);
+  assert.deepEqual(releasedChainLeases, [chain.chainId]);
+  const released = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: chain.task.id,
+    AND: [
+      { metadata: { path: ["state"], equals: "released" } },
+      { metadata: { path: ["toRunId"], equals: matching.id } },
+    ],
+  } });
+  assert.equal((released.metadata as Record<string, unknown>).toRunId, matching.id);
+});
+
 test("a released marker older than a new pending handoff does not suppress recovery", async () => {
   const now = new Date();
   const chain = await seedChain();

--- a/packages/api/src/merge-lease-cancel-release.dbtest.ts
+++ b/packages/api/src/merge-lease-cancel-release.dbtest.ts
@@ -19,7 +19,15 @@
 import assert from "node:assert/strict";
 import { after, before, beforeEach, test } from "node:test";
 
-import { DIRECT_TEMPLATE_NAME, MERGE_TAIL_KIND, PrismaClient, RunStatus, TaskStatus } from "@anneal/db";
+import {
+  DIRECT_TEMPLATE_NAME,
+  INTEGRATOR_AGENT_NAME,
+  INTEGRATOR_SENTINEL_MODEL,
+  MERGE_TAIL_KIND,
+  PrismaClient,
+  RunStatus,
+  TaskStatus,
+} from "@anneal/db";
 
 import type { ReleaseMergeLease } from "./merge-lease.js";
 import { recordMergeLeaseHold } from "./merge-lease-hold.js";
@@ -103,9 +111,13 @@ const seedChain = async (options: { outputKind?: string; chainId?: string; chain
   const suffix = `${process.pid}-${sequence}`;
   const project = await db.project.create({ data: { name: "Cancel release", slug: `cancel-release-${suffix}` } });
   const environment = await db.environment.create({ data: { projectId: project.id, name: "local", allowedHosts: [] } });
+  const mechanical = options.outputKind === "merge-result";
   const agent = await db.agent.create({ data: {
-    projectId: project.id, environmentId: environment.id, name: `agent-${suffix}`, title: "Agent",
-    model: "claude-opus-5:high", foundationalPrompt: "foundation", rolePrompt: "role",
+    projectId: project.id, environmentId: environment.id,
+    name: mechanical ? INTEGRATOR_AGENT_NAME : `agent-${suffix}`,
+    title: mechanical ? "Merge Integrator" : "Agent",
+    model: mechanical ? INTEGRATOR_SENTINEL_MODEL : "claude-opus-5:high",
+    foundationalPrompt: "foundation", rolePrompt: "role",
   } });
   const repo = await db.repo.create({ data: {
     projectId: project.id, name: "repo", remoteUrl: "https://github.com/acme/widgets.git",
@@ -277,9 +289,9 @@ test("reconciliation terminalizing a cancellation after runner loss releases the
   await assertConfirmedHold(chain.task.id);
 });
 
-test("a lost merge-tail run that still has an attempt left keeps the lease for its retry", async () => {
+test("a lost mechanical run hands the lease to its retry until orphan cleanup", async () => {
   const now = new Date();
-  const chain = await seedChain();
+  const chain = await seedChain({ outputKind: "merge-result", chainIndex: 7 });
   const run = await seedRun(chain, {
     runNumber: 1, maxRunsPerTask: 3, leaseExpiresAt: new Date(now.getTime() - 60_000), heartbeatAt: null,
   });
@@ -288,9 +300,19 @@ test("a lost merge-tail run that still has an attempt left keeps the lease for i
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: run.id } })).status, RunStatus.LOST);
   const retry = await db.run.findFirst({ where: { taskId: chain.task.id, runNumber: 2 } });
   assert.ok(retry, "the lost run bought a retry");
-  // The retry remains claimable; readiness will reacquire the same
-  // project-scoped lease identity before handing it to the final consumer.
+  const pending = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: chain.task.id,
+    metadata: { path: ["state"], equals: "pending" },
+  } });
+  assert.equal((pending.metadata as Record<string, unknown>).toRunId, retry.id);
+  assert.equal((pending.metadata as Record<string, unknown>).consumerReadyAt, retry.readyAt.toISOString());
   assert.deepEqual(releasedChainLeases, []);
+
+  assert.equal(
+    await reconcileDatabaseRuns(db, new Date(retry.readyAt.getTime() + 61_000), collectRelease),
+    1,
+  );
+  assert.deepEqual(releasedChainLeases, [chain.chainId]);
 });
 
 test("a lost merge-tail run with no attempts left releases the lease", async () => {
@@ -381,6 +403,129 @@ test("a stranded queued handoff releases once and records settlement after relea
   assert.deepEqual(releasedChainLeases, [chain.chainId]);
 });
 
+test("handoff recovery drains its bounded page oldest-first", async () => {
+  const now = new Date();
+  const chain = await seedChain();
+  const runIds = Array.from({ length: 101 }, (_, index) => `lease-page-${chain.suffix}-${index}`);
+  await db.run.createMany({ data: runIds.map((id, index) => ({
+    id,
+    projectId: chain.project.id,
+    taskId: chain.task.id,
+    agentId: chain.agent.id,
+    repoId: chain.repo.id,
+    runNumber: index + 1,
+    dedupeKey: `task:${chain.task.id}:lease-page:${index}`,
+    status: RunStatus.QUEUED,
+    runner: "CLAUDE",
+    model: chain.agent.model,
+    promptHash: "hash",
+    branch: `claude/${chain.suffix}-lease-page-${index}`,
+    targetBranch: "master",
+  })) });
+  const handedOffAt = new Date(now.getTime() - 120_000).toISOString();
+  await db.taskActivity.createMany({ data: runIds.map((toRunId, index) => ({
+    taskId: chain.task.id,
+    actorType: "control-plane",
+    body: `Unresolved Chain Lease handoff ${index}`,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "pending",
+      chainId: chain.chainId,
+      toRunId,
+      handedOffAt,
+    },
+  })) });
+
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 100);
+  assert.equal(releasedChainLeases.length, 1, "one bounded batch deduplicates the shared release target");
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: chain.task.id,
+    metadata: { path: ["state"], equals: "released" },
+  } }), 100);
+
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 1);
+  assert.equal(releasedChainLeases.length, 2);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: chain.task.id,
+    metadata: { path: ["state"], equals: "released" },
+  } }), 101);
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 0);
+});
+
+test("duplicate pending handoffs for one Run settle once", async () => {
+  const now = new Date();
+  const chain = await seedChain();
+  const run = await seedRun(chain, { status: RunStatus.QUEUED });
+  const handedOffAt = new Date(now.getTime() - 120_000).toISOString();
+  await db.taskActivity.createMany({ data: Array.from({ length: 2 }, (_, index) => ({
+    taskId: chain.task.id,
+    actorType: "control-plane",
+    body: `Duplicate unresolved Chain Lease handoff ${index}`,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "pending",
+      chainId: chain.chainId,
+      toRunId: run.id,
+      handedOffAt,
+    },
+  })) });
+
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 1);
+  assert.deepEqual(releasedChainLeases, [chain.chainId]);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: chain.task.id,
+    AND: [
+      { metadata: { path: ["state"], equals: "released" } },
+      { metadata: { path: ["toRunId"], equals: run.id } },
+    ],
+  } }), 1);
+});
+
+test("a released marker older than a new pending handoff does not suppress recovery", async () => {
+  const now = new Date();
+  const chain = await seedChain();
+  const run = await seedRun(chain, { status: RunStatus.QUEUED });
+  await db.taskActivity.createMany({ data: [
+    {
+      taskId: chain.task.id,
+      actorType: "control-plane",
+      body: "Earlier released Chain Lease handoff",
+      createdAt: new Date(now.getTime() - 180_000),
+      metadata: {
+        kind: MERGE_TAIL_KIND.leaseHandoff,
+        schemaVersion: 1,
+        state: "released",
+        chainId: chain.chainId,
+        toRunId: run.id,
+        releasedAt: new Date(now.getTime() - 180_000).toISOString(),
+      },
+    },
+    {
+      taskId: chain.task.id,
+      actorType: "control-plane",
+      body: "New pending Chain Lease handoff",
+      createdAt: new Date(now.getTime() - 120_000),
+      metadata: {
+        kind: MERGE_TAIL_KIND.leaseHandoff,
+        schemaVersion: 1,
+        state: "pending",
+        chainId: chain.chainId,
+        toRunId: run.id,
+        handedOffAt: new Date(now.getTime() - 120_000).toISOString(),
+      },
+    },
+  ] });
+
+  assert.equal(await reconcileDatabaseRuns(db, now, collectRelease), 1);
+  assert.deepEqual(releasedChainLeases, [chain.chainId]);
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: chain.task.id,
+    metadata: { path: ["state"], equals: "released" },
+  } }), 2);
+});
+
 test("one hold-recording failure does not block other stranded lease releases or settlements", async () => {
   const now = new Date();
   const first = await seedChain();
@@ -416,15 +561,17 @@ test("one hold-recording failure does not block other stranded lease releases or
     (error: unknown) => error instanceof AggregateError && error.errors.includes(recordingFailure),
   );
   assert.deepEqual(new Set(attempted), new Set([first.project.id, second.project.id]));
-  for (const chain of [first, second]) {
-    const settlement = await db.taskActivity.findFirstOrThrow({
-      where: {
-        taskId: chain.task.id,
-        metadata: { path: ["state"], equals: "released" },
-      },
-    });
-    assert.equal((settlement.metadata as Record<string, unknown>).kind, MERGE_TAIL_KIND.leaseHandoff);
-  }
+  assert.equal(await db.taskActivity.count({ where: {
+    taskId: first.task.id,
+    metadata: { path: ["state"], equals: "released" },
+  } }), 0, "a failed release remains pending for a later reconciliation");
+  const settlement = await db.taskActivity.findFirstOrThrow({
+    where: {
+      taskId: second.task.id,
+      metadata: { path: ["state"], equals: "released" },
+    },
+  });
+  assert.equal((settlement.metadata as Record<string, unknown>).kind, MERGE_TAIL_KIND.leaseHandoff);
   assert.equal(await db.taskActivity.count({
     where: { taskId: first.task.id, metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.leaseHold } },
   }), 0);

--- a/packages/api/src/merge-lease.test.ts
+++ b/packages/api/src/merge-lease.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import type { Prisma, PrismaClient } from "@anneal/db";
+import { MERGE_TAIL_KIND, type Prisma, type PrismaClient } from "@anneal/db";
 
 import {
   commitWithLeaseOutcome,
@@ -188,13 +188,17 @@ test("leaseHandoffsWithoutConsumer returns only stale Runs that never claimed", 
   assert.ok(parameters.includes(100), "the query has an explicit row limit");
 });
 
+test("the lease-release marker constant matches the indexed SQL literal", () => {
+  assert.equal(MERGE_TAIL_KIND.leaseRelease, "mergeTail.leaseRelease");
+});
+
 test("deferredLeaseReleases returns one bounded unresolved page", async () => {
   let sql = "";
   let parameters: unknown[] = [];
   const tx = {
-    $queryRaw: async (strings: TemplateStringsArray, ...values: unknown[]) => {
-      sql = strings.join("?");
-      parameters = values;
+    $queryRaw: async (statement: Prisma.Sql) => {
+      sql = statement.sql;
+      parameters = statement.values;
       return [{ activityId: "deferred-1", taskId: "task-1", projectId: "project-1", chainId: "chain-1" }];
     },
   } as unknown as Prisma.TransactionClient;
@@ -208,7 +212,7 @@ test("deferredLeaseReleases returns one bounded unresolved page", async () => {
   assert.match(sql, /state' = 'release-deferred'/u);
   assert.match(sql, /deferredActivityId/u);
   assert.doesNotMatch(sql, /kind' = \?/u, "the partial-index predicate stays a SQL literal");
-  assert.ok(parameters.includes(100));
+  assert.deepEqual(parameters, [100], "only the bounded page limit is parameterized");
 });
 
 const transactionDb = (tx: Prisma.TransactionClient, events: string[] = []) => ({

--- a/packages/api/src/merge-lease.test.ts
+++ b/packages/api/src/merge-lease.test.ts
@@ -204,8 +204,10 @@ test("deferredLeaseReleases returns one bounded unresolved page", async () => {
     taskId: "task-1",
     target: { projectId: "project-1", chainId: "chain-1" },
   }]);
+  assert.match(sql, /kind' = 'mergeTail\.leaseRelease'/u);
   assert.match(sql, /state' = 'release-deferred'/u);
   assert.match(sql, /deferredActivityId/u);
+  assert.doesNotMatch(sql, /kind' = \?/u, "the partial-index predicate stays a SQL literal");
   assert.ok(parameters.includes(100));
 });
 

--- a/packages/api/src/merge-lease.test.ts
+++ b/packages/api/src/merge-lease.test.ts
@@ -4,12 +4,12 @@ import test from "node:test";
 import type { Prisma, PrismaClient } from "@anneal/db";
 
 import {
-  commitWithLeaseDisposition,
+  commitWithLeaseOutcome,
+  commitWithLeaseOutcomes,
   leaseHandoffsWithoutConsumer,
   leaseHolderFor,
   mergeLeaseScriptPath,
   readMergeLeaseRelease,
-  settleLease,
   withMergeLease,
   type MergeLeaseAcquirer,
   type MergeLeaseReleaser,
@@ -31,6 +31,10 @@ const leaseTarget = (chainId: string) => ({ projectId: "project-1", chainId });
 const holdDb = {
   task: { findFirst: async () => ({ id: "tail-task" }) },
   taskActivity: { createMany: async () => ({ count: 1 }) },
+  $transaction: async (fn: (tx: Prisma.TransactionClient) => Promise<unknown>) => fn({
+    run: { findUnique: async () => ({ taskId: "tail-task" }) },
+    taskActivity: { create: async () => ({}) },
+  } as unknown as Prisma.TransactionClient),
 } as unknown as PrismaClient;
 
 const holderTx = (input: {
@@ -95,18 +99,6 @@ test("leaseHolderFor owns every merge-tail Task shape, including a failed auxili
   }
 });
 
-test("settleLease maps continuation and stop outcomes through the holder record", async () => {
-  const tx = holderTx({ task: { chainId: "chain-1", projectId: "project-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } });
-  assert.deepEqual(await settleLease(tx, { taskId: "task-1", outcome: "continue" }), {
-    disposition: "retain",
-    leaseToRelease: null,
-  });
-  assert.deepEqual(await settleLease(tx, { taskId: "task-1", outcome: "stop" }), {
-    disposition: "release",
-    leaseToRelease: leaseTarget("chain-1"),
-  });
-});
-
 test("release parsing requires the timestamp while leaving duration validation to the calculator", () => {
   assert.deepEqual(
     readMergeLeaseRelease("MERGE LEASE: released refs/merge-lease/holder lease-sha 2026-08-27T12:00:00.000Z"),
@@ -143,50 +135,176 @@ test("mergeLeaseHold calculates whole elapsed seconds and clamps invalid or skew
 
 test("leaseHandoffsWithoutConsumer returns only stale Runs that never claimed", async () => {
   const now = new Date("2026-08-27T12:02:00.000Z");
+  let sql = "";
+  let parameters: unknown[] = [];
   const tx = {
-    taskActivity: { findMany: async () => [
-      { taskId: "task-stale", task: { projectId: "project-1" }, metadata: { state: "pending", chainId: "chain-stale", toRunId: "run-stale", handedOffAt: "2026-08-27T12:00:00.000Z" } },
-      { taskId: "task-active", task: { projectId: "project-1" }, metadata: { state: "pending", chainId: "chain-active", toRunId: "run-active", handedOffAt: "2026-08-27T12:01:30.000Z" } },
-      { taskId: "task-done", task: { projectId: "project-1" }, metadata: { state: "released", chainId: "chain-done", toRunId: "run-done" } },
-      { taskId: "task-done", task: { projectId: "project-1" }, metadata: { state: "pending", chainId: "chain-done", toRunId: "run-done" } },
-    ] },
-    run: { findMany: async () => [{ id: "run-stale" }] },
+    $queryRaw: async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      sql = strings.join("?");
+      parameters = values;
+      return [{ toRunId: "run-stale", taskId: "task-stale" }];
+    },
   } as unknown as Prisma.TransactionClient;
 
   assert.deepEqual(await leaseHandoffsWithoutConsumer(tx, now), [
-    { chainId: "chain-stale", projectId: "project-1", toRunId: "run-stale", taskId: "task-stale" },
+    { toRunId: "run-stale", taskId: "task-stale" },
   ]);
+  assert.match(sql, /NOT EXISTS/u);
+  assert.match(sql, /GREATEST/u);
+  assert.match(sql, /\(released\."createdAt", released\.id\) > \(pending\."createdAt", pending\.id\)/u);
+  assert.match(sql, /ORDER BY "createdAt" ASC, id ASC/u);
+  assert.match(sql, /LIMIT/u);
+  assert.ok(parameters.some((value) => value instanceof Date), "the query has a time floor");
+  assert.ok(parameters.includes(100), "the query has an explicit row limit");
 });
 
-test("commitWithLeaseDisposition releases only after the transaction commits", async () => {
-  const events: string[] = [];
-  const db = {
-    $transaction: async (fn: (tx: Prisma.TransactionClient) => Promise<unknown>) => {
-      const result = await fn({} as Prisma.TransactionClient);
-      events.push("commit");
-      return result;
-    },
-  } as unknown as Parameters<typeof commitWithLeaseDisposition>[0];
+const transactionDb = (tx: Prisma.TransactionClient, events: string[] = []) => ({
+  $transaction: async (fn: (client: Prisma.TransactionClient) => Promise<unknown>) => {
+    const result = await fn(tx);
+    events.push("commit");
+    return result;
+  },
+} as unknown as PrismaClient);
 
-  const value = await commitWithLeaseDisposition(db, async () => {
+test("commitWithLeaseOutcome releases only after the transaction commits", async () => {
+  const events: string[] = [];
+  const tx = holderTx({ task: { chainId: "chain-1", projectId: "project-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } });
+  const db = transactionDb(tx, events);
+
+  const value = await commitWithLeaseOutcome(db, async () => {
     events.push("transaction");
     return {
       value: 42,
-      lease: { disposition: "release", leaseToRelease: leaseTarget("chain-1") },
+      leaseOutcome: { kind: "stop", taskId: "task-1" },
     };
-  }, async (target) => {
+  }, { release: async (target) => {
     events.push(`release:${target?.chainId ?? "none"}`);
-  });
+  } });
 
   assert.equal(value, 42);
   assert.deepEqual(events, ["transaction", "commit", "release:chain-1"]);
+});
+
+test("commitWithLeaseOutcome rolls back without release when the callback fails", async () => {
+  let releases = 0;
+  const failure = new Error("transaction failed");
+  const db = transactionDb(holderTx({ task: { chainId: "chain-1", projectId: "project-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } }));
+  await assert.rejects(commitWithLeaseOutcome(db, async () => {
+    throw failure;
+  }, { release: async () => { releases += 1; } }), (error: unknown) => error === failure);
+  assert.equal(releases, 0);
+});
+
+test("commitWithLeaseOutcome surfaces release failure", async () => {
+  const failure = new Error("release failed");
+  const db = transactionDb(holderTx({ task: { chainId: "chain-1", projectId: "project-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } }));
+  await assert.rejects(commitWithLeaseOutcome(db, async () => ({
+    value: null,
+    leaseOutcome: { kind: "stop", taskId: "task-1" },
+  }), { release: async () => { throw failure; } }), (error: unknown) => error === failure);
+});
+
+test("commitWithLeaseOutcomes deduplicates release targets and rolls back without release", async () => {
+  const tx = holderTx({ task: { chainId: "chain-1", projectId: "project-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } });
+  const db = transactionDb(tx);
+  const releasedTargets: unknown[] = [];
+  const value = await commitWithLeaseOutcomes(db, async () => ({
+    value: 7,
+    leaseOutcomes: [
+      { kind: "stop", taskId: "task-1" },
+      { kind: "stop", taskId: "task-1" },
+    ],
+  }), { release: async (target) => { releasedTargets.push(target); } });
+  assert.equal(value, 7);
+  assert.deepEqual(releasedTargets, [leaseTarget("chain-1")]);
+
+  const failure = new Error("batch transaction failed");
+  await assert.rejects(commitWithLeaseOutcomes(db, async () => {
+    throw failure;
+  }, { release: async (target) => { if (target) releasedTargets.push(target); } }), (error: unknown) => error === failure);
+  assert.equal(releasedTargets.length, 1);
+});
+
+test("commitWithLeaseOutcomes surfaces release failure", async () => {
+  const failure = new Error("batch release failed");
+  const db = transactionDb(holderTx({ task: { chainId: "chain-1", projectId: "project-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } }));
+  await assert.rejects(commitWithLeaseOutcomes(db, async () => ({
+    value: null,
+    leaseOutcomes: [{ kind: "stop", taskId: "task-1" }],
+  }), { release: async () => { throw failure; } }), (error: unknown) => (
+    error instanceof AggregateError && error.errors.includes(failure)
+  ));
+});
+
+test("commitWithLeaseOutcome records handoff without release and surfaces record failure", async () => {
+  const activities: unknown[] = [];
+  const tx = {
+    ...holderTx({ task: { chainId: "chain-1", projectId: "project-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } }),
+    run: { findUnique: async () => ({ taskId: "task-2", readyAt: new Date("2026-08-27T12:05:00.000Z") }) },
+    taskActivity: { create: async (input: unknown) => { activities.push(input); } },
+  } as unknown as Prisma.TransactionClient;
+  let releases = 0;
+  const db = transactionDb(tx);
+  await commitWithLeaseOutcome(db, async () => ({
+    value: null,
+    leaseOutcome: {
+      kind: "hand-off",
+      taskId: "task-1",
+      handoffRunId: "run-2",
+      at: new Date("2026-08-27T12:00:00.000Z"),
+    },
+  }), { release: async () => { releases += 1; } });
+  assert.equal(releases, 0);
+  assert.equal(activities.length, 1);
+  assert.equal(
+    ((activities[0] as { data: { metadata: Record<string, unknown> } }).data.metadata).consumerReadyAt,
+    "2026-08-27T12:05:00.000Z",
+  );
+
+  const recordFailure = new Error("handoff record failed");
+  const failingTx = {
+    ...tx,
+    taskActivity: { create: async () => { throw recordFailure; } },
+  } as unknown as Prisma.TransactionClient;
+  await assert.rejects(commitWithLeaseOutcome(transactionDb(failingTx), async () => ({
+    value: null,
+    leaseOutcome: {
+      kind: "hand-off",
+      taskId: "task-1",
+      handoffRunId: "run-2",
+      at: new Date("2026-08-27T12:00:00.000Z"),
+    },
+  })), (error: unknown) => error === recordFailure);
+});
+
+test("commitWithLeaseOutcome refuses to settle a handoff without a holder", async () => {
+  let releases = 0;
+  const tx = holderTx({
+    task: {
+      chainId: "ordinary-chain",
+      projectId: "project-1",
+      templateStep: {
+        stepIndex: 2,
+        outputKind: "implementation",
+        taskTemplate: { name: "direct-engineer-workflow" },
+      },
+    },
+  });
+  await assert.rejects(commitWithLeaseOutcome(transactionDb(tx), async () => ({
+    value: null,
+    leaseOutcome: {
+      kind: "stop",
+      taskId: "task-1",
+      releasedHandoff: { toRunId: "run-orphan", at: new Date("2026-08-27T12:00:00.000Z") },
+    },
+  }), { release: async () => { releases += 1; } }), /Cannot settle a Merge Lease handoff/u);
+  assert.equal(releases, 0);
 });
 
 test("a completed callback releases the merge Lease", async () => {
   const acquiredFor: string[] = [];
   const releasedFor: string[] = [];
   const result = await withMergeLease(leaseTarget("chain-1"), async () => ({
-    disposition: { kind: "release" },
+    leaseOutcome: { kind: "stop" },
     value: 42,
   }), holdDb, {
     acquire: async (chainId) => {
@@ -204,10 +322,10 @@ test("a completed callback releases the merge Lease", async () => {
   assert.deepEqual(releasedFor, ["chain-1"]);
 });
 
-test("retain hands the merge Lease to the downstream consumer", async () => {
+test("continue leaves the merge Lease with its recorded downstream consumer", async () => {
   let releaseCalled = false;
   const result = await withMergeLease(leaseTarget("chain-2"), async () => ({
-    disposition: { kind: "retain", handoffRunId: "run-2" },
+    leaseOutcome: { kind: "continue" },
     value: "authorized",
   }), holdDb, {
     acquire: acquired,
@@ -264,7 +382,7 @@ test("a contended merge Lease does not run the callback", async () => {
   let releaseCalled = false;
   const result = await withMergeLease(leaseTarget("chain-4"), async () => {
     callbackCalled = true;
-    return { disposition: { kind: "release" }, value: null };
+    return { leaseOutcome: { kind: "stop" }, value: null };
   }, holdDb, {
     acquire: async () => ({ outcome: "contended" }),
     release: async () => {
@@ -283,7 +401,7 @@ test("an unreachable merge Lease is a retryable result and does not run the call
   let releaseCalled = false;
   const result = await withMergeLease(leaseTarget("chain-unreachable"), async () => {
     callbackCalled = true;
-    return { disposition: { kind: "release" }, value: null };
+    return { leaseOutcome: { kind: "stop" }, value: null };
   }, holdDb, {
     acquire: async () => ({ outcome: "unreachable", detail: "TLS transport failed" }),
     release: async () => {
@@ -297,37 +415,49 @@ test("an unreachable merge Lease is a retryable result and does not run the call
   assert.equal(releaseCalled, false);
 });
 
-test("the module reports a release anomaly itself", async (t) => {
+test("skipped and refused releases are reported decided outcomes", async (t) => {
   const said: string[] = [];
   t.mock.method(console, "error", (...args: unknown[]) => { said.push(args.map(String).join(" ")); });
 
-  await withMergeLease(leaseTarget("chain-5"), async () => ({ disposition: { kind: "release" }, value: null }), holdDb, {
+  assert.deepEqual(await withMergeLease(leaseTarget("chain-5"), async () => ({ leaseOutcome: { kind: "stop" }, value: "skipped" }), holdDb, {
     acquire: acquired,
     release: async () => ({ outcome: "skipped", heldFor: "chain-42" }),
-  });
+  }), { outcome: "ran", value: "skipped" });
+  assert.deepEqual(await withMergeLease(leaseTarget("chain-6"), async () => ({ leaseOutcome: { kind: "stop" }, value: "refused" }), holdDb, {
+    acquire: acquired,
+    release: async () => ({ outcome: "refused", heldBy: "another-host" }),
+  }), { outcome: "ran", value: "refused" });
 
-  assert.equal(said.length, 1);
+  assert.equal(said.length, 2);
   assert.match(said[0]!, /chain-5/u);
   assert.match(said[0]!, /chain-42/u);
+  assert.match(said[1]!, /chain-6/u);
+  assert.match(said[1]!, /another-host/u);
 });
 
-test("a rejected release adapter is reported as unreachable", async (t) => {
-  const said: string[] = [];
-  t.mock.method(console, "error", (...args: unknown[]) => { said.push(args.map(String).join(" ")); });
+test("an unreachable release outcome fails loudly", async () => {
+  await assert.rejects(withMergeLease(
+    leaseTarget("chain-unreachable-release"),
+    async () => ({ leaseOutcome: { kind: "stop" }, value: null }),
+    holdDb,
+    {
+      acquire: acquired,
+      release: async () => ({ outcome: "unreachable", detail: "release helper timed out" }),
+    },
+  ), /failed with outcome unreachable/u);
+});
+
+test("a rejected release adapter fails loudly", async () => {
   const releaser: MergeLeaseReleaser = async () => { throw new Error("spawn bash ENOENT"); };
 
-  await withMergeLease(leaseTarget("chain-6"), async () => ({ disposition: { kind: "release" }, value: null }), holdDb, {
+  await assert.rejects(withMergeLease(leaseTarget("chain-6"), async () => ({ leaseOutcome: { kind: "stop" }, value: null }), holdDb, {
     acquire: acquired,
     release: releaser,
-  });
-
-  assert.equal(said.length, 1);
-  assert.match(said[0]!, /chain-6/u);
-  assert.match(said[0]!, /spawn bash ENOENT/u);
+  }), /spawn bash ENOENT/u);
 });
 
 test("a Task without a Chain runs without either Lease adapter", async () => {
-  const result = await withMergeLease(null, async () => ({ disposition: { kind: "release" }, value: "unleased" }), holdDb, {
+  const result = await withMergeLease(null, async () => ({ leaseOutcome: { kind: "stop" }, value: "unleased" }), holdDb, {
     acquire: async () => { throw new Error("the acquirer must not be called"); },
     release: async () => { throw new Error("the releaser must not be called"); },
   });

--- a/packages/api/src/merge-lease.test.ts
+++ b/packages/api/src/merge-lease.test.ts
@@ -6,6 +6,8 @@ import type { Prisma, PrismaClient } from "@anneal/db";
 import {
   commitWithLeaseOutcome,
   commitWithLeaseOutcomes,
+  deferredLeaseReleases,
+  LeaseReleaseDeferralRecordError,
   leaseHandoffsWithoutConsumer,
   leaseHolderFor,
   mergeLeaseScriptPath,
@@ -36,6 +38,31 @@ const holdDb = {
     taskActivity: { create: async () => ({}) },
   } as unknown as Prisma.TransactionClient),
 } as unknown as PrismaClient;
+
+const releaseDeferralDb = (
+  chainId: string,
+  writes: Array<Record<string, unknown>> = [],
+  recordFailure?: Error,
+): PrismaClient => ({
+  $transaction: async (fn: (tx: Prisma.TransactionClient) => Promise<unknown>) => fn({
+    task: { findUnique: async () => ({
+      chainId,
+      projectId: "project-1",
+      templateStep: {
+        stepIndex: 7,
+        outputKind: "merge-result",
+        taskTemplate: { name: "direct-engineer-workflow" },
+      },
+    }) },
+    taskActivity: {
+      create: async ({ data }: { data: Record<string, unknown> }) => {
+        if (recordFailure) throw recordFailure;
+        writes.push(data);
+        return data;
+      },
+    },
+  } as unknown as Prisma.TransactionClient),
+} as unknown as PrismaClient);
 
 const holderTx = (input: {
   task: { chainId: string | null; projectId: string; templateStep: { stepIndex: number; outputKind: string; taskTemplate: { name: string } } };
@@ -149,13 +176,37 @@ test("leaseHandoffsWithoutConsumer returns only stale Runs that never claimed", 
     { toRunId: "run-stale", taskId: "task-stale" },
   ]);
   assert.match(sql, /FROM "Run" AS consumer/u);
+  assert.match(sql, /WITH consumers AS/u);
+  assert.match(sql, /AND EXISTS \(/u);
   assert.match(sql, /JOIN LATERAL/u);
+  assert.match(sql, /activity\."taskId" = consumer\."taskId"/u);
   assert.match(sql, /activity\."createdAt" >= LEAST\(consumer\."createdAt", consumer\."readyAt"\)/u);
   assert.match(sql, /GREATEST\(consumer\."createdAt", consumer\."readyAt"\)/u);
   assert.match(sql, /ORDER BY "staleAt" ASC, "toRunId" ASC/u);
   assert.match(sql, /LIMIT/u);
   assert.ok(parameters.some((value) => value instanceof Date), "the query has a time floor");
   assert.ok(parameters.includes(100), "the query has an explicit row limit");
+});
+
+test("deferredLeaseReleases returns one bounded unresolved page", async () => {
+  let sql = "";
+  let parameters: unknown[] = [];
+  const tx = {
+    $queryRaw: async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      sql = strings.join("?");
+      parameters = values;
+      return [{ activityId: "deferred-1", taskId: "task-1", projectId: "project-1", chainId: "chain-1" }];
+    },
+  } as unknown as Prisma.TransactionClient;
+
+  assert.deepEqual(await deferredLeaseReleases(tx), [{
+    activityId: "deferred-1",
+    taskId: "task-1",
+    target: { projectId: "project-1", chainId: "chain-1" },
+  }]);
+  assert.match(sql, /state' = 'release-deferred'/u);
+  assert.match(sql, /deferredActivityId/u);
+  assert.ok(parameters.includes(100));
 });
 
 const transactionDb = (tx: Prisma.TransactionClient, events: string[] = []) => ({
@@ -315,7 +366,7 @@ test("a completed callback releases the merge Lease", async () => {
   const acquiredFor: string[] = [];
   const releasedFor: string[] = [];
   const result = await withMergeLease(leaseTarget("chain-1"), async () => ({
-    leaseOutcome: { kind: "stop" },
+    leaseOutcome: { kind: "stop", taskId: "task-1" },
     value: 42,
   }), holdDb, {
     acquire: async (chainId) => {
@@ -393,7 +444,7 @@ test("a contended merge Lease does not run the callback", async () => {
   let releaseCalled = false;
   const result = await withMergeLease(leaseTarget("chain-4"), async () => {
     callbackCalled = true;
-    return { leaseOutcome: { kind: "stop" }, value: null };
+    return { leaseOutcome: { kind: "stop", taskId: "task-1" }, value: null };
   }, holdDb, {
     acquire: async () => ({ outcome: "contended" }),
     release: async () => {
@@ -412,7 +463,7 @@ test("an unreachable merge Lease is a retryable result and does not run the call
   let releaseCalled = false;
   const result = await withMergeLease(leaseTarget("chain-unreachable"), async () => {
     callbackCalled = true;
-    return { leaseOutcome: { kind: "stop" }, value: null };
+    return { leaseOutcome: { kind: "stop", taskId: "task-1" }, value: null };
   }, holdDb, {
     acquire: async () => ({ outcome: "unreachable", detail: "TLS transport failed" }),
     release: async () => {
@@ -430,11 +481,11 @@ test("skipped and refused releases are reported decided outcomes", async (t) => 
   const said: string[] = [];
   t.mock.method(console, "error", (...args: unknown[]) => { said.push(args.map(String).join(" ")); });
 
-  assert.deepEqual(await withMergeLease(leaseTarget("chain-5"), async () => ({ leaseOutcome: { kind: "stop" }, value: "skipped" }), holdDb, {
+  assert.deepEqual(await withMergeLease(leaseTarget("chain-5"), async () => ({ leaseOutcome: { kind: "stop", taskId: "task-1" }, value: "skipped" }), holdDb, {
     acquire: acquired,
     release: async () => ({ outcome: "skipped", heldFor: "chain-42" }),
   }), { outcome: "ran", value: "skipped" });
-  assert.deepEqual(await withMergeLease(leaseTarget("chain-6"), async () => ({ leaseOutcome: { kind: "stop" }, value: "refused" }), holdDb, {
+  assert.deepEqual(await withMergeLease(leaseTarget("chain-6"), async () => ({ leaseOutcome: { kind: "stop", taskId: "task-1" }, value: "refused" }), holdDb, {
     acquire: acquired,
     release: async () => ({ outcome: "refused", heldBy: "another-host" }),
   }), { outcome: "ran", value: "refused" });
@@ -447,28 +498,63 @@ test("skipped and refused releases are reported decided outcomes", async (t) => 
 });
 
 test("an unreachable release outcome is retryable", async () => {
+  const deferred: Array<Record<string, unknown>> = [];
   assert.deepEqual(await withMergeLease(
     leaseTarget("chain-unreachable-release"),
-    async () => ({ leaseOutcome: { kind: "stop" }, value: null }),
-    holdDb,
+    async () => ({ leaseOutcome: { kind: "stop", taskId: "task-1" }, value: null }),
+    releaseDeferralDb("chain-unreachable-release", deferred),
     {
       acquire: acquired,
       release: async () => ({ outcome: "unreachable", detail: "release helper timed out" }),
     },
-  ), { outcome: "unreachable", detail: "release helper timed out" });
+  ), { outcome: "unreachable", detail: "release helper timed out", releaseDeferred: true });
+  assert.equal(deferred.length, 1);
+  assert.deepEqual((deferred[0]!.metadata as Record<string, unknown>), {
+    kind: "mergeTail.leaseRelease",
+    schemaVersion: 1,
+    state: "release-deferred",
+    projectId: "project-1",
+    chainId: "chain-unreachable-release",
+    taskId: "task-1",
+    failureDetail: "release helper timed out",
+    deferredAt: (deferred[0]!.metadata as Record<string, unknown>).deferredAt,
+  });
 });
 
 test("a rejected release adapter is an unreachable transport", async () => {
   const releaser: MergeLeaseReleaser = async () => { throw new Error("spawn bash ENOENT"); };
 
-  assert.deepEqual(await withMergeLease(leaseTarget("chain-6"), async () => ({ leaseOutcome: { kind: "stop" }, value: null }), holdDb, {
+  assert.deepEqual(await withMergeLease(leaseTarget("chain-6"), async () => ({ leaseOutcome: { kind: "stop", taskId: "task-1" }, value: null }), releaseDeferralDb("chain-6"), {
     acquire: acquired,
     release: releaser,
-  }), { outcome: "unreachable", detail: "Merge lease release transport failed: spawn bash ENOENT" });
+  }), {
+    outcome: "unreachable",
+    detail: "Merge lease release transport failed: spawn bash ENOENT",
+    releaseDeferred: true,
+  });
+});
+
+test("a deferred-release record failure is typed and does not retry the release", async () => {
+  let releases = 0;
+  const recordFailure = new Error("activity writer unavailable");
+  await assert.rejects(withMergeLease(
+    leaseTarget("chain-record-failure"),
+    async () => ({ leaseOutcome: { kind: "stop", taskId: "task-1" }, value: null }),
+    releaseDeferralDb("chain-record-failure", [], recordFailure),
+    {
+      acquire: acquired,
+      release: async () => {
+        releases += 1;
+        return { outcome: "unreachable", detail: "release helper timed out" };
+      },
+    },
+  ), (error: unknown) => error instanceof LeaseReleaseDeferralRecordError
+    && error.cause === recordFailure);
+  assert.equal(releases, 1);
 });
 
 test("a Task without a Chain runs without either Lease adapter", async () => {
-  const result = await withMergeLease(null, async () => ({ leaseOutcome: { kind: "stop" }, value: "unleased" }), holdDb, {
+  const result = await withMergeLease(null, async () => ({ leaseOutcome: { kind: "stop", taskId: "task-1" }, value: "unleased" }), holdDb, {
     acquire: async () => { throw new Error("the acquirer must not be called"); },
     release: async () => { throw new Error("the releaser must not be called"); },
   });

--- a/packages/api/src/merge-lease.test.ts
+++ b/packages/api/src/merge-lease.test.ts
@@ -148,10 +148,11 @@ test("leaseHandoffsWithoutConsumer returns only stale Runs that never claimed", 
   assert.deepEqual(await leaseHandoffsWithoutConsumer(tx, now), [
     { toRunId: "run-stale", taskId: "task-stale" },
   ]);
-  assert.match(sql, /NOT EXISTS/u);
-  assert.match(sql, /GREATEST/u);
-  assert.match(sql, /\(released\."createdAt", released\.id\) > \(pending\."createdAt", pending\.id\)/u);
-  assert.match(sql, /ORDER BY "createdAt" ASC, id ASC/u);
+  assert.match(sql, /FROM "Run" AS consumer/u);
+  assert.match(sql, /JOIN LATERAL/u);
+  assert.match(sql, /activity\."createdAt" >= LEAST\(consumer\."createdAt", consumer\."readyAt"\)/u);
+  assert.match(sql, /GREATEST\(consumer\."createdAt", consumer\."readyAt"\)/u);
+  assert.match(sql, /ORDER BY "staleAt" ASC, "toRunId" ASC/u);
   assert.match(sql, /LIMIT/u);
   assert.ok(parameters.some((value) => value instanceof Date), "the query has a time floor");
   assert.ok(parameters.includes(100), "the query has an explicit row limit");
@@ -239,7 +240,7 @@ test("commitWithLeaseOutcome records handoff without release and surfaces record
   const activities: unknown[] = [];
   const tx = {
     ...holderTx({ task: { chainId: "chain-1", projectId: "project-1", templateStep: { stepIndex: 7, outputKind: "merge-result", taskTemplate: { name: "direct-engineer-workflow" } } } }),
-    run: { findUnique: async () => ({ taskId: "task-2", readyAt: new Date("2026-08-27T12:05:00.000Z") }) },
+    run: { findUnique: async () => ({ taskId: "task-2" }) },
     taskActivity: { create: async (input: unknown) => { activities.push(input); } },
   } as unknown as Prisma.TransactionClient;
   let releases = 0;
@@ -255,10 +256,6 @@ test("commitWithLeaseOutcome records handoff without release and surfaces record
   }), { release: async () => { releases += 1; } });
   assert.equal(releases, 0);
   assert.equal(activities.length, 1);
-  assert.equal(
-    ((activities[0] as { data: { metadata: Record<string, unknown> } }).data.metadata).consumerReadyAt,
-    "2026-08-27T12:05:00.000Z",
-  );
 
   const recordFailure = new Error("handoff record failed");
   const failingTx = {
@@ -276,9 +273,10 @@ test("commitWithLeaseOutcome records handoff without release and surfaces record
   })), (error: unknown) => error === recordFailure);
 });
 
-test("commitWithLeaseOutcome refuses to settle a handoff without a holder", async () => {
+test("commitWithLeaseOutcome durably invalidates a handoff without a holder", async () => {
   let releases = 0;
-  const tx = holderTx({
+  const invalidActivities: Array<{ data: { metadata: Record<string, unknown> } }> = [];
+  const base = holderTx({
     task: {
       chainId: "ordinary-chain",
       projectId: "project-1",
@@ -289,15 +287,28 @@ test("commitWithLeaseOutcome refuses to settle a handoff without a holder", asyn
       },
     },
   });
-  await assert.rejects(commitWithLeaseOutcome(transactionDb(tx), async () => ({
+  const tx = {
+    ...base,
+    taskActivity: {
+      findMany: async () => [],
+      create: async (input: { data: { metadata: Record<string, unknown> } }) => {
+        invalidActivities.push(input);
+        return {};
+      },
+    },
+  } as unknown as Prisma.TransactionClient;
+  await commitWithLeaseOutcome(transactionDb(tx), async () => ({
     value: null,
     leaseOutcome: {
       kind: "stop",
       taskId: "task-1",
       releasedHandoff: { toRunId: "run-orphan", at: new Date("2026-08-27T12:00:00.000Z") },
     },
-  }), { release: async () => { releases += 1; } }), /Cannot settle a Merge Lease handoff/u);
+  }), { release: async () => { releases += 1; } });
   assert.equal(releases, 0);
+  assert.equal(invalidActivities.length, 1);
+  assert.equal(invalidActivities[0]!.data.metadata.state, "invalid");
+  assert.equal(invalidActivities[0]!.data.metadata.toRunId, "run-orphan");
 });
 
 test("a completed callback releases the merge Lease", async () => {
@@ -435,8 +446,8 @@ test("skipped and refused releases are reported decided outcomes", async (t) => 
   assert.match(said[1]!, /another-host/u);
 });
 
-test("an unreachable release outcome fails loudly", async () => {
-  await assert.rejects(withMergeLease(
+test("an unreachable release outcome is retryable", async () => {
+  assert.deepEqual(await withMergeLease(
     leaseTarget("chain-unreachable-release"),
     async () => ({ leaseOutcome: { kind: "stop" }, value: null }),
     holdDb,
@@ -444,16 +455,16 @@ test("an unreachable release outcome fails loudly", async () => {
       acquire: acquired,
       release: async () => ({ outcome: "unreachable", detail: "release helper timed out" }),
     },
-  ), /failed with outcome unreachable/u);
+  ), { outcome: "unreachable", detail: "release helper timed out" });
 });
 
-test("a rejected release adapter fails loudly", async () => {
+test("a rejected release adapter is an unreachable transport", async () => {
   const releaser: MergeLeaseReleaser = async () => { throw new Error("spawn bash ENOENT"); };
 
-  await assert.rejects(withMergeLease(leaseTarget("chain-6"), async () => ({ leaseOutcome: { kind: "stop" }, value: null }), holdDb, {
+  assert.deepEqual(await withMergeLease(leaseTarget("chain-6"), async () => ({ leaseOutcome: { kind: "stop" }, value: null }), holdDb, {
     acquire: acquired,
     release: releaser,
-  }), /spawn bash ENOENT/u);
+  }), { outcome: "unreachable", detail: "Merge lease release transport failed: spawn bash ENOENT" });
 });
 
 test("a Task without a Chain runs without either Lease adapter", async () => {

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -9,7 +9,6 @@ import {
   latestMarker,
   MERGE_TAIL_KIND,
   readMarkers,
-  RunStatus,
   type Prisma,
   type PrismaClient,
 } from "@anneal/db";
@@ -18,6 +17,7 @@ import {
   type MergeLeaseRelease,
   type MergeLeaseTarget,
 } from "./merge-lease-hold.js";
+import { DONE_TASK_ARCHIVE_AGE_MS } from "./scheduler.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -89,13 +89,11 @@ const releaseMergeLeaseWith = async (
   target: MergeLeaseTarget | null,
 ): Promise<MergeLeaseRelease | null> => {
   if (!target) return null;
-  let release: MergeLeaseRelease;
-  try {
-    release = await releaser(target.chainId);
-  } catch (error: unknown) {
-    release = { outcome: "unreachable", detail: error instanceof Error ? error.message : String(error) };
-  }
+  const release = await releaser(target.chainId);
   reportMergeLeaseAnomaly(target.chainId, release);
+  if (release.outcome === "unreachable") {
+    throw new Error(`Merge lease release for chain ${target.chainId} failed with outcome ${release.outcome}`);
+  }
   return release;
 };
 
@@ -196,35 +194,63 @@ export const leaseHolderFor = async (
     : null;
 };
 
-export type LeaseSettlementOutcome = "continue" | "stop";
-export type LeaseSettlement = {
-  disposition: "retain" | "release";
-  leaseToRelease: MergeLeaseTarget | null;
+export type LeaseOutcome =
+  | { kind: "continue" }
+  | {
+    kind: "stop";
+    taskId: string | null;
+    releasedHandoff?: { toRunId: string; at: Date };
+  }
+  | { kind: "hand-off"; taskId: string | null; handoffRunId: string; at: Date };
+
+type LeaseSettlement = {
+  target: MergeLeaseTarget | null;
+  releasedHandoff: { chainId: string; toRunId: string; taskId: string; at: Date } | null;
 };
 
-/** Decide the Lease disposition from one terminal-control outcome. */
-export const settleLease = async (
+/** Resolve one declared outcome to the module-owned holder and persistence. */
+const settleLease = async (
   tx: Prisma.TransactionClient,
-  input: { taskId: string | null; outcome: LeaseSettlementOutcome },
+  outcome: LeaseOutcome,
 ): Promise<LeaseSettlement> => {
-  if (input.outcome === "continue") return { disposition: "retain", leaseToRelease: null };
-  const holder = await leaseHolderFor(tx, input.taskId);
+  if (outcome.kind === "continue") return { target: null, releasedHandoff: null };
+  const holder = await leaseHolderFor(tx, outcome.taskId);
+  if (outcome.kind === "hand-off") {
+    if (!holder) throw new Error(`Cannot hand off a Merge Lease from Task ${outcome.taskId ?? "without a Task"}`);
+    await noteLeaseHandoff(tx, {
+      chainId: holder.chainId,
+      toRunId: outcome.handoffRunId,
+      at: outcome.at,
+    });
+    return { target: null, releasedHandoff: null };
+  }
+  if (outcome.releasedHandoff && !holder) {
+    throw new Error(`Cannot settle a Merge Lease handoff from Task ${outcome.taskId ?? "without a Task"}`);
+  }
   return {
-    disposition: "release",
-    leaseToRelease: holder
+    target: holder
       ? { chainId: holder.chainId, projectId: holder.projectId }
+      : null,
+    releasedHandoff: holder && outcome.releasedHandoff
+      ? {
+        chainId: holder.chainId,
+        toRunId: outcome.releasedHandoff.toRunId,
+        taskId: holder.taskId,
+        at: outcome.releasedHandoff.at,
+      }
       : null,
   };
 };
 
 const LEASE_HANDOFF_GRACE_MS = 60_000;
+const LEASE_HANDOFF_QUERY_LIMIT = 100;
 
 /** Persist the queued Run that must consume a retained Chain Lease. */
-export const noteLeaseHandoff = async (
+const noteLeaseHandoff = async (
   tx: Prisma.TransactionClient,
   input: { chainId: string; toRunId: string; at: Date },
 ): Promise<void> => {
-  const run = await tx.run.findUnique({ where: { id: input.toRunId }, select: { taskId: true } });
+  const run = await tx.run.findUnique({ where: { id: input.toRunId }, select: { taskId: true, readyAt: true } });
   if (!run?.taskId) throw new Error(`Lease handoff target Run ${input.toRunId} has no Task`);
   await tx.taskActivity.create({ data: {
     taskId: run.taskId,
@@ -237,6 +263,7 @@ export const noteLeaseHandoff = async (
       chainId: input.chainId,
       toRunId: input.toRunId,
       handedOffAt: input.at.toISOString(),
+      consumerReadyAt: run.readyAt.toISOString(),
     },
   } });
 };
@@ -245,50 +272,52 @@ export const noteLeaseHandoff = async (
 export const leaseHandoffsWithoutConsumer = async (
   tx: Prisma.TransactionClient,
   now: Date,
-): Promise<Array<{ chainId: string; projectId: string; toRunId: string; taskId: string }>> => {
-  const rows = await tx.taskActivity.findMany({
-    where: {
-      metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.leaseHandoff },
-    },
-    select: { taskId: true, metadata: true, task: { select: { projectId: true } } },
-    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-  });
-  const pending = new Map<string, { chainId: string; projectId: string; toRunId: string; taskId: string }>();
-  const settled = new Set<string>();
-  for (const row of rows) {
-    const raw = row.metadata;
-    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
-    const metadata = raw as Record<string, unknown>;
-    if (typeof metadata.toRunId !== "string") continue;
-    if (metadata.state === "released") {
-      settled.add(metadata.toRunId);
-      continue;
-    }
-    const handedOffAt = typeof metadata.handedOffAt === "string" ? Date.parse(metadata.handedOffAt) : Number.NaN;
-    if (metadata.state === "pending" && typeof metadata.chainId === "string"
-      && Number.isFinite(handedOffAt) && handedOffAt < now.getTime() - LEASE_HANDOFF_GRACE_MS
-      && !settled.has(metadata.toRunId) && !pending.has(metadata.toRunId)) {
-      pending.set(metadata.toRunId, {
-        chainId: metadata.chainId,
-        projectId: row.task.projectId,
-        toRunId: metadata.toRunId,
-        taskId: row.taskId,
-      });
-    }
-  }
-  if (pending.size === 0) return [];
-  const queued = await tx.run.findMany({
-    where: { id: { in: [...pending.keys()] }, status: RunStatus.QUEUED, claimedAt: null, startedAt: null },
-    select: { id: true },
-  });
-  return queued.flatMap((run) => {
-    const handoff = pending.get(run.id);
-    return handoff ? [handoff] : [];
-  });
+): Promise<Array<{ toRunId: string; taskId: string }>> => {
+  const activityFloor = new Date(now.getTime() - DONE_TASK_ARCHIVE_AGE_MS);
+  const staleBefore = new Date(now.getTime() - LEASE_HANDOFF_GRACE_MS).toISOString();
+  return tx.$queryRaw<Array<{ toRunId: string; taskId: string }>>`
+    WITH unresolved AS (
+      SELECT DISTINCT ON (pending.metadata->>'toRunId')
+        pending.metadata->>'toRunId' AS "toRunId",
+        pending."taskId" AS "taskId",
+        pending."createdAt" AS "createdAt",
+        pending.id
+      FROM "TaskActivity" AS pending
+      JOIN "Run" AS consumer ON consumer.id = pending.metadata->>'toRunId'
+      WHERE pending."createdAt" >= ${activityFloor}
+        AND pending."actorType" = 'control-plane'
+        AND pending.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseHandoff}
+        AND pending.metadata->>'state' = 'pending'
+        AND pending.metadata->>'chainId' IS NOT NULL
+        AND pending.metadata->>'toRunId' IS NOT NULL
+        AND GREATEST(
+          pending.metadata->>'handedOffAt',
+          COALESCE(pending.metadata->>'consumerReadyAt', pending.metadata->>'handedOffAt')
+        ) < ${staleBefore}
+        AND consumer.status = 'queued'::"RunStatus"
+        AND consumer."claimedAt" IS NULL
+        AND consumer."startedAt" IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "TaskActivity" AS released
+          WHERE released."createdAt" >= ${activityFloor}
+            AND released."actorType" = 'control-plane'
+            AND released.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseHandoff}
+            AND released.metadata->>'state' = 'released'
+            AND released.metadata->>'toRunId' = pending.metadata->>'toRunId'
+            AND (released."createdAt", released.id) > (pending."createdAt", pending.id)
+        )
+      ORDER BY pending.metadata->>'toRunId', pending."createdAt" DESC, pending.id DESC
+    )
+    SELECT "toRunId", "taskId"
+    FROM unresolved
+    ORDER BY "createdAt" ASC, id ASC
+    LIMIT ${LEASE_HANDOFF_QUERY_LIMIT}
+  `;
 };
 
 /** Record a completed orphan-handoff release after the external release attempt. */
-export const noteLeaseHandoffReleased = async (
+const noteLeaseHandoffReleased = async (
   tx: Prisma.TransactionClient,
   input: { chainId: string; toRunId: string; taskId: string; at: Date },
 ): Promise<void> => {
@@ -307,21 +336,97 @@ export const noteLeaseHandoffReleased = async (
   } });
 };
 
-export type TransactionLeaseDisposition<T> = {
+export type TransactionLeaseOutcome<T> = {
   value: T;
-  lease: LeaseSettlement;
+  leaseOutcome: LeaseOutcome;
 };
 
-/** Commit database state before carrying out its post-commit Lease release. */
-export const commitWithLeaseDisposition = async <T>(
+export type CommitWithLeaseOutcomeOptions = {
+  release?: ReleaseMergeLease | undefined;
+  isolationLevel?: Prisma.TransactionIsolationLevel;
+};
+
+type CommittedLeaseOutcome<T> = {
+  value: T;
+  settlement: LeaseSettlement;
+};
+
+const releaseCommittedLeaseOutcomes = async (
   db: PrismaClient,
-  fn: (tx: Prisma.TransactionClient) => Promise<TransactionLeaseDisposition<T> | null>,
-  release: ReleaseMergeLease = releaseMergeLease,
-  options?: { isolationLevel: Prisma.TransactionIsolationLevel },
+  committed: Array<CommittedLeaseOutcome<unknown>>,
+  release: ReleaseMergeLease,
+  aggregateFailures: boolean,
+): Promise<void> => {
+  const targets = new Map<string, {
+    target: MergeLeaseTarget;
+    handoffs: Array<NonNullable<LeaseSettlement["releasedHandoff"]>>;
+  }>();
+  for (const entry of committed) {
+    const target = entry.settlement.target;
+    if (!target) continue;
+    const key = JSON.stringify([target.projectId, target.chainId]);
+    const existing = targets.get(key) ?? { target, handoffs: [] };
+    if (entry.settlement.releasedHandoff) existing.handoffs.push(entry.settlement.releasedHandoff);
+    targets.set(key, existing);
+  }
+
+  const failures: unknown[] = [];
+  for (const entry of targets.values()) {
+    try {
+      await release(entry.target, db);
+      if (entry.handoffs.length > 0) {
+        await db.$transaction(async (tx) => {
+          for (const handoff of entry.handoffs) await noteLeaseHandoffReleased(tx, handoff);
+        });
+      }
+    } catch (error: unknown) {
+      failures.push(error);
+    }
+  }
+  if (failures.length === 1 && !aggregateFailures) throw failures[0];
+  if (failures.length > 0) throw new AggregateError(failures, "One or more Merge Lease releases or records failed");
+};
+
+/** Commit database state before carrying out its one post-commit Lease release. */
+export const commitWithLeaseOutcome = async <T>(
+  db: PrismaClient,
+  fn: (tx: Prisma.TransactionClient) => Promise<TransactionLeaseOutcome<T> | null>,
+  options: CommitWithLeaseOutcomeOptions = {},
 ): Promise<T | null> => {
-  const committed = await db.$transaction(fn, options);
+  const committed = await db.$transaction(async (tx) => {
+    const result = await fn(tx);
+    if (result === null) return null;
+    return {
+      value: result.value,
+      settlement: await settleLease(tx, result.leaseOutcome),
+    };
+  }, options.isolationLevel ? { isolationLevel: options.isolationLevel } : undefined);
   if (committed === null) return null;
-  if (committed.lease.disposition === "release") await release(committed.lease.leaseToRelease, db);
+  await releaseCommittedLeaseOutcomes(db, [committed], options.release ?? releaseMergeLease, false);
+  return committed.value;
+};
+
+/** Commit a reconciliation batch, deduplicating its post-commit Lease targets. */
+export const commitWithLeaseOutcomes = async <T>(
+  db: PrismaClient,
+  fn: (tx: Prisma.TransactionClient) => Promise<{ value: T; leaseOutcomes: LeaseOutcome[] }>,
+  options: CommitWithLeaseOutcomeOptions = {},
+): Promise<T> => {
+  const committed = await db.$transaction(async (tx) => {
+    const result = await fn(tx);
+    const settlements: LeaseSettlement[] = [];
+    for (const outcome of result.leaseOutcomes) settlements.push(await settleLease(tx, outcome));
+    return {
+      value: result.value,
+      settlements,
+    };
+  }, options.isolationLevel ? { isolationLevel: options.isolationLevel } : undefined);
+  await releaseCommittedLeaseOutcomes(
+    db,
+    committed.settlements.map((settlement) => ({ value: undefined, settlement })),
+    options.release ?? releaseMergeLease,
+    true,
+  );
   return committed.value;
 };
 
@@ -372,9 +477,9 @@ const acquireMergeLease: MergeLeaseAcquirer = async (chainId) => {
   }
 };
 
-export type LeaseDisposition =
-  | { kind: "release" }
-  | { kind: "retain"; handoffRunId: string };
+export type HeldLeaseOutcome =
+  | { kind: "continue" }
+  | { kind: "stop" };
 
 export type MergeLeaseDependencies = {
   acquire: MergeLeaseAcquirer;
@@ -384,7 +489,7 @@ export type MergeLeaseDependencies = {
 
 export type WithMergeLease = <T>(
   target: MergeLeaseTarget | null,
-  fn: () => Promise<{ disposition: LeaseDisposition; value: T }>,
+  fn: () => Promise<{ leaseOutcome: HeldLeaseOutcome; value: T }>,
   db: PrismaClient,
   dependencies?: MergeLeaseDependencies,
 ) => Promise<
@@ -395,14 +500,15 @@ export type WithMergeLease = <T>(
 
 /**
  * Run one authorization attempt under the Chain's merge Lease. A successful
- * authorization explicitly hands the Lease to mechanical merge with `retain`;
- * every other completed or exceptional callback path gives it back here.
+ * authorization continues the Lease for mechanical merge after its handoff
+ * was persisted by commitWithLeaseOutcome; every stop or exceptional callback
+ * path gives it back here.
  * A Task without a Chain has no Lease to acquire or release, but still runs the
  * callback through the same interface.
  */
 export const withMergeLease = async <T>(
   target: MergeLeaseTarget | null,
-  fn: () => Promise<{ disposition: LeaseDisposition; value: T }>,
+  fn: () => Promise<{ leaseOutcome: HeldLeaseOutcome; value: T }>,
   db: PrismaClient,
   dependencies: MergeLeaseDependencies = {
     acquire: acquireMergeLease,
@@ -424,18 +530,18 @@ export const withMergeLease = async <T>(
     return { outcome: "unreachable", detail: acquisition.detail };
   }
 
-  let disposition: LeaseDisposition = { kind: "release" };
+  let leaseOutcome: HeldLeaseOutcome = { kind: "stop" };
   let callbackFailed = false;
   let callbackError: unknown;
-  let result: { disposition: LeaseDisposition; value: T } | undefined;
+  let result: { leaseOutcome: HeldLeaseOutcome; value: T } | undefined;
   try {
     result = await fn();
-    disposition = result.disposition;
+    leaseOutcome = result.leaseOutcome;
   } catch (error: unknown) {
     callbackFailed = true;
     callbackError = error;
   }
-  if (disposition.kind === "release") {
+  if (leaseOutcome.kind === "stop") {
     try {
       const release = await releaseMergeLeaseWith(dependencies.release, target);
       if (release?.outcome === "released") {

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -417,7 +417,7 @@ export const deferredLeaseReleases = async (
       deferred.metadata->>'chainId' AS "chainId"
     FROM "TaskActivity" AS deferred
     WHERE deferred."actorType" = 'control-plane'
-      AND deferred.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseRelease}
+      AND deferred.metadata->>'kind' = 'mergeTail.leaseRelease'
       AND deferred.metadata->>'state' = 'release-deferred'
       AND deferred.metadata->>'projectId' IS NOT NULL
       AND deferred.metadata->>'chainId' IS NOT NULL
@@ -428,7 +428,7 @@ export const deferredLeaseReleases = async (
         WHERE terminal."taskId" = deferred."taskId"
           AND terminal."createdAt" >= deferred."createdAt"
           AND terminal."actorType" = 'control-plane'
-          AND terminal.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseRelease}
+          AND terminal.metadata->>'kind' = 'mergeTail.leaseRelease'
           AND terminal.metadata->>'deferredActivityId' = deferred.id
           AND terminal.metadata->>'state' IN ('released', 'invalid')
       )

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -8,8 +8,8 @@ import {
   isRegressionVerificationOutputKind,
   latestMarker,
   MERGE_TAIL_KIND,
+  Prisma,
   readMarkers,
-  type Prisma,
   type PrismaClient,
 } from "@anneal/db";
 import {
@@ -406,10 +406,7 @@ const noteLeaseReleaseDeferred = async (
   }
 };
 
-export const deferredLeaseReleases = async (
-  tx: Prisma.TransactionClient,
-): Promise<Array<{ activityId: string; taskId: string; target: MergeLeaseTarget }>> => (
-  tx.$queryRaw<Array<{ activityId: string; taskId: string; projectId: string; chainId: string }>>`
+export const deferredLeaseReleasesStatement = Prisma.sql`
     SELECT
       deferred.id AS "activityId",
       deferred."taskId" AS "taskId",
@@ -434,7 +431,14 @@ export const deferredLeaseReleases = async (
       )
     ORDER BY deferred."createdAt" ASC, deferred.id ASC
     LIMIT ${LEASE_RELEASE_QUERY_LIMIT}
-  `
+  `;
+
+export const deferredLeaseReleases = async (
+  tx: Prisma.TransactionClient,
+): Promise<Array<{ activityId: string; taskId: string; target: MergeLeaseTarget }>> => (
+  tx.$queryRaw<Array<{ activityId: string; taskId: string; projectId: string; chainId: string }>>(
+    deferredLeaseReleasesStatement,
+  )
 ).then((rows) => rows.map(({ activityId, taskId, projectId, chainId }) => ({
   activityId,
   taskId,

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -17,7 +17,6 @@ import {
   type MergeLeaseRelease,
   type MergeLeaseTarget,
 } from "./merge-lease-hold.js";
-import { DONE_TASK_ARCHIVE_AGE_MS } from "./scheduler.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -91,9 +90,6 @@ const releaseMergeLeaseWith = async (
   if (!target) return null;
   const release = await releaser(target.chainId);
   reportMergeLeaseAnomaly(target.chainId, release);
-  if (release.outcome === "unreachable") {
-    throw new Error(`Merge lease release for chain ${target.chainId} failed with outcome ${release.outcome}`);
-  }
   return release;
 };
 
@@ -101,6 +97,9 @@ export type ReleaseMergeLease = (target: MergeLeaseTarget | null, db: PrismaClie
 
 export const releaseMergeLease: ReleaseMergeLease = async (target, db) => {
   const release = await releaseMergeLeaseWith(releaseMergeLeaseAdapter, target);
+  if (target && release?.outcome === "unreachable") {
+    throw new Error(`Merge lease release for chain ${target.chainId} was unreachable: ${release.detail}`);
+  }
   if (target && release?.outcome === "released") {
     await recordMergeLeaseHold(db, target, release, new Date());
   }
@@ -208,6 +207,25 @@ type LeaseSettlement = {
   releasedHandoff: { chainId: string; toRunId: string; taskId: string; at: Date } | null;
 };
 
+const noteLeaseHandoffInvalid = async (
+  tx: Prisma.TransactionClient,
+  input: { taskId: string; toRunId: string; at: Date; reason: string },
+): Promise<void> => {
+  await tx.taskActivity.create({ data: {
+    taskId: input.taskId,
+    actorType: "control-plane",
+    body: `Invalid Chain Lease handoff for queued Run ${input.toRunId}: ${input.reason}`,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseHandoff,
+      schemaVersion: 1,
+      state: "invalid",
+      toRunId: input.toRunId,
+      invalidAt: input.at.toISOString(),
+      reason: input.reason,
+    },
+  } });
+};
+
 /** Resolve one declared outcome to the module-owned holder and persistence. */
 const settleLease = async (
   tx: Prisma.TransactionClient,
@@ -225,7 +243,14 @@ const settleLease = async (
     return { target: null, releasedHandoff: null };
   }
   if (outcome.releasedHandoff && !holder) {
-    throw new Error(`Cannot settle a Merge Lease handoff from Task ${outcome.taskId ?? "without a Task"}`);
+    if (!outcome.taskId) throw new Error("Cannot diagnose a Merge Lease handoff without a Task");
+    await noteLeaseHandoffInvalid(tx, {
+      taskId: outcome.taskId,
+      toRunId: outcome.releasedHandoff.toRunId,
+      at: outcome.releasedHandoff.at,
+      reason: "the handoff Task does not resolve to a Merge Lease holder",
+    });
+    return { target: null, releasedHandoff: null };
   }
   return {
     target: holder
@@ -250,7 +275,7 @@ const noteLeaseHandoff = async (
   tx: Prisma.TransactionClient,
   input: { chainId: string; toRunId: string; at: Date },
 ): Promise<void> => {
-  const run = await tx.run.findUnique({ where: { id: input.toRunId }, select: { taskId: true, readyAt: true } });
+  const run = await tx.run.findUnique({ where: { id: input.toRunId }, select: { taskId: true } });
   if (!run?.taskId) throw new Error(`Lease handoff target Run ${input.toRunId} has no Task`);
   await tx.taskActivity.create({ data: {
     taskId: run.taskId,
@@ -263,7 +288,6 @@ const noteLeaseHandoff = async (
       chainId: input.chainId,
       toRunId: input.toRunId,
       handedOffAt: input.at.toISOString(),
-      consumerReadyAt: run.readyAt.toISOString(),
     },
   } });
 };
@@ -273,46 +297,36 @@ export const leaseHandoffsWithoutConsumer = async (
   tx: Prisma.TransactionClient,
   now: Date,
 ): Promise<Array<{ toRunId: string; taskId: string }>> => {
-  const activityFloor = new Date(now.getTime() - DONE_TASK_ARCHIVE_AGE_MS);
-  const staleBefore = new Date(now.getTime() - LEASE_HANDOFF_GRACE_MS).toISOString();
+  const staleBefore = new Date(now.getTime() - LEASE_HANDOFF_GRACE_MS);
   return tx.$queryRaw<Array<{ toRunId: string; taskId: string }>>`
     WITH unresolved AS (
-      SELECT DISTINCT ON (pending.metadata->>'toRunId')
-        pending.metadata->>'toRunId' AS "toRunId",
-        pending."taskId" AS "taskId",
-        pending."createdAt" AS "createdAt",
-        pending.id
-      FROM "TaskActivity" AS pending
-      JOIN "Run" AS consumer ON consumer.id = pending.metadata->>'toRunId'
-      WHERE pending."createdAt" >= ${activityFloor}
-        AND pending."actorType" = 'control-plane'
-        AND pending.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseHandoff}
-        AND pending.metadata->>'state' = 'pending'
-        AND pending.metadata->>'chainId' IS NOT NULL
-        AND pending.metadata->>'toRunId' IS NOT NULL
-        AND GREATEST(
-          pending.metadata->>'handedOffAt',
-          COALESCE(pending.metadata->>'consumerReadyAt', pending.metadata->>'handedOffAt')
-        ) < ${staleBefore}
-        AND consumer.status = 'queued'::"RunStatus"
+      SELECT
+        consumer.id AS "toRunId",
+        latest."taskId" AS "taskId",
+        GREATEST(consumer."createdAt", consumer."readyAt") AS "staleAt"
+      FROM "Run" AS consumer
+      JOIN LATERAL (
+        SELECT activity."taskId", activity.metadata, activity."createdAt", activity.id
+        FROM "TaskActivity" AS activity
+        WHERE activity."createdAt" >= LEAST(consumer."createdAt", consumer."readyAt")
+          AND activity."actorType" = 'control-plane'
+          AND activity.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseHandoff}
+          AND activity.metadata->>'toRunId' = consumer.id
+        ORDER BY activity."createdAt" DESC, activity.id DESC
+        LIMIT 1
+      ) AS latest ON true
+      WHERE consumer.status = 'queued'::"RunStatus"
         AND consumer."claimedAt" IS NULL
         AND consumer."startedAt" IS NULL
-        AND NOT EXISTS (
-          SELECT 1
-          FROM "TaskActivity" AS released
-          WHERE released."createdAt" >= ${activityFloor}
-            AND released."actorType" = 'control-plane'
-            AND released.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseHandoff}
-            AND released.metadata->>'state' = 'released'
-            AND released.metadata->>'toRunId' = pending.metadata->>'toRunId'
-            AND (released."createdAt", released.id) > (pending."createdAt", pending.id)
-        )
-      ORDER BY pending.metadata->>'toRunId', pending."createdAt" DESC, pending.id DESC
+        AND GREATEST(consumer."createdAt", consumer."readyAt") < ${staleBefore}
+        AND latest.metadata->>'state' = 'pending'
+        AND latest.metadata->>'chainId' IS NOT NULL
+      ORDER BY GREATEST(consumer."createdAt", consumer."readyAt") ASC, consumer.id ASC
+      LIMIT ${LEASE_HANDOFF_QUERY_LIMIT}
     )
     SELECT "toRunId", "taskId"
     FROM unresolved
-    ORDER BY "createdAt" ASC, id ASC
-    LIMIT ${LEASE_HANDOFF_QUERY_LIMIT}
+    ORDER BY "staleAt" ASC, "toRunId" ASC
   `;
 };
 
@@ -351,6 +365,22 @@ type CommittedLeaseOutcome<T> = {
   settlement: LeaseSettlement;
 };
 
+export type LeaseOutcomePostCommitFailure = {
+  target: MergeLeaseTarget;
+  phase: "release" | "record";
+  error: unknown;
+};
+
+export class LeaseOutcomePostCommitError extends AggregateError {
+  readonly failures: LeaseOutcomePostCommitFailure[];
+
+  constructor(failures: LeaseOutcomePostCommitFailure[]) {
+    super(failures.map((failure) => failure.error), "One or more Merge Lease releases or records failed");
+    this.name = "LeaseOutcomePostCommitError";
+    this.failures = failures;
+  }
+}
+
 const releaseCommittedLeaseOutcomes = async (
   db: PrismaClient,
   committed: Array<CommittedLeaseOutcome<unknown>>,
@@ -370,21 +400,26 @@ const releaseCommittedLeaseOutcomes = async (
     targets.set(key, existing);
   }
 
-  const failures: unknown[] = [];
+  const failures: LeaseOutcomePostCommitFailure[] = [];
   for (const entry of targets.values()) {
     try {
       await release(entry.target, db);
-      if (entry.handoffs.length > 0) {
+    } catch (error: unknown) {
+      failures.push({ target: entry.target, phase: "release", error });
+      continue;
+    }
+    if (entry.handoffs.length > 0) {
+      try {
         await db.$transaction(async (tx) => {
           for (const handoff of entry.handoffs) await noteLeaseHandoffReleased(tx, handoff);
         });
+      } catch (error: unknown) {
+        failures.push({ target: entry.target, phase: "record", error });
       }
-    } catch (error: unknown) {
-      failures.push(error);
     }
   }
-  if (failures.length === 1 && !aggregateFailures) throw failures[0];
-  if (failures.length > 0) throw new AggregateError(failures, "One or more Merge Lease releases or records failed");
+  if (failures.length === 1 && !aggregateFailures) throw failures[0]!.error;
+  if (failures.length > 0) throw new LeaseOutcomePostCommitError(failures);
 };
 
 /** Commit database state before carrying out its one post-commit Lease release. */
@@ -542,19 +577,38 @@ export const withMergeLease = async <T>(
     callbackError = error;
   }
   if (leaseOutcome.kind === "stop") {
+    let release: MergeLeaseRelease | null;
     try {
-      const release = await releaseMergeLeaseWith(dependencies.release, target);
-      if (release?.outcome === "released") {
-        await recordMergeLeaseHold(db, target, release, dependencies.now?.() ?? new Date());
-      }
+      release = await releaseMergeLeaseWith(dependencies.release, target);
     } catch (releaseError: unknown) {
-      if (callbackFailed) {
-        throw new AggregateError(
-          [callbackError, releaseError],
-          "Merge lease callback and confirmed-release recording both failed",
-        );
+      const releaseDetail = `Merge lease release transport failed: ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`;
+      return {
+        outcome: "unreachable",
+        detail: callbackFailed
+          ? `Merge lease callback failed before release: ${callbackError instanceof Error ? callbackError.message : String(callbackError)}; ${releaseDetail}`
+          : releaseDetail,
+      };
+    }
+    if (release?.outcome === "unreachable") {
+      return {
+        outcome: "unreachable",
+        detail: callbackFailed
+          ? `Merge lease callback failed before release: ${callbackError instanceof Error ? callbackError.message : String(callbackError)}; release transport unreachable: ${release.detail}`
+          : release.detail,
+      };
+    }
+    if (release?.outcome === "released") {
+      try {
+        await recordMergeLeaseHold(db, target, release, dependencies.now?.() ?? new Date());
+      } catch (releaseError: unknown) {
+        if (callbackFailed) {
+          throw new AggregateError(
+            [callbackError, releaseError],
+            "Merge lease callback and confirmed-release recording both failed",
+          );
+        }
+        throw releaseError;
       }
-      throw releaseError;
     }
   }
   if (callbackFailed) throw callbackError;

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -199,12 +199,19 @@ export type LeaseOutcome =
     kind: "stop";
     taskId: string | null;
     releasedHandoff?: { toRunId: string; at: Date };
+    deferredRelease?: { activityId: string; target: MergeLeaseTarget; at: Date };
   }
   | { kind: "hand-off"; taskId: string | null; handoffRunId: string; at: Date };
 
 type LeaseSettlement = {
   target: MergeLeaseTarget | null;
   releasedHandoff: { chainId: string; toRunId: string; taskId: string; at: Date } | null;
+  deferredRelease: {
+    activityId: string;
+    target: MergeLeaseTarget;
+    taskId: string;
+    at: Date;
+  } | null;
 };
 
 const noteLeaseHandoffInvalid = async (
@@ -231,7 +238,9 @@ const settleLease = async (
   tx: Prisma.TransactionClient,
   outcome: LeaseOutcome,
 ): Promise<LeaseSettlement> => {
-  if (outcome.kind === "continue") return { target: null, releasedHandoff: null };
+  if (outcome.kind === "continue") {
+    return { target: null, releasedHandoff: null, deferredRelease: null };
+  }
   const holder = await leaseHolderFor(tx, outcome.taskId);
   if (outcome.kind === "hand-off") {
     if (!holder) throw new Error(`Cannot hand off a Merge Lease from Task ${outcome.taskId ?? "without a Task"}`);
@@ -240,7 +249,10 @@ const settleLease = async (
       toRunId: outcome.handoffRunId,
       at: outcome.at,
     });
-    return { target: null, releasedHandoff: null };
+    return { target: null, releasedHandoff: null, deferredRelease: null };
+  }
+  if (outcome.releasedHandoff && outcome.deferredRelease) {
+    throw new Error("A Merge Lease stop cannot settle both a handoff and a deferred release");
   }
   if (outcome.releasedHandoff && !holder) {
     if (!outcome.taskId) throw new Error("Cannot diagnose a Merge Lease handoff without a Task");
@@ -250,7 +262,23 @@ const settleLease = async (
       at: outcome.releasedHandoff.at,
       reason: "the handoff Task does not resolve to a Merge Lease holder",
     });
-    return { target: null, releasedHandoff: null };
+    return { target: null, releasedHandoff: null, deferredRelease: null };
+  }
+  if (outcome.deferredRelease) {
+    const expected = outcome.deferredRelease.target;
+    if (!holder || holder.chainId !== expected.chainId || holder.projectId !== expected.projectId) {
+      await noteLeaseReleaseTerminal(tx, {
+        activityId: outcome.deferredRelease.activityId,
+        taskId: outcome.taskId,
+        target: expected,
+        state: "invalid",
+        at: outcome.deferredRelease.at,
+        reason: holder
+          ? "the deferred target no longer matches the Task's Merge Lease holder"
+          : "the deferred Task no longer resolves to a Merge Lease holder",
+      });
+      return { target: null, releasedHandoff: null, deferredRelease: null };
+    }
   }
   return {
     target: holder
@@ -264,11 +292,33 @@ const settleLease = async (
         at: outcome.releasedHandoff.at,
       }
       : null,
+    deferredRelease: holder && outcome.deferredRelease
+      ? {
+        activityId: outcome.deferredRelease.activityId,
+        target: { projectId: holder.projectId, chainId: holder.chainId },
+        taskId: holder.taskId,
+        at: outcome.deferredRelease.at,
+      }
+      : null,
   };
 };
 
 const LEASE_HANDOFF_GRACE_MS = 60_000;
 const LEASE_HANDOFF_QUERY_LIMIT = 100;
+const LEASE_RELEASE_QUERY_LIMIT = 100;
+
+export class LeaseReleaseDeferralRecordError extends Error {
+  readonly target: MergeLeaseTarget;
+  readonly taskId: string;
+
+  constructor(target: MergeLeaseTarget, taskId: string, cause: unknown) {
+    super(`Failed to record deferred Merge Lease release for chain ${target.chainId}`);
+    this.name = "LeaseReleaseDeferralRecordError";
+    this.target = target;
+    this.taskId = taskId;
+    this.cause = cause;
+  }
+}
 
 /** Persist the queued Run that must consume a retained Chain Lease. */
 const noteLeaseHandoff = async (
@@ -292,6 +342,105 @@ const noteLeaseHandoff = async (
   } });
 };
 
+const noteLeaseReleaseTerminal = async (
+  tx: Prisma.TransactionClient,
+  input: {
+    activityId: string;
+    taskId: string | null;
+    target: MergeLeaseTarget;
+    state: "released" | "invalid";
+    at: Date;
+    reason?: string;
+  },
+): Promise<void> => {
+  if (!input.taskId) throw new Error("Cannot record a deferred Merge Lease release without a Task");
+  await tx.taskActivity.create({ data: {
+    taskId: input.taskId,
+    actorType: "control-plane",
+    body: input.state === "released"
+      ? `Deferred Merge Lease release completed for chain ${input.target.chainId}`
+      : `Deferred Merge Lease release invalid for chain ${input.target.chainId}: ${input.reason ?? "invalid target"}`,
+    metadata: {
+      kind: MERGE_TAIL_KIND.leaseRelease,
+      schemaVersion: 1,
+      state: input.state,
+      deferredActivityId: input.activityId,
+      projectId: input.target.projectId,
+      chainId: input.target.chainId,
+      taskId: input.taskId,
+      ...(input.state === "released"
+        ? { releasedAt: input.at.toISOString() }
+        : { invalidAt: input.at.toISOString(), reason: input.reason ?? "invalid target" }),
+    },
+  } });
+};
+
+const noteLeaseReleaseDeferred = async (
+  db: PrismaClient,
+  input: { target: MergeLeaseTarget; taskId: string; detail: string; at: Date },
+): Promise<void> => {
+  try {
+    await db.$transaction(async (tx) => {
+      const holder = await leaseHolderFor(tx, input.taskId);
+      if (!holder || holder.projectId !== input.target.projectId || holder.chainId !== input.target.chainId) {
+        throw new Error(`Cannot defer Merge Lease release for Task ${input.taskId}: target validation failed`);
+      }
+      await tx.taskActivity.create({ data: {
+        taskId: holder.taskId,
+        actorType: "control-plane",
+        body: `Merge Lease release deferred for chain ${holder.chainId}: ${input.detail}`,
+        metadata: {
+          kind: MERGE_TAIL_KIND.leaseRelease,
+          schemaVersion: 1,
+          state: "release-deferred",
+          projectId: holder.projectId,
+          chainId: holder.chainId,
+          taskId: holder.taskId,
+          failureDetail: input.detail,
+          deferredAt: input.at.toISOString(),
+        },
+      } });
+    });
+  } catch (error: unknown) {
+    throw new LeaseReleaseDeferralRecordError(input.target, input.taskId, error);
+  }
+};
+
+export const deferredLeaseReleases = async (
+  tx: Prisma.TransactionClient,
+): Promise<Array<{ activityId: string; taskId: string; target: MergeLeaseTarget }>> => (
+  tx.$queryRaw<Array<{ activityId: string; taskId: string; projectId: string; chainId: string }>>`
+    SELECT
+      deferred.id AS "activityId",
+      deferred."taskId" AS "taskId",
+      deferred.metadata->>'projectId' AS "projectId",
+      deferred.metadata->>'chainId' AS "chainId"
+    FROM "TaskActivity" AS deferred
+    WHERE deferred."actorType" = 'control-plane'
+      AND deferred.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseRelease}
+      AND deferred.metadata->>'state' = 'release-deferred'
+      AND deferred.metadata->>'projectId' IS NOT NULL
+      AND deferred.metadata->>'chainId' IS NOT NULL
+      AND deferred.metadata->>'taskId' = deferred."taskId"
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "TaskActivity" AS terminal
+        WHERE terminal."taskId" = deferred."taskId"
+          AND terminal."createdAt" >= deferred."createdAt"
+          AND terminal."actorType" = 'control-plane'
+          AND terminal.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseRelease}
+          AND terminal.metadata->>'deferredActivityId' = deferred.id
+          AND terminal.metadata->>'state' IN ('released', 'invalid')
+      )
+    ORDER BY deferred."createdAt" ASC, deferred.id ASC
+    LIMIT ${LEASE_RELEASE_QUERY_LIMIT}
+  `
+).then((rows) => rows.map(({ activityId, taskId, projectId, chainId }) => ({
+  activityId,
+  taskId,
+  target: { projectId, chainId },
+})));
+
 /** Find retained handoffs whose queued Run never became a Lease consumer. */
 export const leaseHandoffsWithoutConsumer = async (
   tx: Prisma.TransactionClient,
@@ -299,33 +448,80 @@ export const leaseHandoffsWithoutConsumer = async (
 ): Promise<Array<{ toRunId: string; taskId: string }>> => {
   const staleBefore = new Date(now.getTime() - LEASE_HANDOFF_GRACE_MS);
   return tx.$queryRaw<Array<{ toRunId: string; taskId: string }>>`
-    WITH unresolved AS (
+    WITH consumers AS (
       SELECT
         consumer.id AS "toRunId",
-        latest."taskId" AS "taskId",
-        GREATEST(consumer."createdAt", consumer."readyAt") AS "staleAt"
+        consumer."taskId" AS "taskId",
+        consumer."createdAt" AS "createdAt",
+        consumer."readyAt" AS "readyAt"
       FROM "Run" AS consumer
-      JOIN LATERAL (
-        SELECT activity."taskId", activity.metadata, activity."createdAt", activity.id
-        FROM "TaskActivity" AS activity
-        WHERE activity."createdAt" >= LEAST(consumer."createdAt", consumer."readyAt")
-          AND activity."actorType" = 'control-plane'
-          AND activity.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseHandoff}
-          AND activity.metadata->>'toRunId' = consumer.id
-        ORDER BY activity."createdAt" DESC, activity.id DESC
-        LIMIT 1
-      ) AS latest ON true
       WHERE consumer.status = 'queued'::"RunStatus"
         AND consumer."claimedAt" IS NULL
         AND consumer."startedAt" IS NULL
         AND GREATEST(consumer."createdAt", consumer."readyAt") < ${staleBefore}
-        AND latest.metadata->>'state' = 'pending'
-        AND latest.metadata->>'chainId' IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM "TaskActivity" AS activity
+          WHERE activity."taskId" = consumer."taskId"
+            AND activity."createdAt" >= LEAST(consumer."createdAt", consumer."readyAt")
+            AND activity."actorType" = 'control-plane'
+            AND activity.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseHandoff}
+            AND activity.metadata->>'toRunId' = consumer.id
+            AND activity.metadata->>'state' = 'pending'
+            AND activity.metadata->>'chainId' IS NOT NULL
+            AND GREATEST(
+              consumer."createdAt",
+              consumer."readyAt",
+              CASE
+                WHEN activity.metadata->>'handedOffAt' ~ '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$'
+                  THEN (activity.metadata->>'handedOffAt')::timestamptz
+                ELSE activity."createdAt"
+              END
+            ) < ${staleBefore}
+            AND NOT EXISTS (
+              SELECT 1
+              FROM "TaskActivity" AS newer
+              WHERE newer."taskId" = consumer."taskId"
+                AND newer."createdAt" >= LEAST(consumer."createdAt", consumer."readyAt")
+                AND newer."actorType" = 'control-plane'
+                AND newer.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseHandoff}
+                AND newer.metadata->>'toRunId' = consumer.id
+                AND (newer."createdAt", newer.id) > (activity."createdAt", activity.id)
+            )
+        )
       ORDER BY GREATEST(consumer."createdAt", consumer."readyAt") ASC, consumer.id ASC
       LIMIT ${LEASE_HANDOFF_QUERY_LIMIT}
+    ), unresolved AS (
+      SELECT
+        consumer."toRunId" AS "toRunId",
+        consumer."taskId" AS "taskId",
+        GREATEST(
+          consumer."createdAt",
+          consumer."readyAt",
+          CASE
+            WHEN latest.metadata->>'handedOffAt' ~ '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$'
+              THEN (latest.metadata->>'handedOffAt')::timestamptz
+            ELSE latest."createdAt"
+          END
+        ) AS "staleAt"
+      FROM consumers AS consumer
+      JOIN LATERAL (
+        SELECT activity."taskId", activity.metadata, activity."createdAt", activity.id
+        FROM "TaskActivity" AS activity
+        WHERE activity."taskId" = consumer."taskId"
+          AND activity."createdAt" >= LEAST(consumer."createdAt", consumer."readyAt")
+          AND activity."actorType" = 'control-plane'
+          AND activity.metadata->>'kind' = ${MERGE_TAIL_KIND.leaseHandoff}
+          AND activity.metadata->>'toRunId' = consumer."toRunId"
+        ORDER BY activity."createdAt" DESC, activity.id DESC
+        LIMIT 1
+      ) AS latest ON true
+      WHERE latest.metadata->>'state' = 'pending'
+        AND latest.metadata->>'chainId' IS NOT NULL
     )
     SELECT "toRunId", "taskId"
     FROM unresolved
+    WHERE "staleAt" < ${staleBefore}
     ORDER BY "staleAt" ASC, "toRunId" ASC
   `;
 };
@@ -390,13 +586,15 @@ const releaseCommittedLeaseOutcomes = async (
   const targets = new Map<string, {
     target: MergeLeaseTarget;
     handoffs: Array<NonNullable<LeaseSettlement["releasedHandoff"]>>;
+    deferredReleases: Array<NonNullable<LeaseSettlement["deferredRelease"]>>;
   }>();
   for (const entry of committed) {
     const target = entry.settlement.target;
     if (!target) continue;
     const key = JSON.stringify([target.projectId, target.chainId]);
-    const existing = targets.get(key) ?? { target, handoffs: [] };
+    const existing = targets.get(key) ?? { target, handoffs: [], deferredReleases: [] };
     if (entry.settlement.releasedHandoff) existing.handoffs.push(entry.settlement.releasedHandoff);
+    if (entry.settlement.deferredRelease) existing.deferredReleases.push(entry.settlement.deferredRelease);
     targets.set(key, existing);
   }
 
@@ -408,10 +606,19 @@ const releaseCommittedLeaseOutcomes = async (
       failures.push({ target: entry.target, phase: "release", error });
       continue;
     }
-    if (entry.handoffs.length > 0) {
+    if (entry.handoffs.length > 0 || entry.deferredReleases.length > 0) {
       try {
         await db.$transaction(async (tx) => {
           for (const handoff of entry.handoffs) await noteLeaseHandoffReleased(tx, handoff);
+          for (const deferred of entry.deferredReleases) {
+            await noteLeaseReleaseTerminal(tx, {
+              activityId: deferred.activityId,
+              taskId: deferred.taskId,
+              target: deferred.target,
+              state: "released",
+              at: deferred.at,
+            });
+          }
         });
       } catch (error: unknown) {
         failures.push({ target: entry.target, phase: "record", error });
@@ -514,7 +721,7 @@ const acquireMergeLease: MergeLeaseAcquirer = async (chainId) => {
 
 export type HeldLeaseOutcome =
   | { kind: "continue" }
-  | { kind: "stop" };
+  | { kind: "stop"; taskId: string };
 
 export type MergeLeaseDependencies = {
   acquire: MergeLeaseAcquirer;
@@ -529,7 +736,7 @@ export type WithMergeLease = <T>(
   dependencies?: MergeLeaseDependencies,
 ) => Promise<
   | { outcome: "contended" }
-  | { outcome: "unreachable"; detail: string }
+  | { outcome: "unreachable"; detail: string; releaseDeferred?: true }
   | { outcome: "ran"; value: T }
 >;
 
@@ -551,7 +758,7 @@ export const withMergeLease = async <T>(
   },
 ): Promise<
   | { outcome: "contended" }
-  | { outcome: "unreachable"; detail: string }
+  | { outcome: "unreachable"; detail: string; releaseDeferred?: true }
   | { outcome: "ran"; value: T }
 > => {
   if (target === null) {
@@ -565,7 +772,7 @@ export const withMergeLease = async <T>(
     return { outcome: "unreachable", detail: acquisition.detail };
   }
 
-  let leaseOutcome: HeldLeaseOutcome = { kind: "stop" };
+  let leaseOutcome: HeldLeaseOutcome | { kind: "stop"; taskId: null } = { kind: "stop", taskId: null };
   let callbackFailed = false;
   let callbackError: unknown;
   let result: { leaseOutcome: HeldLeaseOutcome; value: T } | undefined;
@@ -577,25 +784,33 @@ export const withMergeLease = async <T>(
     callbackError = error;
   }
   if (leaseOutcome.kind === "stop") {
+    const deferRelease = async (detail: string): Promise<{
+      outcome: "unreachable";
+      detail: string;
+      releaseDeferred?: true;
+    }> => {
+      if (!leaseOutcome.taskId) return { outcome: "unreachable", detail };
+      await noteLeaseReleaseDeferred(db, {
+        target,
+        taskId: leaseOutcome.taskId,
+        detail,
+        at: dependencies.now?.() ?? new Date(),
+      });
+      return { outcome: "unreachable", detail, releaseDeferred: true };
+    };
     let release: MergeLeaseRelease | null;
     try {
       release = await releaseMergeLeaseWith(dependencies.release, target);
     } catch (releaseError: unknown) {
       const releaseDetail = `Merge lease release transport failed: ${releaseError instanceof Error ? releaseError.message : String(releaseError)}`;
-      return {
-        outcome: "unreachable",
-        detail: callbackFailed
-          ? `Merge lease callback failed before release: ${callbackError instanceof Error ? callbackError.message : String(callbackError)}; ${releaseDetail}`
-          : releaseDetail,
-      };
+      return deferRelease(callbackFailed
+        ? `Merge lease callback failed before release: ${callbackError instanceof Error ? callbackError.message : String(callbackError)}; ${releaseDetail}`
+        : releaseDetail);
     }
     if (release?.outcome === "unreachable") {
-      return {
-        outcome: "unreachable",
-        detail: callbackFailed
-          ? `Merge lease callback failed before release: ${callbackError instanceof Error ? callbackError.message : String(callbackError)}; release transport unreachable: ${release.detail}`
-          : release.detail,
-      };
+      return deferRelease(callbackFailed
+        ? `Merge lease callback failed before release: ${callbackError instanceof Error ? callbackError.message : String(callbackError)}; release transport unreachable: ${release.detail}`
+        : release.detail);
     }
     if (release?.outcome === "released") {
       try {

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -38,8 +38,11 @@ import {
   type ReadinessInput,
 } from "./readiness-decision.js";
 import {
+  commitWithLeaseOutcome,
   releaseMergeLease,
   withMergeLease,
+  type HeldLeaseOutcome,
+  type LeaseOutcome,
   type ReleaseMergeLease,
   type WithMergeLease,
 } from "./merge-lease.js";
@@ -188,11 +191,30 @@ const stopReadiness = async (
     recovery: RecoveryContext | null;
   },
   claim: ReadinessClaimHandle,
+  releaseChainLease: ReleaseMergeLease,
 ): Promise<{
   applied: boolean;
-  leaseToRelease: MergeLeaseTarget | null;
   ownership: ReadinessLeaseOwnership;
-}> => db.$transaction(async (tx) => {
+}> => commitWithLeaseOutcome(db, (tx) => settleReadinessStop(tx, input, claim), {
+  release: releaseChainLease,
+}).then((settlement) => {
+  if (!settlement) throw new Error("Readiness stop transaction returned no settlement");
+  return settlement;
+});
+
+const settleReadinessStop = async (
+  tx: Prisma.TransactionClient,
+  input: {
+    readinessTaskId: string;
+    regressionTaskId: string;
+    reason: string;
+    recovery: RecoveryContext | null;
+  },
+  claim: ReadinessClaimHandle,
+): Promise<{
+  value: { applied: boolean; ownership: ReadinessLeaseOwnership };
+  leaseOutcome: LeaseOutcome;
+}> => {
   const settlement = await claim.settle(tx, {
     kind: "finish",
     at: new Date(),
@@ -209,15 +231,17 @@ const stopReadiness = async (
     },
   });
   if (!settlement.settled) {
-    return { applied: false, leaseToRelease: null, ownership: settlement.ownership };
+    return {
+      value: { applied: false, ownership: settlement.ownership },
+      leaseOutcome: { kind: "continue" },
+    };
   }
   if (settlement.claim !== "released") throw new Error("Readiness stop retained a finished claim");
   return {
-    applied: true,
-    leaseToRelease: settlement.value.leaseToRelease,
-    ownership: settlement.ownership,
+    value: { applied: true, ownership: settlement.ownership },
+    leaseOutcome: settlement.value.leaseOutcome,
   };
-});
+};
 
 export type ReadinessTickResult = { claimed: number; authorized: number; requeued: number; stopped: number };
 
@@ -233,7 +257,32 @@ const requeueRegression = async (
     recovery: RecoveryContext | null;
   },
   claim: ReadinessClaimHandle,
-): Promise<{ applied: boolean; ownership: ReadinessLeaseOwnership }> => db.$transaction(async (tx) => {
+  releaseChainLease: ReleaseMergeLease,
+): Promise<{ applied: boolean; ownership: ReadinessLeaseOwnership }> => commitWithLeaseOutcome(
+  db,
+  (tx) => settleRegressionRequeue(tx, input, claim),
+  { release: releaseChainLease },
+).then((settlement) => {
+  if (!settlement) throw new Error("Regression requeue transaction returned no settlement");
+  return settlement;
+});
+
+const settleRegressionRequeue = async (
+  tx: Prisma.TransactionClient,
+  input: {
+    readinessTaskId: string;
+    regressionTaskId: string;
+    staleBaseSha: string;
+    currentBaseSha: string;
+    reason: string;
+    now: Date;
+    recovery: RecoveryContext | null;
+  },
+  claim: ReadinessClaimHandle,
+): Promise<{
+  value: { applied: boolean; ownership: ReadinessLeaseOwnership };
+  leaseOutcome: LeaseOutcome;
+}> => {
   const settlement = await claim.settle(tx, {
     kind: "finish",
     at: input.now,
@@ -275,10 +324,15 @@ const requeueRegression = async (
       return { value: undefined, ownership: "released" as const };
     },
   });
-  if (!settlement.settled) return { applied: false, ownership: settlement.ownership };
+  if (!settlement.settled) {
+    return { value: { applied: false, ownership: settlement.ownership }, leaseOutcome: { kind: "continue" } };
+  }
   if (settlement.claim !== "released") throw new Error("Regression requeue retained a finished claim");
-  return { applied: true, ownership: settlement.ownership };
-});
+  return {
+    value: { applied: true, ownership: settlement.ownership },
+    leaseOutcome: { kind: "stop", taskId: input.regressionTaskId },
+  };
+};
 
 type ClaimedReadiness = {
   claimed: true;
@@ -425,9 +479,9 @@ const recordLeaseDeferral = async (
   return settlement.settled;
 });
 
-const leaseDisposition = (ownership: ReadinessLeaseOwnership) => ownership === "released"
-  ? { kind: "release" as const }
-  : { kind: "retain" as const, handoffRunId: ownership.retainFor };
+const heldLeaseOutcome = (ownership: ReadinessLeaseOwnership): HeldLeaseOutcome => ownership === "released"
+  ? { kind: "stop" }
+  : { kind: "continue" };
 
 const applyReadinessDecision = async (
   db: PrismaClient,
@@ -448,10 +502,9 @@ const applyReadinessDecision = async (
       regressionTaskId: regression.id,
       reason,
       recovery,
-    }, claim);
+    }, claim, releaseChainLease);
     if (!stopped.applied) return false;
     result.stopped += 1;
-    await releaseChainLease(stopped.leaseToRelease, db);
     return true;
   };
   const requeue = async (input: {
@@ -465,10 +518,9 @@ const applyReadinessDecision = async (
       ...input,
       now: read.input.now,
       recovery,
-    }, claim);
+    }, claim, releaseChainLease);
     if (!requeued.applied) return false;
     result.requeued += 1;
-    await releaseChainLease(target, db);
     return true;
   };
 
@@ -494,7 +546,7 @@ const applyReadinessDecision = async (
   const leased = await runWithMergeLease(target, async () => {
     if (!await claim.renew()) {
       const ownership = await claim.ownershipAfterLoss(db);
-      return { disposition: leaseDisposition(ownership), value: "claim-lost" as const };
+      return { leaseOutcome: heldLeaseOutcome(ownership), value: "claim-lost" as const };
     }
 
     // Regression evidence is durable before this short Lease window. Repeat
@@ -503,40 +555,52 @@ const applyReadinessDecision = async (
     const leasedDecision = await evaluateReadiness(reader, read.input);
     switch (leasedDecision.kind) {
       case "skip":
-        return { disposition: { kind: "release" as const }, value: "lease-recheck-skipped" as const };
+        return { leaseOutcome: { kind: "stop" as const }, value: "lease-recheck-skipped" as const };
       case "defer": {
         const deferred = await deferReadiness(db, readiness.id, claim);
-        return { disposition: leaseDisposition(deferred.ownership), value: "lease-recheck-deferred" as const };
+        return {
+          leaseOutcome: heldLeaseOutcome(deferred.ownership),
+          value: "lease-recheck-deferred" as const,
+        };
       }
       case "stop": {
-        const stopped = await stopReadiness(db, {
+        const stoppedResult = await db.$transaction((tx) => settleReadinessStop(tx, {
           readinessTaskId: readiness.id,
           regressionTaskId: regression.id,
           reason: leasedDecision.evidence,
           recovery,
-        }, claim);
+        }, claim));
+        const stopped = stoppedResult.value;
         if (stopped.applied) result.stopped += 1;
-        return { disposition: leaseDisposition(stopped.ownership), value: "lease-recheck-stopped" as const };
+        return {
+          leaseOutcome: stopped.applied ? { kind: "stop" as const } : heldLeaseOutcome(stopped.ownership),
+          value: "lease-recheck-stopped" as const,
+        };
       }
       case "requeue-regression": {
-        const requeued = await requeueRegression(db, {
+        const requeuedResult = await db.$transaction((tx) => settleRegressionRequeue(tx, {
           readinessTaskId: readiness.id,
           regressionTaskId: regression.id,
           ...leasedDecision,
           now: read.input.now,
           recovery,
-        }, claim);
+        }, claim));
+        const requeued = requeuedResult.value;
         if (requeued.applied) result.requeued += 1;
-        return { disposition: leaseDisposition(requeued.ownership), value: "lease-recheck-requeued" as const };
+        return {
+          leaseOutcome: requeued.applied ? { kind: "stop" as const } : heldLeaseOutcome(requeued.ownership),
+          value: "lease-recheck-requeued" as const,
+        };
       }
       case "authorize":
         break;
     }
 
-    const authorization = await db.$transaction((tx) => claim.settle(tx, {
-      kind: "finish",
-      at: read.input.now,
-      apply: async (client) => {
+    const authorization = await commitWithLeaseOutcome(db, async (tx) => {
+      const settlement = await claim.settle(tx, {
+        kind: "finish",
+        at: read.input.now,
+        apply: async (client) => {
         await client.task.update({
           where: { id: readiness.id },
           data: { status: TaskStatus.DONE, failureReason: null },
@@ -631,13 +695,37 @@ const applyReadinessDecision = async (
           value: "authorized" as const,
           ownership: handoff ? { retainFor: handoff.id } : "released" as const,
         };
-      },
-    }));
+        },
+      });
+      return {
+        value: settlement,
+        leaseOutcome: settlement.settled
+          && settlement.claim === "released"
+          && settlement.ownership !== "released"
+          ? {
+            kind: "hand-off",
+            taskId: regression.id,
+            handoffRunId: settlement.ownership.retainFor,
+            at: read.input.now,
+          }
+          : { kind: "continue" },
+      };
+    }, { release: releaseChainLease });
+    if (!authorization) throw new Error("Readiness authorization transaction returned no settlement");
     if (!authorization.settled) {
-      return { disposition: leaseDisposition(authorization.ownership), value: "claim-lost" as const };
+      return {
+        leaseOutcome: heldLeaseOutcome(authorization.ownership),
+        value: "claim-lost" as const,
+      };
     }
     if (authorization.claim !== "released") throw new Error("Authorization retained a finished claim");
-    return { disposition: leaseDisposition(authorization.ownership), value: authorization.value };
+    return {
+      // A retained ownership was recorded atomically with authorization by
+      // commitWithLeaseOutcome. Continue leaves that Lease for its consumer;
+      // a missing successor still releases through this outer owner.
+      leaseOutcome: heldLeaseOutcome(authorization.ownership),
+      value: authorization.value,
+    };
   }, db);
   if (leased.outcome === "contended") return;
   if (leased.outcome === "unreachable") {
@@ -687,10 +775,9 @@ export const readinessTick = async (
         regressionTaskId: read.regression.id,
         reason,
         recovery: read.recovery,
-      }, read.claim);
+      }, read.claim, releaseChainLease);
       if (stopped.applied) {
         result.stopped += 1;
-        await releaseChainLease(stopped.leaseToRelease, db);
       }
       // A failed release/hold recording can happen after stopMergeTail has
       // already committed its state transition. A second stop then returns

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -39,6 +39,7 @@ import {
 } from "./readiness-decision.js";
 import {
   commitWithLeaseOutcome,
+  LeaseReleaseDeferralRecordError,
   releaseMergeLease,
   withMergeLease,
   type HeldLeaseOutcome,
@@ -479,8 +480,8 @@ const recordLeaseDeferral = async (
   return settlement.settled;
 });
 
-const heldLeaseOutcome = (ownership: ReadinessLeaseOwnership): HeldLeaseOutcome => ownership === "released"
-  ? { kind: "stop" }
+const heldLeaseOutcome = (ownership: ReadinessLeaseOwnership, taskId: string): HeldLeaseOutcome => ownership === "released"
+  ? { kind: "stop", taskId }
   : { kind: "continue" };
 
 const applyReadinessDecision = async (
@@ -546,7 +547,7 @@ const applyReadinessDecision = async (
   const leased = await runWithMergeLease(target, async () => {
     if (!await claim.renew()) {
       const ownership = await claim.ownershipAfterLoss(db);
-      return { leaseOutcome: heldLeaseOutcome(ownership), value: "claim-lost" as const };
+      return { leaseOutcome: heldLeaseOutcome(ownership, regression.id), value: "claim-lost" as const };
     }
 
     // Regression evidence is durable before this short Lease window. Repeat
@@ -555,11 +556,14 @@ const applyReadinessDecision = async (
     const leasedDecision = await evaluateReadiness(reader, read.input);
     switch (leasedDecision.kind) {
       case "skip":
-        return { leaseOutcome: { kind: "stop" as const }, value: "lease-recheck-skipped" as const };
+        return {
+          leaseOutcome: { kind: "stop" as const, taskId: regression.id },
+          value: "lease-recheck-skipped" as const,
+        };
       case "defer": {
         const deferred = await deferReadiness(db, readiness.id, claim);
         return {
-          leaseOutcome: heldLeaseOutcome(deferred.ownership),
+          leaseOutcome: heldLeaseOutcome(deferred.ownership, regression.id),
           value: "lease-recheck-deferred" as const,
         };
       }
@@ -573,7 +577,9 @@ const applyReadinessDecision = async (
         const stopped = stoppedResult.value;
         if (stopped.applied) result.stopped += 1;
         return {
-          leaseOutcome: stopped.applied ? { kind: "stop" as const } : heldLeaseOutcome(stopped.ownership),
+          leaseOutcome: stopped.applied
+            ? { kind: "stop" as const, taskId: regression.id }
+            : heldLeaseOutcome(stopped.ownership, regression.id),
           value: "lease-recheck-stopped" as const,
         };
       }
@@ -588,7 +594,9 @@ const applyReadinessDecision = async (
         const requeued = requeuedResult.value;
         if (requeued.applied) result.requeued += 1;
         return {
-          leaseOutcome: requeued.applied ? { kind: "stop" as const } : heldLeaseOutcome(requeued.ownership),
+          leaseOutcome: requeued.applied
+            ? { kind: "stop" as const, taskId: regression.id }
+            : heldLeaseOutcome(requeued.ownership, regression.id),
           value: "lease-recheck-requeued" as const,
         };
       }
@@ -714,7 +722,7 @@ const applyReadinessDecision = async (
     if (!authorization) throw new Error("Readiness authorization transaction returned no settlement");
     if (!authorization.settled) {
       return {
-        leaseOutcome: heldLeaseOutcome(authorization.ownership),
+        leaseOutcome: heldLeaseOutcome(authorization.ownership, regression.id),
         value: "claim-lost" as const,
       };
     }
@@ -723,18 +731,20 @@ const applyReadinessDecision = async (
       // A retained ownership was recorded atomically with authorization by
       // commitWithLeaseOutcome. Continue leaves that Lease for its consumer;
       // a missing successor still releases through this outer owner.
-      leaseOutcome: heldLeaseOutcome(authorization.ownership),
+      leaseOutcome: heldLeaseOutcome(authorization.ownership, regression.id),
       value: authorization.value,
     };
   }, db);
   if (leased.outcome === "contended") return;
   if (leased.outcome === "unreachable") {
-    await recordLeaseDeferral(db, {
-      readinessTaskId: readiness.id,
-      chainId: readiness.chainId,
-      detail: leased.detail,
-      at: read.input.now,
-    }, claim);
+    if (!leased.releaseDeferred) {
+      await recordLeaseDeferral(db, {
+        readinessTaskId: readiness.id,
+        chainId: readiness.chainId,
+        detail: leased.detail,
+        at: read.input.now,
+      }, claim);
+    }
     return;
   }
   if (leased.value === "authorized") result.authorized += 1;
@@ -769,6 +779,7 @@ export const readinessTick = async (
         reader,
       );
     } catch (error: unknown) {
+      if (error instanceof LeaseReleaseDeferralRecordError) throw error;
       const reason = `readiness evaluation failed: ${error instanceof Error ? error.message : String(error)}`;
       const stopped = await stopReadiness(db, {
         readinessTaskId: readiness.id,

--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -466,10 +466,10 @@ const recordLeaseDeferral = async (
     apply: async (client) => client.taskActivity.create({ data: {
       taskId: input.readinessTaskId,
       actorType: "control-plane",
-      body: `Merge lease acquisition deferred: ${input.detail}`,
+      body: `Merge lease transport deferred: ${input.detail}`,
       metadata: {
         kind: MERGE_TAIL_KIND.readiness,
-        state: "lease-acquire-deferred",
+        state: "lease-transport-deferred",
         chainId: input.chainId,
         detail: input.detail,
         retryAfter: new Date(input.at.getTime() + READINESS_CLAIM_LEASE_MS).toISOString(),

--- a/packages/api/src/merge-stop-state.dbtest.ts
+++ b/packages/api/src/merge-stop-state.dbtest.ts
@@ -25,7 +25,9 @@ import {
 import { type PullRequestSnapshot } from "./github-read.js";
 import { evidenceTick } from "./merge-evidence-worker.js";
 import { seedIntegratorChain, type IntegratorChain } from "./merge-integrator-fixture.js";
+import type { ReleaseMergeLease } from "./merge-lease.js";
 import { recordMergeLeaseHold } from "./merge-lease-hold.js";
+import { reconcileDatabaseRuns } from "./reconcile.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
@@ -53,6 +55,13 @@ const CONFIRMED_RELEASE = {
   acquiredAt: "2026-08-27T12:00:00.250Z",
 };
 
+const collectRelease: ReleaseMergeLease = async (target, database) => {
+  if (!target) return;
+  releasedChainLeases.push(target.chainId);
+  releasedLeaseTargets.push(target);
+  await recordMergeLeaseHold(database, target, CONFIRMED_RELEASE, CONFIRMED_RELEASED_AT);
+};
+
 const freshSnapshot = (): PullRequestSnapshot => ({
   repository: "acme/widgets", number: 123, state: "OPEN", isDraft: false, merged: false,
   mergeable: "MERGEABLE", mergeStateStatus: "CLEAN", baseRefName: "master", baseSha: "b".repeat(40),
@@ -75,13 +84,7 @@ const call = async (method: string, path: string, body?: unknown, token = OPERAT
   process.env.MERGE_EXECUTOR_RUNNER_IDS = "merge-executor-1";
   try {
     const response = await createApp(db, {
-      releaseMergeLease: async (target) => {
-        if (target) {
-          releasedChainLeases.push(target.chainId);
-          releasedLeaseTargets.push(target);
-          await recordMergeLeaseHold(db, target, CONFIRMED_RELEASE, CONFIRMED_RELEASED_AT);
-        }
-      },
+      releaseMergeLease: collectRelease,
     }).request(path, {
       method,
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
@@ -143,6 +146,45 @@ const stoppedChain = async (
   assert.equal((await completeRun(run)).status, 200);
   return { chain, run };
 };
+
+test("a failed mechanical completion hands the lease to its delayed retry until orphan cleanup", async () => {
+  const chain = await seedIntegratorChain(db, { label: "completion-retry-handoff", shape: "twelve-step" });
+  const run = await liveIntegratorRun(chain, 1, 3);
+  const completed = await completeRun(run, {
+    exitCode: 1,
+    terminalSuccess: false,
+    failureClass: "TRANSIENT_PROVIDER",
+    retryable: true,
+    externalFailure: true,
+    failureReason: "provider disconnected",
+  });
+  assert.equal(completed.status, 200, JSON.stringify(completed.body));
+  assert.equal(completed.body.retryCreated, true);
+  const retry = await db.run.findFirstOrThrow({ where: {
+    taskId: chain.integratorTask!.id,
+    runNumber: 2,
+  } });
+  const pending = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: chain.integratorTask!.id,
+    metadata: { path: ["state"], equals: "pending" },
+  } });
+  assert.equal((pending.metadata as Record<string, unknown>).kind, MERGE_TAIL_KIND.leaseHandoff);
+  assert.equal((pending.metadata as Record<string, unknown>).toRunId, retry.id);
+  assert.equal((pending.metadata as Record<string, unknown>).consumerReadyAt, retry.readyAt.toISOString());
+  assert.deepEqual(releasedChainLeases, []);
+
+  const handedOffAt = Date.parse(String((pending.metadata as Record<string, unknown>).handedOffAt));
+  const beforeConsumerGrace = new Date(handedOffAt + 61_000);
+  assert.ok(beforeConsumerGrace.getTime() < retry.readyAt.getTime() + 60_000);
+  assert.equal(await reconcileDatabaseRuns(db, beforeConsumerGrace, collectRelease), 0);
+  assert.deepEqual(releasedChainLeases, []);
+
+  assert.equal(
+    await reconcileDatabaseRuns(db, new Date(retry.readyAt.getTime() + 61_000), collectRelease),
+    1,
+  );
+  assert.deepEqual(releasedChainLeases, [chain.integratorTask!.chainId]);
+});
 
 test("N16 a recorded stop lands the stop state: run SUCCEEDED, task REVIEW, question open, no chain advance", async () => {
   const { chain, run } = await stoppedChain("n16");

--- a/packages/api/src/merge-stop-state.dbtest.ts
+++ b/packages/api/src/merge-stop-state.dbtest.ts
@@ -25,9 +25,7 @@ import {
 import { type PullRequestSnapshot } from "./github-read.js";
 import { evidenceTick } from "./merge-evidence-worker.js";
 import { seedIntegratorChain, type IntegratorChain } from "./merge-integrator-fixture.js";
-import type { ReleaseMergeLease } from "./merge-lease.js";
 import { recordMergeLeaseHold } from "./merge-lease-hold.js";
-import { reconcileDatabaseRuns } from "./reconcile.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
@@ -55,13 +53,6 @@ const CONFIRMED_RELEASE = {
   acquiredAt: "2026-08-27T12:00:00.250Z",
 };
 
-const collectRelease: ReleaseMergeLease = async (target, database) => {
-  if (!target) return;
-  releasedChainLeases.push(target.chainId);
-  releasedLeaseTargets.push(target);
-  await recordMergeLeaseHold(database, target, CONFIRMED_RELEASE, CONFIRMED_RELEASED_AT);
-};
-
 const freshSnapshot = (): PullRequestSnapshot => ({
   repository: "acme/widgets", number: 123, state: "OPEN", isDraft: false, merged: false,
   mergeable: "MERGEABLE", mergeStateStatus: "CLEAN", baseRefName: "master", baseSha: "b".repeat(40),
@@ -84,7 +75,13 @@ const call = async (method: string, path: string, body?: unknown, token = OPERAT
   process.env.MERGE_EXECUTOR_RUNNER_IDS = "merge-executor-1";
   try {
     const response = await createApp(db, {
-      releaseMergeLease: collectRelease,
+      releaseMergeLease: async (target) => {
+        if (target) {
+          releasedChainLeases.push(target.chainId);
+          releasedLeaseTargets.push(target);
+          await recordMergeLeaseHold(db, target, CONFIRMED_RELEASE, CONFIRMED_RELEASED_AT);
+        }
+      },
     }).request(path, {
       method,
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
@@ -147,8 +144,8 @@ const stoppedChain = async (
   return { chain, run };
 };
 
-test("a failed mechanical completion hands the lease to its delayed retry until orphan cleanup", async () => {
-  const chain = await seedIntegratorChain(db, { label: "completion-retry-handoff", shape: "twelve-step" });
+test("a failed mechanical completion keeps the existing lease across its retry", async () => {
+  const chain = await seedIntegratorChain(db, { label: "completion-retry-hold", shape: "twelve-step" });
   const run = await liveIntegratorRun(chain, 1, 3);
   const completed = await completeRun(run, {
     exitCode: 1,
@@ -160,30 +157,12 @@ test("a failed mechanical completion hands the lease to its delayed retry until 
   });
   assert.equal(completed.status, 200, JSON.stringify(completed.body));
   assert.equal(completed.body.retryCreated, true);
-  const retry = await db.run.findFirstOrThrow({ where: {
+  assert.equal(await db.run.count({ where: { taskId: chain.integratorTask!.id } }), 2);
+  assert.equal(await db.taskActivity.count({ where: {
     taskId: chain.integratorTask!.id,
-    runNumber: 2,
-  } });
-  const pending = await db.taskActivity.findFirstOrThrow({ where: {
-    taskId: chain.integratorTask!.id,
-    metadata: { path: ["state"], equals: "pending" },
-  } });
-  assert.equal((pending.metadata as Record<string, unknown>).kind, MERGE_TAIL_KIND.leaseHandoff);
-  assert.equal((pending.metadata as Record<string, unknown>).toRunId, retry.id);
-  assert.equal((pending.metadata as Record<string, unknown>).consumerReadyAt, retry.readyAt.toISOString());
+    metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.leaseHandoff },
+  } }), 0);
   assert.deepEqual(releasedChainLeases, []);
-
-  const handedOffAt = Date.parse(String((pending.metadata as Record<string, unknown>).handedOffAt));
-  const beforeConsumerGrace = new Date(handedOffAt + 61_000);
-  assert.ok(beforeConsumerGrace.getTime() < retry.readyAt.getTime() + 60_000);
-  assert.equal(await reconcileDatabaseRuns(db, beforeConsumerGrace, collectRelease), 0);
-  assert.deepEqual(releasedChainLeases, []);
-
-  assert.equal(
-    await reconcileDatabaseRuns(db, new Date(retry.readyAt.getTime() + 61_000), collectRelease),
-    1,
-  );
-  assert.deepEqual(releasedChainLeases, [chain.integratorTask!.chainId]);
 });
 
 test("N16 a recorded stop lands the stop state: run SUCCEEDED, task REVIEW, question open, no chain advance", async () => {

--- a/packages/api/src/merge-tail-actions.test.ts
+++ b/packages/api/src/merge-tail-actions.test.ts
@@ -295,7 +295,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
     markerStates: string[];
     noticeKey: RegExp;
     recoveryTarget: MergeRecoveryStatus | null;
-    result: { leaseToRelease: { chainId: string; projectId: string } | null } | undefined;
+    result: { leaseOutcome: { kind: "stop"; taskId: string | null } } | undefined;
   }> = [
     {
       name: "regression without recovery",
@@ -322,7 +322,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
       markerStates: ["stopped"],
       noticeKey: /^merge-readiness-stop:readiness-1:/u,
       recoveryTarget: null,
-      result: { leaseToRelease: { chainId: "chain-1", projectId: "project-1" } },
+      result: { leaseOutcome: { kind: "stop", taskId: "regression-1" } },
     },
     {
       name: "readiness during recovery",
@@ -331,7 +331,7 @@ test("stopMergeTail owns the phase by recovery matrix", async () => {
       markerStates: ["tail-stopped", "tail-stopped", "stopped"],
       noticeKey: /:stop-1:readiness$/u,
       recoveryTarget: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
-      result: { leaseToRelease: { chainId: "chain-1", projectId: "project-1" } },
+      result: { leaseOutcome: { kind: "stop", taskId: "regression-1" } },
     },
     {
       name: "recovery validation",

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -24,8 +24,7 @@ import {
 
 import { FAILURE_REASON_LIMIT, truncateFailureReason } from "./failure-reason.js";
 import { canonicalOutputRefusal } from "./canonical-task-output.js";
-import { settleLease, type LeaseSettlementOutcome } from "./merge-lease.js";
-import type { MergeLeaseTarget } from "./merge-lease-hold.js";
+import type { LeaseOutcome } from "./merge-lease.js";
 import { awaitAuthorization, blockDownstream, exhaust } from "./merge-tail-state.js";
 
 /**
@@ -262,7 +261,7 @@ export type StopMergeTailInput =
     sessionId?: string;
   };
 
-export type StopMergeTailResult = { leaseToRelease: MergeLeaseTarget | null };
+export type StopMergeTailResult = { leaseOutcome: LeaseOutcome };
 
 type ReadinessStopMergeTailInput = Extract<StopMergeTailInput, { phase: "readiness" }>;
 type CompletionOwnedStopMergeTailInput = Exclude<StopMergeTailInput, ReadinessStopMergeTailInput>;
@@ -344,8 +343,7 @@ export async function stopMergeTail(
       }
     }
     if (input.phase === "readiness") {
-      const lease = await settleLease(tx, { taskId: input.regressionTaskId, outcome: "stop" });
-      return { leaseToRelease: lease.leaseToRelease };
+      return { leaseOutcome: { kind: "stop", taskId: input.regressionTaskId } };
     }
     return;
   }
@@ -402,7 +400,7 @@ type MergeTailCompletionTask = {
 
 export type MergeTailCompletionResult = {
   handled: boolean;
-  leaseOutcome: LeaseSettlementOutcome;
+  leaseOutcome: "continue" | "stop";
 };
 
 /**

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -6,6 +6,7 @@ import {
   type ChangedFile,
   INTEGRATOR_SENTINEL_MODEL,
   MERGE_TAIL_KIND,
+  Prisma,
   PrismaClient,
   RunStatus,
   TaskStatus,
@@ -14,6 +15,7 @@ import {
 import type { PullRequestReader, PullRequestSnapshot } from "./github-read.js";
 import {
   deferredLeaseReleases,
+  deferredLeaseReleasesStatement,
   LeaseReleaseDeferralRecordError,
   withMergeLease,
   type MergeLeaseAcquirer,
@@ -283,33 +285,9 @@ test("the no-deferral sweep uses its partial index without a TaskActivity scan o
   };
   const rows = await db.$transaction(async (tx) => {
     assert.deepEqual(await deferredLeaseReleases(tx), []);
-    return tx.$queryRaw<Array<{ "QUERY PLAN": Array<{ Plan: PlanNode }> }>>`
-      EXPLAIN (FORMAT JSON, COSTS OFF)
-      SELECT
-        deferred.id AS "activityId",
-        deferred."taskId" AS "taskId",
-        deferred.metadata->>'projectId' AS "projectId",
-        deferred.metadata->>'chainId' AS "chainId"
-      FROM "TaskActivity" AS deferred
-      WHERE deferred."actorType" = 'control-plane'
-        AND deferred.metadata->>'kind' = 'mergeTail.leaseRelease'
-        AND deferred.metadata->>'state' = 'release-deferred'
-        AND deferred.metadata->>'projectId' IS NOT NULL
-        AND deferred.metadata->>'chainId' IS NOT NULL
-        AND deferred.metadata->>'taskId' = deferred."taskId"
-        AND NOT EXISTS (
-          SELECT 1
-          FROM "TaskActivity" AS terminal
-          WHERE terminal."taskId" = deferred."taskId"
-            AND terminal."createdAt" >= deferred."createdAt"
-            AND terminal."actorType" = 'control-plane'
-            AND terminal.metadata->>'kind' = 'mergeTail.leaseRelease'
-            AND terminal.metadata->>'deferredActivityId' = deferred.id
-            AND terminal.metadata->>'state' IN ('released', 'invalid')
-        )
-      ORDER BY deferred."createdAt" ASC, deferred.id ASC
-      LIMIT ${100}
-    `;
+    return tx.$queryRaw<Array<{ "QUERY PLAN": Array<{ Plan: PlanNode }> }>>(
+      Prisma.sql`EXPLAIN (FORMAT JSON, COSTS OFF) ${deferredLeaseReleasesStatement}`,
+    );
   });
 
   const root = rows[0]?.["QUERY PLAN"]?.[0]?.Plan;

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -13,6 +13,7 @@ import {
 
 import type { PullRequestReader, PullRequestSnapshot } from "./github-read.js";
 import {
+  deferredLeaseReleases,
   LeaseReleaseDeferralRecordError,
   withMergeLease,
   type MergeLeaseAcquirer,
@@ -262,6 +263,67 @@ const assertDeferredReleaseAndRetry = async (
     throw new Error("a terminal deferred release must not retry");
   }), 0);
 };
+
+test("the no-deferral sweep uses its partial index without a TaskActivity scan or sort", async () => {
+  const seeded = await seedReadiness();
+  const noise = Array.from({ length: 5_000 }, (_, index) => ({
+    taskId: seeded.regression.id,
+    actorType: "control-plane",
+    body: `Unrelated activity ${index}`,
+    metadata: { kind: "test.noise", schemaVersion: 1, index },
+  }));
+  await db.taskActivity.createMany({ data: noise });
+  await db.$executeRawUnsafe('ANALYZE "TaskActivity"');
+
+  type PlanNode = {
+    "Node Type"?: string;
+    "Relation Name"?: string;
+    "Index Name"?: string;
+    Plans?: PlanNode[];
+  };
+  const rows = await db.$transaction(async (tx) => {
+    assert.deepEqual(await deferredLeaseReleases(tx), []);
+    return tx.$queryRaw<Array<{ "QUERY PLAN": Array<{ Plan: PlanNode }> }>>`
+      EXPLAIN (FORMAT JSON, COSTS OFF)
+      SELECT
+        deferred.id AS "activityId",
+        deferred."taskId" AS "taskId",
+        deferred.metadata->>'projectId' AS "projectId",
+        deferred.metadata->>'chainId' AS "chainId"
+      FROM "TaskActivity" AS deferred
+      WHERE deferred."actorType" = 'control-plane'
+        AND deferred.metadata->>'kind' = 'mergeTail.leaseRelease'
+        AND deferred.metadata->>'state' = 'release-deferred'
+        AND deferred.metadata->>'projectId' IS NOT NULL
+        AND deferred.metadata->>'chainId' IS NOT NULL
+        AND deferred.metadata->>'taskId' = deferred."taskId"
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "TaskActivity" AS terminal
+          WHERE terminal."taskId" = deferred."taskId"
+            AND terminal."createdAt" >= deferred."createdAt"
+            AND terminal."actorType" = 'control-plane'
+            AND terminal.metadata->>'kind' = 'mergeTail.leaseRelease'
+            AND terminal.metadata->>'deferredActivityId' = deferred.id
+            AND terminal.metadata->>'state' IN ('released', 'invalid')
+        )
+      ORDER BY deferred."createdAt" ASC, deferred.id ASC
+      LIMIT ${100}
+    `;
+  });
+
+  const root = rows[0]?.["QUERY PLAN"]?.[0]?.Plan;
+  assert.ok(root, "PostgreSQL returned an EXPLAIN plan");
+  const nodes: PlanNode[] = [];
+  const collect = (node: PlanNode): void => {
+    nodes.push(node);
+    node.Plans?.forEach(collect);
+  };
+  collect(root);
+  assert.ok(nodes.some((node) => node["Index Name"] === "TaskActivity_release_deferred_createdAt_id_idx"));
+  assert.equal(nodes.some((node) => node["Node Type"] === "Seq Scan" && node["Relation Name"] === "TaskActivity"), false);
+  assert.equal(nodes.some((node) => node["Node Type"] === "Sort"), false);
+});
 
 test("clean exact-head readiness authorizes and queues mechanical merge", async () => {
   const seeded = await seedReadiness();

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -347,7 +347,7 @@ test("a post-acquire release or hold-recording failure remains observable", asyn
   const failingFinalRelease: WithMergeLease = async (target, fn) => {
     if (target) leasedTargets.push(target);
     const result = await fn();
-    if (result.disposition.kind === "release") throw releaseFailure;
+    if (result.leaseOutcome.kind === "stop") throw releaseFailure;
     return { outcome: "ran", value: result.value };
   };
 

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -13,6 +13,7 @@ import {
 
 import type { PullRequestReader, PullRequestSnapshot } from "./github-read.js";
 import {
+  LeaseReleaseDeferralRecordError,
   withMergeLease,
   type MergeLeaseAcquirer,
   type MergeLeaseReleaser,
@@ -21,6 +22,7 @@ import {
 } from "./merge-lease.js";
 import type { MergeLeaseTarget } from "./merge-lease-hold.js";
 import { READINESS_CLAIM_LEASE_MS, readinessTick } from "./merge-readiness-worker.js";
+import { reconcileDatabaseRuns } from "./reconcile.js";
 import { createApp } from "./test-app.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
 
@@ -62,6 +64,17 @@ const leaseRunner = (acquire: MergeLeaseAcquirer): WithMergeLease => (
   });
 };
 const runWithMergeLease = leaseRunner(acquireChainLease);
+const unreachableReleaseRunner = (attempts: { count: number }): WithMergeLease => (
+  target,
+  fn,
+  database,
+) => withMergeLease(target, fn, database, {
+  acquire: acquireChainLease,
+  release: async () => {
+    attempts.count += 1;
+    return { outcome: "unreachable", detail: "release helper timed out" };
+  },
+});
 const leaseHoldMarkers = (projectId: string) => db.taskActivity.findMany({
   where: {
     task: { projectId },
@@ -214,6 +227,40 @@ const seedReadiness = async () => {
     commitSha: HEAD,
   } });
   return { project, repo, regression, readiness, integrator };
+};
+
+const assertDeferredReleaseAndRetry = async (
+  seeded: Awaited<ReturnType<typeof seedReadiness>>,
+  now: Date,
+): Promise<void> => {
+  const pending = await db.taskActivity.findMany({ where: {
+    taskId: seeded.regression.id,
+    metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.leaseRelease },
+  }, orderBy: [{ createdAt: "asc" }, { id: "asc" }] });
+  assert.equal(pending.length, 1, "the failed release writes exactly one durable record");
+  const metadata = pending[0]!.metadata as Record<string, unknown>;
+  assert.equal(metadata.state, "release-deferred");
+  assert.equal(metadata.projectId, seeded.project.id);
+  assert.equal(metadata.chainId, seeded.regression.chainId);
+  assert.equal(metadata.taskId, seeded.regression.id);
+  assert.equal(metadata.failureDetail, "release helper timed out");
+
+  const retried: MergeLeaseTarget[] = [];
+  assert.equal(await reconcileDatabaseRuns(db, new Date(now.getTime() + 1_000), async (target) => {
+    if (target) retried.push(target);
+  }), 1);
+  assert.deepEqual(retried, [{ projectId: seeded.project.id, chainId: seeded.regression.chainId }]);
+  const terminal = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: seeded.regression.id,
+    AND: [
+      { metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.leaseRelease } },
+      { metadata: { path: ["state"], equals: "released" } },
+    ],
+  } });
+  assert.equal((terminal.metadata as Record<string, unknown>).deferredActivityId, pending[0]!.id);
+  assert.equal(await reconcileDatabaseRuns(db, new Date(now.getTime() + 2_000), async () => {
+    throw new Error("a terminal deferred release must not retry");
+  }), 0);
 };
 
 test("clean exact-head readiness authorizes and queues mechanical merge", async () => {
@@ -598,6 +645,123 @@ test("an unreachable merge lease acquire defers mechanically without spending re
   );
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.DONE);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 1);
+});
+
+test("authorize without a handoff durably defers an unreachable finished-claim release for reconciliation", async () => {
+  const seeded = await seedReadiness();
+  await db.task.update({ where: { id: seeded.integrator.id }, data: { status: TaskStatus.DONE } });
+  const now = new Date();
+  const attempts = { count: 0 };
+
+  assert.deepEqual(
+    await readinessTick(db, reader(), now, 5, releaseChainLease, unreachableReleaseRunner(attempts)),
+    { claimed: 1, authorized: 0, requeued: 0, stopped: 0 },
+  );
+  assert.equal(attempts.count, 1);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.DONE);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } })).status, TaskStatus.DONE);
+  await assertDeferredReleaseAndRetry(seeded, now);
+  assert.equal(attempts.count, 1, "readiness does not immediately retry the unreachable release");
+});
+
+test("a semantic stop durably defers an unreachable finished-claim release for reconciliation", async () => {
+  const seeded = await seedReadiness();
+  const now = new Date();
+  const attempts = { count: 0 };
+  let reads = 0;
+  const movingReader: PullRequestReader = {
+    readPullRequest: async () => {
+      reads += 1;
+      return snapshot({ baseSha: reads === 1 ? BASE : null });
+    },
+    compareCommits: async () => ({ status: "ahead", behindBy: 0, filesComplete: true, files: [] }),
+  };
+
+  assert.deepEqual(
+    await readinessTick(db, movingReader, now, 5, releaseChainLease, unreachableReleaseRunner(attempts)),
+    { claimed: 1, authorized: 0, requeued: 0, stopped: 1 },
+  );
+  assert.equal(attempts.count, 1);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.REVIEW);
+  await assertDeferredReleaseAndRetry(seeded, now);
+  assert.equal(attempts.count, 1);
+});
+
+test("a base requeue durably defers an unreachable finished-claim release for reconciliation", async () => {
+  const seeded = await seedReadiness();
+  const now = new Date();
+  const attempts = { count: 0 };
+  const movedBase = "d".repeat(40);
+  let reads = 0;
+  const movingReader: PullRequestReader = {
+    readPullRequest: async () => {
+      reads += 1;
+      return snapshot({ baseSha: reads === 1 ? BASE : movedBase });
+    },
+    compareCommits: async () => ({ status: "ahead", behindBy: 0, filesComplete: true, files: [] }),
+  };
+
+  assert.deepEqual(
+    await readinessTick(db, movingReader, now, 5, releaseChainLease, unreachableReleaseRunner(attempts)),
+    { claimed: 1, authorized: 0, requeued: 1, stopped: 0 },
+  );
+  assert.equal(attempts.count, 1);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.TODO);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } })).status, TaskStatus.TODO);
+  await assertDeferredReleaseAndRetry(seeded, now);
+  assert.equal(attempts.count, 1);
+});
+
+test("a deferred-release record failure surfaces without a readiness REVIEW or second release", async () => {
+  const seeded = await seedReadiness();
+  await db.task.update({ where: { id: seeded.integrator.id }, data: { status: TaskStatus.DONE } });
+  const target = { projectId: seeded.project.id, chainId: seeded.regression.chainId! };
+  const recordFailure = new Error("release-deferred activity write failed");
+  let callbackRan = false;
+  const failedWriter: WithMergeLease = async (_target, fn) => {
+    await fn();
+    callbackRan = true;
+    throw new LeaseReleaseDeferralRecordError(target, seeded.regression.id, recordFailure);
+  };
+
+  await assert.rejects(
+    readinessTick(db, reader(), new Date(), 5, releaseChainLease, failedWriter),
+    (error: unknown) => error instanceof LeaseReleaseDeferralRecordError && error.cause === recordFailure,
+  );
+  assert.equal(callbackRan, true);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.DONE);
+  assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.regression.id } })).status, TaskStatus.DONE);
+  assert.deepEqual(releasedLeaseTargets, []);
+});
+
+test("reconciliation invalidates a deferred release whose validated holder later changes", async () => {
+  const seeded = await seedReadiness();
+  await db.task.update({ where: { id: seeded.integrator.id }, data: { status: TaskStatus.DONE } });
+  const now = new Date();
+  const attempts = { count: 0 };
+  await readinessTick(db, reader(), now, 5, releaseChainLease, unreachableReleaseRunner(attempts));
+  const deferred = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: seeded.regression.id,
+    metadata: { path: ["state"], equals: "release-deferred" },
+  } });
+  await db.task.update({
+    where: { id: seeded.regression.id },
+    data: { chainId: `${seeded.regression.chainId}-changed` },
+  });
+
+  assert.equal(await reconcileDatabaseRuns(db, new Date(now.getTime() + 1_000), async () => {
+    throw new Error("an invalid deferred target must not be released");
+  }), 1);
+  const invalid = await db.taskActivity.findFirstOrThrow({ where: {
+    taskId: seeded.regression.id,
+    metadata: { path: ["state"], equals: "invalid" },
+  } });
+  const metadata = invalid.metadata as Record<string, unknown>;
+  assert.equal(metadata.deferredActivityId, deferred.id);
+  assert.match(String(metadata.reason), /no longer matches/u);
+  assert.equal(await reconcileDatabaseRuns(db, new Date(now.getTime() + 2_000), async () => {
+    throw new Error("an invalid deferred target must remain terminal");
+  }), 0);
 });
 
 test("an unreachable post-acquire release durably defers without review or a second release", async () => {

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -581,7 +581,7 @@ test("an unreachable merge lease acquire defers mechanically without spending re
   assert.notEqual(readiness.readinessClaimExpiresAt, null);
   assert.equal(readiness.failureReason, null);
   const activity = await db.taskActivity.findFirstOrThrow({ where: { taskId: seeded.readiness.id } });
-  assert.match(activity.body, /lease acquisition deferred.*ENOENT/ui);
+  assert.match(activity.body, /lease transport deferred.*ENOENT/ui);
   assert.deepEqual(releasedChainLeases, []);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 1);
 
@@ -598,6 +598,36 @@ test("an unreachable merge lease acquire defers mechanically without spending re
   );
   assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.DONE);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 1);
+});
+
+test("an unreachable post-acquire release durably defers without review or a second release", async () => {
+  const seeded = await seedReadiness();
+  let releaseAttempts = 0;
+  const unreachableRelease: WithMergeLease = (target, _fn, database) => withMergeLease(target, async () => {
+    throw new Error("authorization transaction failed before settlement");
+  }, database, {
+    acquire: acquireChainLease,
+    release: async () => {
+      releaseAttempts += 1;
+      return { outcome: "unreachable", detail: "release helper timed out" };
+    },
+  });
+
+  assert.deepEqual(
+    await readinessTick(db, reader(), new Date(), 5, releaseChainLease, unreachableRelease),
+    { claimed: 1, authorized: 0, requeued: 0, stopped: 0 },
+  );
+  assert.equal(releaseAttempts, 1);
+  assert.deepEqual(releasedLeaseTargets, []);
+  const readiness = await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } });
+  assert.equal(readiness.status, TaskStatus.DOING);
+  assert.equal(readiness.failureReason, null);
+  assert.notEqual(readiness.readinessClaimToken, null);
+  const activity = await db.taskActivity.findFirstOrThrow({
+    where: { taskId: seeded.readiness.id, metadata: { path: ["state"], equals: "lease-transport-deferred" } },
+  });
+  assert.match(activity.body, /authorization transaction failed before settlement/u);
+  assert.match(activity.body, /release helper timed out/u);
 });
 
 test("a worker that acquired then lost its claim releases without a concrete successor Run", async () => {

--- a/packages/api/src/readiness-claim.test.ts
+++ b/packages/api/src/readiness-claim.test.ts
@@ -185,7 +185,7 @@ test("claim loss classifies a concrete active successor as retained ownership", 
   assert.equal(await handle.ownershipAfterLoss(fake.db), "released");
 });
 
-test("retained settlement records the Run handoff before clearing the claim", async () => {
+test("retained settlement returns ownership before clearing the claim", async () => {
   const fake = fakeDatabase({ chainId: "chain-1" });
   const handle = await claimReadinessStep(fake.db, fake.task.id, NOW);
   assert.ok(handle);
@@ -209,5 +209,5 @@ test("retained settlement records the Run handoff before clearing the claim", as
     value: "authorized",
     ownership: { retainFor: "run-2" },
   });
-  assert.deepEqual(fake.events, ["transition-applied", "handoff-recorded", "claim-cleared"]);
+  assert.deepEqual(fake.events, ["transition-applied", "claim-cleared"]);
 });

--- a/packages/api/src/readiness-claim.ts
+++ b/packages/api/src/readiness-claim.ts
@@ -7,7 +7,6 @@ import {
   type PrismaClient,
 } from "@anneal/db";
 
-import { noteLeaseHandoff } from "./merge-lease.js";
 import { lockTaskMutationRows } from "./task-write.js";
 
 export const READINESS_CLAIM_LEASE_MS = 60_000;
@@ -131,7 +130,7 @@ class ReadinessClaim implements ReadinessClaimHandle {
     await lockTaskMutationRows(tx, this.taskId);
     const held = await tx.task.findUnique({
       where: { id: this.taskId },
-      select: { status: true, readinessClaimToken: true, chainId: true },
+      select: { status: true, readinessClaimToken: true },
     });
     if (held?.status !== TaskStatus.DOING || held.readinessClaimToken !== this.state.token) {
       return { settled: false, ownership: await this.ownershipAfterLoss(tx) };
@@ -142,16 +141,6 @@ class ReadinessClaim implements ReadinessClaimHandle {
     }
 
     const finished = await transition.apply(tx);
-    if (finished.ownership !== "released") {
-      if (!held.chainId) {
-        throw new Error(`Cannot retain the Merge Lease for readiness Step ${this.taskId} without a Chain`);
-      }
-      await noteLeaseHandoff(tx, {
-        chainId: held.chainId,
-        toRunId: finished.ownership.retainFor,
-        at: transition.at,
-      });
-    }
     await tx.task.update({
       where: { id: this.taskId },
       data: { readinessClaimToken: null, readinessClaimExpiresAt: null },

--- a/packages/api/src/reconcile.test.ts
+++ b/packages/api/src/reconcile.test.ts
@@ -18,7 +18,7 @@ test("database reconciliation active status query remains limited to three execu
       return [];
     } },
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
-      taskActivity: { findMany: async () => [] },
+      $queryRaw: async () => [],
     }),
   } as unknown as PrismaClient;
   assert.equal(await reconcileDatabaseRuns(database), 0);
@@ -130,6 +130,7 @@ test("database reconciliation times out expired Inbox waits and makes retained w
       },
     },
     $transaction: async (operation: (tx: any) => Promise<unknown>) => operation({
+      $queryRaw: async () => [],
       run: { updateMany: async ({ data }: { data: Record<string, unknown> }) => { writes.push({ target: "run", data }); return { count: 1 }; } },
       session: { updateMany: async ({ data }: { data: Record<string, unknown> }) => { writes.push({ target: "session", data }); return { count: 1 }; } },
       inboxMessage: { updateMany: async ({ data }: { data: Record<string, unknown> }) => { writes.push({ target: "message", data }); return { count: 1 }; } },
@@ -160,7 +161,7 @@ test("startup reconciliation does not fail when archived notice persistence fail
     taskActivity: { findMany: async () => [] },
     taskTemplate: { findMany: async () => [] },
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
-      taskActivity: { findMany: async () => [] },
+      $queryRaw: async () => [],
     }),
   } as unknown as PrismaClient;
   const originalError = console.error;
@@ -200,7 +201,9 @@ test("lease-loss retry refuses an archived Agent and parks the Task visibly", as
         : queued ? [{ id: "retry-2", taskId: "task-1", runNumber: 2, agent: { name: "Archived", archivedAt: now } }] : [],
     },
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
-      $queryRaw: async () => [{ id: "task-1", archivedAt: null }],
+      $queryRaw: async (strings: TemplateStringsArray) => strings.join("").includes("TaskActivity")
+        ? []
+        : [{ id: "task-1", archivedAt: null }],
       agent: { findUnique: async () => ({ id: "agent-1", name: "Archived", archivedAt: now }) },
       run: {
         findFirst: async () => ({ cancelRequestId: null, cancelReason: null, cancelRequestedAt: null }),

--- a/packages/api/src/reconcile.test.ts
+++ b/packages/api/src/reconcile.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { CleanupStatus, RunStatus, SessionExecutionStatus, TaskStatus, type PrismaClient } from "@anneal/db";
+import { CleanupStatus, Prisma, RunStatus, SessionExecutionStatus, TaskStatus, type PrismaClient } from "@anneal/db";
 
 import {
   createArchivedRunNoticeScheduler,
@@ -201,9 +201,15 @@ test("lease-loss retry refuses an archived Agent and parks the Task visibly", as
         : queued ? [{ id: "retry-2", taskId: "task-1", runNumber: 2, agent: { name: "Archived", archivedAt: now } }] : [],
     },
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation({
-      $queryRaw: async (strings: TemplateStringsArray) => strings.join("").includes("TaskActivity")
-        ? []
-        : [{ id: "task-1", archivedAt: null }],
+      $queryRaw: async (query: TemplateStringsArray | Prisma.Sql, ...parameters: unknown[]) => {
+        const sql = "sql" in query ? query.sql : query.join("");
+        const values = "values" in query ? query.values : parameters;
+        if (sql.includes('FROM "TaskActivity" AS deferred')) {
+          assert.deepEqual(values, [100]);
+          return [];
+        }
+        return sql.includes("TaskActivity") ? [] : [{ id: "task-1", archivedAt: null }];
+      },
       agent: { findUnique: async () => ({ id: "agent-1", name: "Archived", archivedAt: now }) },
       run: {
         findFirst: async () => ({ cancelRequestId: null, cancelReason: null, cancelRequestedAt: null }),

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -10,6 +10,7 @@ import {
 
 import {
   commitWithLeaseOutcomes,
+  deferredLeaseReleases,
   LeaseOutcomePostCommitError,
   leaseHandoffsWithoutConsumer,
   releaseMergeLease,
@@ -174,7 +175,9 @@ export const reconcileDatabaseRuns = async (
   ));
   const reconciliation = await commitWithLeaseOutcomes(db, async (tx) => {
     const strandedHandoffs = await leaseHandoffsWithoutConsumer(tx, now);
-    if (orphans.length === 0 && expiredInboxRuns.length === 0 && strandedHandoffs.length === 0) {
+    const deferredReleases = await deferredLeaseReleases(tx);
+    if (orphans.length === 0 && expiredInboxRuns.length === 0
+      && strandedHandoffs.length === 0 && deferredReleases.length === 0) {
       return { value: { count: 0 }, leaseOutcomes: [] };
     }
     const leaseOutcomes: LeaseOutcome[] = [];
@@ -353,8 +356,17 @@ export const reconcileDatabaseRuns = async (
         releasedHandoff: { toRunId: handoff.toRunId, at: now },
       });
     }
+    for (const deferred of deferredReleases) {
+      leaseOutcomes.push({
+        kind: "stop",
+        taskId: deferred.taskId,
+        deferredRelease: { activityId: deferred.activityId, target: deferred.target, at: now },
+      });
+    }
     return {
-      value: { count: orphans.length + expiredInboxRuns.length + strandedHandoffs.length },
+      value: {
+        count: orphans.length + expiredInboxRuns.length + strandedHandoffs.length + deferredReleases.length,
+      },
       leaseOutcomes,
     };
   }, { release: releaseChainLease }).catch((error: unknown) => {

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -1,5 +1,6 @@
 import {
   isRegressionVerificationOutputKind,
+  isIntegratorStep,
   lockTaskRow,
   openRun,
   runBudgetCeiling,
@@ -9,20 +10,18 @@ import {
 } from "@anneal/db";
 
 import {
+  commitWithLeaseOutcomes,
   leaseHandoffsWithoutConsumer,
-  noteLeaseHandoffReleased,
   releaseMergeLease,
-  settleLease,
+  type LeaseOutcome,
   type ReleaseMergeLease,
 } from "./merge-lease.js";
-import type { MergeLeaseTarget } from "./merge-lease-hold.js";
 import { handleRegressionCompletion, regressionVerdictForRun } from "./merge-tail-actions.js";
 import { openReclaimIntentCount } from "./workspace-reclaim.js";
 import { terminalizeRun } from "./run-terminal.js";
 
 const activeStatuses = [RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING] as const;
 const archivedNoticePageSize = 100;
-const mergeLeaseTargetKey = (target: MergeLeaseTarget): string => JSON.stringify([target.projectId, target.chainId]);
 export const archivedNoticeSweepIntervalMs = 60_000;
 
 export const noteArchivedQueuedRuns = async (
@@ -159,19 +158,12 @@ export const reconcileDatabaseRuns = async (
   const orphans = candidates.filter((run) => run.cancelRequestedAt !== null || !(
     run.heartbeatAt && now.getTime() - run.heartbeatAt.getTime() < run.stallTimeoutMin * 60_000
   ));
-  const reconciliation = await db.$transaction(async (tx) => {
+  const reconciliation = await commitWithLeaseOutcomes(db, async (tx) => {
     const strandedHandoffs = await leaseHandoffsWithoutConsumer(tx, now);
     if (orphans.length === 0 && expiredInboxRuns.length === 0 && strandedHandoffs.length === 0) {
-      return { strandedChainLeases: [] as MergeLeaseTarget[], strandedHandoffs, count: 0 };
+      return { value: { count: 0 }, leaseOutcomes: [] };
     }
-    // Chains whose tail run this sweep terminalizes without a successor. Held
-    // until the sweep commits, because a lease released against a transaction
-    // that then rolls back would free a window the chain still owns.
-    // A Chain id is only unique within a project. Keep the project in the
-    // release target and dedupe by both fields, otherwise one project's
-    // reconciliation can suppress the other project's confirmed release and
-    // its hold evidence.
-    const stranded = new Map<string, MergeLeaseTarget>();
+    const leaseOutcomes: LeaseOutcome[] = [];
     for (const run of orphans) {
       const leaseLossReason = !run.leaseExpiresAt
         ? "Platform lease missing during startup reconciliation; runner heartbeat authority was lost"
@@ -209,9 +201,7 @@ export const reconcileDatabaseRuns = async (
           },
         });
         if (terminal === null || "message" in terminal) continue;
-        if (terminal.leaseToRelease) {
-          stranded.set(mergeLeaseTargetKey(terminal.leaseToRelease), terminal.leaseToRelease);
-        }
+        leaseOutcomes.push(terminal.leaseOutcome);
         continue;
       }
       // Order PATCH and retry creation through the same Task-row mutex. The
@@ -269,10 +259,7 @@ export const reconcileDatabaseRuns = async (
           qualifiedVerdict: durableNegativeRegressionVerdict,
           now,
         });
-        const lease = await settleLease(tx, { taskId: run.taskId, outcome: "stop" });
-        if (lease.leaseToRelease) {
-          stranded.set(mergeLeaseTargetKey(lease.leaseToRelease), lease.leaseToRelease);
-        }
+        leaseOutcomes.push({ kind: "stop", taskId: run.taskId });
         await tx.taskActivity.create({
           data: {
             taskId: run.taskId,
@@ -291,15 +278,20 @@ export const reconcileDatabaseRuns = async (
           readyAt: now,
         });
         if (opened.ok) {
+          if (isIntegratorStep(run.task?.templateStep ?? null)) {
+            leaseOutcomes.push({
+              kind: "hand-off",
+              taskId: run.taskId,
+              handoffRunId: opened.run.id,
+              at: now,
+            });
+          }
           await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DOING, failureReason: null } });
           await tx.taskActivity.create({
             data: { taskId: run.taskId, actorType: "control-plane", body: `Run ${run.runNumber} lost; retry ${opened.run.runNumber} queued` },
           });
         } else {
-          const lease = await settleLease(tx, { taskId: run.taskId, outcome: "stop" });
-          if (lease.leaseToRelease) {
-            stranded.set(mergeLeaseTargetKey(lease.leaseToRelease), lease.leaseToRelease);
-          }
+          leaseOutcomes.push({ kind: "stop", taskId: run.taskId });
           await tx.task.update({
             where: { id: run.taskId },
             data: { status: TaskStatus.REVIEW, failureReason: `Lease-loss retry refused: ${opened.refusal.message}` },
@@ -319,10 +311,7 @@ export const reconcileDatabaseRuns = async (
       } else {
         // Budget exhausted: no retry follows, so this lost run is the chain's
         // last word and its lease has no successor to hand itself to.
-        const lease = await settleLease(tx, { taskId: run.taskId, outcome: "stop" });
-        if (lease.leaseToRelease) {
-          stranded.set(mergeLeaseTargetKey(lease.leaseToRelease), lease.leaseToRelease);
-        }
+        leaseOutcomes.push({ kind: "stop", taskId: run.taskId });
         await tx.task.update({
           where: { id: run.taskId },
           data: { status: TaskStatus.REVIEW, failureReason: `Maximum ${budgetCeiling} runs reached after lease loss` },
@@ -352,37 +341,17 @@ export const reconcileDatabaseRuns = async (
       if (expired === null || "message" in expired) continue;
     }
     for (const handoff of strandedHandoffs) {
-      const target = { chainId: handoff.chainId, projectId: handoff.projectId };
-      stranded.set(mergeLeaseTargetKey(target), target);
+      leaseOutcomes.push({
+        kind: "stop",
+        taskId: handoff.taskId,
+        releasedHandoff: { toRunId: handoff.toRunId, at: now },
+      });
     }
     return {
-      strandedChainLeases: [...stranded.values()],
-      strandedHandoffs,
-      count: orphans.length + expiredInboxRuns.length + strandedHandoffs.length,
+      value: { count: orphans.length + expiredInboxRuns.length + strandedHandoffs.length },
+      leaseOutcomes,
     };
-  });
-  const releaseFailures: unknown[] = [];
-  for (const target of reconciliation.strandedChainLeases) {
-    try {
-      await releaseChainLease(target, db);
-    } catch (error: unknown) {
-      releaseFailures.push(error);
-    }
-  }
-  if (reconciliation.strandedHandoffs.length > 0) {
-    try {
-      await db.$transaction(async (tx) => {
-        for (const handoff of reconciliation.strandedHandoffs) {
-          await noteLeaseHandoffReleased(tx, { ...handoff, at: now });
-        }
-      });
-    } catch (error: unknown) {
-      releaseFailures.push(error);
-    }
-  }
-  if (releaseFailures.length > 0) {
-    throw new AggregateError(releaseFailures, "One or more stranded merge lease releases or settlements failed");
-  }
+  }, { release: releaseChainLease });
   return reconciliation.count;
 };
 

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -1,6 +1,5 @@
 import {
   isRegressionVerificationOutputKind,
-  isIntegratorStep,
   lockTaskRow,
   openRun,
   runBudgetCeiling,
@@ -11,9 +10,11 @@ import {
 
 import {
   commitWithLeaseOutcomes,
+  LeaseOutcomePostCommitError,
   leaseHandoffsWithoutConsumer,
   releaseMergeLease,
   type LeaseOutcome,
+  type LeaseOutcomePostCommitFailure,
   type ReleaseMergeLease,
 } from "./merge-lease.js";
 import { handleRegressionCompletion, regressionVerdictForRun } from "./merge-tail-actions.js";
@@ -23,6 +24,19 @@ import { terminalizeRun } from "./run-terminal.js";
 const activeStatuses = [RunStatus.CLAIMED, RunStatus.PROVISIONING, RunStatus.RUNNING] as const;
 const archivedNoticePageSize = 100;
 export const archivedNoticeSweepIntervalMs = 60_000;
+
+export class ReconciliationMaintenanceError extends Error {
+  readonly reconciledAt: Date;
+  readonly failures: LeaseOutcomePostCommitFailure[];
+
+  constructor(reconciledAt: Date, cause: LeaseOutcomePostCommitError) {
+    super("Run reconciliation committed, but Merge Lease maintenance failed");
+    this.name = "ReconciliationMaintenanceError";
+    this.reconciledAt = reconciledAt;
+    this.failures = cause.failures;
+    this.cause = cause;
+  }
+}
 
 export const noteArchivedQueuedRuns = async (
   db: PrismaClient,
@@ -278,14 +292,6 @@ export const reconcileDatabaseRuns = async (
           readyAt: now,
         });
         if (opened.ok) {
-          if (isIntegratorStep(run.task?.templateStep ?? null)) {
-            leaseOutcomes.push({
-              kind: "hand-off",
-              taskId: run.taskId,
-              handoffRunId: opened.run.id,
-              at: now,
-            });
-          }
           await tx.task.update({ where: { id: run.taskId }, data: { status: TaskStatus.DOING, failureReason: null } });
           await tx.taskActivity.create({
             data: { taskId: run.taskId, actorType: "control-plane", body: `Run ${run.runNumber} lost; retry ${opened.run.runNumber} queued` },
@@ -351,7 +357,12 @@ export const reconcileDatabaseRuns = async (
       value: { count: orphans.length + expiredInboxRuns.length + strandedHandoffs.length },
       leaseOutcomes,
     };
-  }, { release: releaseChainLease });
+  }, { release: releaseChainLease }).catch((error: unknown) => {
+    if (error instanceof LeaseOutcomePostCommitError) {
+      throw new ReconciliationMaintenanceError(now, error);
+    }
+    throw error;
+  });
   return reconciliation.count;
 };
 

--- a/packages/api/src/run-cancel.ts
+++ b/packages/api/src/run-cancel.ts
@@ -6,7 +6,7 @@ import {
   TaskStatus,
 } from "@anneal/db";
 
-import type { MergeLeaseTarget } from "./merge-lease-hold.js";
+import { commitWithLeaseOutcome, type ReleaseMergeLease } from "./merge-lease.js";
 import type { Refusal } from "./refusal.js";
 import { activeRunStatuses } from "./run-fence.js";
 import { terminalizeRun } from "./run-terminal.js";
@@ -38,7 +38,6 @@ export type RunCancellation = {
   cancellationState: CancellationState;
   requestId: string;
   reason?: string | null;
-  releaseMergeLeaseTask: MergeLeaseTarget | null;
 };
 
 export type CancellationAcknowledgement = {
@@ -47,7 +46,6 @@ export type CancellationAcknowledgement = {
   status: RunStatus;
   cancellationState: CancellationState;
   requestId: string;
-  releaseMergeLeaseTask: MergeLeaseTarget | null;
 };
 
 const refused = (reason: "not-found" | "conflict", message: string): Refusal => ({ reason, message });
@@ -56,8 +54,9 @@ export const cancelRun = async (
   db: PrismaClient,
   runId: string,
   body: CancelRunInput,
+  releaseMergeLease: ReleaseMergeLease,
 ): Promise<RunCancellation | Refusal> => {
-  const result = await db.$transaction(async (tx) => {
+  const result = await commitWithLeaseOutcome<RunCancellation | Refusal>(db, async (tx) => {
     // Run owns cancellation and terminalization. Take that mutex before Task,
     // matching completion so the two actions cannot enter the rows backwards.
     await lockRunRow(tx, runId);
@@ -84,14 +83,20 @@ export const cancelRun = async (
         } } } },
       },
     });
-    if (!run) return refused("not-found", "Run not found");
-    if (body.parkTask && !run.taskId) return refused("conflict", "Run has no Task to park");
-    const parkTarget = body.parkTask && run.taskId ? await lockTaskMutationRows(tx, run.taskId) : null;
-    if (body.parkTask && run.taskId && !parkTarget) return refused("not-found", "Task not found");
-    if (parkTarget?.archivedAt !== null && parkTarget !== null) {
-      return refused("conflict", "Cannot park an archived task");
+    if (!run) return { value: refused("not-found", "Run not found"), leaseOutcome: { kind: "continue" } };
+    if (body.parkTask && !run.taskId) {
+      return { value: refused("conflict", "Run has no Task to park"), leaseOutcome: { kind: "continue" } };
     }
-    if (parkTarget?.status === TaskStatus.DONE) return refused("conflict", "Cannot park a completed task");
+    const parkTarget = body.parkTask && run.taskId ? await lockTaskMutationRows(tx, run.taskId) : null;
+    if (body.parkTask && run.taskId && !parkTarget) {
+      return { value: refused("not-found", "Task not found"), leaseOutcome: { kind: "continue" } };
+    }
+    if (parkTarget?.archivedAt !== null && parkTarget !== null) {
+      return { value: refused("conflict", "Cannot park an archived task"), leaseOutcome: { kind: "continue" } };
+    }
+    if (parkTarget?.status === TaskStatus.DONE) {
+      return { value: refused("conflict", "Cannot park a completed task"), leaseOutcome: { kind: "continue" } };
+    }
 
     const parkRequestedTask = async () => {
       if (!parkTarget || parkTarget.status === TaskStatus.BACKLOG) return;
@@ -108,33 +113,43 @@ export const cancelRun = async (
 
     if (run.cancelRequestId) {
       if (run.cancelRequestId !== body.requestId) {
-        return refused("conflict", `Run already has cancellation request ${run.cancelRequestId}`);
+        return {
+          value: refused("conflict", `Run already has cancellation request ${run.cancelRequestId}`),
+          leaseOutcome: { kind: "continue" },
+        };
       }
       await parkRequestedTask();
       return {
-        runId: run.id,
-        taskId: run.taskId,
-        status: run.status,
-        cancellationState: run.cancelAcknowledgedAt
-          ? "acknowledged" as const
-          : run.status === RunStatus.CANCELLED ? "unconfirmed" as const : "requested" as const,
-        requestId: run.cancelRequestId,
-        reason: run.cancelReason,
-        releaseMergeLeaseTask: null,
+        value: {
+          runId: run.id,
+          taskId: run.taskId,
+          status: run.status,
+          cancellationState: run.cancelAcknowledgedAt
+            ? "acknowledged" as const
+            : run.status === RunStatus.CANCELLED ? "unconfirmed" as const : "requested" as const,
+          requestId: run.cancelRequestId,
+          reason: run.cancelReason,
+        },
+        leaseOutcome: { kind: "continue" },
       };
     }
     if (executionModeFor(run.task?.templateStep ?? null) === "mechanical") {
-      return refused("conflict", "Mechanical merge Runs cannot be cancelled after authorization");
+      return {
+        value: refused("conflict", "Mechanical merge Runs cannot be cancelled after authorization"),
+        leaseOutcome: { kind: "continue" },
+      };
     }
     if (!([RunStatus.QUEUED, ...activeRunStatuses] as RunStatus[]).includes(run.status)) {
       return {
-        runId: run.id,
-        taskId: run.taskId,
-        status: run.status,
-        cancellationState: "terminal" as const,
-        requestId: body.requestId,
-        reason: null,
-        releaseMergeLeaseTask: null,
+        value: {
+          runId: run.id,
+          taskId: run.taskId,
+          status: run.status,
+          cancellationState: "terminal" as const,
+          requestId: body.requestId,
+          reason: null,
+        },
+        leaseOutcome: { kind: "continue" },
       };
     }
 
@@ -148,7 +163,12 @@ export const cancelRun = async (
         sessionTokenRevokedAt: now,
       },
     });
-    if (requested.count !== 1) return refused("conflict", "Run changed while cancellation was being requested");
+    if (requested.count !== 1) {
+      return {
+        value: refused("conflict", "Run changed while cancellation was being requested"),
+        leaseOutcome: { kind: "continue" },
+      };
+    }
     await parkRequestedTask();
     if (run.taskId) await tx.taskActivity.create({ data: {
       taskId: run.taskId,
@@ -171,28 +191,33 @@ export const cancelRun = async (
           activity: "acknowledged",
         },
       });
-      if (terminal === null || "message" in terminal) return terminal;
+      if (terminal === null) return null;
+      if ("message" in terminal) return { value: terminal, leaseOutcome: { kind: "continue" } };
       return {
-        runId: terminal.runId,
-        taskId: terminal.taskId,
-        status: terminal.status,
-        cancellationState: "acknowledged" as const,
-        requestId: body.requestId,
-        releaseMergeLeaseTask: terminal.leaseToRelease,
+        value: {
+          runId: terminal.runId,
+          taskId: terminal.taskId,
+          status: terminal.status,
+          cancellationState: "acknowledged" as const,
+          requestId: body.requestId,
+        },
+        leaseOutcome: terminal.leaseOutcome,
       };
     }
     return {
-      runId: run.id,
-      taskId: run.taskId,
-      status: run.status,
-      cancellationState: "requested" as const,
-      requestId: body.requestId,
-      reason: body.reason,
+      value: {
+        runId: run.id,
+        taskId: run.taskId,
+        status: run.status,
+        cancellationState: "requested" as const,
+        requestId: body.requestId,
+        reason: body.reason,
+      },
       // Terminalization is still owed by the runner acknowledgement or by
       // reconciliation, and only a terminal writer may free the lease.
-      releaseMergeLeaseTask: null,
+      leaseOutcome: { kind: "continue" },
     };
-  });
+  }, { release: releaseMergeLease });
 
   return result ?? refused("conflict", "Run changed while cancellation was being settled");
 };
@@ -201,34 +226,42 @@ export const acknowledgeCancellation = async (
   db: PrismaClient,
   runId: string,
   body: CancellationAcknowledgementInput,
+  releaseMergeLease: ReleaseMergeLease,
 ): Promise<CancellationAcknowledgement | Refusal> => {
-  const result = await db.$transaction((tx) => terminalizeRun(tx, {
-    runId,
-    at: new Date(),
-    outcome: {
-      kind: "cancelled",
-      requestId: body.requestId,
-      runnerId: body.runnerId,
-      fencingToken: body.fencingToken,
-      actorId: body.runnerId,
-      cleanupConfirmed: true,
-      activity: "acknowledged",
-      ...(body.workspacePath === undefined ? {} : { workspacePath: body.workspacePath }),
-      ...(body.branch === undefined ? {} : { branch: body.branch }),
-      ...(body.baseSha === undefined ? {} : { baseSha: body.baseSha }),
-      ...(body.worktreeContainmentViolations === undefined
-        ? {}
-        : { worktreeContainmentViolations: body.worktreeContainmentViolations }),
-    },
-  }));
+  const result = await commitWithLeaseOutcome<CancellationAcknowledgement | Refusal>(db, async (tx) => {
+    const terminal = await terminalizeRun(tx, {
+      runId,
+      at: new Date(),
+      outcome: {
+        kind: "cancelled",
+        requestId: body.requestId,
+        runnerId: body.runnerId,
+        fencingToken: body.fencingToken,
+        actorId: body.runnerId,
+        cleanupConfirmed: true,
+        activity: "acknowledged",
+        ...(body.workspacePath === undefined ? {} : { workspacePath: body.workspacePath }),
+        ...(body.branch === undefined ? {} : { branch: body.branch }),
+        ...(body.baseSha === undefined ? {} : { baseSha: body.baseSha }),
+        ...(body.worktreeContainmentViolations === undefined
+          ? {}
+          : { worktreeContainmentViolations: body.worktreeContainmentViolations }),
+      },
+    });
+    if (terminal === null) return null;
+    if ("message" in terminal) return { value: terminal, leaseOutcome: { kind: "continue" } };
+    return {
+      value: {
+        runId: terminal.runId,
+        taskId: terminal.taskId,
+        status: terminal.status,
+        cancellationState: "acknowledged" as const,
+        requestId: body.requestId,
+      },
+      leaseOutcome: terminal.leaseOutcome,
+    };
+  }, { release: releaseMergeLease });
   if (result === null) return refused("conflict", "Run changed while cancellation was being acknowledged");
   if ("message" in result) return result;
-  return {
-    runId: result.runId,
-    taskId: result.taskId,
-    status: result.status,
-    cancellationState: "acknowledged",
-    requestId: body.requestId,
-    releaseMergeLeaseTask: result.leaseToRelease,
-  };
+  return result;
 };

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -538,7 +538,7 @@ export const completeRun = async (
       },
     });
     if (terminal === null || "message" in terminal) return null;
-    let retryRunId: string | null = null;
+    let retryCreated = false;
     let retryRefusal: Refusal | null = null;
     if (!succeeded && retryable && !durableNegativeRegressionVerdict && run.task && run.runNumber < budgetCeiling) {
       const opened = await openRun(tx, run.task.id, {
@@ -549,10 +549,9 @@ export const completeRun = async (
         budgetGrant: refunded,
         readyAt: retryAt ?? now,
       });
-      if (opened.ok) retryRunId = opened.run.id;
+      if (opened.ok) retryCreated = true;
       else retryRefusal = opened.refusal;
     }
-    const retryCreated = retryRunId !== null;
     if (run.taskId) {
       const budgetExhausted = !succeeded && retryable && !durableNegativeRegressionVerdict
         && !retryCreated && !retryRefusal;
@@ -811,11 +810,9 @@ export const completeRun = async (
     }
     return {
       value: { taskId: run.taskId, succeeded, retryCreated, failureClass },
-      leaseOutcome: retryRunId && mechanical
-        ? { kind: "hand-off", taskId: run.taskId, handoffRunId: retryRunId, at: now }
-        : leaseOutcome === "stop"
-          ? { kind: "stop", taskId: run.taskId }
-          : { kind: "continue" },
+      leaseOutcome: leaseOutcome === "stop"
+        ? { kind: "stop", taskId: run.taskId }
+        : { kind: "continue" },
     };
   // ReadCommitted lets successor CAS losers observe count=0 instead of
   // surfacing a serialization failure to runners. Every task status write

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -61,9 +61,7 @@ import {
 import { explainFenceRefusal, fenceRefusalResponse, fencedRunWhere, type RunFence } from "./run-fence.js";
 import { terminalizeRun } from "./run-terminal.js";
 import {
-  commitWithLeaseDisposition,
-  settleLease,
-  type LeaseSettlementOutcome,
+  commitWithLeaseOutcome,
   type ReleaseMergeLease,
 } from "./merge-lease.js";
 import type { Refusal } from "./refusal.js";
@@ -244,7 +242,7 @@ export const completeRun = async (
     );
     if (refusal) return { reason: "forbidden", message: refusal };
   }
-  const result = await commitWithLeaseDisposition(db, async (tx) => {
+  const result = await commitWithLeaseOutcome<RunCompletion>(db, async (tx) => {
     // Run owns fencing, cancellation, and terminalization. Take that mutex
     // before Task so completion, cancellation, and canonical output writes
     // cannot deadlock by entering the same two rows in opposite orders.
@@ -448,7 +446,7 @@ export const completeRun = async (
     // row: a task's budget being edited mid-run must not retroactively refuse
     // an attempt already authorized.
     const budgetGrants = run.budgetGrants + refunded;
-    let leaseOutcome: LeaseSettlementOutcome = "continue";
+    let leaseOutcome: "continue" | "stop" = "continue";
     // Completion always mutates its Task, including terminal non-retryable
     // failures. Run is already locked above; acquire the Task/chain mutex now
     // for every outcome rather than only the branches that may retry or
@@ -540,7 +538,7 @@ export const completeRun = async (
       },
     });
     if (terminal === null || "message" in terminal) return null;
-    let retryCreated = false;
+    let retryRunId: string | null = null;
     let retryRefusal: Refusal | null = null;
     if (!succeeded && retryable && !durableNegativeRegressionVerdict && run.task && run.runNumber < budgetCeiling) {
       const opened = await openRun(tx, run.task.id, {
@@ -551,9 +549,10 @@ export const completeRun = async (
         budgetGrant: refunded,
         readyAt: retryAt ?? now,
       });
-      if (opened.ok) retryCreated = true;
+      if (opened.ok) retryRunId = opened.run.id;
       else retryRefusal = opened.refusal;
     }
+    const retryCreated = retryRunId !== null;
     if (run.taskId) {
       const budgetExhausted = !succeeded && retryable && !durableNegativeRegressionVerdict
         && !retryCreated && !retryRefusal;
@@ -810,15 +809,21 @@ export const completeRun = async (
         update: { consecutiveAuthFailures: 0 },
       });
     }
-    const lease = await settleLease(tx, { taskId: run.taskId, outcome: leaseOutcome });
     return {
       value: { taskId: run.taskId, succeeded, retryCreated, failureClass },
-      lease,
+      leaseOutcome: retryRunId && mechanical
+        ? { kind: "hand-off", taskId: run.taskId, handoffRunId: retryRunId, at: now }
+        : leaseOutcome === "stop"
+          ? { kind: "stop", taskId: run.taskId }
+          : { kind: "continue" },
     };
   // ReadCommitted lets successor CAS losers observe count=0 instead of
   // surfacing a serialization failure to runners. Every task status write
   // above has its own status CAS so concurrent operator decisions win.
-  }, releaseMergeLease, { isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted });
+  }, {
+    release: releaseMergeLease,
+    isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
+  });
   // Why the transaction refused, answered here rather than by the caller: a
   // caller that had to re-query the run to tell "suspended for Inbox" from
   // "stale fence" would be re-deriving a distinction this action already made.

--- a/packages/api/src/run-terminal.ts
+++ b/packages/api/src/run-terminal.ts
@@ -10,8 +10,7 @@ import {
 } from "@anneal/db";
 
 import { jsonValue } from "./execution.js";
-import { settleLease } from "./merge-lease.js";
-import type { MergeLeaseTarget } from "./merge-lease-hold.js";
+import type { LeaseOutcome } from "./merge-lease.js";
 import type { Refusal } from "./refusal.js";
 import { activeRunStatuses } from "./run-fence.js";
 import { lockTaskMutationRows } from "./task-write.js";
@@ -72,13 +71,7 @@ export type TerminalResult = {
   runId: string;
   taskId: string | null;
   status: RunStatus;
-  /**
-   * The final consumer's project-scoped Chain Lease identity. The release
-   * happens after this transaction commits, so carrying the project along with
-   * the chain is necessary both for attribution and for two projects that use
-   * the same chain id not to collapse into one evidence record.
-   */
-  leaseToRelease: MergeLeaseTarget | null;
+  leaseOutcome: LeaseOutcome;
   cancellationState?: "acknowledged";
   requestId?: string;
 };
@@ -271,7 +264,7 @@ export const terminalizeRun = async (
         status: run.status,
         cancellationState: "acknowledged",
         requestId: input.outcome.requestId,
-        leaseToRelease: null,
+        leaseOutcome: { kind: "continue" },
       };
     }
     if (run.taskId) await lockTaskMutationRows(tx, run.taskId);
@@ -319,14 +312,13 @@ export const terminalizeRun = async (
           : { runId: run.id, requestId: input.outcome.requestId, status: RunStatus.CANCELLED },
       } });
     }
-    const disposition = await settleLease(tx, { taskId: run.taskId, outcome: "stop" });
     return {
       runId: run.id,
       taskId: run.taskId,
       status: RunStatus.CANCELLED,
       cancellationState: "acknowledged",
       requestId: input.outcome.requestId,
-      leaseToRelease: disposition.leaseToRelease,
+      leaseOutcome: { kind: "stop", taskId: run.taskId },
     };
   }
 
@@ -350,7 +342,7 @@ export const terminalizeRun = async (
   }
 
   if (input.outcome.kind !== "timed-out") {
-    return { runId: input.runId, taskId: null, status: fields.run.status as RunStatus, leaseToRelease: null };
+    return { runId: input.runId, taskId: null, status: fields.run.status as RunStatus, leaseOutcome: { kind: "continue" } };
   }
   if (input.outcome.waitingOnMessageId) {
     await tx.inboxMessage.updateMany({
@@ -373,6 +365,6 @@ export const terminalizeRun = async (
     runId: input.runId,
     taskId: input.outcome.taskId,
     status: RunStatus.TIMED_OUT,
-    leaseToRelease: null,
+    leaseOutcome: { kind: "continue" },
   };
 };

--- a/packages/api/src/runners.test.ts
+++ b/packages/api/src/runners.test.ts
@@ -69,6 +69,7 @@ const makeDatabase = (
       const sql = Array.isArray(query) ? query.join("") : JSON.stringify(query);
       if (sql.includes("pg_try_advisory_xact_lock_shared")) return [{ granted: barrierGranted }];
       if (sql.includes('FROM \\"TaskActivity\\" AS activity') || sql.includes('FROM "TaskActivity" AS activity')) return [];
+      if (sql.includes('FROM \\"TaskActivity\\" AS deferred') || sql.includes('FROM "TaskActivity" AS deferred')) return [];
       if (sql.includes('FROM "Run" AS candidate')) {
         onCandidateRead();
         return candidates.map(({ id }) => ({ id }));

--- a/packages/api/src/runners.test.ts
+++ b/packages/api/src/runners.test.ts
@@ -68,7 +68,7 @@ const makeDatabase = (
     $queryRaw: async (query: unknown) => {
       const sql = Array.isArray(query) ? query.join("") : JSON.stringify(query);
       if (sql.includes("pg_try_advisory_xact_lock_shared")) return [{ granted: barrierGranted }];
-      if (sql.includes('FROM \\"TaskActivity\\" AS pending') || sql.includes('FROM "TaskActivity" AS pending')) return [];
+      if (sql.includes('FROM \\"TaskActivity\\" AS activity') || sql.includes('FROM "TaskActivity" AS activity')) return [];
       if (sql.includes('FROM "Run" AS candidate')) {
         onCandidateRead();
         return candidates.map(({ id }) => ({ id }));

--- a/packages/api/src/runners.test.ts
+++ b/packages/api/src/runners.test.ts
@@ -68,6 +68,7 @@ const makeDatabase = (
     $queryRaw: async (query: unknown) => {
       const sql = Array.isArray(query) ? query.join("") : JSON.stringify(query);
       if (sql.includes("pg_try_advisory_xact_lock_shared")) return [{ granted: barrierGranted }];
+      if (sql.includes('FROM \\"TaskActivity\\" AS pending') || sql.includes('FROM "TaskActivity" AS pending')) return [];
       if (sql.includes('FROM "Run" AS candidate')) {
         onCandidateRead();
         return candidates.map(({ id }) => ({ id }));

--- a/packages/db/prisma/migrations/20260829210000_lease_release_deferred_index/migration.sql
+++ b/packages/db/prisma/migrations/20260829210000_lease_release_deferred_index/migration.sql
@@ -1,0 +1,11 @@
+-- Keep the claim-route deferred-release sweep on its narrow candidate history.
+-- The hot query repeats this predicate as canonical SQL literals so PostgreSQL
+-- can prove that its prepared statement is eligible for the partial index.
+CREATE INDEX "TaskActivity_release_deferred_createdAt_id_idx"
+ON "TaskActivity"("createdAt", "id")
+WHERE "actorType" = 'control-plane'
+  AND metadata->>'kind' = 'mergeTail.leaseRelease'
+  AND metadata->>'state' = 'release-deferred'
+  AND metadata->>'projectId' IS NOT NULL
+  AND metadata->>'chainId' IS NOT NULL
+  AND metadata->>'taskId' = "taskId";

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -24,6 +24,7 @@ export const MERGE_TAIL_KIND = {
   baseDriftRecovery: "mergeTail.baseDriftRecovery",
   leaseHandoff: "mergeTail.leaseHandoff",
   leaseHold: "mergeTail.leaseHold",
+  leaseRelease: "mergeTail.leaseRelease",
   regression: "mergeTail.regression",
   repairAttempt: "mergeTail.repairAttempt",
   repairResult: "mergeTail.repairResult",

--- a/packages/db/src/release-migrate.ts
+++ b/packages/db/src/release-migrate.ts
@@ -74,8 +74,8 @@ export const FILES_PRECHECK_COMMAND = ["npm", "run", "db:files-precheck"] as con
  * match what is on disk.
  */
 export const RELEASE_CANDIDATE_MIGRATIONS = {
-  count: 40,
-  terminal: "20260829150000_readiness_claim_handle",
+  count: 41,
+  terminal: "20260829210000_lease_release_deferred_index",
 } as const;
 
 /** Stable stop conditions owned by the orchestrator itself. */


### PR DESCRIPTION
Candidate: 04

## Summary

Centralize merge-lease settlement behind one outcome-based entry point while preserving ADR-0003 unreachable semantics, acquisition timing, and every existing Lease holding window.

Exact head: `71e618f1d71f68f5128a9cd39c18acf4c9ef8524`

## Changes

- Added the `LeaseOutcome` model with `continue`, `stop`, and `hand-off` outcomes.
- Added `commitWithLeaseOutcome` and `commitWithLeaseOutcomes`; all lease settlement is routed through the private `settleLease`.
- Removed the former disposition naming and caller-owned release ordering.
- Added batch target deduplication so one committed batch releases each holder/target pair at most once while still reporting every real release or record failure.
- Kept handoff persistence inside the lease module for the existing readiness-authorization handoff to merge execution.
- Kept mechanical retry ownership unchanged: completion and reconciliation retries retain the already-held Lease without creating an orphan-handoff release path.
- Added the append-only `mergeTail.leaseRelease` protocol. A finished readiness claim whose release transport is unreachable writes one module-owned, claim-independent `release-deferred` activity containing the validated Task/target and failure detail.
- Added a bounded reconciliation retry for deferred releases. Reconciliation revalidates the persisted holder/target, releases post-commit, and appends a terminal `released` record; holder drift appends `invalid` without guessing or releasing.
- Reworked stranded-handoff reconciliation around a pre-LATERAL driver CTE limited to 100 matching stale queued/unclaimed Runs. Its correlated `EXISTS` and latest-state LATERAL both use the indexed `taskId + createdAt` constraints.
- The handoff stale clock is the maximum of Run `createdAt`, Run `readyAt`, and the latest persisted `handedOffAt`. A newly recorded handoff to an old Run therefore receives the full existing grace window.
- Isolated malformed handoffs by appending an operator-visible `invalid` diagnostic without guessing a release target; valid siblings in the same batch still settle.
- Added typed post-commit reconciliation maintenance failures with exact target and `release | record` phase context. The runner claim route catches only that type, reports it, and continues to `claimRun`; transaction, ownership, and claim failures still surface normally.
- Added a partial `(createdAt, id)` index over canonical `release-deferred` activities so the unconditional claim-route sweep reads only its narrow candidate history while retaining the existing `LIMIT 100` bound.
- Kept the partial-index eligibility predicates as canonical SQL literals so PostgreSQL generic prepared plans can use the index.

## Review disposition

Initial blind-review findings:

- F1: unreachable acquire and release transports return an explicit retryable result and do not cause a second immediate release.
- F2: reconciliation post-commit failures are typed and isolated at the runner claim route boundary.
- F3: mechanical retries retain the already-held Lease; only readiness authorization writes handoff records.
- F4: unresolvable handoffs append an `invalid` marker and cannot poison valid batch siblings or later ticks.
- F5: the fixed seven-day floor was removed in favor of stale Run drivers and per-Run activity lower bounds.

Fresh closure follow-up:

1. Closed: authorize-without-handoff, semantic-stop, and base-requeue finished-claim paths now durably record an unreachable release independent of the cleared claim. A later bounded reconcile sweep retries it and appends a terminal record. The initial path performs exactly one release attempt. A deferral-record write failure is typed, fail-loud, and bypasses the readiness REVIEW/second-release fallback.
2. Closed: persisted `handedOffAt` participates in the stale clock; an old queued Run with a fresh handoff is not immediately released.
3. Closed: matching consumers are preselected and limited before latest-state LATERAL work. More than 100 unrelated or malformed stale queued Runs do not hide a real pending handoff, while 101 matching consumers still drain 100/1/0.

Final closure follow-up:

- Closed: the zero-deferral steady-state sweep no longer performs an unconditional full `TaskActivity` scan. The new partial index exactly matches the canonical deferred-release predicate and supplies `(createdAt, id)` order for the bounded page.
- Regression coverage runs the default PostgreSQL planner after 5,000 unrelated activities and asserts the new index is present with no `TaskActivity` sequential scan and no explicit sort.

## Final delta review follow-up

- Closed: `MERGE_TAIL_KIND.leaseRelease` now has an explicit invariant tying it to the indexed SQL literal `mergeTail.leaseRelease`.
- Closed: production selection and the DB `EXPLAIN` consume the same exported `Prisma.sql` statement; the copied query was removed and only the `LIMIT 100` value is parameterized.

## Exact-head Merge gate failure closure

- Closed: the two stale `` mocks in `app.test.ts` and `reconcile.test.ts` now consume the actual `Prisma.Sql` `.sql` and `.values` shape while retaining their tagged-template handling for the other queries.
- Both mocks preserve their existing query routing and explicitly assert the deferred statement bind values are exactly `[100]`; production code is unchanged.

## Ordering and holding-window evidence

- The outcome callback and all transaction writes commit before any release attempt.
- A transaction rollback performs zero releases.
- Inside `withMergeLease`, the outer lease scope remains the sole immediate release owner; inner work records transaction state only.
- Authorization and readiness handoff persistence are atomic with their state transitions.
- Finished-claim release-unreachable recovery is append-only and deferred to a later reconcile transaction/post-commit release; it never performs a second immediate release.
- Deferred targets are validated when recorded and revalidated before retry.
- Handoff-record failures roll back the transaction; post-commit release/record failures remain typed and observable.
- Mechanical retries neither release nor create a cleanup handoff; the original terminal stop/success path remains the Lease owner.
- Acquisition still occurs at the existing readiness `withMergeLease` boundary around final re-evaluation and authorization. Acquisition adapter timing, heartbeat, expiry, scheduling, grace duration, and all Lease holding windows are unchanged.

## Verification

Validation was rerun on the exact head above:

- Full `/api` unit suite: 663 total, 662 pass, 1 skip, 0 fail
- `npm run lint`: pass
- `npm run typecheck`: pass
- Targeted DB plan test, `merge-tail-readiness.dbtest.ts`: 27/27 pass
- Default PostgreSQL planner uses `TaskActivity_release_deferred_createdAt_id_idx`, with no `TaskActivity` sequential scan or explicit sort.
- `git diff --check`: pass

The preceding performance-closure head also passed the five brief-targeted DB files 113/113, migration deploy for all 41 migrations, Prisma drift check with `No difference detected`, and Prisma schema validation. This test-only delta does not change production, the migration, or Lease behavior.

The full Merge gate was intentionally not run for this candidate PR.

## Out of scope observed

A mutable persisted handoff status row (`pending | consumed | released`) is not included. Adding it would require a schema migration, expand the run-claim consumer write surface, and introduce migration/upgrade and race coverage outside this candidate's targeted scope. This change instead preserves append-only `TaskActivity` history for handoff pending/released/invalid and release deferred/released/invalid states, deriving consumer state from the existing `Run` record.

No HTTP route was added or removed, and route response shapes are unchanged.