### PR TITLE
refactor(runner): retire failure envelope mirror

### DIFF
--- a/packages/db/src/failure-envelope.test.ts
+++ b/packages/db/src/failure-envelope.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { FAILURE_EVIDENCE_LIMIT, truncateEvidence } from "./failure-envelope.js";
+
+test("truncation keeps the tail, where a CLI states its verdict", () => {
+  const noise = "progress\n".repeat(2_000);
+  const summary = truncateEvidence(`${noise}fatal: Authentication failed`);
+  assert.ok(summary);
+  assert.ok(summary.endsWith("fatal: Authentication failed"), "the verdict at the end of the stream must survive");
+  assert.match(summary, /^…\[\d+ earlier characters truncated\]\n/u);
+  assert.ok(summary.length <= FAILURE_EVIDENCE_LIMIT + 64);
+});

--- a/packages/db/src/failure-envelope.ts
+++ b/packages/db/src/failure-envelope.ts
@@ -24,12 +24,6 @@ import type { FailureClass } from "@prisma/client";
  * here is already the truncated, channel-separated form that evidence storage
  * wants, so growing it later means adding rows of detail, not reinterpreting
  * what is here.
- *
- * The runner package cannot import this module — it has no `@anneal/db`
- * dependency on purpose, because it must not be able to reach a database. It
- * mirrors this shape in `packages/runner/src/envelope.ts`; this file is the
- * canonical definition, and the API's zod schema is the boundary that catches
- * drift between the two.
  */
 export type FailureEnvelope = {
   /** Bumped when the meaning of a field changes. An API that does not

--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -1,22 +1,10 @@
 import { statfs } from "node:fs/promises";
 
-import type { RegressionRepairHandoff } from "@anneal/db";
+import type { CleanupStatus, FailureClass, FailureEnvelope, RegressionRepairHandoff } from "@anneal/db";
 
 import type { RunnerConfig, RunnerKind } from "./config.js";
-import type { FailureEnvelope } from "./envelope.js";
 
-export type FailureClass =
-  | "BINARY_NOT_FOUND"
-  | "AUTH_REQUIRED"
-  | "RATE_LIMITED"
-  | "CANCELLED_OR_TIMED_OUT"
-  | "TOOL_FAILED"
-  | "TRANSIENT_PROVIDER"
-  | "PROTOCOL_ERROR"
-  | "TASK_FAILED"
-  | "BUDGET_EXCEEDED";
-
-export type CleanupStatus = "SUCCEEDED" | "FAILED" | "RETAINED";
+export type { CleanupStatus, FailureClass } from "@anneal/db";
 export type CodexServiceTier = "DEFAULT" | "FAST";
 export type CancellationRequest = { requestId: string; reason: string; requestedAt: string };
 export type HeartbeatResult = { ok: boolean; cancellation: CancellationRequest | null };

--- a/packages/runner/src/envelope.test.ts
+++ b/packages/runner/src/envelope.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { ExitEvidence } from "./adapters.js";
-import { buildFailureEnvelope, FAILURE_EVIDENCE_LIMIT, summarizeEvidence } from "./envelope.js";
+import { buildFailureEnvelope } from "./envelope.js";
 import { CommandTimeoutError } from "./exec.js";
 
 const evidence = (overrides: Partial<ExitEvidence> = {}): ExitEvidence => ({
@@ -40,15 +40,6 @@ test("empty and whitespace-only streams become null rather than empty strings", 
   assert.equal(envelope.stdoutSummary, null);
   assert.equal(envelope.providerError, null);
   assert.equal(envelope.runnerClass, null);
-});
-
-test("truncation keeps the tail, where a CLI states its verdict", () => {
-  const noise = "progress\n".repeat(2_000);
-  const summary = summarizeEvidence(`${noise}fatal: Authentication failed`);
-  assert.ok(summary);
-  assert.ok(summary.endsWith("fatal: Authentication failed"), "the verdict at the end of the stream must survive");
-  assert.match(summary, /^…\[\d+ earlier characters truncated\]\n/u);
-  assert.ok(summary.length <= FAILURE_EVIDENCE_LIMIT + 64);
 });
 
 test("a typed CommandTimeoutError marks the envelope timed out and transient", () => {

--- a/packages/runner/src/envelope.ts
+++ b/packages/runner/src/envelope.ts
@@ -1,18 +1,23 @@
+import {
+  FAILURE_ENVELOPE_VERSION,
+  truncateEvidence,
+  type FailureClass,
+  type FailureEnvelope,
+  type FailurePhase,
+} from "@anneal/db";
+
 import type { ExitEvidence } from "./adapters.js";
-import type { FailureClass } from "./api.js";
 import type { DeliveryFailure } from "./delivery.js";
 import { isCommandTimeout } from "./exec.js";
 import { isTransientNetworkError } from "./network-retry.js";
 
+export {
+  type FailureEnvelope,
+  type FailurePhase,
+  truncateEvidence as summarizeEvidence,
+} from "@anneal/db";
+
 /**
- * The runner half of the structured failure envelope.
- *
- * `packages/db/src/failure-envelope.ts` is the canonical definition; this is a
- * hand-kept mirror, for the same reason `FailureClass` and `CleanupStatus` are
- * mirrored in api.ts — this package deliberately does not import the Prisma
- * client. The API's zod schema for the complete route is the boundary that
- * catches drift.
- *
  * What this module does *not* do is decide anything. It reports facts: which
  * phase the run was in, what exited with what, which channel each piece of text
  * came off, and whether the runner's own typed `CommandTimeoutError` fired. The
@@ -21,43 +26,6 @@ import { isTransientNetworkError } from "./network-retry.js";
  * regex sweep that produced it is precisely what misread an agent's stdout as
  * an auth failure.
  */
-export type FailureEnvelope = {
-  version: number;
-  phase: FailurePhase;
-  runnerClass: FailureClass | null;
-  exitCode: number | null;
-  signal: string | null;
-  terminationReason: string | null;
-  terminalEventSeen: boolean;
-  terminalSuccess: boolean;
-  agentExited: boolean;
-  providerError: string | null;
-  stderrSummary: string | null;
-  stdoutSummary: string | null;
-  timedOut: boolean;
-  transient: boolean;
-  timeoutMs: number | null;
-};
-
-export type FailurePhase = "PROVISION" | "EXECUTE" | "DELIVER" | "COMPLETE";
-
-export const FAILURE_ENVELOPE_VERSION = 1;
-
-export const FAILURE_EVIDENCE_LIMIT = 4_000;
-
-/** Keeps the tail: a CLI states its verdict last, and a head-truncated stderr is
- *  a progress log with the error cut off. */
-export const summarizeEvidence = (
-  value: string | null | undefined,
-  limit: number = FAILURE_EVIDENCE_LIMIT,
-): string | null => {
-  const text = value?.trim();
-  if (!text) return null;
-  if (text.length <= limit) return text;
-  const dropped = text.length - limit;
-  return `…[${dropped} earlier characters truncated]\n${text.slice(text.length - limit)}`;
-};
-
 export const buildFailureEnvelope = (input: {
   phase: FailurePhase;
   evidence: ExitEvidence;
@@ -85,9 +53,9 @@ export const buildFailureEnvelope = (input: {
     terminalEventSeen: input.evidence.terminalEventSeen,
     terminalSuccess: input.evidence.terminalSuccess,
     agentExited: input.agentExited,
-    providerError: summarizeEvidence(input.evidence.providerError),
-    stderrSummary: summarizeEvidence(input.evidence.stderr),
-    stdoutSummary: summarizeEvidence(input.evidence.stdout),
+    providerError: truncateEvidence(input.evidence.providerError),
+    stderrSummary: truncateEvidence(input.evidence.stderr),
+    stdoutSummary: truncateEvidence(input.evidence.stdout),
     timedOut: timeout !== null,
     transient: timeout !== null || (input.error !== undefined && isTransientNetworkError(input.error)),
     timeoutMs: timeout?.timeoutMs ?? null,


### PR DESCRIPTION
## Summary

- make `@anneal/db` the single failure-envelope contract seam
- keep only runner-owned evidence conversion in `envelope.ts`
- replace mirrored `FailureClass` and `CleanupStatus` declarations with canonical type exports
- move truncation behavior coverage to the db contract test

## Verification

- `npm run lint`
- `node --import tsx --test packages/runner/src/envelope.test.ts packages/db/src/failure-envelope.test.ts`
- `npm run typecheck -w @anneal/db`
- `npm run typecheck -w @anneal/runner`