### PR TITLE
refactor(api): unify template refusal handling

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -161,7 +161,6 @@ import { InboxRunFenceRefusal, supersedeTaskInboxMessage, suspendForInbox } from
 import { createStarterInstallation, onboardingInput, onboardingStatus } from "./onboarding.js";
 import { preflightOnboardingRepository, RepositoryPreflightError } from "./onboarding-preflight.js";
 import { instantiateTemplate, isUsableTemplateVariable } from "./templates.js";
-import { isTemplateInstantiationRefusal } from "./template-errors.js";
 import type { SpecificationReader } from "./specification-fidelity.js";
 import {
   readCommitted,
@@ -803,18 +802,7 @@ const inboxQuestionInput = z.object({
   resumableUntil: z.coerce.date().nullable().optional(),
 });
 const stepOverrideInput = z.object({ assigneeAgentId: id }).strict();
-const stepOverridesInput = z.record(z.string(), stepOverrideInput).superRefine((overrides, context) => {
-  for (const stepIndex of Object.keys(overrides)) {
-    if (!/^[1-9]\d*$/u.test(stepIndex)) {
-      context.addIssue({
-        code: "custom",
-        path: [stepIndex],
-        message: `Step override key ${stepIndex} must be a positive decimal step index without leading zeros`,
-        params: { templateRefusalCode: "step_override_invalid_key" },
-      });
-    }
-  }
-});
+const stepOverridesInput = z.record(z.string(), stepOverrideInput);
 const instantiateTemplateInput = z.object({
   repoId: id,
   variables: z.record(z.string(), z.string().refine(isUsableTemplateVariable, "Template variables must not be blank")),
@@ -828,31 +816,7 @@ const instantiateTemplateInput = z.object({
   if (branchName !== undefined && !isValidBranchName(branchName)) {
     context.addIssue({ code: "custom", path: ["variables", "branchName"], message: "Template branchName is not a valid Git branch name" });
   }
-  if (value.afterTaskId && value.autoStart) {
-    context.addIssue({
-      code: "custom",
-      path: ["afterTaskId"],
-      message: `afterTaskId ${value.afterTaskId} cannot be combined with autoStart=true; a bound chain waits for its predecessor`,
-      params: { templateRefusalCode: "dispatch_conflicts_with_auto_start" },
-    });
-  }
 });
-const isTemplateInputError = (error: unknown): error is Error => (
-  error instanceof Error
-  && /(not found|has no|is archived|Missing template|Unknown template|must be agent|Invalid template branch)/iu.test(error.message)
-);
-const templateSchemaRefusal = (error: unknown): Refusal | null => {
-  if (!(error instanceof z.ZodError)) return null;
-  const issue = error.issues.find((candidate) => {
-    const params = (candidate as unknown as { params?: Record<string, unknown> }).params;
-    return typeof params?.templateRefusalCode === "string";
-  });
-  if (!issue) return null;
-  const params = (issue as unknown as { params?: Record<string, unknown> }).params;
-  return typeof params?.templateRefusalCode === "string"
-    ? refusal("invalid-request", issue.message, { code: params.templateRefusalCode })
-    : null;
-};
 // `Fire now` merges over the template's own defaults, so an all-defaulted
 // trigger fires from an empty body.
 const manualFireInput = z.object({
@@ -1159,20 +1123,15 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     }
     const resolved = resolvePayloadVariables(template, payload as Record<string, unknown>);
     if ("unresolved" in resolved) return context.json({ error: "Unresolved template variables", unresolved: resolved.unresolved }, 400);
-    try {
-      const result = await instantiateTemplate(db, template.projectId, template.id, {
-        repoId: template.webhookRepoId!, variables: resolved.variables, autoStart: true,
-      }, {
-        actorType: "webhook",
-        activityMetadata: { webhookTemplateId: template.id, firedAt: new Date().toISOString() },
-        source: TaskSource.WEBHOOK,
-        fire: { source: TriggerFireSource.WEBHOOK, dedupeKey },
-      });
-      return context.json({ chainId: result.chainId, taskIds: result.tasks.map((task) => task.id) }, 201);
-    } catch (error: unknown) {
-      if (isTemplateInputError(error)) return context.json({ error: error.message }, 400);
-      throw error;
-    }
+    const result = await instantiateTemplate(db, template.projectId, template.id, {
+      repoId: template.webhookRepoId!, variables: resolved.variables, autoStart: true,
+    }, {
+      actorType: "webhook",
+      activityMetadata: { webhookTemplateId: template.id, firedAt: new Date().toISOString() },
+      source: TaskSource.WEBHOOK,
+      fire: { source: TriggerFireSource.WEBHOOK, dedupeKey },
+    });
+    return context.json({ chainId: result.chainId, taskIds: result.tasks.map((task) => task.id) }, 201);
   });
 
   app.get("/files", async (context) => {
@@ -1984,24 +1943,12 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     }));
   });
   app.post("/projects/:projectId/task-templates/:templateId/instantiate", async (context) => {
-    try {
-      return context.json(await instantiateTemplate(
-        db,
-        id.parse(context.req.param("projectId")),
-        id.parse(context.req.param("templateId")),
-        await readJson(context.req.raw, instantiateTemplateInput),
-      ), 201);
-    } catch (error: unknown) {
-      if (isTemplateInstantiationRefusal(error)) {
-        return refusalJson(context, refusal("invalid-request", error.message, { code: error.code }));
-      }
-      const schemaRefusal = templateSchemaRefusal(error);
-      if (schemaRefusal) return refusalJson(context, schemaRefusal);
-      if (isTemplateInputError(error)) {
-        return context.json({ error: error.message }, 400);
-      }
-      throw error;
-    }
+    return context.json(await instantiateTemplate(
+      db,
+      id.parse(context.req.param("projectId")),
+      id.parse(context.req.param("templateId")),
+      await readJson(context.req.raw, instantiateTemplateInput),
+    ), 201);
   });
 
   // --- triggers: webhook-configured templates, their ledger, and manual fire --
@@ -2197,22 +2144,15 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     if (unresolved.length > 0) {
       return context.json({ error: `Unresolved template variables: ${unresolved.join(", ")}`, unresolved }, 400);
     }
-    try {
-      const result = await instantiateTemplate(db, trigger.projectId, trigger.id, {
-        repoId: trigger.webhookRepoId!, variables, autoStart: true,
-      }, {
-        actorType: "operator",
-        activityMetadata: { manualFireTemplateId: trigger.id, firedAt: new Date().toISOString() },
-        source: TaskSource.MANUAL,
-        fire: { source: TriggerFireSource.MANUAL },
-      });
-      return context.json({ chainId: result.chainId, taskIds: result.tasks.map((task) => task.id), fireId: result.fireId }, 201);
-    } catch (error: unknown) {
-      if (isTemplateInputError(error)) {
-        return context.json({ error: error.message }, 400);
-      }
-      throw error;
-    }
+    const result = await instantiateTemplate(db, trigger.projectId, trigger.id, {
+      repoId: trigger.webhookRepoId!, variables, autoStart: true,
+    }, {
+      actorType: "operator",
+      activityMetadata: { manualFireTemplateId: trigger.id, firedAt: new Date().toISOString() },
+      source: TaskSource.MANUAL,
+      fire: { source: TriggerFireSource.MANUAL },
+    });
+    return context.json({ chainId: result.chainId, taskIds: result.tasks.map((task) => task.id), fireId: result.fireId }, 201);
   });
 
   app.get("/tasks", async (context) => {

--- a/packages/api/src/refusal.ts
+++ b/packages/api/src/refusal.ts
@@ -11,6 +11,11 @@ import {
   type WorkflowRefusalReason,
 } from "@anneal/db";
 
+import {
+  isTemplateInstantiationRefusal,
+  type TemplateInstantiationRefusalCode,
+} from "./template-errors.js";
+
 export type RefusalReason =
   | WorkflowRefusalReason
   | "forbidden"
@@ -35,7 +40,7 @@ export type RefusalValue =
 export type RefusalDetail = Readonly<Record<string, RefusalValue> & { error?: never }>;
 
 export type Refusal = {
-  reason: RefusalReason;
+  reason: RefusalReason | TemplateInstantiationRefusalCode;
   message: string;
   detail?: RefusalDetail;
 };
@@ -48,6 +53,40 @@ export type RefusalResponse = {
 export const refusalResponse = (refusal: Refusal): RefusalResponse => {
   let status: RefusalResponse["status"];
   switch (refusal.reason) {
+    case "after_task_already_bound":
+    case "after_task_already_done":
+    case "after_task_archived":
+    case "after_task_not_chained":
+    case "after_task_not_found":
+    case "after_task_not_terminal":
+    case "dispatch_conflicts_with_auto_start":
+    case "implementation_route_agent_renamed":
+    case "implementation_route_conflicts_with_step_override":
+    case "implementation_route_unknown_agent":
+    case "repo_not_found":
+    case "step_override_agent_archived":
+    case "step_override_agent_not_found":
+    case "step_override_compound_implementation":
+    case "step_override_integrator_binding":
+    case "step_override_invalid_key":
+    case "step_override_missing_repo_grant":
+    case "step_override_step_not_agent":
+    case "step_override_too_many":
+    case "step_override_unknown_step":
+    case "template_agent_repo_grant_missing":
+    case "template_base_reference_missing":
+    case "template_base_reference_not_earlier":
+    case "template_branch_invalid":
+    case "template_compound_implementation_assignee_invalid":
+    case "template_first_step_not_agent":
+    case "template_has_no_instantiable_steps":
+    case "template_has_no_steps":
+    case "template_integrator_binding_invalid":
+    case "template_not_found":
+    case "template_step_agent_archived":
+    case "template_step_agent_missing":
+    case "template_variables_missing":
+    case "template_variables_unknown":
     case "invalid-request":
       status = 400;
       break;
@@ -87,6 +126,13 @@ export const refusalResponse = (refusal: Refusal): RefusalResponse => {
 };
 
 export const refusalFor = (error: unknown): Refusal | null => {
+  if (isTemplateInstantiationRefusal(error)) {
+    return {
+      reason: error.code,
+      message: error.message,
+      detail: { code: error.code },
+    };
+  }
   if (isWorkflowRefusalError(error)) return { reason: error.reason, message: error.message };
   if (isCompoundImplementationAssigneeError(error)) {
     return {

--- a/packages/api/src/template-errors.ts
+++ b/packages/api/src/template-errors.ts
@@ -1,13 +1,43 @@
-/**
- * Refusals raised while materialising a template chain.
- *
- * The instantiate route deliberately handles this type before its legacy
- * message-based compatibility matcher.  A refusal therefore keeps its stable
- * machine-readable code even when its human-facing wording changes.
- */
+export type TemplateInstantiationRefusalCode =
+  | "after_task_already_bound"
+  | "after_task_already_done"
+  | "after_task_archived"
+  | "after_task_not_chained"
+  | "after_task_not_found"
+  | "after_task_not_terminal"
+  | "dispatch_conflicts_with_auto_start"
+  | "implementation_route_agent_renamed"
+  | "implementation_route_conflicts_with_step_override"
+  | "implementation_route_unknown_agent"
+  | "repo_not_found"
+  | "step_override_agent_archived"
+  | "step_override_agent_not_found"
+  | "step_override_compound_implementation"
+  | "step_override_integrator_binding"
+  | "step_override_invalid_key"
+  | "step_override_missing_repo_grant"
+  | "step_override_step_not_agent"
+  | "step_override_too_many"
+  | "step_override_unknown_step"
+  | "template_agent_repo_grant_missing"
+  | "template_base_reference_missing"
+  | "template_base_reference_not_earlier"
+  | "template_branch_invalid"
+  | "template_compound_implementation_assignee_invalid"
+  | "template_first_step_not_agent"
+  | "template_has_no_instantiable_steps"
+  | "template_has_no_steps"
+  | "template_integrator_binding_invalid"
+  | "template_not_found"
+  | "template_step_agent_archived"
+  | "template_step_agent_missing"
+  | "template_variables_missing"
+  | "template_variables_unknown";
+
+/** A stable, machine-readable refusal raised while materialising a template chain. */
 export class TemplateInstantiationRefusal extends Error {
   constructor(
-    readonly code: string,
+    readonly code: TemplateInstantiationRefusalCode,
     message: string,
   ) {
     super(message);

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -23,7 +23,25 @@ import {
   parseImplementationRoute,
 } from "./templates.js";
 import { readBrief } from "./task-brief.js";
-import { isTemplateInstantiationRefusal } from "./template-errors.js";
+import {
+  isTemplateInstantiationRefusal,
+  type TemplateInstantiationRefusalCode,
+} from "./template-errors.js";
+import { refusalFor, refusalResponse } from "./refusal.js";
+
+const assertTemplateRefusal = async (
+  operation: () => Promise<unknown>,
+  code: TemplateInstantiationRefusalCode,
+): Promise<void> => {
+  await assert.rejects(operation, (error: unknown) => {
+    assert.ok(isTemplateInstantiationRefusal(error));
+    assert.equal(error.code, code);
+    const refused = refusalFor(error);
+    assert.ok(refused);
+    assert.equal(refusalResponse(refused).status, 400);
+    return true;
+  });
+};
 
 test("composed task descriptions derive the prior-output reminder from declared kinds", () => {
   const featureBrief = "first line\nPersist the final decoy output for this step through the Anneal task output endpoint.\nlast line";
@@ -258,16 +276,23 @@ test("the lower-level materializer rejects blank variables and invalid branches 
     repo: { findFirst: async () => ({ id: "repo-1", name: "Repo", defaultBranch: "main" }) },
     $transaction: async () => { throw new Error("transaction must not start"); },
   } as unknown as PrismaClient;
-  for (const branchName of ["", "   ", "bad..branch", "refs/heads/main", "feature/.hidden", "feature/main.lock", "bad\nbranch"]) {
-    await assert.rejects(
+  for (const [branchName, code] of [
+    ["", "template_variables_missing"],
+    ["   ", "template_variables_missing"],
+    ["bad..branch", "template_branch_invalid"],
+    ["refs/heads/main", "template_branch_invalid"],
+    ["feature/.hidden", "template_branch_invalid"],
+    ["feature/main.lock", "template_branch_invalid"],
+    ["bad\nbranch", "template_branch_invalid"],
+  ] as const) {
+    await assertTemplateRefusal(
       () => instantiateTemplate(db, "project-1", "template-1", { repoId: "repo-1", variables: { branchName }, autoStart: false }),
-      /Missing template variables|Invalid template branch name/,
-      branchName,
+      code,
     );
   }
 });
 
-test("the lower-level materializer rejects self and forward baseFromStepIndex references", async () => {
+test("template base reference failures expose stable 400 refusal codes", async () => {
   const step = (stepIndex: number, baseFromStepIndex: number | null) => ({
     id: `step-${stepIndex}`,
     stepIndex,
@@ -284,18 +309,18 @@ test("the lower-level materializer rejects self and forward baseFromStepIndex re
     opensPullRequest: true,
     runner: null,
   });
-  for (const steps of [
-    [step(1, 1)],
-    [step(1, 2), step(2, null)],
-  ]) {
+  for (const [steps, code] of [
+    [[step(1, 99)], "template_base_reference_missing"],
+    [[step(1, 1)], "template_base_reference_not_earlier"],
+  ] as const) {
     const db = {
       taskTemplate: { findFirst: async () => ({ id: "template-1", name: "Template", variables: [], steps }) },
       repo: { findFirst: async () => ({ id: "repo-1", name: "Repo", defaultBranch: "main" }) },
       $transaction: async () => { throw new Error("transaction must not start"); },
     } as unknown as PrismaClient;
-    await assert.rejects(
+    await assertTemplateRefusal(
       () => instantiateTemplate(db, "project-1", "template-1", { repoId: "repo-1", variables: {} }),
-      /baseFromStepIndex must reference a strictly earlier stepIndex/u,
+      code,
     );
   }
 });
@@ -330,9 +355,9 @@ test("an agent archived after the step check still loses to the locked re-read",
       taskActivity: { createMany: async () => ({ count: 0 }) },
     }),
   } as unknown as PrismaClient;
-  await assert.rejects(
+  await assertTemplateRefusal(
     () => instantiateTemplate(db, "project-1", "template-1", { repoId: "repo-1", variables: {}, autoStart: false }),
-    /Template step Implementation agent Racing Agent is archived/,
+    "template_step_agent_archived",
   );
   assert.equal(taskCreates, 0, "no chain row is written once the lock says archived");
 });
@@ -378,9 +403,9 @@ test("a serializable conflict raised by the raw Agent lock is retried, not surfa
       taskActivity: { createMany: async () => ({ count: 0 }) },
     }),
   } as unknown as PrismaClient;
-  await assert.rejects(
+  await assertTemplateRefusal(
     () => instantiateTemplate(db, "project-1", "template-1", { repoId: "repo-1", variables: {}, autoStart: false }),
-    /Template step Implementation agent Racing Agent is archived/,
+    "template_step_agent_archived",
   );
   assert.equal(attempts, 2, "the conflicting attempt is retried once and then decides on the re-read");
 });
@@ -404,9 +429,9 @@ test("template instantiation rejects an archived step agent and names the step",
     },
     repo: { findFirst: async () => ({ id: "repo-1", name: "Repo", defaultBranch: "main" }) },
   } as unknown as PrismaClient;
-  await assert.rejects(
+  await assertTemplateRefusal(
     () => instantiateTemplate(db, "project-1", "template-1", { repoId: "repo-1", variables: {}, autoStart: false }),
-    /Template step Implementation agent Archived Agent is archived/,
+    "template_step_agent_archived",
   );
 });
 
@@ -480,9 +505,9 @@ test("step override structural refusals happen before template reads and carry s
     [{ "1.5": { assigneeAgentId: "agent" } }, "step_override_invalid_key"],
     [Object.fromEntries(Array.from({ length: 65 }, (_, index) => [String(index + 1), { assigneeAgentId: "agent" }])), "step_override_too_many"],
   ] as const) {
-    await assert.rejects(
+    await assertTemplateRefusal(
       () => instantiateTemplate(db, "project-1", "template-1", { repoId: "repo-1", variables: {}, stepOverrides }),
-      (error: unknown) => isTemplateInstantiationRefusal(error) && error.code === code,
+      code,
     );
   }
 });
@@ -567,26 +592,24 @@ test("an unbound direct chain omits revalidation while Route overrides the renum
   assert.deepEqual(created.map((task) => task.chainLayer), [1, 2]);
   assert.deepEqual(created.map((task) => task.targetBranch), ["main", result.branchName]);
 
-  await assert.rejects(
+  await assertTemplateRefusal(
     () => instantiateTemplate(db, "project-1", "template-1", {
       repoId: "repo-1",
       variables: {},
       description: "Build it\nRoute: implementation=senior-dev\n",
       stepOverrides: { "2": { assigneeAgentId: routed.id } },
     }),
-    (error: unknown) => isTemplateInstantiationRefusal(error)
-      && error.code === "implementation_route_conflicts_with_step_override",
+    "implementation_route_conflicts_with_step_override",
   );
 
   lockedRouteAgentName = "renamed-senior-dev";
-  await assert.rejects(
+  await assertTemplateRefusal(
     () => instantiateTemplate(db, "project-1", "template-1", {
       repoId: "repo-1",
       variables: {},
       description: "Build it\nRoute: implementation=senior-dev\n",
     }),
-    (error: unknown) => isTemplateInstantiationRefusal(error)
-      && error.code === "implementation_route_agent_renamed",
+    "implementation_route_agent_renamed",
   );
 
   lockedRouteAgentName = routed.name;

--- a/packages/api/src/templates.ts
+++ b/packages/api/src/templates.ts
@@ -18,7 +18,10 @@ import {
 
 import { isValidBranchName } from "./branch-name.js";
 import { composeBrief } from "./task-brief.js";
-import { TemplateInstantiationRefusal } from "./template-errors.js";
+import {
+  TemplateInstantiationRefusal,
+  type TemplateInstantiationRefusalCode,
+} from "./template-errors.js";
 import { serializable } from "./transaction.js";
 
 export type InstantiateTemplateInput = {
@@ -99,13 +102,8 @@ type DispatchChainRow = {
   name: string;
 };
 
-const overrideRefusal = (
-  code: string,
-  message: string,
-): TemplateInstantiationRefusal => new TemplateInstantiationRefusal(code, message);
-
-const bindingRefusal = (
-  code: string,
+const templateRefusal = (
+  code: TemplateInstantiationRefusalCode,
   message: string,
 ): TemplateInstantiationRefusal => new TemplateInstantiationRefusal(code, message);
 
@@ -157,10 +155,16 @@ const assertValidBaseReferences = (
   for (const step of steps) {
     if (step.baseFromStepIndex == null) continue;
     if (!indexes.has(step.baseFromStepIndex)) {
-      throw new Error(`Template step ${step.name} baseFromStepIndex ${step.baseFromStepIndex} does not reference the same template`);
+      throw templateRefusal(
+        "template_base_reference_missing",
+        `Template step ${step.name} baseFromStepIndex ${step.baseFromStepIndex} does not reference the same template`,
+      );
     }
     if (step.baseFromStepIndex >= step.stepIndex) {
-      throw new Error(`Template step ${step.name} baseFromStepIndex must reference a strictly earlier stepIndex`);
+      throw templateRefusal(
+        "template_base_reference_not_earlier",
+        `Template step ${step.name} baseFromStepIndex must reference a strictly earlier stepIndex`,
+      );
     }
   }
 };
@@ -181,7 +185,7 @@ export const instantiateTemplate = async (
   } = {},
 ) => {
   if (input.afterTaskId && input.autoStart) {
-    throw bindingRefusal(
+    throw templateRefusal(
       "dispatch_conflicts_with_auto_start",
       `afterTaskId ${input.afterTaskId} cannot be combined with autoStart=true; a bound chain waits for its predecessor`,
     );
@@ -191,14 +195,14 @@ export const instantiateTemplate = async (
   };
   let overrideEntries = Object.entries(effectiveStepOverrides);
   if (overrideEntries.length > 64) {
-    throw overrideRefusal(
+    throw templateRefusal(
       "step_override_too_many",
       `stepOverrides contains ${overrideEntries.length} entries; at most 64 step overrides are allowed`,
     );
   }
   for (const [stepIndex] of overrideEntries) {
     if (!stepOverrideKey.test(stepIndex)) {
-      throw overrideRefusal(
+      throw templateRefusal(
         "step_override_invalid_key",
         `Step override key ${stepIndex} must be a positive decimal step index without leading zeros`,
       );
@@ -211,24 +215,28 @@ export const instantiateTemplate = async (
     }),
     db.repo.findFirst({ where: { id: input.repoId, projectId } }),
   ]);
-  if (!template) throw new Error("Template not found in project");
-  if (!repo) throw new Error("Repo not found in project");
-  if (template.steps.length === 0) throw new Error("Template has no steps");
+  if (!template) throw templateRefusal("template_not_found", "Template not found in project");
+  if (!repo) throw templateRefusal("repo_not_found", "Repo not found in project");
+  if (template.steps.length === 0) throw templateRefusal("template_has_no_steps", "Template has no steps");
   const implementationRoute = template.name === "direct-engineer-workflow"
     ? parseImplementationRoute(input.description)
     : null;
   if (implementationRoute !== null && !implementationRouteAgents.has(implementationRoute)) {
-    throw overrideRefusal(
+    throw templateRefusal(
       "implementation_route_unknown_agent",
       `Unknown implementation route agent ${implementationRoute}; expected one of senior-dev-luna, senior-dev, frontend-dev`,
     );
   }
   const missing = template.variables.filter((variable) => !isUsableTemplateVariable(input.variables[variable]));
   const unknown = Object.keys(input.variables).filter((variable) => !template.variables.includes(variable));
-  if (missing.length > 0) throw new Error(`Missing template variables: ${missing.join(", ")}`);
-  if (unknown.length > 0) throw new Error(`Unknown template variables: ${unknown.join(", ")}`);
+  if (missing.length > 0) {
+    throw templateRefusal("template_variables_missing", `Missing template variables: ${missing.join(", ")}`);
+  }
+  if (unknown.length > 0) {
+    throw templateRefusal("template_variables_unknown", `Unknown template variables: ${unknown.join(", ")}`);
+  }
   if (input.variables.branchName !== undefined && !isValidBranchName(input.variables.branchName)) {
-    throw new Error("Invalid template branch name");
+    throw templateRefusal("template_branch_invalid", "Invalid template branch name");
   }
   assertValidBaseReferences(template.steps);
 
@@ -239,7 +247,9 @@ export const instantiateTemplate = async (
   const instantiatedTemplateSteps = omitRevalidation
     ? template.steps.filter((step) => step.id !== conditionalRevalidation.id)
     : template.steps;
-  if (instantiatedTemplateSteps.length === 0) throw new Error("Template has no instantiable steps");
+  if (instantiatedTemplateSteps.length === 0) {
+    throw templateRefusal("template_has_no_instantiable_steps", "Template has no instantiable steps");
+  }
 
   let routedImplementationStepIndex: number | null = null;
   if (implementationRoute !== null) {
@@ -250,7 +260,7 @@ export const instantiateTemplate = async (
     if (implementationStep) {
       const stepKey = String(implementationStep.stepIndex);
       if (effectiveStepOverrides[stepKey]) {
-        throw overrideRefusal(
+        throw templateRefusal(
           "implementation_route_conflicts_with_step_override",
           `Implementation Route conflicts with explicit stepOverrides entry ${stepKey}`,
         );
@@ -260,7 +270,7 @@ export const instantiateTemplate = async (
         select: { id: true, name: true, projectId: true, archivedAt: true },
       });
       if (!routeAgent) {
-        throw overrideRefusal(
+        throw templateRefusal(
           "step_override_agent_not_found",
           `Implementation route agent ${implementationRoute} was not found in this project`,
         );
@@ -272,7 +282,7 @@ export const instantiateTemplate = async (
       routedImplementationStepIndex = implementationStep.stepIndex;
       overrideEntries = Object.entries(effectiveStepOverrides);
       if (overrideEntries.length > 64) {
-        throw overrideRefusal(
+        throw templateRefusal(
           "step_override_too_many",
           `stepOverrides contains ${overrideEntries.length} entries; at most 64 step overrides are allowed`,
         );
@@ -283,7 +293,7 @@ export const instantiateTemplate = async (
   const templateStepsByIndex = new Map(template.steps.map((step) => [String(step.stepIndex), step]));
   for (const [stepIndex] of overrideEntries) {
     if (!templateStepsByIndex.has(stepIndex)) {
-      throw overrideRefusal(
+      throw templateRefusal(
         "step_override_unknown_step",
         `Step override names unknown template step ${stepIndex}`,
       );
@@ -314,13 +324,13 @@ export const instantiateTemplate = async (
   for (const effective of effectiveSteps) {
     const { step, override, assigneeAgent } = effective;
     if (override && step.assigneeType !== AssigneeType.AGENT) {
-      throw overrideRefusal(
+      throw templateRefusal(
         "step_override_step_not_agent",
         `Step override ${step.stepIndex} targets ${step.name}, whose assigneeType is ${step.assigneeType}; only AGENT steps may be overridden`,
       );
     }
     if (override && (!assigneeAgent || assigneeAgent.projectId !== projectId)) {
-      throw overrideRefusal(
+      throw templateRefusal(
         "step_override_agent_not_found",
         `Override agent ${override.assigneeAgentId} for step ${step.stepIndex} was not found in this project`,
       );
@@ -335,26 +345,29 @@ export const instantiateTemplate = async (
       taskTemplateName: template.name,
     });
     if (bindingRefusal) {
-      if (override) throw overrideRefusal("step_override_integrator_binding", `Template step ${step.name}: ${bindingRefusal}`);
-      throw new Error(`Template step ${step.name}: ${bindingRefusal}`);
+      if (override) throw templateRefusal("step_override_integrator_binding", `Template step ${step.name}: ${bindingRefusal}`);
+      throw templateRefusal("template_integrator_binding_invalid", `Template step ${step.name}: ${bindingRefusal}`);
     }
     if (step.assigneeType === AssigneeType.AGENT && !assigneeAgent) {
       if (override) {
-        throw overrideRefusal(
+        throw templateRefusal(
           "step_override_agent_not_found",
           `Override agent ${override.assigneeAgentId} for step ${step.stepIndex} was not found in this project`,
         );
       }
-      throw new Error(`Template step ${step.name} has no agent`);
+      throw templateRefusal("template_step_agent_missing", `Template step ${step.name} has no agent`);
     }
     if (assigneeAgent?.archivedAt) {
       if (override) {
-        throw overrideRefusal(
+        throw templateRefusal(
           "step_override_agent_archived",
           `Override agent ${assigneeAgent.name} (${assigneeAgent.id}) for step ${step.stepIndex} is archived`,
         );
       }
-      throw new Error(`Template step ${step.name} agent ${assigneeAgent.name} is archived`);
+      throw templateRefusal(
+        "template_step_agent_archived",
+        `Template step ${step.name} agent ${assigneeAgent.name} is archived`,
+      );
     }
     if (override && !compoundImplementationAssigneeValid(
       projectId,
@@ -362,7 +375,7 @@ export const instantiateTemplate = async (
       assigneeAgent,
       { stepIndex: step.stepIndex, outputKind: step.outputKind, taskTemplate: { name: template.name } },
     )) {
-      throw overrideRefusal(
+      throw templateRefusal(
         "step_override_compound_implementation",
         `Compound implementation step must remain assigned to the active in-project Agent implementation-plan-executioner (step ${step.stepIndex})`,
       );
@@ -373,12 +386,15 @@ export const instantiateTemplate = async (
       });
       if (!access) {
         if (override) {
-          throw overrideRefusal(
+          throw templateRefusal(
             "step_override_missing_repo_grant",
             `Override agent ${assigneeAgent.name} (${assigneeAgent.id}) for step ${step.stepIndex} has no grant for Repo ${repo.name}`,
           );
         }
-        throw new Error(`Agent ${assigneeAgent.name} has no grant for Repo ${repo.name}`);
+        throw templateRefusal(
+          "template_agent_repo_grant_missing",
+          `Agent ${assigneeAgent.name} has no grant for Repo ${repo.name}`,
+        );
       }
     }
   }
@@ -397,13 +413,13 @@ export const instantiateTemplate = async (
             select: { id: true, chainId: true },
           });
           if (!predecessorIdentity) {
-            throw bindingRefusal(
+            throw templateRefusal(
               "after_task_not_found",
               `Predecessor task ${input.afterTaskId} was not found in this project`,
             );
           }
           if (!predecessorIdentity.chainId) {
-            throw bindingRefusal(
+            throw templateRefusal(
               "after_task_not_chained",
               `Predecessor task ${input.afterTaskId} is not a chained task`,
             );
@@ -423,7 +439,7 @@ export const instantiateTemplate = async (
           });
           const lockedPredecessor = chainRows.find((row) => row.id === input.afterTaskId);
           if (!lockedPredecessor || !lockedPredecessor.chainId) {
-            throw bindingRefusal(
+            throw templateRefusal(
               "after_task_not_found",
               `Predecessor task ${input.afterTaskId} was not found in this project`,
             );
@@ -436,19 +452,19 @@ export const instantiateTemplate = async (
             select: { id: true },
           });
           if (occupied) {
-            throw bindingRefusal(
+            throw templateRefusal(
               "after_task_already_bound",
               `Predecessor task ${input.afterTaskId} is already bound to another chain`,
             );
           }
           if (lockedPredecessor.archivedAt) {
-            throw bindingRefusal(
+            throw templateRefusal(
               "after_task_archived",
               `Predecessor task ${lockedPredecessor.name} (${lockedPredecessor.id}) is archived`,
             );
           }
           if (lockedPredecessor.status === TaskStatus.DONE) {
-            throw bindingRefusal(
+            throw templateRefusal(
               "after_task_already_done",
               `Predecessor task ${lockedPredecessor.name} (${lockedPredecessor.id}) is already DONE`,
             );
@@ -462,7 +478,7 @@ export const instantiateTemplate = async (
             ? []
             : chainRows.filter((row) => executionLayer(row) === terminalLayer);
           if (predecessorLayer === null || terminalRows.length !== 1 || terminalRows[0]!.id !== lockedPredecessor.id) {
-            throw bindingRefusal(
+            throw templateRefusal(
               "after_task_not_terminal",
               `Predecessor task ${lockedPredecessor.name} (${lockedPredecessor.id}) is not the sole terminal task of its chain`,
             );
@@ -495,26 +511,29 @@ export const instantiateTemplate = async (
           const lockedAgent = lockedAgents.get(assigneeAgentId);
           if (!lockedAgent || lockedAgent.projectId !== projectId) {
             if (override) {
-              throw overrideRefusal(
+              throw templateRefusal(
                 "step_override_agent_not_found",
                 `Override agent ${assigneeAgentId} for step ${step.stepIndex} was not found in this project`,
               );
             }
-            throw new Error(`Template step ${step.name} agent was not found`);
+            throw templateRefusal("template_step_agent_missing", `Template step ${step.name} agent was not found`);
           }
           if (lockedAgent.archivedAt) {
             if (override) {
-              throw overrideRefusal(
+              throw templateRefusal(
                 "step_override_agent_archived",
                 `Override agent ${lockedAgent.name} (${assigneeAgentId}) for step ${step.stepIndex} is archived`,
               );
             }
-            throw new Error(`Template step ${step.name} agent ${lockedAgent.name} is archived`);
+            throw templateRefusal(
+              "template_step_agent_archived",
+              `Template step ${step.name} agent ${lockedAgent.name} is archived`,
+            );
           }
           if (implementationRoute !== null
             && step.stepIndex === routedImplementationStepIndex
             && lockedAgent.name !== implementationRoute) {
-            throw overrideRefusal(
+            throw templateRefusal(
               "implementation_route_agent_renamed",
               `Implementation route agent ${implementationRoute} changed identity before the chain was created`,
             );
@@ -526,9 +545,12 @@ export const instantiateTemplate = async (
           });
           if (lockedBindingRefusal) {
             if (override) {
-              throw overrideRefusal("step_override_integrator_binding", `Template step ${step.name}: ${lockedBindingRefusal}`);
+              throw templateRefusal("step_override_integrator_binding", `Template step ${step.name}: ${lockedBindingRefusal}`);
             }
-            throw new Error(`Template step ${step.name}: ${lockedBindingRefusal}`);
+            throw templateRefusal(
+              "template_integrator_binding_invalid",
+              `Template step ${step.name}: ${lockedBindingRefusal}`,
+            );
           }
           if (!compoundImplementationAssigneeValid(
             projectId,
@@ -537,8 +559,8 @@ export const instantiateTemplate = async (
             { stepIndex: step.stepIndex, outputKind: step.outputKind, taskTemplate: { name: template.name } },
           )) {
             const message = `Compound implementation step must remain assigned to the active in-project Agent implementation-plan-executioner (step ${step.stepIndex})`;
-            if (override) throw overrideRefusal("step_override_compound_implementation", message);
-            throw new Error(message);
+            if (override) throw templateRefusal("step_override_compound_implementation", message);
+            throw templateRefusal("template_compound_implementation_assignee_invalid", message);
           }
         }
         const grantedAgentIds = [...new Set(effectiveSteps.flatMap((effective) => (
@@ -550,12 +572,15 @@ export const instantiateTemplate = async (
             const effective = effectiveSteps.find((candidate) => candidate.assigneeAgentId === agentId);
             const agentName = effective?.assigneeAgent?.name ?? agentId;
             if (effective?.override) {
-              throw overrideRefusal(
+              throw templateRefusal(
                 "step_override_missing_repo_grant",
                 `Override agent ${agentName} (${agentId}) for step ${effective.step.stepIndex} has no grant for Repo ${repo.name}`,
               );
             }
-            throw new Error(`Agent ${agentName} has no grant for Repo ${repo.name}`);
+            throw templateRefusal(
+              "template_agent_repo_grant_missing",
+              `Agent ${agentName} has no grant for Repo ${repo.name}`,
+            );
           }
         }
         const tasks = [];
@@ -590,7 +615,9 @@ export const instantiateTemplate = async (
           } }));
         }
         const first = tasks[0]!;
-        if (first.assigneeType !== AssigneeType.AGENT) throw new Error("The first template step must be agent-executable");
+        if (first.assigneeType !== AssigneeType.AGENT) {
+          throw templateRefusal("template_first_step_not_agent", "The first template step must be agent-executable");
+        }
         if (input.autoStart ?? false) {
           await enqueueTaskRun(tx, first.id);
         }
@@ -650,7 +677,7 @@ export const instantiateTemplate = async (
     });
   } catch (error: unknown) {
     if (dispatchBindingUniqueConflict(error)) {
-      throw bindingRefusal(
+      throw templateRefusal(
         "after_task_already_bound",
         `Predecessor task ${input.afterTaskId} is already bound to another chain`,
       );


### PR DESCRIPTION
## Summary
- give every explicit template-instantiation refusal a stable typed code
- route all three template callers through the shared exhaustive refusal mapping
- remove message regex and Zod issue-param refusal channels
- replace prose-coupled tests with code and HTTP status assertions

## Verification
- npm run lint
- node --import tsx --test src/templates.test.ts
- node --import tsx --test src/refusal.test.ts