### PR TITLE
refactor(runner): centralize run authority

### DIFF
--- a/packages/runner/src/run-authority.test.ts
+++ b/packages/runner/src/run-authority.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { CancellationRequest } from "./api.js";
+import { createRunAuthority } from "./run-authority.js";
+
+type Provider = { id: string };
+
+const cancellation = (requestId: string): CancellationRequest => ({
+  requestId,
+  reason: "operator stop",
+  requestedAt: new Date(0).toISOString(),
+});
+
+test("revocation during an awaited launch drains the provider before launch returns", async () => {
+  let finishLaunch!: (provider: Provider) => void;
+  const launchResult = new Promise<Provider>((resolve) => { finishLaunch = resolve; });
+  const stops: Array<{ provider: Provider; reason: string }> = [];
+  const authority = createRunAuthority<Provider>({
+    stopProvider: async (provider, reason) => {
+      stops.push({ provider, reason });
+      return { processAlive: false };
+    },
+    acknowledgeCancellation: async () => undefined,
+  });
+
+  const launched = authority.launch(async () => launchResult);
+  const revoked = authority.adopt({ held: false, reason: "revoked" });
+  finishLaunch({ id: "provider-1" });
+
+  assert.equal(await launched, null);
+  await revoked;
+  assert.equal(await authority.checkpoint(), "revoked");
+  assert.deepEqual(stops, [{ provider: { id: "provider-1" }, reason: "fencing token rejected" }]);
+});
+
+test("duplicate cancellation acknowledges the first request once", async () => {
+  const acknowledgements: CancellationRequest[] = [];
+  const authority = createRunAuthority<Provider>({
+    stopProvider: async () => ({ processAlive: false }),
+    acknowledgeCancellation: async (request) => { acknowledgements.push(request); },
+  });
+  authority.abandonProviderLaunch();
+
+  await Promise.all([
+    authority.adopt({ held: false, reason: "cancelled", request: cancellation("cancel-1") }),
+    authority.adopt({ held: false, reason: "cancelled", request: cancellation("cancel-2") }),
+  ]);
+
+  assert.equal(await authority.checkpoint(), "cancelled");
+  assert.deepEqual(acknowledgements.map((request) => request.requestId), ["cancel-1"]);
+});
+
+test("cancellation wins a revocation race without stopping or acknowledging twice", async () => {
+  let finishLaunch!: (provider: Provider) => void;
+  const launchResult = new Promise<Provider>((resolve) => { finishLaunch = resolve; });
+  const stops: Provider[] = [];
+  const acknowledgements: CancellationRequest[] = [];
+  const authority = createRunAuthority<Provider>({
+    stopProvider: async (provider) => {
+      stops.push(provider);
+      return { processAlive: false };
+    },
+    acknowledgeCancellation: async (request) => { acknowledgements.push(request); },
+  });
+
+  const launched = authority.launch(async () => launchResult);
+  const revoked = authority.adopt({ held: false, reason: "revoked" });
+  const cancelled = authority.adopt({ held: false, reason: "cancelled", request: cancellation("cancel-1") });
+  finishLaunch({ id: "provider-1" });
+
+  assert.equal(await launched, null);
+  await Promise.all([revoked, cancelled]);
+  assert.equal(await authority.checkpoint(), "cancelled");
+  assert.deepEqual(stops, [{ id: "provider-1" }]);
+  assert.deepEqual(acknowledgements.map((request) => request.requestId), ["cancel-1"]);
+});

--- a/packages/runner/src/run-authority.ts
+++ b/packages/runner/src/run-authority.ts
@@ -1,0 +1,158 @@
+import type { Authority, CancellationRequest } from "./api.js";
+
+export type RunAuthorityState = "held" | "revoked" | "waiting-inbox" | "cancelled";
+
+type ProviderStopResult = { processAlive: boolean };
+
+export type RunAuthorityOptions<ProviderHandle extends object> = {
+  stopProvider: (handle: ProviderHandle, reason: string) => Promise<ProviderStopResult>;
+  acknowledgeCancellation: (request: CancellationRequest) => Promise<void>;
+  onRevocationStopError?: (error: unknown) => void;
+};
+
+export type RunAuthority<ProviderHandle extends object> = {
+  readonly state: RunAuthorityState;
+  readonly held: boolean;
+  adopt: (authority: Authority) => Promise<void>;
+  launch: (start: () => Promise<ProviderHandle>) => Promise<ProviderHandle | null>;
+  abandonProviderLaunch: () => void;
+  stopProvider: (handle: ProviderHandle, reason: string) => Promise<void>;
+  checkpoint: () => Promise<RunAuthorityState>;
+};
+
+type LaunchSlot<ProviderHandle> = {
+  readonly settled: Promise<ProviderHandle | null>;
+  readonly settle: (handle: ProviderHandle | null) => void;
+  started: boolean;
+};
+
+const launchSlot = <ProviderHandle>(): LaunchSlot<ProviderHandle> => {
+  let settle!: (handle: ProviderHandle | null) => void;
+  const settled = new Promise<ProviderHandle | null>((resolve) => { settle = resolve; });
+  return { settled, settle, started: false };
+};
+
+const stopReason = (state: Exclude<RunAuthorityState, "held" | "cancelled">): string =>
+  state === "waiting-inbox" ? "waiting for Inbox reply" : "fencing token rejected";
+
+/**
+ * Owns the Run's authority over every provider launch. A cancellation ACK is
+ * emitted only after the current launch can no longer produce an undrained
+ * process group.
+ */
+export const createRunAuthority = <ProviderHandle extends object>(
+  options: RunAuthorityOptions<ProviderHandle>,
+): RunAuthority<ProviderHandle> => {
+  let state: RunAuthorityState = "held";
+  let currentProvider: ProviderHandle | null = null;
+  // The initial slot spans provisioning: until the runner either launches or
+  // abandons it, a provider process could still appear.
+  let currentLaunch: LaunchSlot<ProviderHandle> | null = launchSlot();
+  const providerStops = new WeakMap<ProviderHandle, Promise<void>>();
+  const pendingTransitions = new Set<Promise<void>>();
+  let cancellationTask: Promise<void> | null = null;
+
+  const stopProvider = (handle: ProviderHandle, reason: string): Promise<void> => {
+    const active = providerStops.get(handle);
+    if (active) return active;
+    const stopping = options.stopProvider(handle, reason).then((result) => {
+      if (result.processAlive) throw new Error("Run still owns a live provider process");
+    });
+    providerStops.set(handle, stopping);
+    return stopping;
+  };
+
+  const track = (task: Promise<void>): Promise<void> => {
+    const tracked = task.finally(() => { pendingTransitions.delete(tracked); });
+    pendingTransitions.add(tracked);
+    return tracked;
+  };
+
+  const providerForCurrentLaunch = async (): Promise<ProviderHandle | null> => {
+    const launch = currentLaunch;
+    return launch ? launch.settled : currentProvider;
+  };
+
+  const stopCurrentProvider = async (reason: string): Promise<void> => {
+    const provider = await providerForCurrentLaunch();
+    if (provider) await stopProvider(provider, reason);
+  };
+
+  const adopt = (authority: Authority): Promise<void> => {
+    if (authority.held) return Promise.resolve();
+    if (state === "cancelled") return cancellationTask ?? Promise.resolve();
+
+    if (authority.reason === "cancelled") {
+      state = "cancelled";
+      cancellationTask ??= track((async () => {
+        await stopCurrentProvider(authority.request.reason);
+        await options.acknowledgeCancellation(authority.request);
+      })());
+      return cancellationTask;
+    }
+
+    if (state === "held" || (state === "revoked" && authority.reason === "waiting-inbox")) {
+      state = authority.reason;
+    }
+    const revokedState = state === "waiting-inbox" ? "waiting-inbox" : "revoked";
+    return track(stopCurrentProvider(stopReason(revokedState)).catch((error: unknown) => {
+      if (!options.onRevocationStopError) throw error;
+      options.onRevocationStopError(error);
+    }));
+  };
+
+  const launch = async (start: () => Promise<ProviderHandle>): Promise<ProviderHandle | null> => {
+    if (state !== "held") {
+      if (currentLaunch && !currentLaunch.started) {
+        currentLaunch.settle(null);
+        currentLaunch = null;
+      }
+      await checkpoint();
+      return null;
+    }
+
+    const slot = currentLaunch ?? launchSlot<ProviderHandle>();
+    currentLaunch = slot;
+    slot.started = true;
+    let launchedProvider: ProviderHandle;
+    try {
+      launchedProvider = await start();
+      currentProvider = launchedProvider;
+      slot.settle(launchedProvider);
+    } catch (error: unknown) {
+      slot.settle(null);
+      throw error;
+    } finally {
+      if (currentLaunch === slot) currentLaunch = null;
+    }
+
+    if (state !== "held") {
+      await checkpoint();
+      return null;
+    }
+    return launchedProvider;
+  };
+
+  const abandonProviderLaunch = (): void => {
+    if (!currentLaunch) return;
+    if (currentLaunch.started) throw new Error("Cannot abandon a provider launch after it started");
+    currentLaunch.settle(null);
+    currentLaunch = null;
+  };
+
+  const checkpoint = async (): Promise<RunAuthorityState> => {
+    if (cancellationTask) await cancellationTask;
+    while (pendingTransitions.size > 0) await Promise.all(pendingTransitions);
+    return state;
+  };
+
+  return {
+    get state() { return state; },
+    get held() { return state === "held"; },
+    adopt,
+    launch,
+    abandonProviderLaunch,
+    stopProvider,
+    checkpoint,
+  };
+};

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -17,7 +17,7 @@ import {
 } from "./runner.js";
 import { createControlPlaneDouble, createRoutedControlPlaneDouble, type ControlPlaneFetchHandler } from "./test-control-plane.js";
 import {
-  cleanupAgentScratch, provisionSessionConfig, writeSessionCredentials, type AgentScratch,
+  cleanupAgentScratch, provisionSessionConfig, type AgentScratch,
 } from "./workspace.js";
 
 const config = (workspaceRoot: string): RunnerConfig => ({
@@ -1234,64 +1234,6 @@ test("a heartbeat cancellation kills the provider group, acknowledges once, and 
     assert.deepEqual(acknowledgements[0]?.body.worktreeContainmentViolations, [await realpath(outsideWorktree)]);
     assert.equal(posts.some((post) => post.path.endsWith("/complete")), false);
     assert.equal(posts.some((post) => post.path.endsWith("/publication")), false);
-    await access(join(workspaces, "run-10"));
-  } finally {
-    await cleanupTestSession(root);
-    await rm(root, { recursive: true, force: true });
-  }
-});
-
-test("a provisioning cancellation is acknowledged only after provider launch is closed", async () => {
-  const root = await mkdtemp(join(tmpdir(), "runner-prelaunch-cancellation-"));
-  try {
-    const workspaces = join(root, "workspaces");
-    const log = join(root, "codex-argv.log");
-    const binary = join(root, "codex.sh");
-    await writeFile(binary, successfulCodexMutationStub(log, "sleep 30"));
-    await chmod(binary, 0o755);
-    const remote = await seedRemote(root);
-    await seedCodexAuth(root);
-    const posts: Array<{ path: string; body: Record<string, any> }> = [];
-    let credentialsWriting = false;
-    let cancellationSent = false;
-    setControlPlane(async (input: string | URL | Request, init?: RequestInit) => {
-      const path = String(input);
-      posts.push({ path, body: JSON.parse(String(init?.body ?? "{}")) as Record<string, any> });
-      if (credentialsWriting && path.endsWith("/heartbeat") && !cancellationSent) {
-        cancellationSent = true;
-        return new Response(JSON.stringify({
-          ok: false,
-          cancellation: { requestId: "cancel-before-launch", reason: "operator stop", requestedAt: new Date(0).toISOString() },
-        }), { status: 200, headers: { "content-type": "application/json" } });
-      }
-      return new Response(JSON.stringify({ ok: true, cancellation: null }), { status: 200, headers: { "content-type": "application/json" } });
-    });
-    const configured = { ...codexOnly(workspaces, root, binary), heartbeatIntervalMs: 20 };
-
-    await executeClaim(configured, {
-      ...mechanicalClaim,
-      executionMode: "agent",
-      runner: "CODEX",
-      session: testSession(root),
-      repo: { ...mechanicalClaim.repo, remoteUrl: remote, defaultBranch: "master" },
-      agent: { ...mechanicalClaim.agent, model: "gpt-5.6-sol" },
-      run: { ...mechanicalClaim.run, model: "gpt-5.6-sol", maxRunsPerTask: 3 },
-    }, {
-      writeSessionCredentials: async (...args) => {
-        const path = await writeSessionCredentials(...args);
-        credentialsWriting = true;
-        await new Promise<void>((resolve) => setTimeout(resolve, 80));
-        return path;
-      },
-    });
-
-    const acknowledgements = posts.filter((post) => post.path.endsWith("/cancel/acknowledge"));
-    assert.equal(cancellationSent, true);
-    assert.equal(acknowledgements.length, 1);
-    assert.equal(acknowledgements[0]?.body.workspacePath, join(workspaces, "run-10"));
-    assert.equal(acknowledgements[0]?.body.worktreeContainmentViolations, undefined);
-    assert.equal(posts.some((post) => post.path.endsWith("/start")), false);
-    assert.equal(posts.some((post) => post.path.endsWith("/complete")), false);
     await access(join(workspaces, "run-10"));
   } finally {
     await cleanupTestSession(root);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -22,7 +22,6 @@ import {
 import {
   controlPlane as defaultControlPlane,
   type ClaimedTask,
-  type CancellationRequest,
   type ControlPlane,
   type SessionEventPayload,
   type SessionTaskOutputStatus,
@@ -47,6 +46,7 @@ import {
 import { deliverUnderLease, openDeliveryLease, type DeliveryLease } from "./lease.js";
 import { openSessionConfig, type SessionConfigLease } from "./session-config-lease.js";
 import { readRegressionOutputHandoff } from "./regression-output-handoff.js";
+import { createRunAuthority } from "./run-authority.js";
 import {
   captureWorkspaceResult, captureWorkspaceSnapshot, cleanupAgentScratch, provisionAgentScratch, provisionSessionConfig,
   provisionWorkspace, reuseWorkspace, workspaceEnvironment, writeSessionCredentials,
@@ -170,34 +170,6 @@ export const executeClaim = async (
   let lease: DeliveryLease | null = null;
   let sessionConfigLease: SessionConfigLease | null = null;
   let heartbeatBusy = false;
-  let fencingRejected = false;
-  let waitingInbox = false;
-  let cancellation: CancellationRequest | null = null;
-  let cancellationPromise: Promise<void> | null = null;
-  let providerLaunchSettled = Promise.resolve();
-  let closeProviderLaunch = (): void => undefined;
-  const openProviderLaunch = (): void => {
-    let closed = false;
-    let resolveLaunch!: () => void;
-    providerLaunchSettled = new Promise<void>((resolve) => { resolveLaunch = resolve; });
-    closeProviderLaunch = () => {
-      if (closed) return;
-      closed = true;
-      resolveLaunch();
-    };
-  };
-  // Cancellation may arrive at any provisioning point before the first start.
-  openProviderLaunch();
-  const providerKillPromises = new WeakMap<RuntimeHandle, Promise<void>>();
-  const drainProviderHandle = (target: RuntimeHandle, reason: string): Promise<void> => {
-    const active = providerKillPromises.get(target);
-    if (active) return active;
-    const draining = adapter.kill(target, reason).then((killed) => {
-      if (killed.processAlive) throw new Error(`Run ${claim.run.id} still owns a live provider process`);
-    });
-    providerKillPromises.set(target, draining);
-    return draining;
-  };
   let budgetReason: string | null = null;
   let remediationFailureReason: string | null = null;
   let workspacePublicationForbidden = false;
@@ -239,6 +211,19 @@ export const executeClaim = async (
     }
     return worktreeContainmentViolations.length > 0 ? { worktreeContainmentViolations } : {};
   };
+  const runAuthority = createRunAuthority<RuntimeHandle>({
+    stopProvider: (target, reason) => adapter.kill(target, reason),
+    acknowledgeCancellation: async (request) => controlPlane.acknowledgeCancellation(
+      config,
+      claim,
+      request,
+      workspace,
+      await worktreeContainmentReport(),
+    ),
+    onRevocationStopError: (error) => {
+      console.error(`Unable to drain fenced Run ${claim.run.id}: ${errorMessage(error)}`);
+    },
+  });
   // The lease the claim granted; every successful heartbeat below moves it.
   // Delivery derives its deadline from this, not from "now", because by the
   // time the agent exits the last renewal can already be half a lease old.
@@ -260,7 +245,7 @@ export const executeClaim = async (
   const flushEvents = (): Promise<void> => {
     if (eventFlushPromise) return eventFlushPromise;
     eventFlushPromise = (async () => {
-      while (pendingEvents.length > 0 && !fencingRejected) {
+      while (pendingEvents.length > 0 && runAuthority.held) {
         // Keep the batch in the queue until the API accepts it. A failed append
         // therefore remains the head of the queue for the next flush attempt,
         // while the single worker prevents a later batch overtaking it.
@@ -272,56 +257,19 @@ export const executeClaim = async (
     return eventFlushPromise;
   };
 
-  const noteFencingError = async (error: unknown): Promise<void> => {
+  const adoptAuthorityError = async (error: unknown): Promise<boolean> => {
     const authority = controlPlane.authorityFor(error);
-    if (authority.held) return;
-    waitingInbox = authority.reason === "waiting-inbox";
-    fencingRejected = true;
-    if (handle) {
-      try {
-        await drainProviderHandle(handle, waitingInbox ? "waiting for Inbox reply" : "fencing token rejected");
-      } catch (killError: unknown) {
-        console.error(`Unable to drain fenced Run ${claim.run.id}: ${errorMessage(killError)}`);
-      }
-    }
+    await runAuthority.adopt(authority);
+    return authority.held;
   };
-
-  const acceptCancellation = async (request: CancellationRequest | null): Promise<void> => {
-    if (!request) return;
-    cancellation = request;
-    fencingRejected = true;
-    cancellationPromise ??= (async () => {
-      // ACK is proof that no provider group can still appear. Cancellation
-      // during credential preparation or adapter startup waits until launch is
-      // either abandoned or has produced the handle that must be killed.
-      await providerLaunchSettled;
-      if (handle) {
-        await drainProviderHandle(handle, request.reason);
-      }
-      await controlPlane.acknowledgeCancellation(
-        config,
-        claim,
-        request,
-        workspace,
-        await worktreeContainmentReport(),
-      );
-    })();
-    await cancellationPromise;
-  };
-
-  // Cancellation and fencing are mutated by heartbeat continuations, which
-  // TypeScript cannot observe across the awaited provider launch.
-  const providerStopReason = (): string => cancellation?.reason
-    ?? (waitingInbox ? "waiting for Inbox reply" : "fencing token rejected");
 
   const observeEventFlush = async (error: unknown): Promise<void> => {
-    await noteFencingError(error);
-    if (controlPlane.authorityFor(error).held) console.error("Event flush failed", error);
+    if (await adoptAuthorityError(error)) console.error("Event flush failed", error);
   };
 
   const drainEventsUnderLease = async (openLease: DeliveryLease): Promise<void> => {
     let lastError: unknown = null;
-    while (pendingEvents.length > 0 && !fencingRejected && !openLease.rejected) {
+    while (pendingEvents.length > 0 && runAuthority.held && !openLease.rejected) {
       try {
         // This may first await an active-run flush. Recheck the retained queue
         // after it settles so its rejection can never become the terminal
@@ -332,7 +280,7 @@ export const executeClaim = async (
         lastError = error;
         await observeEventFlush(error);
       }
-      if (pendingEvents.length === 0 || fencingRejected || openLease.rejected) break;
+      if (pendingEvents.length === 0 || !runAuthority.held || openLease.rejected) break;
       const remainingMs = openLease.deadline - Date.now();
       if (remainingMs <= 0) throw lastError ?? new Error("Event delivery lease expired with events still pending");
       // Reuse the lease's heartbeat cadence instead of introducing a separate
@@ -400,15 +348,12 @@ export const executeClaim = async (
         },
       }).then(async (result) => {
         const authority = controlPlane.authorityAfterHeartbeat(result);
-        if (!authority.held && authority.reason === "cancelled") await acceptCancellation(authority.request);
-        else leaseRenewedAt = Date.now();
-      }).catch((error: unknown) => {
+        await runAuthority.adopt(authority);
+        if (authority.held) leaseRenewedAt = Date.now();
+      }).catch(async (error: unknown) => {
         const authority = controlPlane.authorityFor(error);
-        if (!authority.held) {
-          waitingInbox = authority.reason === "waiting-inbox";
-          fencingRejected = true;
-        }
-        else console.error("Provisioning heartbeat failed", error);
+        await runAuthority.adopt(authority);
+        if (authority.held) console.error("Provisioning heartbeat failed", error);
       });
     }, config.heartbeatIntervalMs);
     workspace = claim.resume ? await reuseWorkspace(config, claim) : await provisionWorkspace(config, claim);
@@ -420,13 +365,10 @@ export const executeClaim = async (
     });
     const env = buildChildEnvironment(config, claim, scratch, workspace.path, workspace.commitHooksPath);
     const preflight = await adapter.preflight({ config, runner: claim.runner, model: claim.run.model, env });
-    if (fencingRejected) {
+    if (!runAuthority.held) {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
-      closeProviderLaunch();
-      if (cancellation) {
-        await cancellationPromise;
-        return;
-      }
+      runAuthority.abandonProviderLaunch();
+      if (await runAuthority.checkpoint() === "cancelled") return;
       const cleaned = await cleanup(config, claim, workspace, false, false, controlPlane);
       const { salvage: _salvage, ...cleanupOutcome } = cleaned;
       await controlPlane.recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((error: unknown) => {
@@ -436,6 +378,7 @@ export const executeClaim = async (
     }
     if (!preflight.ok) {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
+      runAuthority.abandonProviderLaunch();
       const evidence = preflightEvidence(preflight.error ?? "Preflight failed");
       const classified = adapter.classifyError(evidence);
       const worktreeReport = await worktreeContainmentReport();
@@ -463,25 +406,21 @@ export const executeClaim = async (
     }
 
     const credentialsPath = await (dependencies.writeSessionCredentials ?? writeSessionCredentials)(config, claim, workspace);
-    if (fencingRejected) {
+    if (!runAuthority.held) {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
-      closeProviderLaunch();
-      if (cancellation) await cancellationPromise;
+      runAuthority.abandonProviderLaunch();
+      await runAuthority.checkpoint();
       return;
     }
     const spec = { config, claim, workingDirectory: workspace.path, env, prompt, credentialsPath };
-    try {
-      handle = claim.resume
-        ? await adapter.resume({ ...spec, ...claim.resume }, sink)
-        : await adapter.start(spec, sink);
-    } finally {
-      closeProviderLaunch();
-    }
-    if (fencingRejected) {
+    const launchedHandle = await runAuthority.launch(() => claim.resume
+      ? adapter.resume({ ...spec, ...claim.resume }, sink)
+      : adapter.start(spec, sink));
+    if (!launchedHandle) {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
-      if (cancellation) await cancellationPromise;
       return;
     }
+    handle = launchedHandle;
     if (heartbeatTimer) clearInterval(heartbeatTimer);
     phase = "EXECUTE";
     // A resume dispatches its continuation input rather than the fresh prompt.
@@ -507,7 +446,7 @@ export const executeClaim = async (
 
     const executionStartedAt = handle.startedAt;
     heartbeatTimer = setInterval(() => {
-      if (!handle || heartbeatBusy || fencingRejected) return;
+      if (!handle || heartbeatBusy || !runAuthority.held) return;
       const heartbeatHandle = handle;
       heartbeatBusy = true;
       void (async () => {
@@ -526,7 +465,7 @@ export const executeClaim = async (
         });
         if (!decision.allowed && snapshot.processAlive) {
           budgetReason = `${decision.gate}: ${decision.reason}`;
-          await drainProviderHandle(heartbeatHandle, budgetReason);
+          await runAuthority.stopProvider(heartbeatHandle, budgetReason);
         }
         try {
           const result = await controlPlane.heartbeat(config, claim, {
@@ -535,19 +474,17 @@ export const executeClaim = async (
             inFlightTool: serializeTool(snapshot.inFlightTool),
           });
           const authority = controlPlane.authorityAfterHeartbeat(result);
-          if (!authority.held && authority.reason === "cancelled") await acceptCancellation(authority.request);
-          else if (snapshot.processAlive) leaseRenewedAt = Date.now();
+          await runAuthority.adopt(authority);
+          if (authority.held && snapshot.processAlive) leaseRenewedAt = Date.now();
         } catch (error: unknown) {
-          await noteFencingError(error);
-          if (controlPlane.authorityFor(error).held) console.error("Run heartbeat failed", error);
+          if (await adoptAuthorityError(error)) console.error("Run heartbeat failed", error);
         }
         // Event delivery is deliberately detached from the heartbeat attempt:
         // a failed or slow append must not occupy heartbeatBusy or suppress the
         // next lease renewal. The queue itself remains ordered and retryable.
-        if (!fencingRejected) void flushEvents().catch(observeEventFlush);
+        if (runAuthority.held) void flushEvents().catch(observeEventFlush);
       })().catch(async (error: unknown) => {
-        await noteFencingError(error);
-        if (controlPlane.authorityFor(error).held) console.error("Run heartbeat failed", error);
+        if (await adoptAuthorityError(error)) console.error("Run heartbeat failed", error);
       }).finally(() => { heartbeatBusy = false; });
     }, config.heartbeatIntervalMs);
 
@@ -555,7 +492,7 @@ export const executeClaim = async (
     const evidence = await completedHandle.exit;
     producedOutput = outputTail(evidence);
     let regressionHandoffPersisted = false;
-    if (!fencingRejected) {
+    if (runAuthority.held) {
       try {
         const handoff = await readRegressionOutputHandoff(config, claim, workspace);
         if (handoff) {
@@ -578,7 +515,7 @@ export const executeClaim = async (
     }
     if (adapterExecutionSucceeded(evidence)
       && claim.task.templateStep?.outputKind
-      && !fencingRejected
+      && runAuthority.held
       && remediationFailureReason === null) {
       let outputStatus: SessionTaskOutputStatus | null = null;
       try {
@@ -614,40 +551,24 @@ export const executeClaim = async (
         } else if (outputStatus.outputRemediationAllowed
           && outputKind
           && providerConversationId
-          && !fencingRejected) {
+          && runAuthority.held) {
           const beforeRemediation = await captureWorkspaceSnapshot(config, workspace);
           // Snapshotting is asynchronous. Cancellation may have been ACKed
           // against the already-closed first launch while it ran, so no second
           // provider launch may be opened without this fresh fence check.
-          if (!fencingRejected) {
+          if (runAuthority.held) {
             sink({
               source: "RUNNER",
               type: "TASK_OUTPUT_REMEDIATION_STARTED",
               payload: { outputKind, workspace: workspaceSnapshotEvidence(beforeRemediation) },
             });
-            let remediationHandle: RuntimeHandle | null = null;
-            openProviderLaunch();
-            try {
-              remediationHandle = await adapter.resume({
-                ...spec,
-                providerConversationId,
-                input: missingOutputRemediationInput(outputKind),
-              }, sink);
+            const remediationHandle = await runAuthority.launch(() => adapter.resume({
+              ...spec,
+              providerConversationId,
+              input: missingOutputRemediationInput(outputKind),
+            }, sink));
+            if (remediationHandle) {
               handle = remediationHandle;
-            } finally {
-              closeProviderLaunch();
-            }
-            // A cancellation can win while adapter.resume is constructing the
-            // process group. Recheck before awaiting its exit and drain the newly
-            // returned handle; the ACK waits on this same deduplicated kill.
-            if (fencingRejected && remediationHandle) {
-              await drainProviderHandle(
-                remediationHandle,
-                providerStopReason(),
-              );
-              if (cancellation) await cancellationPromise;
-            }
-            if (!fencingRejected && remediationHandle) {
               const remediationEvidence = await remediationHandle.exit;
               const afterRemediation = await captureWorkspaceSnapshot(config, workspace);
               const workspaceChanged = !sameWorkspaceSnapshot(beforeRemediation, afterRemediation);
@@ -712,8 +633,8 @@ export const executeClaim = async (
       }
     }
     if (heartbeatTimer) clearInterval(heartbeatTimer);
-    if (cancellation) {
-      await cancellationPromise;
+    if (runAuthority.state === "cancelled") {
+      await runAuthority.checkpoint();
       return;
     }
     phase = "DELIVER";
@@ -729,23 +650,20 @@ export const executeClaim = async (
       authorityFor: controlPlane.authorityFor,
       authorityAfterHeartbeat: controlPlane.authorityAfterHeartbeat,
     });
-    const adoptLeaseVerdict = (openLease: DeliveryLease): void => {
+    const adoptLeaseVerdict = async (openLease: DeliveryLease): Promise<void> => {
       if (!openLease.rejected) return;
-      fencingRejected = true;
-      waitingInbox = openLease.waitingInbox;
-      if (openLease.cancellation) cancellation = openLease.cancellation;
+      await runAuthority.adopt(openLease.cancellation
+        ? { held: false, reason: "cancelled", request: openLease.cancellation }
+        : { held: false, reason: openLease.waitingInbox ? "waiting-inbox" : "revoked" });
     };
-    adoptLeaseVerdict(lease);
+    await adoptLeaseVerdict(lease);
     await drainEventsUnderLease(lease);
     // Re-read: a periodic renewal may have been rejected while the events above
     // were still draining, and everything past this point writes to a remote.
-    adoptLeaseVerdict(lease);
-    if (fencingRejected) {
-      if (cancellation) {
-        await acceptCancellation(cancellation);
-        return;
-      }
-      if (waitingInbox) return;
+    await adoptLeaseVerdict(lease);
+    if (!runAuthority.held) {
+      const authorityState = await runAuthority.checkpoint();
+      if (authorityState === "cancelled" || authorityState === "waiting-inbox") return;
       const cleaned = await cleanup(config, claim, workspace, false, false, controlPlane);
       const { salvage: _salvage, ...cleanupOutcome } = cleaned;
       await controlPlane.recordLeaseIndependentCleanup(config, claim, cleanupOutcome).catch((error: unknown) => {
@@ -902,23 +820,19 @@ export const executeClaim = async (
     });
     scratch = null;
   } catch (error: unknown) {
-    closeProviderLaunch();
+    runAuthority.abandonProviderLaunch();
     if (heartbeatTimer) clearInterval(heartbeatTimer);
     const authority = controlPlane.authorityFor(error);
-    if (!authority.held) {
-      waitingInbox = authority.reason === "waiting-inbox";
-      fencingRejected = true;
-      if (handle) await adapter.kill(handle, waitingInbox ? "waiting for Inbox reply" : "fencing token rejected").catch(() => undefined);
-      if (waitingInbox) return;
-    }
+    await runAuthority.adopt(authority);
+    const authorityState = await runAuthority.checkpoint();
+    if (authorityState === "waiting-inbox" || authorityState === "cancelled") return;
     const message = errorMessage(error);
-    if (handle) await adapter.kill(handle, RUNNER_EXCEPTION_REASON).catch(() => undefined);
-    if (fencingRejected) {
-      if (cancellation) {
-        await acceptCancellation(cancellation);
-        return;
-      }
-      if (waitingInbox) return;
+    if (handle && authorityState === "held") {
+      await runAuthority.stopProvider(handle, RUNNER_EXCEPTION_REASON).catch((stopError: unknown) => {
+        console.error(`Unable to drain failed Run ${claim.run.id}: ${errorMessage(stopError)}`);
+      });
+    }
+    if (authorityState === "revoked") {
       if (workspace) {
         const cleaned = await cleanup(config, claim, workspace, false, false, controlPlane);
         const { salvage: _salvage, ...cleanupOutcome } = cleaned;
@@ -968,7 +882,7 @@ export const executeClaim = async (
       } : {}),
     });
   } finally {
-    closeProviderLaunch();
+    runAuthority.abandonProviderLaunch();
     if (heartbeatTimer) clearInterval(heartbeatTimer);
     lease?.close();
     // Throwaway by construction, so losing it costs nothing and leaving it


### PR DESCRIPTION
## Summary
- add a first-class run authority module for held, revoked, waiting-inbox, and cancelled transitions
- centralize provider launch fencing, deduplicated process-group stop, and single cancellation acknowledgement
- replace the provisioning cancellation world test with direct interface race tests

## Verification
- npm run lint
- node --import tsx --test packages/runner/src/run-authority.test.ts packages/runner/src/runner.test.ts