### PR TITLE
refactor(runner): deepen adapter declarations

### DIFF
--- a/apps/web/src/tests/agent-tools.test.tsx
+++ b/apps/web/src/tests/agent-tools.test.tsx
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
 import { JSDOM } from "jsdom";
 import { act } from "react";
@@ -9,6 +8,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { AgentToolsCard, BindingToggle } from "../pages/Agents";
 import { ENFORCED_BY, TOOL_KEYS } from "../lib/tools";
 import type { Agent, RunnerPreference } from "../lib/types";
+import { claudeDeclaration } from "../../../../packages/runner/src/adapters/claude.js";
+import { codexDeclaration } from "../../../../packages/runner/src/adapters/codex.js";
+import { piDeclaration } from "../../../../packages/runner/src/adapters/pi.js";
 
 const agent = (overrides: Partial<Agent> = {}): Agent => ({
   id: "a", projectId: "p", environmentId: "e", name: "senior-dev", title: "Senior Developer",
@@ -61,16 +63,12 @@ test("Custom model preferences always resolve to a concrete honesty answer", () 
   }
 });
 
-test("the web honesty map stays aligned with the two adapter maps", () => {
-  // Hand-copied intentionally: this fails review visibly if either side changes.
+test("the web honesty map stays aligned with the provider declarations", () => {
   assert.deepEqual(ENFORCED_BY, {
-    CLAUDE: ["BASH", "READ", "WRITE", "EDIT", "GLOB", "GREP", "WEB_FETCH", "WEB_SEARCH"],
-    CODEX: [],
-    PI: ["BASH", "READ", "WRITE", "EDIT"],
+    CLAUDE: claudeDeclaration.enforcedTools,
+    CODEX: codexDeclaration.enforcedTools,
+    PI: piDeclaration.enforcedTools,
   });
-  const source = readFileSync(new URL("../../../../packages/runner/src/adapters.ts", import.meta.url), "utf8");
-  assert.match(source, /const TOOL_ORDER: ToolKey\[\] = \["BASH", "READ", "WRITE", "EDIT", "GLOB", "GREP", "WEB_FETCH", "WEB_SEARCH"\]/u);
-  assert.match(source, /const PI_TOOL_NAMES:[\s\S]*?BASH: "bash", READ: "read", WRITE: "write", EDIT: "edit"/u);
 });
 
 test("BindingToggle keeps its switch in a flex wrapper to prevent the 3px baseline drift", () => {

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -12,9 +12,9 @@ import {
   claudePlatformSettingsPath, inputForRunner, launchArgv, mcpConfig, mcpServerPath, nodeBinaryPath, piExtensionPath,
   PREFLIGHT_REASONS, RUNNER_DEFINITIONS, RUNNER_KINDS, runtimeDescriptor, type AdapterState, type ExitEvidence,
 } from "./adapters.js";
-import { parseClaudeTranscript } from "./adapters/claude.js";
-import { CODEX_STARTER_MODEL, parseCodexEvent, parseCodexTranscript } from "./adapters/codex.js";
-import { parsePiTranscript } from "./adapters/pi.js";
+import { claudeDeclaration, parseClaudeTranscript } from "./adapters/claude.js";
+import { CODEX_STARTER_MODEL, codexDeclaration, parseCodexEvent, parseCodexTranscript } from "./adapters/codex.js";
+import { parsePiTranscript, piDeclaration } from "./adapters/pi.js";
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
 import { cleanupAgentScratch, provisionAgentScratch } from "./workspace.js";
@@ -374,6 +374,7 @@ test("Claude excludes host settings and auto-memory with the versioned platform 
     "/work",
   );
   assert.equal(env.CLAUDE_CONFIG_DIR, undefined);
+  assert.equal(env.AGENTOS_CODEX_SERVICE_TIER, undefined);
   assert.equal(env.HOME, "/runner", "Claude keeps the runner's existing HOME/authentication path");
 });
 
@@ -540,6 +541,13 @@ test("Codex fresh and resume launches pin the Run service tier explicitly", () =
     assert.ok(args.includes('model_reasoning_effort="max"'));
     assert.ok(args.includes("gpt-5.6-luna"));
   }
+  const env = buildChildEnvironment(
+    { path: "/bin", home: "/runner", apiUrl: "http://api", runAsPrefix: [] },
+    fast.claim,
+    scratch,
+    "/work",
+  );
+  assert.equal(env.AGENTOS_CODEX_SERVICE_TIER, "fast");
 });
 
 test("Codex fresh and resume launches preserve non-interactive tool authorization", () => {
@@ -658,6 +666,7 @@ test("PI runtime preflight rejects an openai-codex Run whose explicit service ti
     "/work",
   );
   assert.equal(env.AGENTOS_PI_EXPECTS_OPENAI_CODEX, "1");
+  assert.equal(env.AGENTOS_CODEX_SERVICE_TIER, "default");
   const result = await adapters.PI.preflight({
     config: {} as RunnerConfig,
     runner: "PI",
@@ -1666,16 +1675,27 @@ test("an adapter is substituted by injection, never by writing over the exported
   assert.notEqual(adapters.CODEX.classifyError, adapters.PI.classifyError);
 });
 
-test("the runner registry owns session isolation and startup preflight model identity", () => {
+test("the runner registry derives session policy from provider declarations", () => {
+  const declarations = { CLAUDE: claudeDeclaration, CODEX: codexDeclaration, PI: piDeclaration } as const;
   assert.deepEqual(
     Object.fromEntries(RUNNER_KINDS.map((runner) => [runner, {
       isolatesSessionConfig: RUNNER_DEFINITIONS[runner].isolatesSessionConfig,
       startupPreflightModel: RUNNER_DEFINITIONS[runner].startupPreflightModel,
+      binaryEnvironment: RUNNER_DEFINITIONS[runner].binaryEnvironment,
     }])),
     {
-      CLAUDE: { isolatesSessionConfig: false, startupPreflightModel: null },
-      CODEX: { isolatesSessionConfig: true, startupPreflightModel: CODEX_STARTER_MODEL },
-      PI: { isolatesSessionConfig: true, startupPreflightModel: "openai-codex/gpt-5.6-luna" },
+      CLAUDE: { isolatesSessionConfig: false, startupPreflightModel: null, binaryEnvironment: "CLAUDE_BINARY" },
+      CODEX: { isolatesSessionConfig: true, startupPreflightModel: CODEX_STARTER_MODEL, binaryEnvironment: "CODEX_BINARY" },
+      PI: { isolatesSessionConfig: true, startupPreflightModel: "openai-codex/gpt-5.6-luna", binaryEnvironment: "PI_BINARY" },
     },
   );
+  for (const runner of RUNNER_KINDS) {
+    assert.equal(RUNNER_DEFINITIONS[runner].args, declarations[runner].args);
+    assert.equal(RUNNER_DEFINITIONS[runner].childEnvironment, declarations[runner].childEnvironment);
+    assert.equal(RUNNER_DEFINITIONS[runner].provisionSessionConfig, declarations[runner].provisionSessionConfig);
+  }
+  assert.deepEqual(piDeclaration.protectedEnvironmentVariables, [
+    "PI_CODING_AGENT_DIR", "PI_CODING_AGENT_SESSION_DIR", "AGENTOS_CODEX_SERVICE_TIER", "AGENTOS_PI_EXPECTS_OPENAI_CODEX",
+  ]);
+  assert.equal(piDeclaration.launcherEnvironmentVariables.includes("PI_CODING_AGENT_SESSION_DIR"), false);
 });

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -13,6 +13,7 @@ import {
   launchAdapterArgv,
   mcpServerPath,
   nodeBinaryPath,
+  promptHashFor,
   type AdapterDeclaration,
   type CliAdapter,
   type ResumeSpec,

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -1,48 +1,54 @@
-import { execFile, spawn, type ChildProcess } from "node:child_process";
-import { createHash } from "node:crypto";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-
 import { stepRole } from "@anneal/db";
 
-import type { ClaimedTask, FailureClass } from "./api.js";
-import type { InFlightTool } from "./budget.js";
+import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
-import { isTransientNetworkError } from "./network-retry.js";
 import { manifestLines, toolsFor, type SessionToolTransport } from "./session-tool-contract.js";
 import type { AgentScratch } from "./workspace.js";
-import { createClaudeAdapter, claudeArgs, claudeChildEnvironment, provisionClaudeSessionConfig } from "./adapters/claude.js";
-import {
-  CODEX_STARTER_MODEL, codexArgs, codexChildEnvironment, codexNativeSubagentProfile, codexPlatformBaselinePath, createCodexAdapter,
-  provisionCodexSessionConfig,
-} from "./adapters/codex.js";
+import { claudeDeclaration, claudePlatformSettingsPath } from "./adapters/claude.js";
+import { codexDeclaration, codexPlatformBaselinePath } from "./adapters/codex.js";
 import { workspaceEnvironment } from "./adapters/environment.js";
-import { createPiAdapter, piArgs, piChildEnvironment, provisionPiSessionConfig } from "./adapters/pi.js";
+import { piDeclaration, piExtensionPath } from "./adapters/pi.js";
+import {
+  createCliAdapter,
+  launchAdapterArgv,
+  mcpServerPath,
+  nodeBinaryPath,
+  type AdapterDeclaration,
+  type CliAdapter,
+  type ResumeSpec,
+  type RunSpec,
+} from "./adapters/runtime.js";
 import type { SessionConfigOptions } from "./adapters/session-config.js";
+
+export * from "./adapters/runtime.js";
+export { claudePlatformSettingsPath } from "./adapters/claude.js";
+export { piExtensionPath } from "./adapters/pi.js";
 
 export const ADAPTER_VERSION = "2.1.0";
 
-export type ToolKey = "BASH" | "READ" | "WRITE" | "EDIT" | "GLOB" | "GREP" | "WEB_FETCH" | "WEB_SEARCH";
-export const TOOL_ORDER: ToolKey[] = ["BASH", "READ", "WRITE", "EDIT", "GLOB", "GREP", "WEB_FETCH", "WEB_SEARCH"];
-export const CLAUDE_TOOL_NAMES: Record<ToolKey, string> = {
-  BASH: "Bash", READ: "Read", WRITE: "Write", EDIT: "Edit",
-  GLOB: "Glob", GREP: "Grep", WEB_FETCH: "WebFetch", WEB_SEARCH: "WebSearch",
-};
-export const PI_TOOL_NAMES: Partial<Record<ToolKey, string>> = {
-  BASH: "bash", READ: "read", WRITE: "write", EDIT: "edit",
-};
+const ADAPTER_DECLARATIONS: Readonly<Record<RunnerKind, AdapterDeclaration>> = Object.freeze({
+  CLAUDE: claudeDeclaration,
+  CODEX: codexDeclaration,
+  PI: piDeclaration,
+});
 
-// The seat manual tells the agent to use the Anneal tools; the manifest has to
-// name them, or the agent has no way to know what it was actually granted.
+const COMMON_PROTECTED_SECRET_ENVIRONMENT = [
+  "GIT_CONFIG_GLOBAL", "AGENTOS_GATE_SERVER",
+  "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy",
+] as const;
+
+const PROTECTED_SECRET_ENVIRONMENT = new Set([
+  ...COMMON_PROTECTED_SECRET_ENVIRONMENT,
+  ...Object.values(ADAPTER_DECLARATIONS).flatMap((declaration) => declaration.protectedEnvironmentVariables),
+]);
+
 const toolManifest = (claim: ClaimedTask): string[] => [
   "",
   RUNNER_DEFINITIONS[claim.runner].toolIntroduction,
   ...manifestLines(RUNNER_DEFINITIONS[claim.runner].toolTransport),
 ];
 
-export const buildPrompt = (claim: ClaimedTask): string => {
-  const subagents = codexNativeSubagentProfile(claim.run, claim.runner);
-  return [
+export const buildPrompt = (claim: ClaimedTask): string => [
   claim.agent.foundationalPrompt,
   "",
   `Role (${claim.agent.name}): ${claim.agent.rolePrompt}`,
@@ -68,17 +74,7 @@ export const buildPrompt = (claim: ClaimedTask): string => {
     `- implementationBaseSha: ${claim.run.implementationBaseSha}`,
     `- implementationHeadSha: ${claim.run.implementationHeadSha}`,
   ] : []),
-  ...(subagents ? [
-    "",
-    "Platform-pinned native implementation subagents:",
-    `- model: ${subagents.model}`,
-    `- reasoning effort: ${subagents.effort}`,
-    `- maximum concurrent child threads: ${subagents.maxConcurrent} (root excluded)`,
-    "- multi_agent_v2 is enabled by the runner. Spawn, message, wait for, and close native children through the session collaboration tools; do not launch nested Codex CLI processes.",
-    "- The runner enforces the same child model and concurrency snapshot on fresh starts and resumes. Do not select or escalate a child model.",
-    "- Implementation proof is limited to each assignment's focused tests, one affected-workspace compile or typecheck after integration, and tests for seams crossed by multiple assignments.",
-    "- Do not run repository-wide suites or the repository Merge Gate in Implementation; the later Regression step owns the formal Gate.",
-  ] : []),
+  ...ADAPTER_DECLARATIONS[claim.runner].promptSections(claim),
   "",
   `Task: ${claim.task.name}`,
   claim.task.description,
@@ -131,8 +127,7 @@ export const buildPrompt = (claim: ClaimedTask): string => {
     ]),
     `- Repair task output (${claim.regressionRepairHandoff.repair.outputKind}):\n${claim.regressionRepairHandoff.repair.outputBody}`,
   ] : []),
-  ].join("\n");
-};
+].join("\n");
 
 export const buildChildEnvironment = (
   config: Pick<RunnerConfig, "path" | "home" | "apiUrl" | "runAsPrefix">
@@ -147,28 +142,9 @@ export const buildChildEnvironment = (
   if (regressionStep && !claim.task.chainId) {
     throw new Error("regression-verification task is missing its platform chain id");
   }
-  // These names are runner-owned. In particular, a task secret must never be
-  // able to reintroduce the host Codex home or the CLAUDE_CONFIG_DIR path that
-  // this chain deliberately does not use.
-  const {
-    CLAUDE_CONFIG_DIR: _claudeConfigDir,
-    CODEX_HOME: _codexHome,
-    GIT_CONFIG_GLOBAL: _gitConfigGlobal,
-    PI_CODING_AGENT_DIR: _piCodingAgentDir,
-    PI_CODING_AGENT_SESSION_DIR: _piCodingAgentSessionDir,
-    AGENTOS_CODEX_SERVICE_TIER: _codexServiceTier,
-    AGENTOS_PI_EXPECTS_OPENAI_CODEX: _piExpectsOpenAICodex,
-    AGENTOS_GATE_SERVER: _gateServer,
-    HTTP_PROXY: _httpProxy,
-    HTTPS_PROXY: _httpsProxy,
-    NO_PROXY: _noProxy,
-    http_proxy: _httpProxyLower,
-    https_proxy: _httpsProxyLower,
-    no_proxy: _noProxyLower,
-    ...unfilteredTaskSecrets
-  } = claim.secrets;
-  const taskSecrets = Object.fromEntries(Object.entries(unfilteredTaskSecrets).filter(([name]) =>
-    !name.startsWith("GIT_CONFIG_")
+  const taskSecrets = Object.fromEntries(Object.entries(claim.secrets).filter(([name]) =>
+    !PROTECTED_SECRET_ENVIRONMENT.has(name)
+    && !name.startsWith("GIT_CONFIG_")
     && !["GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"].includes(name)));
   return {
     ...taskSecrets,
@@ -187,102 +163,20 @@ export const buildChildEnvironment = (
       AGENTOS_CHAIN_ID: claim.task.chainId!,
       AGENTOS_PULL_REQUEST_BASE: claim.run.pullRequestBase,
     } : {}),
-    AGENTOS_CODEX_SERVICE_TIER: claim.run.codexServiceTier.toLowerCase(),
     ...RUNNER_DEFINITIONS[claim.runner].childEnvironment(claim, scratch),
-    // Last on purpose, so no task secret can point a session back at the
-    // production roots. See provisionAgentScratch for why this containment has
-    // to live in the runner rather than in the run's checkout.
     RUNNER_WORKSPACE_ROOT: scratch.workspaceRoot,
     CONTROL_PLANE_STATE_DIR: scratch.stateDir,
   };
 };
 
-const isolationVariables = [
-  "RUNNER_WORKSPACE_ROOT", "CONTROL_PLANE_STATE_DIR", "HOME", "GIT_CONFIG_GLOBAL", "CODEX_HOME", "PI_CODING_AGENT_DIR",
-  "AGENTOS_CODEX_SERVICE_TIER", "AGENTOS_PI_EXPECTS_OPENAI_CODEX", "AGENTOS_GATE_SERVER",
-  "AGENTOS_RUN_ID", "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
-] as const;
-
-/**
- * The command line for a session, re-asserting the isolation variables on the
- * far side of RUNNER_RUN_AS_PREFIX.
- *
- * The prefix is an arbitrary launcher, and a launcher is free to scrub the
- * environment it was handed. #117's shipped example is `sudo -u _agentos1 -E
- * --`, where everything the session inherits rests on that `-E`: without it
- * sudo's env_reset strips the lot. Putting the two roots only in the
- * environment we pass to the *launcher* is therefore not a guarantee.
- *
- * Losing them is also the one failure that is both silent and catastrophic: an
- * old base falls back to the production default and sweeps it, which is #125.
- * Everything else a scrubbing launcher drops — PATH and
- * AGENTOS_SESSION_TOKEN — fails loudly and immediately instead. HOME is a
- * containment variable because Codex discovers ~/.agents/skills independently
- * of CODEX_HOME; losing it could silently expose the launched account's home.
- * GIT_CONFIG_GLOBAL travels with it so that relocation does not silently
- * replace the configured runner identity or drop credential helpers.
- *
- * So the containment variables and the non-secret, Run-snapshotted Codex
- * profile are set again by `/usr/bin/env`, which runs after
- * the launcher and immediately before the CLI. That also makes the contract
- * fail-closed: a launcher that will not exec `/usr/bin/env` cannot start the
- * session at all, rather than starting it pointed at production.
- *
- * Proxy values deliberately stay in the inherited environment instead of this
- * argv: proxy URLs may contain credentials, and argv is readable through `ps`.
- * A configured RUNNER_RUN_AS_PREFIX therefore has to preserve the environment
- * it receives (the shipped sudo prefix uses `-E`). This is the same channel the
- * runner's Git and workspace commands use, so a prefix that scrubs it cannot
- * provide the platform-wide proxy contract.
- */
+/** Re-assert containment and provider-owned policy after a scrubbing launcher. */
 export const launchArgv = (
   config: Pick<RunnerConfig, "runAsPrefix" | "binaries">,
   runner: RunnerKind,
   args: string[],
   env: NodeJS.ProcessEnv,
-): { executable: string; args: string[] } => {
-  const binary = config.binaries[runner];
-  if (config.runAsPrefix.length === 0) return { executable: binary, args };
-  const assignments = isolationVariables.flatMap((name) => env[name] !== undefined ? [`${name}=${env[name]}`] : []);
-  return {
-    executable: config.runAsPrefix[0]!,
-    args: [
-      ...config.runAsPrefix.slice(1),
-      ...(assignments.length > 0 ? ["/usr/bin/env", ...assignments] : []),
-      binary,
-      ...args,
-    ],
-  };
-};
+): { executable: string; args: string[] } => launchAdapterArgv(config, ADAPTER_DECLARATIONS[runner], args, env);
 
-// Resolved from the package root so it works from dist/ (launchd) and src/ (tsx).
-const packageRoot = fileURLToPath(new URL("..", import.meta.url));
-
-export const mcpServerPath = (): string => process.env.RUNNER_MCP_SERVER_PATH ?? join(packageRoot, "dist", "mcp-server.js");
-export const piExtensionPath = (): string => process.env.RUNNER_PI_EXTENSION_PATH ?? join(packageRoot, "assets", "pi-agentos-extension.ts");
-export const claudePlatformSettingsPath = (): string =>
-  process.env.RUNNER_CLAUDE_SETTINGS_PATH ?? join(packageRoot, "assets", "claude-platform-settings.json");
-
-/**
- * The interpreter the CLI is told to run the MCP server with.
- *
- * The default is this daemon's own `process.execPath`, which is a resolved real
- * path — typically a Homebrew Cellar or version-manager directory, not the
- * symlink in `RUNNER_PATH`. Under a run-as prefix the CLI is a different account
- * that may not be able to traverse it, and the failure surfaces as an MCP
- * startup error inside the session rather than as a deployment error. The
- * override exists so a deployment can name an interpreter both principals can
- * execute, and `runtimeDescriptor()` publishes whichever one is in force so it
- * can be checked from outside the process.
- */
-export const nodeBinaryPath = (): string => process.env.RUNNER_NODE_BINARY ?? process.execPath;
-
-/**
- * One machine-readable line naming every path the agent's session depends on and
- * that a different OS principal has to be able to reach. Printed at startup so
- * `scripts/os-isolation/verify.sh` can test the paths the daemon actually uses
- * instead of whatever the operator's own shell happens to resolve.
- */
 export const runtimeDescriptor = (runnerId: string, runAsPrefix: string[]): string => JSON.stringify({
   runtime: "agentos-runner",
   runnerId,
@@ -295,553 +189,6 @@ export const runtimeDescriptor = (runnerId: string, runAsPrefix: string[]): stri
   runAsPrefix: runAsPrefix.join(" "),
 });
 
-/**
- * The Anneal MCP server the agent's CLI session spawns for itself. It carries
- * no credentials: they reach the server through the inherited child environment,
- * so nothing secret ends up in a command line other processes can read.
- */
-export const mcpServerArgs = (credentialsPath: string): string[] => [mcpServerPath(), "--credentials", credentialsPath];
-
-export const mcpConfig = (credentialsPath: string): { mcpServers: Record<string, { type: string; command: string; args: string[] }> } => ({
-  mcpServers: { agentos: { type: "stdio", command: nodeBinaryPath(), args: mcpServerArgs(credentialsPath) } },
-});
-
-export type AdapterEvent = {
-  source: "RUNNER" | "CLAUDE" | "CODEX" | "PI";
-  type: string;
-  providerEventId?: string | null;
-  toolCallId?: string | null;
-  payload: Record<string, unknown>;
-};
-
-export type SessionEventSink = (event: AdapterEvent) => void;
-
-export type ExitEvidence = {
-  exitCode: number | null;
-  signal: string | null;
-  terminalEventSeen: boolean;
-  terminalSuccess: boolean;
-  terminationReason: string | null;
-  finalOutput: string | null;
-  providerError: string | null;
-  stdout: string;
-  stderr: string;
-};
-
-export type ClassifiedFailure = {
-  failureClass: FailureClass;
-  retryable: boolean;
-  operatorAction?: string;
-};
-
-export type HeartbeatSnapshot = {
-  processAlive: boolean;
-  lastProcessAliveAt: Date;
-  lastProgressEventAt: Date;
-  inFlightTool: InFlightTool | null;
-};
-
-/**
- * A PI session's harvested token and cost totals. Every field is `null` until a
- * message actually reports it — absent is never zero, matching the
- * `SessionUsage` contract these totals are ingested through.
- *
- * `messages` and `reported` are diagnostics carried into the payload: they are
- * what lets an operator tell "the session sent nothing" apart from "the session
- * sent messages and PI reported no usage for them".
- */
-export type PiUsageTotals = {
-  messages: number;
-  reported: number;
-  input: number | null;
-  output: number | null;
-  cacheRead: number | null;
-  cacheWrite: number | null;
-  costNanoUsd: number | null;
-};
-
-export type AdapterState = {
-  runId: string;
-  runner: RunnerKind;
-  startedAt: Date;
-  lastProcessAliveAt: Date;
-  lastProgressEventAt: Date;
-  inFlightTool: InFlightTool | null;
-  providerConversationId: string | null;
-  terminalEventSeen: boolean;
-  terminalSuccess: boolean;
-  terminationReason: string | null;
-  sawError: boolean;
-  providerError: string | null;
-  piTurnCompleted: boolean;
-  piFinalAttemptFailed: boolean;
-  piUsage: PiUsageTotals;
-  finalOutput: string | null;
-  stdout: string;
-  stderr: string;
-};
-
-export type RuntimeHandle = AdapterState & {
-  child: ChildProcess;
-  pid: number | null;
-  exit: Promise<ExitEvidence>;
-};
-
-export type PreflightSpec = {
-  config: RunnerConfig;
-  runner: RunnerKind;
-  model: string | null;
-  env: NodeJS.ProcessEnv;
-};
-
-export type PreflightResult = {
-  ok: boolean;
-  cliVersion: string | null;
-  authMode: string | null;
-  capabilities: Record<string, unknown>;
-  error?: string;
-};
-
-export type RunSpec = {
-  config: RunnerConfig;
-  claim: ClaimedTask;
-  workingDirectory: string;
-  env: NodeJS.ProcessEnv;
-  prompt: string;
-  /** 0600 file the Anneal MCP server reads its session credentials from. */
-  credentialsPath: string;
-};
-
-export type ResumeSpec = RunSpec & { providerConversationId: string; input: string };
-
-export type KillResult = { signal: "SIGTERM" | "SIGKILL" | null; processAlive: boolean };
-
-/**
- * One CLI implementation at the runner seam.
- *
- * `claim.agent.disabledTools` is not a universal capability: Claude enforces
- * all eight current tool keys, PI enforces BASH/READ/WRITE/EDIT, and Codex
- * exposes no supported per-tool deny mechanism. An adapter must keep that
- * limitation explicit in its argv implementation; callers must not infer that
- * a non-empty disabledTools list was enforced merely because start succeeded.
- */
-export interface CliAdapter {
-  preflight(spec: PreflightSpec): Promise<PreflightResult>;
-  start(spec: RunSpec, sink: SessionEventSink): Promise<RuntimeHandle>;
-  resume(spec: ResumeSpec, sink: SessionEventSink): Promise<RuntimeHandle>;
-  kill(handle: RuntimeHandle, reason: string): Promise<KillResult>;
-  heartbeat(handle: RuntimeHandle): Promise<HeartbeatSnapshot>;
-  classifyError(evidence: ExitEvidence): ClassifiedFailure;
-}
-
-export type AdapterEventParser = (
-  state: AdapterState,
-  event: Record<string, unknown>,
-  sink: SessionEventSink,
-) => void;
-
-export type AdapterImplementation = {
-  runner: RunnerKind;
-  args(spec: RunSpec, resume?: ResumeSpec): string[];
-  parseEvent: AdapterEventParser;
-};
-
-const emptyPiUsage = (): PiUsageTotals =>
-  ({ messages: 0, reported: 0, input: null, output: null, cacheRead: null, cacheWrite: null, costNanoUsd: null });
-
-export const createAdapterState = (
-  runner: RunnerKind,
-  runId: string,
-  startedAt = new Date(),
-): AdapterState => ({
-  runId,
-  runner,
-  startedAt,
-  lastProcessAliveAt: startedAt,
-  lastProgressEventAt: startedAt,
-  inFlightTool: null,
-  providerConversationId: null,
-  terminalEventSeen: false,
-  terminalSuccess: false,
-  terminationReason: null,
-  sawError: false,
-  providerError: null,
-  piTurnCompleted: false,
-  piFinalAttemptFailed: false,
-  piUsage: emptyPiUsage(),
-  finalOutput: null,
-  stdout: "",
-  stderr: "",
-});
-
-const cap = (value: string, limit = 1_000_000): string => value.length <= limit ? value : value.slice(value.length - limit);
-
-const sourceFor = (runner: RunnerKind): AdapterEvent["source"] => runner;
-
-export const asRecord = (value: unknown): Record<string, unknown> | null =>
-  typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null;
-
-export const stringField = (object: Record<string, unknown> | null, field: string): string | null =>
-  typeof object?.[field] === "string" ? object[field] as string : null;
-
-export const eventErrorMessage = (event: Record<string, unknown>): string | null =>
-  stringField(event, "message")
-  ?? stringField(event, "error")
-  ?? stringField(asRecord(event.error), "message");
-
-export const emitAdapterEvent = (state: AdapterState, sink: SessionEventSink, type: string, payload: Record<string, unknown>, toolCallId?: string | null): void => {
-  state.lastProgressEventAt = new Date();
-  sink({ source: sourceFor(state.runner), type, payload, ...(toolCallId !== undefined ? { toolCallId } : {}) });
-};
-
-export const markInFlightToolProgress = (state: AdapterState): void => {
-  if (state.inFlightTool) state.inFlightTool.lastProgressAt = new Date();
-};
-
-export const processProviderEvent = (
-  state: AdapterState,
-  event: Record<string, unknown>,
-  sink: SessionEventSink,
-  parseEvent: AdapterEventParser,
-): void => {
-  sink({ source: sourceFor(state.runner), type: "PROVIDER_RAW", payload: event });
-  parseEvent(state, event, sink);
-};
-
-const processLine = (
-  state: AdapterState,
-  line: string,
-  sink: SessionEventSink,
-  parseEvent: AdapterEventParser,
-): void => {
-  if (!line.trim()) return;
-  let event: Record<string, unknown>;
-  try {
-    const parsed = JSON.parse(line) as unknown;
-    event = asRecord(parsed) ?? { value: parsed };
-  } catch {
-    state.sawError = true;
-    emitAdapterEvent(state, sink, "ADAPTER_ERROR", { error: "invalid-json", line });
-    return;
-  }
-  processProviderEvent(state, event, sink, parseEvent);
-};
-
-// Run.model carries an optional reasoning-effort suffix: "<model>[:<effort>]".
-export const modelSpec = (raw: string): { model: string; effort: string | null } => {
-  const at = raw.lastIndexOf(":");
-  return at > 0 ? { model: raw.slice(0, at), effort: raw.slice(at + 1) } : { model: raw, effort: null };
-};
-
-/**
- * What the session is actually asked to do: a fresh prompt, or the resume input.
- *
- * It never appears in argv. A claim carries the chain's persisted prior outputs
- * verbatim, each capped at 500k by the write endpoint, so a nine-step chain's
- * cumulative prompt is measured in megabytes — past Linux's 128 KiB per-argument
- * MAX_ARG_STRLEN and past macOS's ~1 MiB total argument block. As an argv
- * element that is E2BIG: `spawn` fails before the provider ever starts, and no
- * amount of retrying fixes it.
- *
- * Every runner reads it from stdin instead, on a documented path of its own:
- * `claude -p` with no prompt argument, `codex exec -` and `codex exec resume
- * <id> -` (`-` means "read the instructions from stdin"), and pi, which
- * prepends piped stdin to the initial message in every non-RPC mode. Resume ids,
- * MCP wiring and deny flags stay on argv, where they are small and stable.
- *
- * The prompt also stops being visible in every `ps` on the box, which is where
- * a task description and its predecessors' outputs used to sit in the clear.
- */
-export const inputForRunner = (spec: RunSpec, resume?: ResumeSpec): string => resume?.input ?? spec.prompt;
-
-export const argsForRunner = (runner: RunnerKind, spec: RunSpec, resume?: ResumeSpec): string[] =>
-  RUNNER_DEFINITIONS[runner].args(spec, resume);
-
-export const spawnAdapterRuntime = (implementation: AdapterImplementation, spec: RunSpec, sink: SessionEventSink, resume?: ResumeSpec): RuntimeHandle => {
-  const { runner } = implementation;
-  const binary = spec.config.binaries[runner];
-  const args = implementation.args(spec, resume);
-  const input = inputForRunner(spec, resume);
-  const { executable, args: fullArgs } = launchArgv(spec.config, runner, args, spec.env);
-  const startedAt = new Date();
-  const child = spawn(executable, fullArgs, {
-    cwd: spec.workingDirectory,
-    env: spec.env,
-    // stdin is the prompt channel (see inputForRunner); stdout stays the
-    // structured event protocol every parser below reads.
-    detached: true,
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  const handle: RuntimeHandle = {
-    ...createAdapterState(runner, spec.claim.run.id, startedAt),
-    child,
-    pid: child.pid ?? null,
-    exit: Promise.resolve({} as ExitEvidence),
-  };
-  let buffer = "";
-  child.stdout!.setEncoding("utf8");
-  child.stderr!.setEncoding("utf8");
-  child.stdout!.on("data", (chunk: string) => {
-    handle.stdout = cap(handle.stdout + chunk);
-    buffer += chunk;
-    const lines = buffer.split(/\r?\n/u);
-    buffer = lines.pop() ?? "";
-    for (const line of lines) processLine(handle, line, sink, implementation.parseEvent);
-  });
-  child.stderr!.on("data", (chunk: string) => {
-    handle.stderr = cap(handle.stderr + chunk);
-    sink({ source: sourceFor(runner), type: "STDERR", payload: { text: chunk } });
-  });
-  handle.exit = new Promise<ExitEvidence>((resolvePromise) => {
-    let settled = false;
-    const finish = (exitCode: number | null, signal: string | null): void => {
-      if (settled) return;
-      settled = true;
-      if (buffer.trim()) processLine(handle, buffer, sink, implementation.parseEvent);
-      resolvePromise({
-        exitCode,
-        signal,
-        terminalEventSeen: handle.terminalEventSeen,
-        terminalSuccess: handle.terminalSuccess,
-        terminationReason: handle.terminationReason,
-        finalOutput: handle.finalOutput,
-        providerError: handle.providerError,
-        stdout: handle.stdout,
-        stderr: handle.stderr,
-      });
-    };
-    child.once("error", (error: NodeJS.ErrnoException) => {
-      handle.sawError = true;
-      handle.stderr = cap(`${handle.stderr}\n${error.message}`);
-      finish(error.code === "ENOENT" ? 127 : 1, null);
-    });
-    child.once("close", (code, signal) => finish(code, signal));
-  });
-  // A CLI that dies before it drains a multi-megabyte prompt (missing binary,
-  // failed auth) closes the pipe under us. That EPIPE is a symptom, never the
-  // diagnosis, so it is recorded as its own event and deliberately kept out of
-  // stderr: the CLI's own exit evidence is what classifies the run.
-  child.stdin!.on("error", (error: NodeJS.ErrnoException) => {
-    sink({
-      source: "RUNNER",
-      type: "PROMPT_DELIVERY_FAILED",
-      payload: { message: error.message, code: error.code ?? null },
-    });
-  });
-  child.stdin!.end(input);
-  sink({ source: "RUNNER", type: "PROCESS_STARTED", payload: {
-    pid: handle.pid,
-    binary,
-    // argv no longer carries the prompt, so this stays safe to persist and read.
-    args,
-    promptTransport: "stdin",
-    promptBytes: Buffer.byteLength(input),
-    // The persisted Run value is the hash available at queue time, before
-    // claim-time handoffs and notes have been appended. Hash the bytes actually
-    // delivered to this provider invocation so this event cannot claim a digest
-    // for a different prompt (and resume inputs are covered too).
-    promptHash: promptHashFor(input),
-  } });
-  return handle;
-};
-
-export const capturePreflight = async (config: RunnerConfig, runner: RunnerKind, args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> =>
-  new Promise((resolvePromise) => {
-    const launch = launchArgv(config, runner, args, env);
-    const child = spawn(launch.executable, launch.args, {
-      env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-    const finish = (code: number | null, extra = ""): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolvePromise({ code, stdout, stderr: `${stderr}${extra}` });
-    };
-    const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-      finish(1, "\npreflight timed out after 30 seconds");
-    }, 30_000);
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => { stdout += chunk; });
-    child.stderr.on("data", (chunk: string) => { stderr += chunk; });
-    child.once("error", (error: NodeJS.ErrnoException) => finish(error.code === "ENOENT" ? 127 : 1, `\n${error.message}`));
-    child.once("close", (code) => finish(code));
-  });
-
-/**
- * What a failed preflight is allowed to say about itself.
- *
- * A preflight failure used to report the CLI's own stdout and stderr verbatim.
- * That text is persisted as `RunnerBackendState.circuitReason`, returned by
- * `GET /runners`, and rendered — so whatever an unauthenticated `codex login
- * status` happened to print, including an environment variable, a remote URL
- * with a password in it or a home-directory path, became telemetry and then
- * became a screenshot. Nothing about that channel is bounded, so nothing about
- * it can be sanitised; the fix is not to carry it.
- *
- * What is carried instead is a class: a fixed phrase this file authors, one per
- * way a preflight can fail, plus the exit code, which is a number. The CLI's own
- * account of the failure stays where the operator can already read it — their
- * terminal, running the same official command the guidance names.
- */
-export const PREFLIGHT_CLASS = {
-  cliMissing: "cli-missing",
-  cliIncompatible: "cli-incompatible",
-  notAuthenticated: "not-authenticated",
-  unsupportedModel: "unsupported-model",
-} as const;
-
-export const PREFLIGHT_REASONS = {
-  cliMissing: `${PREFLIGHT_CLASS.cliMissing}: the CLI did not answer --version`,
-  cliIncompatible: `${PREFLIGHT_CLASS.cliIncompatible}: the CLI does not expose the required Anneal exec protocol`,
-  notAuthenticated: `${PREFLIGHT_CLASS.notAuthenticated}: the CLI's own login check did not pass`,
-  unsupportedModel: `${PREFLIGHT_CLASS.unsupportedModel}: an explicit provider/model is required`,
-} as const;
-
-export const preflightFailure = (reason: string, code: number | null): string =>
-  code === null ? reason : `${reason} (exit ${code})`;
-
-export const adapterExecutionSucceeded = (evidence: ExitEvidence): boolean =>
-  evidence.exitCode === 0
-  && evidence.signal === null
-  && evidence.terminationReason === null
-  && evidence.terminalEventSeen
-  && evidence.terminalSuccess;
-
-/**
- * The tail of what a run produced: the agent's own final output when it emitted
- * one, otherwise its stdout. Capped at 500k because it is sent on the wire and
- * stored whole (`Run.output`); the *tail* is kept rather than the head because
- * the end of a run is where its account of itself is.
- *
- * One definition, because two call sites in runner.ts send it: the ordinary
- * completion, and the exception path, which reports a run whose agent had
- * already finished when the runner's own plumbing failed.
- */
-export const outputTail = (evidence: ExitEvidence): string | null =>
-  (evidence.finalOutput ?? evidence.stdout).trim().slice(-500_000) || null;
-
-export const failureReasonFromEvidence = (evidence: ExitEvidence): string =>
-  evidence.providerError?.trim()
-  || evidence.stderr.trim()
-  || `CLI exited with code ${evidence.exitCode}`;
-
-export const classifyRuntimeError = (evidence: ExitEvidence): ClassifiedFailure => {
-  const text = evidence.providerError?.trim()
-    ? `${evidence.providerError}\n${evidence.stderr}`
-    : `${evidence.stderr}\n${evidence.stdout}`;
-  // Auth verdicts must never be read out of stdout: stdout is the agent's
-  // working output, and a task that edits auth code contains "401"/"not
-  // logged in" as content (run cmsy26f2s0ibqmpmx8t6gyltg was classified
-  // AUTH_REQUIRED off a literal 401 in the code it was writing). Provider
-  // error and stderr are the only channels the CLI reports auth trouble on.
-  const authEvidence = `${evidence.providerError ?? ""}\n${evidence.stderr}`;
-  if (evidence.terminationReason) return { failureClass: "CANCELLED_OR_TIMED_OUT", retryable: false };
-  if (evidence.exitCode === 127) {
-    return { failureClass: "BINARY_NOT_FOUND", retryable: false, operatorAction: "Install the configured CLI or repair RUNNER_PATH" };
-  }
-  // Auth outranks transient: a providerError that names an auth failure must
-  // not be retried into a lockout just because the same message also mentions
-  // a dropped connection or server_error.
-  // `not-authenticated` is this file's own preflight class, not CLI text: the
-  // preflight stopped forwarding the CLI's words (they are unbounded and end up
-  // in telemetry), so the classifier recognises the class instead.
-  if (new RegExp(`authentication_failed|\\b401\\b|Missing authentication|No API key found|not logged in|${PREFLIGHT_CLASS.notAuthenticated}`, "iu").test(authEvidence)) {
-    return { failureClass: "AUTH_REQUIRED", retryable: false, operatorAction: "Log the runner account into the CLI" };
-  }
-  if (/connection lost|server_error/iu.test(`${evidence.providerError ?? ""}`)) {
-    return { failureClass: "TRANSIENT_PROVIDER", retryable: true };
-  }
-  if (/\b429\b|rate.?limit|usage.?limit|quota/iu.test(text)) return { failureClass: "RATE_LIMITED", retryable: true };
-  if (isTransientNetworkError(text) || /\b5\d\d\b|provider outage/iu.test(text)) {
-    return { failureClass: "TRANSIENT_PROVIDER", retryable: true };
-  }
-  if (/"isError"\s*:\s*true|"command_execution"[\s\S]{0,500}"status"\s*:\s*"failed"/u.test(text)) {
-    return { failureClass: "TOOL_FAILED", retryable: false };
-  }
-  if (evidence.exitCode === 0 && (!evidence.terminalEventSeen || !evidence.terminalSuccess)) {
-    return { failureClass: "PROTOCOL_ERROR", retryable: true, operatorAction: "Check CLI protocol/version drift" };
-  }
-  return { failureClass: "TASK_FAILED", retryable: false };
-};
-
-const ownedRunProcesses = async (runId: string): Promise<number[]> => new Promise((resolvePromise, rejectPromise) => {
-  const args = process.platform === "darwin"
-    ? ["-Eww", "-axo", "pid=,ppid=,pgid=,command="]
-    : ["-axeww", "-o", "pid=,ppid=,pgid=,command="];
-  execFile("ps", args, { maxBuffer: 64 * 1024 * 1024 }, (error, stdout) => {
-    if (error) {
-      rejectPromise(new Error(`Unable to inspect Run-owned processes: ${error.message}`));
-      return;
-    }
-    const marker = ` AGENTOS_RUN_ID=${runId}`;
-    const pids = stdout.split("\n").flatMap((line) => {
-      if (!line.includes(marker)) return [];
-      const match = /^\s*(\d+)\s+/u.exec(line);
-      return match ? [Number.parseInt(match[1]!, 10)] : [];
-    });
-    resolvePromise(pids.filter((pid) => pid !== process.pid));
-  });
-});
-
-const signalProcesses = (pids: number[], signal: NodeJS.Signals): void => {
-  for (const pid of pids) {
-    try {
-      process.kill(pid, signal);
-    } catch (error: unknown) {
-      if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
-    }
-  }
-};
-
-const waitForRunDrain = async (runId: string, timeoutMs: number): Promise<number[]> => {
-  const deadline = Date.now() + timeoutMs;
-  let remaining = await ownedRunProcesses(runId);
-  while (remaining.length > 0 && Date.now() < deadline) {
-    await new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 50));
-    remaining = await ownedRunProcesses(runId);
-  }
-  return remaining;
-};
-
-export const killRuntime = async (handle: RuntimeHandle, reason: string): Promise<KillResult> => {
-  handle.terminationReason = reason;
-  const pid = handle.pid;
-  if (pid && handle.child.exitCode === null && handle.child.signalCode === null) {
-    try { process.kill(-pid, "SIGTERM"); } catch { /* the ownership scan below is authoritative */ }
-  }
-  let remaining = await ownedRunProcesses(handle.runId);
-  signalProcesses(remaining, "SIGTERM");
-  remaining = await waitForRunDrain(handle.runId, 5_000);
-  if (remaining.length === 0) {
-    await handle.exit;
-    return { signal: pid ? "SIGTERM" : null, processAlive: false };
-  }
-  signalProcesses(remaining, "SIGKILL");
-  remaining = await waitForRunDrain(handle.runId, 5_000);
-  if (remaining.length > 0) {
-    throw new Error(`Unable to terminate ${remaining.length} process(es) owned by Run ${handle.runId}`);
-  }
-  await handle.exit;
-  return { signal: "SIGKILL", processAlive: false };
-};
-
-export const heartbeatRuntime = async (handle: RuntimeHandle): Promise<HeartbeatSnapshot> => {
-  const processAlive = handle.child.exitCode === null && handle.child.signalCode === null;
-  if (processAlive) handle.lastProcessAliveAt = new Date();
-  return {
-    processAlive,
-    lastProcessAliveAt: handle.lastProcessAliveAt,
-    lastProgressEventAt: handle.lastProgressEventAt,
-    inFlightTool: handle.inFlightTool,
-  };
-};
-
 export type RunnerDefinition = {
   binaryEnvironment: string;
   defaultBinary: string;
@@ -849,91 +196,42 @@ export type RunnerDefinition = {
   toolTransport: SessionToolTransport;
   toolEntrypoint(): string;
   adapter: CliAdapter;
-  /** Whether this CLI owns a per-Session config root outside disposable scratch. */
   isolatesSessionConfig: boolean;
-  /** Model identity used only for daemon startup preflight, when that adapter requires one. */
   startupPreflightModel: string | null;
   args(spec: RunSpec, resume?: ResumeSpec): string[];
   childEnvironment(claim: Pick<ClaimedTask, "run">, scratch: AgentScratch): NodeJS.ProcessEnv;
-  provisionSessionConfig(
-    config: RunnerConfig,
-    scratch: AgentScratch,
-    options?: SessionConfigOptions,
-  ): Promise<void>;
+  provisionSessionConfig(config: RunnerConfig, scratch: AgentScratch, options?: SessionConfigOptions): Promise<void>;
 };
 
-const deferredAdapter = (create: () => CliAdapter): CliAdapter => {
-  let concrete: CliAdapter | null = null;
-  const get = (): CliAdapter => {
-    concrete ??= create();
-    return concrete;
-  };
-  return Object.freeze<CliAdapter>({
-    preflight: (spec) => get().preflight(spec),
-    start: (spec, sink) => get().start(spec, sink),
-    resume: (spec, sink) => get().resume(spec, sink),
-    kill: (handle, reason) => get().kill(handle, reason),
-    heartbeat: (handle) => get().heartbeat(handle),
-    classifyError: (evidence) => get().classifyError(evidence),
-  });
-};
+const definitionFrom = (declaration: AdapterDeclaration): Readonly<RunnerDefinition> => Object.freeze({
+  binaryEnvironment: declaration.binaryEnvironment,
+  defaultBinary: declaration.defaultBinary,
+  toolIntroduction: declaration.toolIntroduction,
+  toolTransport: declaration.toolTransport,
+  toolEntrypoint: declaration.toolEntrypoint,
+  adapter: createCliAdapter(declaration),
+  isolatesSessionConfig: declaration.isolatesSessionConfig,
+  startupPreflightModel: declaration.startupPreflightModel,
+  args: declaration.args,
+  childEnvironment: declaration.childEnvironment,
+  provisionSessionConfig: declaration.provisionSessionConfig,
+});
 
-/**
- * The only per-CLI registry. Binary configuration, adapter selection,
- * availability enumeration, child config roots, and argv all derive from it.
- */
+/** The public runner registry is a derived view of provider-owned declarations. */
 export const RUNNER_DEFINITIONS: Readonly<Record<RunnerKind, Readonly<RunnerDefinition>>> = Object.freeze({
-  CLAUDE: Object.freeze<RunnerDefinition>({
-    binaryEnvironment: "CLAUDE_BINARY",
-    defaultBinary: "claude",
-    toolIntroduction: "Anneal tools attached to this session (MCP server 'agentos'; your client may prefix them, e.g. mcp__agentos__task_output):",
-    toolTransport: "mcp-stdio",
-    toolEntrypoint: mcpServerPath,
-    adapter: deferredAdapter(() => createClaudeAdapter()),
-    isolatesSessionConfig: false,
-    startupPreflightModel: null,
-    args: (spec, resume) => claudeArgs(spec, resume),
-    childEnvironment: (claim, scratch) => claudeChildEnvironment(claim, scratch),
-    provisionSessionConfig: (config, scratch, options) => provisionClaudeSessionConfig(config, scratch, options),
-  }),
-  CODEX: Object.freeze<RunnerDefinition>({
-    binaryEnvironment: "CODEX_BINARY",
-    defaultBinary: "codex",
-    toolIntroduction: "Anneal tools attached to this session (MCP server 'agentos'; your client may prefix them, e.g. mcp__agentos__task_output):",
-    toolTransport: "mcp-stdio",
-    toolEntrypoint: mcpServerPath,
-    adapter: deferredAdapter(() => createCodexAdapter()),
-    isolatesSessionConfig: true,
-    startupPreflightModel: CODEX_STARTER_MODEL,
-    args: (spec, resume) => codexArgs(spec, resume),
-    childEnvironment: (claim, scratch) => codexChildEnvironment(claim, scratch),
-    provisionSessionConfig: (config, scratch, options) => provisionCodexSessionConfig(config, scratch, options),
-  }),
-  PI: Object.freeze<RunnerDefinition>({
-    binaryEnvironment: "PI_BINARY",
-    defaultBinary: "pi",
-    toolIntroduction: "Anneal tools attached to this session (pi extension tools):",
-    toolTransport: "pi-extension",
-    toolEntrypoint: piExtensionPath,
-    adapter: deferredAdapter(() => createPiAdapter()),
-    isolatesSessionConfig: true,
-    startupPreflightModel: "openai-codex/gpt-5.6-luna",
-    args: (spec, resume) => piArgs(spec, resume),
-    childEnvironment: (claim, scratch) => piChildEnvironment(claim, scratch),
-    provisionSessionConfig: (config, scratch, options) => provisionPiSessionConfig(config, scratch, options),
-  }),
+  CLAUDE: definitionFrom(ADAPTER_DECLARATIONS.CLAUDE),
+  CODEX: definitionFrom(ADAPTER_DECLARATIONS.CODEX),
+  PI: definitionFrom(ADAPTER_DECLARATIONS.PI),
 });
 
 export const RUNNER_KINDS = Object.freeze(Object.keys(RUNNER_DEFINITIONS) as RunnerKind[]);
 
-/** Frozen: a caller substitutes an adapter by passing one to `executeClaim`,
- *  not by writing over this derived view. */
 export const adapters: Readonly<Record<RunnerKind, CliAdapter>> = Object.freeze(Object.fromEntries(
   RUNNER_KINDS.map((runner) => [runner, RUNNER_DEFINITIONS[runner].adapter]),
 ) as Record<RunnerKind, CliAdapter>);
 
-/** Hash the exact prompt bytes sent to the provider on this invocation. */
-export const promptHashFor = (prompt: string): string => createHash("sha256").update(prompt).digest("hex");
+export const argsForRunner = (runner: RunnerKind, spec: RunSpec, resume?: ResumeSpec): string[] =>
+  RUNNER_DEFINITIONS[runner].args(spec, resume);
 
 export const manifestFor = (spec: RunSpec, dispatchedPrompt: string): Record<string, unknown> => ({
   adapterVersion: ADAPTER_VERSION,
@@ -947,7 +245,6 @@ export const manifestFor = (spec: RunSpec, dispatchedPrompt: string): Record<str
   promptHash: promptHashFor(dispatchedPrompt),
   promptTransport: "stdin",
   structuredEvents: true,
-  // What the seat manual promises the agent, and how it was actually injected.
   agentosTools: {
     transport: RUNNER_DEFINITIONS[spec.claim.runner].toolTransport,
     entrypoint: RUNNER_DEFINITIONS[spec.claim.runner].toolEntrypoint(),

--- a/packages/runner/src/adapters/claude.ts
+++ b/packages/runner/src/adapters/claude.ts
@@ -6,7 +6,6 @@ import type { RunnerConfig } from "../config.js";
 import type { AgentScratch } from "../workspace.js";
 import {
   asRecord,
-  CLAUDE_TOOL_NAMES,
   capturePreflight,
   createAdapterState,
   emitAdapterEvent,
@@ -17,7 +16,6 @@ import {
   preflightFailure,
   processProviderEvent,
   stringField,
-  TOOL_ORDER,
   type AdapterDeclaration,
   type AdapterState,
   type PreflightResult,
@@ -34,9 +32,18 @@ const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
 export const claudePlatformSettingsPath = (): string =>
   process.env.RUNNER_CLAUDE_SETTINGS_PATH ?? join(packageRoot, "assets", "claude-platform-settings.json");
 
+const CLAUDE_ENFORCED_TOOLS = Object.freeze([
+  "BASH", "READ", "WRITE", "EDIT", "GLOB", "GREP", "WEB_FETCH", "WEB_SEARCH",
+] as const);
+
+const CLAUDE_TOOL_NAMES: Record<ToolKey, string> = {
+  BASH: "Bash", READ: "Read", WRITE: "Write", EDIT: "Edit",
+  GLOB: "Glob", GREP: "Grep", WEB_FETCH: "WebFetch", WEB_SEARCH: "WebSearch",
+};
+
 const denyArgs = (disabledTools: string[]): string[] => {
   const denied = new Set(disabledTools);
-  const names = TOOL_ORDER.flatMap((tool: ToolKey) => denied.has(tool) ? [CLAUDE_TOOL_NAMES[tool]] : []);
+  const names = CLAUDE_ENFORCED_TOOLS.flatMap((tool) => denied.has(tool) ? [CLAUDE_TOOL_NAMES[tool]] : []);
   return names.length === 0 ? [] : ["--disallowedTools", names.join(",")];
 };
 
@@ -174,6 +181,7 @@ export const claudeDeclaration: AdapterDeclaration = Object.freeze({
   toolIntroduction: "Anneal tools attached to this session (MCP server 'agentos'; your client may prefix them, e.g. mcp__agentos__task_output):",
   toolTransport: "mcp-stdio",
   toolEntrypoint: mcpServerPath,
+  enforcedTools: CLAUDE_ENFORCED_TOOLS,
   isolatesSessionConfig: false,
   startupPreflightModel: null,
   protectedEnvironmentVariables: ["CLAUDE_CONFIG_DIR"],

--- a/packages/runner/src/adapters/claude.ts
+++ b/packages/runner/src/adapters/claude.ts
@@ -1,3 +1,6 @@
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import type { ClaimedTask } from "../api.js";
 import type { RunnerConfig } from "../config.js";
 import type { AgentScratch } from "../workspace.js";
@@ -5,31 +8,31 @@ import {
   asRecord,
   CLAUDE_TOOL_NAMES,
   capturePreflight,
-  claudePlatformSettingsPath,
-  classifyRuntimeError,
   createAdapterState,
   emitAdapterEvent,
-  heartbeatRuntime,
-  killRuntime,
   mcpConfig,
+  mcpServerPath,
   modelSpec,
   PREFLIGHT_REASONS,
   preflightFailure,
   processProviderEvent,
-  spawnAdapterRuntime,
   stringField,
   TOOL_ORDER,
-  type AdapterImplementation,
+  type AdapterDeclaration,
   type AdapterState,
-  type CliAdapter,
   type PreflightResult,
   type PreflightSpec,
   type ResumeSpec,
   type RunSpec,
   type SessionEventSink,
   type ToolKey,
-} from "../adapters.js";
+} from "./runtime.js";
 import type { SessionConfigOptions } from "./session-config.js";
+
+const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+export const claudePlatformSettingsPath = (): string =>
+  process.env.RUNNER_CLAUDE_SETTINGS_PATH ?? join(packageRoot, "assets", "claude-platform-settings.json");
 
 const denyArgs = (disabledTools: string[]): string[] => {
   const denied = new Set(disabledTools);
@@ -115,11 +118,11 @@ export const parseClaudeTranscript = (
 
 const preflight = async (spec: PreflightSpec): Promise<PreflightResult> => {
   const capabilities = { structuredEvents: true, resume: true, killProcessGroup: true, heartbeat: true, classifyError: true };
-  const version = await capturePreflight(spec.config, "CLAUDE", ["--version"], spec.env);
+  const version = await capturePreflight(spec.config, claudeDeclaration, ["--version"], spec.env);
   if (version.code !== 0) {
     return { ok: false, cliVersion: null, authMode: null, capabilities, error: preflightFailure(PREFLIGHT_REASONS.cliMissing, version.code) };
   }
-  const help = await capturePreflight(spec.config, "CLAUDE", ["--help"], spec.env);
+  const help = await capturePreflight(spec.config, claudeDeclaration, ["--help"], spec.env);
   if (help.code !== 0 || !`${help.stdout}\n${help.stderr}`.includes("--setting-sources")) {
     return {
       ok: false,
@@ -133,7 +136,7 @@ const preflight = async (spec: PreflightSpec): Promise<PreflightResult> => {
     ...(spec.model === null ? {} : { verifiedModel: spec.model }),
     cliProtocol: "print-stream-json-user-source-isolated",
   });
-  const auth = await capturePreflight(spec.config, "CLAUDE", ["auth", "status"], spec.env);
+  const auth = await capturePreflight(spec.config, claudeDeclaration, ["auth", "status"], spec.env);
   const text = `${auth.stdout}\n${auth.stderr}`;
   const ok = auth.code === 0 && /"loggedIn"\s*:\s*true/u.test(text);
   return {
@@ -157,17 +160,29 @@ export const provisionClaudeSessionConfig = async (
   _options: SessionConfigOptions = {},
 ): Promise<void> => undefined;
 
-const implementation: AdapterImplementation = {
-  runner: "CLAUDE",
-  args: claudeArgs,
-  parseEvent: parseClaudeEvent,
+const promptSections = (claim: ClaimedTask): string[] => {
+  if (claim.run.subagentModel !== null || claim.run.subagentMaxConcurrent !== null) {
+    throw new Error("Native implementation subagents require a Codex root Run");
+  }
+  return [];
 };
 
-export const createClaudeAdapter = (): CliAdapter => Object.freeze<CliAdapter>({
-  preflight: (spec) => preflight({ ...spec, runner: "CLAUDE" }),
-  start: async (spec, sink) => spawnAdapterRuntime(implementation, spec, sink),
-  resume: async (spec, sink) => spawnAdapterRuntime(implementation, spec, sink, spec),
-  kill: (handle, reason) => killRuntime(handle, reason),
-  heartbeat: (handle) => heartbeatRuntime(handle),
-  classifyError: (evidence) => classifyRuntimeError(evidence),
+export const claudeDeclaration: AdapterDeclaration = Object.freeze({
+  runner: "CLAUDE",
+  binaryEnvironment: "CLAUDE_BINARY",
+  defaultBinary: "claude",
+  toolIntroduction: "Anneal tools attached to this session (MCP server 'agentos'; your client may prefix them, e.g. mcp__agentos__task_output):",
+  toolTransport: "mcp-stdio",
+  toolEntrypoint: mcpServerPath,
+  isolatesSessionConfig: false,
+  startupPreflightModel: null,
+  protectedEnvironmentVariables: ["CLAUDE_CONFIG_DIR"],
+  launcherEnvironmentVariables: [],
+  promptSections,
+  args: claudeArgs,
+  childEnvironment: claudeChildEnvironment,
+  provisionSessionConfig: provisionClaudeSessionConfig,
+  initialProviderState: () => undefined,
+  parseEvent: parseClaudeEvent,
+  preflight,
 });

--- a/packages/runner/src/adapters/codex.ts
+++ b/packages/runner/src/adapters/codex.ts
@@ -267,6 +267,7 @@ export const codexDeclaration: AdapterDeclaration = Object.freeze({
   toolIntroduction: "Anneal tools attached to this session (MCP server 'agentos'; your client may prefix them, e.g. mcp__agentos__task_output):",
   toolTransport: "mcp-stdio",
   toolEntrypoint: mcpServerPath,
+  enforcedTools: [],
   isolatesSessionConfig: true,
   startupPreflightModel: CODEX_STARTER_MODEL,
   protectedEnvironmentVariables: ["CODEX_HOME", "AGENTOS_CODEX_SERVICE_TIER"],

--- a/packages/runner/src/adapters/codex.ts
+++ b/packages/runner/src/adapters/codex.ts
@@ -7,30 +7,26 @@ import type { AgentScratch } from "../workspace.js";
 import {
   asRecord,
   capturePreflight,
-  classifyRuntimeError,
   createAdapterState,
   emitAdapterEvent,
   eventErrorMessage,
-  heartbeatRuntime,
-  killRuntime,
   markInFlightToolProgress,
   mcpServerArgs,
+  mcpServerPath,
   modelSpec,
   nodeBinaryPath,
   PREFLIGHT_REASONS,
   preflightFailure,
   processProviderEvent,
-  spawnAdapterRuntime,
   stringField,
-  type AdapterImplementation,
+  type AdapterDeclaration,
   type AdapterState,
-  type CliAdapter,
   type PreflightResult,
   type PreflightSpec,
   type ResumeSpec,
   type RunSpec,
   type SessionEventSink,
-} from "../adapters.js";
+} from "./runtime.js";
 import { provisionIsolatedSessionConfig, type SessionConfigOptions } from "./session-config.js";
 
 export const CODEX_STARTER_MODEL = "gpt-5.6-sol:medium";
@@ -75,6 +71,22 @@ const nativeSubagentArgs = (run: ClaimedTask["run"]): string[] => {
     "-c", `agents.default_subagent_model=${JSON.stringify(profile.model)}`,
     "-c", `agents.default_subagent_reasoning_effort=${JSON.stringify(profile.effort)}`,
     "-c", `agents.max_concurrent_threads_per_session=${profile.maxConcurrent}`,
+  ];
+};
+
+const codexPromptSections = (claim: ClaimedTask): string[] => {
+  const profile = codexNativeSubagentProfile(claim.run, "CODEX");
+  if (!profile) return [];
+  return [
+    "",
+    "Platform-pinned native implementation subagents:",
+    `- model: ${profile.model}`,
+    `- reasoning effort: ${profile.effort}`,
+    `- maximum concurrent child threads: ${profile.maxConcurrent} (root excluded)`,
+    "- multi_agent_v2 is enabled by the runner. Spawn, message, wait for, and close native children through the session collaboration tools; do not launch nested Codex CLI processes.",
+    "- The runner enforces the same child model and concurrency snapshot on fresh starts and resumes. Do not select or escalate a child model.",
+    "- Implementation proof is limited to each assignment's focused tests, one affected-workspace compile or typecheck after integration, and tests for seams crossed by multiple assignments.",
+    "- Do not run repository-wide suites or the repository Merge Gate in Implementation; the later Regression step owns the formal Gate.",
   ];
 };
 
@@ -197,12 +209,12 @@ const preflight = async (spec: PreflightSpec): Promise<PreflightResult> => {
   if (spec.model === null) {
     return { ok: false, cliVersion: null, authMode: null, capabilities, error: PREFLIGHT_REASONS.unsupportedModel };
   }
-  const version = await capturePreflight(spec.config, "CODEX", ["--version"], spec.env);
+  const version = await capturePreflight(spec.config, codexDeclaration, ["--version"], spec.env);
   if (version.code !== 0) {
     return { ok: false, cliVersion: null, authMode: null, capabilities, error: preflightFailure(PREFLIGHT_REASONS.cliMissing, version.code) };
   }
-  const help = await capturePreflight(spec.config, "CODEX", ["exec", "--help"], spec.env);
-  const resumeHelp = await capturePreflight(spec.config, "CODEX", ["exec", "resume", "--help"], spec.env);
+  const help = await capturePreflight(spec.config, codexDeclaration, ["exec", "--help"], spec.env);
+  const resumeHelp = await capturePreflight(spec.config, codexDeclaration, ["exec", "resume", "--help"], spec.env);
   if (help.code !== 0 || resumeHelp.code !== 0 || !execHelpIsCompatible(help.stdout, resumeHelp.stdout)) {
     return {
       ok: false,
@@ -213,7 +225,7 @@ const preflight = async (spec: PreflightSpec): Promise<PreflightResult> => {
     };
   }
   Object.assign(capabilities, { verifiedModel: spec.model, cliProtocol: "exec-json-stdin-resume" });
-  const auth = await capturePreflight(spec.config, "CODEX", ["login", "status"], spec.env);
+  const auth = await capturePreflight(spec.config, codexDeclaration, ["login", "status"], spec.env);
   const text = `${auth.stdout}\n${auth.stderr}`;
   const ok = auth.code === 0;
   return {
@@ -235,6 +247,7 @@ export const codexChildEnvironment = (
   // there, so relocating HOME does not change the authentication channel.
   HOME: scratch.configRoot,
   CODEX_HOME: scratch.configRoot,
+  AGENTOS_CODEX_SERVICE_TIER: _claim.run.codexServiceTier.toLowerCase(),
 });
 
 export const provisionCodexSessionConfig = (
@@ -247,17 +260,22 @@ export const provisionCodexSessionConfig = (
   baselineFile: join(config.sessionConfigBaselineRoot ?? codexSessionConfigBaselineRoot(), "codex", "config.toml"),
 }, options);
 
-const implementation: AdapterImplementation = {
+export const codexDeclaration: AdapterDeclaration = Object.freeze({
   runner: "CODEX",
+  binaryEnvironment: "CODEX_BINARY",
+  defaultBinary: "codex",
+  toolIntroduction: "Anneal tools attached to this session (MCP server 'agentos'; your client may prefix them, e.g. mcp__agentos__task_output):",
+  toolTransport: "mcp-stdio",
+  toolEntrypoint: mcpServerPath,
+  isolatesSessionConfig: true,
+  startupPreflightModel: CODEX_STARTER_MODEL,
+  protectedEnvironmentVariables: ["CODEX_HOME", "AGENTOS_CODEX_SERVICE_TIER"],
+  launcherEnvironmentVariables: ["CODEX_HOME", "AGENTOS_CODEX_SERVICE_TIER"],
+  promptSections: codexPromptSections,
   args: codexArgs,
+  childEnvironment: codexChildEnvironment,
+  provisionSessionConfig: provisionCodexSessionConfig,
+  initialProviderState: () => undefined,
   parseEvent: parseCodexEvent,
-};
-
-export const createCodexAdapter = (): CliAdapter => Object.freeze<CliAdapter>({
-  preflight: (spec) => preflight({ ...spec, runner: "CODEX" }),
-  start: async (spec, sink) => spawnAdapterRuntime(implementation, spec, sink),
-  resume: async (spec, sink) => spawnAdapterRuntime(implementation, spec, sink, spec),
-  kill: (handle, reason) => killRuntime(handle, reason),
-  heartbeat: (handle) => heartbeatRuntime(handle),
-  classifyError: (evidence) => classifyRuntimeError(evidence),
+  preflight,
 });

--- a/packages/runner/src/adapters/pi.test.ts
+++ b/packages/runner/src/adapters/pi.test.ts
@@ -19,17 +19,8 @@ const finalOutputOf = (events: Array<{ type: string; payload: Record<string, unk
 
 test("PI harvests one fresh openai-codex Luna message despite provisional and repeated usage", async () => {
   const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
-  const state = parsePiTranscript(await capturedTranscript(), (event) => { events.push(event); });
+  parsePiTranscript(await capturedTranscript(), (event) => { events.push(event); });
 
-  assert.deepEqual(state.piUsage, {
-    messages: 1,
-    reported: 1,
-    input: 2197,
-    output: 5,
-    cacheRead: 0,
-    cacheWrite: 0,
-    costNanoUsd: 445400,
-  });
   assert.deepEqual(finalOutputOf(events).agentosPiUsage, {
     messages: 1,
     reported: 1,

--- a/packages/runner/src/adapters/pi.ts
+++ b/packages/runner/src/adapters/pi.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { ClaimedTask } from "../api.js";
 import type { RunnerConfig } from "../config.js";
@@ -6,32 +7,30 @@ import type { AgentScratch } from "../workspace.js";
 import {
   asRecord,
   capturePreflight,
-  classifyRuntimeError,
   createAdapterState,
   emitAdapterEvent,
-  heartbeatRuntime,
-  killRuntime,
   modelSpec,
   PI_TOOL_NAMES,
-  piExtensionPath,
   PREFLIGHT_REASONS,
   preflightFailure,
   processProviderEvent,
-  spawnAdapterRuntime,
   stringField,
   TOOL_ORDER,
-  type AdapterImplementation,
+  type AdapterDeclaration,
   type AdapterState,
-  type CliAdapter,
-  type PiUsageTotals,
   type PreflightResult,
   type PreflightSpec,
   type ResumeSpec,
   type RunSpec,
   type SessionEventSink,
   type ToolKey,
-} from "../adapters.js";
+} from "./runtime.js";
 import { provisionIsolatedSessionConfig, type SessionConfigOptions } from "./session-config.js";
+
+const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+export const piExtensionPath = (): string =>
+  process.env.RUNNER_PI_EXTENSION_PATH ?? join(packageRoot, "assets", "pi-agentos-extension.ts");
 
 const denyArgs = (disabledTools: string[]): string[] => {
   const denied = new Set(disabledTools);
@@ -62,6 +61,30 @@ export const piArgs = (spec: RunSpec, resume?: ResumeSpec): string[] => {
 
 /** PI prices per message in USD; the accumulator carries integer nano-USD. */
 const NANOS_PER_USD = 1_000_000_000;
+
+export type PiUsageTotals = {
+  messages: number;
+  reported: number;
+  input: number | null;
+  output: number | null;
+  cacheRead: number | null;
+  cacheWrite: number | null;
+  costNanoUsd: number | null;
+};
+
+type PiState = {
+  turnCompleted: boolean;
+  finalAttemptFailed: boolean;
+  usage: PiUsageTotals;
+};
+
+const initialPiState = (): PiState => ({
+  turnCompleted: false,
+  finalAttemptFailed: false,
+  usage: { messages: 0, reported: 0, input: null, output: null, cacheRead: null, cacheWrite: null, costNanoUsd: null },
+});
+
+const piState = (state: AdapterState): PiState => state.providerState as PiState;
 
 const piNumber = (value: unknown, field: string, integral: boolean): number | null => {
   if (value === undefined || value === null) return null;
@@ -130,6 +153,7 @@ export const parsePiEvent = (
   event: Record<string, unknown>,
   sink: SessionEventSink,
 ): void => {
+  const provider = piState(state);
   const type = stringField(event, "type");
   if (type === "session") {
     state.providerConversationId = stringField(event, "id") ?? state.providerConversationId;
@@ -146,10 +170,10 @@ export const parsePiEvent = (
     state.inFlightTool = null;
     emitAdapterEvent(state, sink, "TOOL_COMPLETED", event, stringField(event, "toolCallId"));
   } else if (type === "turn_end" || type === "message_end") {
-    state.piTurnCompleted = true;
+    provider.turnCompleted = true;
     const message = asRecord(event.message);
     if (type === "message_end" && message && stringField(message, "role") === "assistant") {
-      harvestUsage(state.piUsage, message);
+      harvestUsage(provider.usage, message);
     }
     if (message && stringField(message, "role") === "assistant" && Array.isArray(message.content)) {
       const text = message.content
@@ -164,23 +188,23 @@ export const parsePiEvent = (
     const finalMessage = asRecord(messages.at(-1));
     const stopReason = stringField(finalMessage, "stopReason");
     const errorMessage = stringField(finalMessage, "errorMessage");
-    state.piFinalAttemptFailed = event.willRetry === true || stopReason === "error" || errorMessage !== null;
-    state.providerError = state.piFinalAttemptFailed
+    provider.finalAttemptFailed = event.willRetry === true || stopReason === "error" || errorMessage !== null;
+    state.providerError = provider.finalAttemptFailed
       ? errorMessage ?? (stopReason ? `PI stopped with ${stopReason}` : "PI provider retry failed")
       : null;
     emitAdapterEvent(state, sink, "PROVIDER_STATUS", event);
   } else if (type === "agent_settled") {
     state.terminalEventSeen = true;
-    state.terminalSuccess = state.piTurnCompleted && !state.piFinalAttemptFailed && !state.sawError;
-    const gaps = usageGaps(state.piUsage);
+    state.terminalSuccess = provider.turnCompleted && !provider.finalAttemptFailed && !state.sawError;
+    const gaps = usageGaps(provider.usage);
     if (gaps.length > 0) {
       const reason = gaps.join("; ");
       console.warn(JSON.stringify({ audit: "pi-usage", event: "incomplete", runId: state.runId, reason }));
-      emitAdapterEvent(state, sink, "ADAPTER_ERROR", { error: `Session cost is incomplete: ${reason}`, ...usagePayload(state.piUsage) });
+      emitAdapterEvent(state, sink, "ADAPTER_ERROR", { error: `Session cost is incomplete: ${reason}`, ...usagePayload(provider.usage) });
     }
-    emitAdapterEvent(state, sink, "FINAL_OUTPUT", state.piUsage.reported === 0
+    emitAdapterEvent(state, sink, "FINAL_OUTPUT", provider.usage.reported === 0
       ? event
-      : { ...event, agentosPiUsage: usagePayload(state.piUsage) });
+      : { ...event, agentosPiUsage: usagePayload(provider.usage) });
   } else {
     if (type?.includes("error")) state.sawError = true;
     emitAdapterEvent(state, sink, type?.includes("message") ? "MODEL_DELTA" : "PROVIDER_STATUS", event);
@@ -191,7 +215,7 @@ export const parsePiTranscript = (
   transcript: readonly unknown[],
   sink: SessionEventSink = () => undefined,
 ): AdapterState => {
-  const state = createAdapterState("PI", "transcript");
+  const state = createAdapterState("PI", "transcript", initialPiState());
   for (const value of transcript) processProviderEvent(state, asRecord(value) ?? { value }, sink, parsePiEvent);
   return state;
 };
@@ -219,11 +243,11 @@ const preflight = async (spec: PreflightSpec): Promise<PreflightResult> => {
       error: "PI openai-codex runs require an explicit Anneal Codex service tier",
     };
   }
-  const version = await capturePreflight(spec.config, "PI", ["--version"], spec.env);
+  const version = await capturePreflight(spec.config, piDeclaration, ["--version"], spec.env);
   if (version.code !== 0) {
     return { ok: false, cliVersion: null, authMode: null, capabilities, error: preflightFailure(PREFLIGHT_REASONS.cliMissing, version.code) };
   }
-  const help = await capturePreflight(spec.config, "PI", ["--help"], spec.env);
+  const help = await capturePreflight(spec.config, piDeclaration, ["--help"], spec.env);
   if (help.code !== 0 || !helpIsCompatible(`${help.stdout}\n${help.stderr}`)) {
     return {
       ok: false,
@@ -235,7 +259,7 @@ const preflight = async (spec: PreflightSpec): Promise<PreflightResult> => {
   }
   Object.assign(capabilities, { verifiedModel: spec.model, cliProtocol: "json-stdin-resume-isolated" });
   const provider = spec.model.split("/")[0] ?? "openai-codex";
-  const auth = await capturePreflight(spec.config, "PI", ["auth", "check", "--provider", provider], spec.env);
+  const auth = await capturePreflight(spec.config, piDeclaration, ["auth", "check", "--provider", provider], spec.env);
   const ok = auth.code === 0;
   return {
     ok,
@@ -256,7 +280,10 @@ export const piChildEnvironment = (
   // the existing auth channel.
   HOME: scratch.configRoot,
   PI_CODING_AGENT_DIR: scratch.configRoot,
-  ...(claim.run.model.startsWith("openai-codex/") ? { AGENTOS_PI_EXPECTS_OPENAI_CODEX: "1" } : {}),
+  ...(claim.run.model.startsWith("openai-codex/") ? {
+    AGENTOS_CODEX_SERVICE_TIER: claim.run.codexServiceTier.toLowerCase(),
+    AGENTOS_PI_EXPECTS_OPENAI_CODEX: "1",
+  } : {}),
 });
 
 export const provisionPiSessionConfig = (
@@ -268,17 +295,33 @@ export const provisionPiSessionConfig = (
   authFile: join(config.home, ".pi", "agent", "auth.json"),
 }, options);
 
-const implementation: AdapterImplementation = {
-  runner: "PI",
-  args: piArgs,
-  parseEvent: parsePiEvent,
+const promptSections = (claim: ClaimedTask): string[] => {
+  if (claim.run.subagentModel !== null || claim.run.subagentMaxConcurrent !== null) {
+    throw new Error("Native implementation subagents require a Codex root Run");
+  }
+  return [];
 };
 
-export const createPiAdapter = (): CliAdapter => Object.freeze<CliAdapter>({
-  preflight: (spec) => preflight({ ...spec, runner: "PI" }),
-  start: async (spec, sink) => spawnAdapterRuntime(implementation, spec, sink),
-  resume: async (spec, sink) => spawnAdapterRuntime(implementation, spec, sink, spec),
-  kill: (handle, reason) => killRuntime(handle, reason),
-  heartbeat: (handle) => heartbeatRuntime(handle),
-  classifyError: (evidence) => classifyRuntimeError(evidence),
+export const piDeclaration: AdapterDeclaration = Object.freeze({
+  runner: "PI",
+  binaryEnvironment: "PI_BINARY",
+  defaultBinary: "pi",
+  toolIntroduction: "Anneal tools attached to this session (pi extension tools):",
+  toolTransport: "pi-extension",
+  toolEntrypoint: piExtensionPath,
+  isolatesSessionConfig: true,
+  startupPreflightModel: "openai-codex/gpt-5.6-luna",
+  // PI_CODING_AGENT_SESSION_DIR is real, but --session-dir is authoritative.
+  // Deny task overrides without pretending the adapter depends on the variable.
+  protectedEnvironmentVariables: [
+    "PI_CODING_AGENT_DIR", "PI_CODING_AGENT_SESSION_DIR", "AGENTOS_CODEX_SERVICE_TIER", "AGENTOS_PI_EXPECTS_OPENAI_CODEX",
+  ],
+  launcherEnvironmentVariables: ["PI_CODING_AGENT_DIR", "AGENTOS_CODEX_SERVICE_TIER", "AGENTOS_PI_EXPECTS_OPENAI_CODEX"],
+  promptSections,
+  args: piArgs,
+  childEnvironment: piChildEnvironment,
+  provisionSessionConfig: provisionPiSessionConfig,
+  initialProviderState: initialPiState,
+  parseEvent: parsePiEvent,
+  preflight,
 });

--- a/packages/runner/src/adapters/pi.ts
+++ b/packages/runner/src/adapters/pi.ts
@@ -10,12 +10,10 @@ import {
   createAdapterState,
   emitAdapterEvent,
   modelSpec,
-  PI_TOOL_NAMES,
   PREFLIGHT_REASONS,
   preflightFailure,
   processProviderEvent,
   stringField,
-  TOOL_ORDER,
   type AdapterDeclaration,
   type AdapterState,
   type PreflightResult,
@@ -23,7 +21,6 @@ import {
   type ResumeSpec,
   type RunSpec,
   type SessionEventSink,
-  type ToolKey,
 } from "./runtime.js";
 import { provisionIsolatedSessionConfig, type SessionConfigOptions } from "./session-config.js";
 
@@ -32,12 +29,15 @@ const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
 export const piExtensionPath = (): string =>
   process.env.RUNNER_PI_EXTENSION_PATH ?? join(packageRoot, "assets", "pi-agentos-extension.ts");
 
+const PI_ENFORCED_TOOLS = Object.freeze(["BASH", "READ", "WRITE", "EDIT"] as const);
+
+const PI_TOOL_NAMES: Record<(typeof PI_ENFORCED_TOOLS)[number], string> = {
+  BASH: "bash", READ: "read", WRITE: "write", EDIT: "edit",
+};
+
 const denyArgs = (disabledTools: string[]): string[] => {
   const denied = new Set(disabledTools);
-  const names = TOOL_ORDER.flatMap((tool: ToolKey) => {
-    const name = denied.has(tool) ? PI_TOOL_NAMES[tool] : undefined;
-    return name ? [name] : [];
-  });
+  const names = PI_ENFORCED_TOOLS.flatMap((tool) => denied.has(tool) ? [PI_TOOL_NAMES[tool]] : []);
   return names.length === 0 ? [] : ["--exclude-tools", names.join(",")];
 };
 
@@ -309,6 +309,7 @@ export const piDeclaration: AdapterDeclaration = Object.freeze({
   toolIntroduction: "Anneal tools attached to this session (pi extension tools):",
   toolTransport: "pi-extension",
   toolEntrypoint: piExtensionPath,
+  enforcedTools: PI_ENFORCED_TOOLS,
   isolatesSessionConfig: true,
   startupPreflightModel: "openai-codex/gpt-5.6-luna",
   // PI_CODING_AGENT_SESSION_DIR is real, but --session-dir is authoritative.

--- a/packages/runner/src/adapters/runtime.ts
+++ b/packages/runner/src/adapters/runtime.ts
@@ -1,0 +1,531 @@
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { ClaimedTask, FailureClass } from "../api.js";
+import type { InFlightTool } from "../budget.js";
+import type { RunnerConfig, RunnerKind } from "../config.js";
+import { isTransientNetworkError } from "../network-retry.js";
+import type { SessionToolTransport } from "../session-tool-contract.js";
+import type { AgentScratch } from "../workspace.js";
+import type { SessionConfigOptions } from "./session-config.js";
+
+export type ToolKey = "BASH" | "READ" | "WRITE" | "EDIT" | "GLOB" | "GREP" | "WEB_FETCH" | "WEB_SEARCH";
+export const TOOL_ORDER: ToolKey[] = ["BASH", "READ", "WRITE", "EDIT", "GLOB", "GREP", "WEB_FETCH", "WEB_SEARCH"];
+export const CLAUDE_TOOL_NAMES: Record<ToolKey, string> = {
+  BASH: "Bash", READ: "Read", WRITE: "Write", EDIT: "Edit",
+  GLOB: "Glob", GREP: "Grep", WEB_FETCH: "WebFetch", WEB_SEARCH: "WebSearch",
+};
+export const PI_TOOL_NAMES: Partial<Record<ToolKey, string>> = {
+  BASH: "bash", READ: "read", WRITE: "write", EDIT: "edit",
+};
+
+export type AdapterEvent = {
+  source: "RUNNER" | "CLAUDE" | "CODEX" | "PI";
+  type: string;
+  providerEventId?: string | null;
+  toolCallId?: string | null;
+  payload: Record<string, unknown>;
+};
+
+export type SessionEventSink = (event: AdapterEvent) => void;
+
+export type ExitEvidence = {
+  exitCode: number | null;
+  signal: string | null;
+  terminalEventSeen: boolean;
+  terminalSuccess: boolean;
+  terminationReason: string | null;
+  finalOutput: string | null;
+  providerError: string | null;
+  stdout: string;
+  stderr: string;
+};
+
+export type ClassifiedFailure = {
+  failureClass: FailureClass;
+  retryable: boolean;
+  operatorAction?: string;
+};
+
+export type HeartbeatSnapshot = {
+  processAlive: boolean;
+  lastProcessAliveAt: Date;
+  lastProgressEventAt: Date;
+  inFlightTool: InFlightTool | null;
+};
+
+export type AdapterState = {
+  runId: string;
+  runner: RunnerKind;
+  startedAt: Date;
+  lastProcessAliveAt: Date;
+  lastProgressEventAt: Date;
+  inFlightTool: InFlightTool | null;
+  providerConversationId: string | null;
+  terminalEventSeen: boolean;
+  terminalSuccess: boolean;
+  terminationReason: string | null;
+  sawError: boolean;
+  providerError: string | null;
+  providerState: unknown;
+  finalOutput: string | null;
+  stdout: string;
+  stderr: string;
+};
+
+export type RuntimeHandle = AdapterState & {
+  child: ChildProcess;
+  pid: number | null;
+  exit: Promise<ExitEvidence>;
+};
+
+export type PreflightSpec = {
+  config: RunnerConfig;
+  runner: RunnerKind;
+  model: string | null;
+  env: NodeJS.ProcessEnv;
+};
+
+export type PreflightResult = {
+  ok: boolean;
+  cliVersion: string | null;
+  authMode: string | null;
+  capabilities: Record<string, unknown>;
+  error?: string;
+};
+
+export type RunSpec = {
+  config: RunnerConfig;
+  claim: ClaimedTask;
+  workingDirectory: string;
+  env: NodeJS.ProcessEnv;
+  prompt: string;
+  /** 0600 file the Anneal MCP server reads its session credentials from. */
+  credentialsPath: string;
+};
+
+export type ResumeSpec = RunSpec & { providerConversationId: string; input: string };
+export type KillResult = { signal: "SIGTERM" | "SIGKILL" | null; processAlive: boolean };
+
+/** One CLI implementation at the runner seam. */
+export interface CliAdapter {
+  preflight(spec: PreflightSpec): Promise<PreflightResult>;
+  start(spec: RunSpec, sink: SessionEventSink): Promise<RuntimeHandle>;
+  resume(spec: ResumeSpec, sink: SessionEventSink): Promise<RuntimeHandle>;
+  kill(handle: RuntimeHandle, reason: string): Promise<KillResult>;
+  heartbeat(handle: RuntimeHandle): Promise<HeartbeatSnapshot>;
+  classifyError(evidence: ExitEvidence): ClassifiedFailure;
+}
+
+export type AdapterEventParser = (
+  state: AdapterState,
+  event: Record<string, unknown>,
+  sink: SessionEventSink,
+) => void;
+
+/**
+ * Everything provider-specific that the runner needs, declared by the provider
+ * module that owns it. The hub derives its public registry and environment
+ * policy from these declarations.
+ */
+export type AdapterDeclaration = {
+  runner: RunnerKind;
+  binaryEnvironment: string;
+  defaultBinary: string;
+  toolIntroduction: string;
+  toolTransport: SessionToolTransport;
+  toolEntrypoint(): string;
+  isolatesSessionConfig: boolean;
+  startupPreflightModel: string | null;
+  /** Task secrets with these names may not override provider policy. */
+  protectedEnvironmentVariables: readonly string[];
+  /** Provider-owned values that must survive a scrubbing run-as launcher. */
+  launcherEnvironmentVariables: readonly string[];
+  promptSections(claim: ClaimedTask): string[];
+  args(spec: RunSpec, resume?: ResumeSpec): string[];
+  childEnvironment(claim: Pick<ClaimedTask, "run">, scratch: AgentScratch): NodeJS.ProcessEnv;
+  provisionSessionConfig(
+    config: RunnerConfig,
+    scratch: AgentScratch,
+    options?: SessionConfigOptions,
+  ): Promise<void>;
+  initialProviderState(): unknown;
+  parseEvent: AdapterEventParser;
+  preflight(spec: PreflightSpec): Promise<PreflightResult>;
+};
+
+export const createAdapterState = (
+  runner: RunnerKind,
+  runId: string,
+  providerState: unknown = undefined,
+  startedAt = new Date(),
+): AdapterState => ({
+  runId,
+  runner,
+  startedAt,
+  lastProcessAliveAt: startedAt,
+  lastProgressEventAt: startedAt,
+  inFlightTool: null,
+  providerConversationId: null,
+  terminalEventSeen: false,
+  terminalSuccess: false,
+  terminationReason: null,
+  sawError: false,
+  providerError: null,
+  providerState,
+  finalOutput: null,
+  stdout: "",
+  stderr: "",
+});
+
+const cap = (value: string, limit = 1_000_000): string => value.length <= limit ? value : value.slice(value.length - limit);
+const sourceFor = (runner: RunnerKind): AdapterEvent["source"] => runner;
+
+export const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null;
+
+export const stringField = (object: Record<string, unknown> | null, field: string): string | null =>
+  typeof object?.[field] === "string" ? object[field] as string : null;
+
+export const eventErrorMessage = (event: Record<string, unknown>): string | null =>
+  stringField(event, "message")
+  ?? stringField(event, "error")
+  ?? stringField(asRecord(event.error), "message");
+
+export const emitAdapterEvent = (state: AdapterState, sink: SessionEventSink, type: string, payload: Record<string, unknown>, toolCallId?: string | null): void => {
+  state.lastProgressEventAt = new Date();
+  sink({ source: sourceFor(state.runner), type, payload, ...(toolCallId !== undefined ? { toolCallId } : {}) });
+};
+
+export const markInFlightToolProgress = (state: AdapterState): void => {
+  if (state.inFlightTool) state.inFlightTool.lastProgressAt = new Date();
+};
+
+export const processProviderEvent = (
+  state: AdapterState,
+  event: Record<string, unknown>,
+  sink: SessionEventSink,
+  parseEvent: AdapterEventParser,
+): void => {
+  sink({ source: sourceFor(state.runner), type: "PROVIDER_RAW", payload: event });
+  parseEvent(state, event, sink);
+};
+
+const processLine = (
+  state: AdapterState,
+  line: string,
+  sink: SessionEventSink,
+  parseEvent: AdapterEventParser,
+): void => {
+  if (!line.trim()) return;
+  let event: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    event = asRecord(parsed) ?? { value: parsed };
+  } catch {
+    state.sawError = true;
+    emitAdapterEvent(state, sink, "ADAPTER_ERROR", { error: "invalid-json", line });
+    return;
+  }
+  processProviderEvent(state, event, sink, parseEvent);
+};
+
+// Run.model carries an optional reasoning-effort suffix: "<model>[:<effort>]".
+export const modelSpec = (raw: string): { model: string; effort: string | null } => {
+  const at = raw.lastIndexOf(":");
+  return at > 0 ? { model: raw.slice(0, at), effort: raw.slice(at + 1) } : { model: raw, effort: null };
+};
+
+/**
+ * The prompt or resume input is stdin, never argv. Persisted predecessor
+ * outputs can exceed operating-system argv limits, and argv is visible in ps.
+ */
+export const inputForRunner = (spec: RunSpec, resume?: ResumeSpec): string => resume?.input ?? spec.prompt;
+
+export const promptHashFor = (prompt: string): string => createHash("sha256").update(prompt).digest("hex");
+
+const COMMON_LAUNCHER_ENVIRONMENT = [
+  "RUNNER_WORKSPACE_ROOT", "CONTROL_PLANE_STATE_DIR", "HOME", "GIT_CONFIG_GLOBAL", "AGENTOS_GATE_SERVER",
+  "AGENTOS_RUN_ID", "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
+] as const;
+
+export const launchAdapterArgv = (
+  config: Pick<RunnerConfig, "runAsPrefix" | "binaries">,
+  declaration: Pick<AdapterDeclaration, "runner" | "launcherEnvironmentVariables">,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): { executable: string; args: string[] } => {
+  const binary = config.binaries[declaration.runner];
+  if (config.runAsPrefix.length === 0) return { executable: binary, args };
+  const names = [...COMMON_LAUNCHER_ENVIRONMENT, ...declaration.launcherEnvironmentVariables];
+  const assignments = names.flatMap((name) => env[name] !== undefined ? [`${name}=${env[name]}`] : []);
+  return {
+    executable: config.runAsPrefix[0]!,
+    args: [
+      ...config.runAsPrefix.slice(1),
+      ...(assignments.length > 0 ? ["/usr/bin/env", ...assignments] : []),
+      binary,
+      ...args,
+    ],
+  };
+};
+
+export const spawnAdapterRuntime = (
+  declaration: AdapterDeclaration,
+  spec: RunSpec,
+  sink: SessionEventSink,
+  resume?: ResumeSpec,
+): RuntimeHandle => {
+  const { runner } = declaration;
+  const binary = spec.config.binaries[runner];
+  const args = declaration.args(spec, resume);
+  const input = inputForRunner(spec, resume);
+  const { executable, args: fullArgs } = launchAdapterArgv(spec.config, declaration, args, spec.env);
+  const startedAt = new Date();
+  const child = spawn(executable, fullArgs, {
+    cwd: spec.workingDirectory,
+    env: spec.env,
+    detached: true,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const handle: RuntimeHandle = {
+    ...createAdapterState(runner, spec.claim.run.id, declaration.initialProviderState(), startedAt),
+    child,
+    pid: child.pid ?? null,
+    exit: Promise.resolve({} as ExitEvidence),
+  };
+  let buffer = "";
+  child.stdout!.setEncoding("utf8");
+  child.stderr!.setEncoding("utf8");
+  child.stdout!.on("data", (chunk: string) => {
+    handle.stdout = cap(handle.stdout + chunk);
+    buffer += chunk;
+    const lines = buffer.split(/\r?\n/u);
+    buffer = lines.pop() ?? "";
+    for (const line of lines) processLine(handle, line, sink, declaration.parseEvent);
+  });
+  child.stderr!.on("data", (chunk: string) => {
+    handle.stderr = cap(handle.stderr + chunk);
+    sink({ source: sourceFor(runner), type: "STDERR", payload: { text: chunk } });
+  });
+  handle.exit = new Promise<ExitEvidence>((resolvePromise) => {
+    let settled = false;
+    const finish = (exitCode: number | null, signal: string | null): void => {
+      if (settled) return;
+      settled = true;
+      if (buffer.trim()) processLine(handle, buffer, sink, declaration.parseEvent);
+      resolvePromise({
+        exitCode,
+        signal,
+        terminalEventSeen: handle.terminalEventSeen,
+        terminalSuccess: handle.terminalSuccess,
+        terminationReason: handle.terminationReason,
+        finalOutput: handle.finalOutput,
+        providerError: handle.providerError,
+        stdout: handle.stdout,
+        stderr: handle.stderr,
+      });
+    };
+    child.once("error", (error: NodeJS.ErrnoException) => {
+      handle.sawError = true;
+      handle.stderr = cap(`${handle.stderr}\n${error.message}`);
+      finish(error.code === "ENOENT" ? 127 : 1, null);
+    });
+    child.once("close", (code, signal) => finish(code, signal));
+  });
+  child.stdin!.on("error", (error: NodeJS.ErrnoException) => {
+    sink({
+      source: "RUNNER",
+      type: "PROMPT_DELIVERY_FAILED",
+      payload: { message: error.message, code: error.code ?? null },
+    });
+  });
+  child.stdin!.end(input);
+  sink({ source: "RUNNER", type: "PROCESS_STARTED", payload: {
+    pid: handle.pid,
+    binary,
+    args,
+    promptTransport: "stdin",
+    promptBytes: Buffer.byteLength(input),
+    promptHash: promptHashFor(input),
+  } });
+  return handle;
+};
+
+export const capturePreflight = async (
+  config: RunnerConfig,
+  declaration: Pick<AdapterDeclaration, "runner" | "launcherEnvironmentVariables">,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ code: number | null; stdout: string; stderr: string }> => new Promise((resolvePromise) => {
+  const launch = launchAdapterArgv(config, declaration, args, env);
+  const child = spawn(launch.executable, launch.args, { env, stdio: ["ignore", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  let settled = false;
+  const finish = (code: number | null, extra = ""): void => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    resolvePromise({ code, stdout, stderr: `${stderr}${extra}` });
+  };
+  const timer = setTimeout(() => {
+    child.kill("SIGKILL");
+    finish(1, "\npreflight timed out after 30 seconds");
+  }, 30_000);
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+  child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+  child.once("error", (error: NodeJS.ErrnoException) => finish(error.code === "ENOENT" ? 127 : 1, `\n${error.message}`));
+  child.once("close", (code) => finish(code));
+});
+
+export const PREFLIGHT_CLASS = {
+  cliMissing: "cli-missing",
+  cliIncompatible: "cli-incompatible",
+  notAuthenticated: "not-authenticated",
+  unsupportedModel: "unsupported-model",
+} as const;
+
+export const PREFLIGHT_REASONS = {
+  cliMissing: `${PREFLIGHT_CLASS.cliMissing}: the CLI did not answer --version`,
+  cliIncompatible: `${PREFLIGHT_CLASS.cliIncompatible}: the CLI does not expose the required Anneal exec protocol`,
+  notAuthenticated: `${PREFLIGHT_CLASS.notAuthenticated}: the CLI's own login check did not pass`,
+  unsupportedModel: `${PREFLIGHT_CLASS.unsupportedModel}: an explicit provider/model is required`,
+} as const;
+
+export const preflightFailure = (reason: string, code: number | null): string =>
+  code === null ? reason : `${reason} (exit ${code})`;
+
+export const adapterExecutionSucceeded = (evidence: ExitEvidence): boolean =>
+  evidence.exitCode === 0
+  && evidence.signal === null
+  && evidence.terminationReason === null
+  && evidence.terminalEventSeen
+  && evidence.terminalSuccess;
+
+export const outputTail = (evidence: ExitEvidence): string | null =>
+  (evidence.finalOutput ?? evidence.stdout).trim().slice(-500_000) || null;
+
+export const failureReasonFromEvidence = (evidence: ExitEvidence): string =>
+  evidence.providerError?.trim()
+  || evidence.stderr.trim()
+  || `CLI exited with code ${evidence.exitCode}`;
+
+export const classifyRuntimeError = (evidence: ExitEvidence): ClassifiedFailure => {
+  const text = evidence.providerError?.trim()
+    ? `${evidence.providerError}\n${evidence.stderr}`
+    : `${evidence.stderr}\n${evidence.stdout}`;
+  const authEvidence = `${evidence.providerError ?? ""}\n${evidence.stderr}`;
+  if (evidence.terminationReason) return { failureClass: "CANCELLED_OR_TIMED_OUT", retryable: false };
+  if (evidence.exitCode === 127) {
+    return { failureClass: "BINARY_NOT_FOUND", retryable: false, operatorAction: "Install the configured CLI or repair RUNNER_PATH" };
+  }
+  if (new RegExp(`authentication_failed|\\b401\\b|Missing authentication|No API key found|not logged in|${PREFLIGHT_CLASS.notAuthenticated}`, "iu").test(authEvidence)) {
+    return { failureClass: "AUTH_REQUIRED", retryable: false, operatorAction: "Log the runner account into the CLI" };
+  }
+  if (/connection lost|server_error/iu.test(`${evidence.providerError ?? ""}`)) {
+    return { failureClass: "TRANSIENT_PROVIDER", retryable: true };
+  }
+  if (/\b429\b|rate.?limit|usage.?limit|quota/iu.test(text)) return { failureClass: "RATE_LIMITED", retryable: true };
+  if (isTransientNetworkError(text) || /\b5\d\d\b|provider outage/iu.test(text)) {
+    return { failureClass: "TRANSIENT_PROVIDER", retryable: true };
+  }
+  if (/"isError"\s*:\s*true|"command_execution"[\s\S]{0,500}"status"\s*:\s*"failed"/u.test(text)) {
+    return { failureClass: "TOOL_FAILED", retryable: false };
+  }
+  if (evidence.exitCode === 0 && (!evidence.terminalEventSeen || !evidence.terminalSuccess)) {
+    return { failureClass: "PROTOCOL_ERROR", retryable: true, operatorAction: "Check CLI protocol/version drift" };
+  }
+  return { failureClass: "TASK_FAILED", retryable: false };
+};
+
+const ownedRunProcesses = async (runId: string): Promise<number[]> => new Promise((resolvePromise, rejectPromise) => {
+  const args = process.platform === "darwin"
+    ? ["-Eww", "-axo", "pid=,ppid=,pgid=,command="]
+    : ["-axeww", "-o", "pid=,ppid=,pgid=,command="];
+  execFile("ps", args, { maxBuffer: 64 * 1024 * 1024 }, (error, stdout) => {
+    if (error) {
+      rejectPromise(new Error(`Unable to inspect Run-owned processes: ${error.message}`));
+      return;
+    }
+    const marker = ` AGENTOS_RUN_ID=${runId}`;
+    const pids = stdout.split("\n").flatMap((line) => {
+      if (!line.includes(marker)) return [];
+      const match = /^\s*(\d+)\s+/u.exec(line);
+      return match ? [Number.parseInt(match[1]!, 10)] : [];
+    });
+    resolvePromise(pids.filter((pid) => pid !== process.pid));
+  });
+});
+
+const signalProcesses = (pids: number[], signal: NodeJS.Signals): void => {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+    }
+  }
+};
+
+const waitForRunDrain = async (runId: string, timeoutMs: number): Promise<number[]> => {
+  const deadline = Date.now() + timeoutMs;
+  let remaining = await ownedRunProcesses(runId);
+  while (remaining.length > 0 && Date.now() < deadline) {
+    await new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 50));
+    remaining = await ownedRunProcesses(runId);
+  }
+  return remaining;
+};
+
+export const killRuntime = async (handle: RuntimeHandle, reason: string): Promise<KillResult> => {
+  handle.terminationReason = reason;
+  const pid = handle.pid;
+  if (pid && handle.child.exitCode === null && handle.child.signalCode === null) {
+    try { process.kill(-pid, "SIGTERM"); } catch { /* the ownership scan below is authoritative */ }
+  }
+  let remaining = await ownedRunProcesses(handle.runId);
+  signalProcesses(remaining, "SIGTERM");
+  remaining = await waitForRunDrain(handle.runId, 5_000);
+  if (remaining.length === 0) {
+    await handle.exit;
+    return { signal: pid ? "SIGTERM" : null, processAlive: false };
+  }
+  signalProcesses(remaining, "SIGKILL");
+  remaining = await waitForRunDrain(handle.runId, 5_000);
+  if (remaining.length > 0) throw new Error(`Unable to terminate ${remaining.length} process(es) owned by Run ${handle.runId}`);
+  await handle.exit;
+  return { signal: "SIGKILL", processAlive: false };
+};
+
+export const heartbeatRuntime = async (handle: RuntimeHandle): Promise<HeartbeatSnapshot> => {
+  const processAlive = handle.child.exitCode === null && handle.child.signalCode === null;
+  if (processAlive) handle.lastProcessAliveAt = new Date();
+  return {
+    processAlive,
+    lastProcessAliveAt: handle.lastProcessAliveAt,
+    lastProgressEventAt: handle.lastProgressEventAt,
+    inFlightTool: handle.inFlightTool,
+  };
+};
+
+export const createCliAdapter = (declaration: AdapterDeclaration): CliAdapter => Object.freeze<CliAdapter>({
+  preflight: (spec) => declaration.preflight({ ...spec, runner: declaration.runner }),
+  start: async (spec, sink) => spawnAdapterRuntime(declaration, spec, sink),
+  resume: async (spec, sink) => spawnAdapterRuntime(declaration, spec, sink, spec),
+  kill: (handle, reason) => killRuntime(handle, reason),
+  heartbeat: (handle) => heartbeatRuntime(handle),
+  classifyError: (evidence) => classifyRuntimeError(evidence),
+});
+
+const packageRoot = fileURLToPath(new URL("../..", import.meta.url));
+export const mcpServerPath = (): string => process.env.RUNNER_MCP_SERVER_PATH ?? join(packageRoot, "dist", "mcp-server.js");
+export const nodeBinaryPath = (): string => process.env.RUNNER_NODE_BINARY ?? process.execPath;
+export const mcpServerArgs = (credentialsPath: string): string[] => [mcpServerPath(), "--credentials", credentialsPath];
+export const mcpConfig = (credentialsPath: string): { mcpServers: Record<string, { type: string; command: string; args: string[] }> } => ({
+  mcpServers: { agentos: { type: "stdio", command: nodeBinaryPath(), args: mcpServerArgs(credentialsPath) } },
+});

--- a/packages/runner/src/adapters/runtime.ts
+++ b/packages/runner/src/adapters/runtime.ts
@@ -12,14 +12,6 @@ import type { AgentScratch } from "../workspace.js";
 import type { SessionConfigOptions } from "./session-config.js";
 
 export type ToolKey = "BASH" | "READ" | "WRITE" | "EDIT" | "GLOB" | "GREP" | "WEB_FETCH" | "WEB_SEARCH";
-export const TOOL_ORDER: ToolKey[] = ["BASH", "READ", "WRITE", "EDIT", "GLOB", "GREP", "WEB_FETCH", "WEB_SEARCH"];
-export const CLAUDE_TOOL_NAMES: Record<ToolKey, string> = {
-  BASH: "Bash", READ: "Read", WRITE: "Write", EDIT: "Edit",
-  GLOB: "Glob", GREP: "Grep", WEB_FETCH: "WebFetch", WEB_SEARCH: "WebSearch",
-};
-export const PI_TOOL_NAMES: Partial<Record<ToolKey, string>> = {
-  BASH: "bash", READ: "read", WRITE: "write", EDIT: "edit",
-};
 
 export type AdapterEvent = {
   source: "RUNNER" | "CLAUDE" | "CODEX" | "PI";
@@ -137,6 +129,8 @@ export type AdapterDeclaration = {
   toolIntroduction: string;
   toolTransport: SessionToolTransport;
   toolEntrypoint(): string;
+  /** Tool policy keys this CLI can actually deny in argv. */
+  enforcedTools: readonly ToolKey[];
   isolatesSessionConfig: boolean;
   startupPreflightModel: string | null;
   /** Task secrets with these names may not override provider policy. */


### PR DESCRIPTION
## Summary
- make each CLI provider own one complete adapter declaration
- derive the runner registry and environment policy from declarations
- move shared runtime mechanics out of the registry hub and keep PI state provider-owned

## Verification
- npm run lint
- RUNNER_WORKSPACE_ROOT=$(mktemp -d) node --import tsx --test src/adapters.test.ts src/adapters/pi.test.ts src/codex-usage.test.ts