### PR TITLE
refactor(board): deepen card rendering modules

### DIFF
--- a/apps/web/src/components/board-card-shell.tsx
+++ b/apps/web/src/components/board-card-shell.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+
+import { navigate } from "../lib/router";
+import { cn } from "../lib/utils";
+import { ROW, RowMenu, type RowMenuEntry } from "./ui";
+
+/* The shell is deliberately not fixed-height: cards with fewer facts should
+ * not reserve rows. Free text is bounded here because a 2KB failure once made
+ * one card 1,792px tall and a long path widened another past its column. */
+const CARD = "relative cursor-pointer rounded-xl border border-border bg-card px-[14px] py-[13px] hover:border-[color:var(--border-hover)] has-[a:focus-visible]:border-[color:var(--primary)]";
+const TITLE = "line-clamp-3 text-foreground [overflow-wrap:anywhere] hover:underline focus-visible:underline";
+/** An explicit minmax column prevents a nowrap row from setting the card's
+ * min-content width; this is what keeps schedule prose inside narrow columns. */
+const META = "mt-[9px] grid grid-cols-[minmax(0,1fr)] gap-[6px] text-[11.5px] text-muted-foreground";
+/** Plain text and a 20px pill share a stable row height. */
+const META_ROW = "flex min-h-[20px] flex-wrap items-center gap-[8px]";
+const FAILURE = "line-clamp-3 text-[var(--destructive-fg)] [overflow-wrap:anywhere]";
+/** Board icons are 13px; the generic button rule would otherwise make them 16px. */
+const FOOT = "mt-[10px] flex items-center gap-[10px] text-[11.5px] text-muted-foreground [&_svg]:size-[13px] [&_svg]:flex-none [&_svg]:opacity-85";
+
+const opensCard = (event: React.MouseEvent<HTMLElement>): boolean => {
+  if (event.defaultPrevented) return false;
+  const target = event.target;
+  if (target instanceof Element && target.closest("a, button, [role='menuitem'], [role='menu']") !== null) return false;
+  return (window.getSelection()?.toString() ?? "") === "";
+};
+
+/**
+ * The board card's chrome and click delegation.
+ *
+ * Callers supply content slots; the module owns the geometry, link/menu header,
+ * drag handoff, and the rule that selecting card text must never navigate.
+ */
+export const BoardCardShell = ({
+  cardId,
+  chainId,
+  route,
+  title,
+  menuItems,
+  menuLabel,
+  metaRows,
+  failure,
+  footer,
+  after,
+  dragId,
+}: {
+  cardId: string;
+  chainId?: string | undefined;
+  route: string;
+  title: string;
+  menuItems: RowMenuEntry[];
+  menuLabel: string;
+  metaRows: readonly ReactNode[];
+  failure?: ReactNode;
+  footer: ReactNode;
+  after?: ReactNode;
+  dragId?: string | undefined;
+}): ReactNode => (
+  <article
+    data-card={cardId}
+    data-chain-card={chainId === undefined ? undefined : ""}
+    data-chain-id={chainId}
+    className={CARD}
+    draggable={dragId === undefined ? undefined : true}
+    onDragStart={dragId === undefined ? undefined : (event) => event.dataTransfer.setData("text/plain", dragId)}
+    onClick={(event) => { if (opensCard(event)) navigate(route); }}
+  >
+    <div className={cn(ROW, "items-start")}>
+      <h3 className="min-w-0 flex-1 text-[13px] leading-[1.45]">
+        <a data-card-title="" href={`#${route}`} className={TITLE}>{title}</a>
+      </h3>
+      <RowMenu items={menuItems} label={menuLabel} />
+    </div>
+    <div className={META}>
+      {metaRows.map((row, index) => <div className={META_ROW} key={index}>{row}</div>)}
+      {failure === undefined ? null : <div className={cn(META_ROW, FAILURE)}>{failure}</div>}
+    </div>
+    <div className={FOOT}>{footer}</div>
+    {after}
+  </article>
+);

--- a/apps/web/src/components/chain-aggregate-card.tsx
+++ b/apps/web/src/components/chain-aggregate-card.tsx
@@ -1,20 +1,14 @@
-import { type MouseEvent, type ReactNode } from "react";
+import type { ReactNode } from "react";
 
-import { duration, timeAgo, usageCostLabel } from "../lib/format";
+import { timeAgo, usageCostLabel } from "../lib/format";
 import type { BoardTask, ChainAggregate, ChainAggregateState } from "../lib/types";
-import { cn } from "../lib/utils";
 import { navigate } from "../lib/router";
+import { BoardCardShell } from "./board-card-shell";
 import { IconLock } from "./icons";
-import { DOT, DOT_TONE, Pill, ROW, RowMenu, type RowMenuEntry } from "./ui";
+import { RunLine } from "./run-line";
+import { Pill, type RowMenuEntry } from "./ui";
 import { Button } from "./ui/button";
 import { useT, type Translate } from "../lib/i18n";
-
-const CARD = "relative cursor-pointer rounded-xl border border-border bg-card px-[14px] py-[13px] hover:border-[color:var(--border-hover)] has-[a:focus-visible]:border-[color:var(--primary)]";
-const TITLE = "line-clamp-2 text-foreground [overflow-wrap:anywhere] hover:underline focus-visible:underline";
-const META = "mt-[9px] grid grid-cols-[minmax(0,1fr)] gap-[6px] text-[11.5px] text-muted-foreground";
-const META_ROW = "flex min-h-[20px] flex-wrap items-center gap-[8px]";
-const FOOT = "mt-[10px] flex items-center gap-[10px] text-[11.5px] text-muted-foreground";
-const FAILURE = "line-clamp-3 text-[var(--destructive-fg)] [overflow-wrap:anywhere]";
 
 export type ChainAggregateActions = {
   onActivate: (taskId: string) => void;
@@ -29,8 +23,6 @@ const STATE_TONE: Record<ChainAggregateState, "green" | "amber" | "grey"> = {
   idle: "grey",
   settled: "green",
 };
-
-const ACTIVE_RUNS = new Set(["QUEUED", "CLAIMED", "PROVISIONING", "RUNNING"]);
 
 const chainName = (aggregate: ChainAggregate): string => aggregate.chainName ?? aggregate.chainId.slice(0, 8);
 
@@ -48,19 +40,6 @@ const memberPosition = (aggregate: ChainAggregate, members: readonly BoardTask[]
 
 const aggregateCost = (value: ChainAggregate["totalCost"]): string =>
   value === null ? "—" : usageCostLabel(value);
-
-const runLine = (aggregate: ChainAggregate, t: Translate): ReactNode => {
-  const run = aggregate.frontier.latestRun;
-  if (run === null) return null;
-  const active = ACTIVE_RUNS.has(run.status);
-  const tone = run.status === "SUCCEEDED" ? "green" : run.status === "FAILED" || run.status === "TIMED_OUT" || run.status === "LOST" ? "red" : "amber";
-  const elapsed = active && run.startedAt !== null ? t("tasks.card.runningDuration", { duration: duration(run.startedAt, null) }) : null;
-  return <span data-chain-frontier-run="" className="inline-flex min-w-0 items-center gap-[6px] whitespace-nowrap">
-    <span className={cn(DOT, DOT_TONE[tone])} />
-    <span className="text-primary">{t("tasks.card.run", { n: run.runNumber })}</span>
-    <span className="overflow-hidden text-ellipsis text-[color:var(--faint)]"> · {t(`status.run.${run.status}`)}{elapsed === null ? "" : ` · ${elapsed}`}</span>
-  </span>;
-};
 
 const routeFor = (representativeTaskId: string): string => `/tasks/${representativeTaskId}`;
 
@@ -95,31 +74,12 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
   const predecessor = aggregate.activation.predecessor;
   const memberTaskIds = members.map((member) => member.id);
   const handlers: ChainAggregateActions = actions ?? { onActivate: () => undefined, onFilter: () => undefined, onArchive: () => undefined };
-  const frontierRun = runLine(aggregate, t);
-  const onBodyClick = (event: MouseEvent<HTMLElement>): void => {
-    const target = event.target;
-    if (target instanceof Element && target.closest("a, button, [role='menuitem'], [role='menu']") !== null) return;
-    navigate(routeFor(representative));
-  };
-  return <article
-    data-card={`chain:${aggregate.chainId}`}
-    data-chain-card=""
-    data-chain-id={aggregate.chainId}
-    className={CARD}
-    onClick={onBodyClick}
-  >
-    <div className={cn(ROW, "items-start")}>
-      <h3 className="min-w-0 flex-1 text-[13px] leading-[1.45]">
-        <a data-card-title="" href={`#${routeFor(representative)}`} className={TITLE}>{title}</a>
-      </h3>
-      <RowMenu items={menu(aggregate, representative, memberTaskIds, handlers, t)} label={t("tasks.aggregate.actionsFor", { name: title })} />
-    </div>
-    <div className={META}>
-      <div data-chain-progress="" className={META_ROW}>
+  const metaRows: ReactNode[] = [
+      <span data-chain-progress="" className="contents">
         <span>{t("tasks.aggregate.progress", { current: position, total: aggregate.stepCount })}</span>
         <Pill tone={STATE_TONE[state]}>{t(`tasks.aggregate.state.${state}`)}</Pill>
-      </div>
-      <div data-chain-frontier="" className={META_ROW}>
+      </span>,
+      <span data-chain-frontier="" className="contents">
         <span className="line-clamp-2 min-w-0 [overflow-wrap:anywhere]">{aggregate.frontier.title}</span>
         <button
           type="button"
@@ -130,27 +90,35 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
         >
           {t("tasks.aggregate.filter")}
         </button>
-      </div>
-      {frontierRun === null ? null : <div className={META_ROW}>{frontierRun}</div>}
-      {aggregate.frontier.failureReason === null ? null : (
-        <div data-chain-failure="" className={cn(META_ROW, FAILURE)}>{aggregate.frontier.failureReason}</div>
-      )}
-      {state === "parked-unactivated" && aggregate.activation.taskId !== null ? (
-        <div className={META_ROW}>
+      </span>,
+      ...(aggregate.frontier.latestRun === null ? [] : [
+        <RunLine run={aggregate.frontier.latestRun} mergeOutcome={aggregate.frontier.mergeOutcome} showElapsed />,
+      ]),
+      ...(state === "parked-unactivated" && aggregate.activation.taskId !== null ? [
           <Button type="button" variant="legacyPrimary" size="legacySmall" onClick={(event) => { event.stopPropagation(); handlers.onActivate(aggregate.activation.taskId!); }}>
             {t("tasks.aggregate.activate")}
-          </Button>
-        </div>
-      ) : state === "waiting-on-predecessor" && predecessor !== null ? (
-        <div data-chain-locked="" className={cn(META_ROW, "text-[color:var(--status-amber-fg)]")}>
+          </Button>,
+      ] : state === "waiting-on-predecessor" && predecessor !== null ? [
+        <span data-chain-locked="" className="contents text-[color:var(--status-amber-fg)]">
           <IconLock /> <span className="line-clamp-2 min-w-0 [overflow-wrap:anywhere]">{t("tasks.aggregate.waitingOn", { name: predecessor.taskName })}</span>
-        </div>
-      ) : null}
-    </div>
-    <div className={FOOT}>
+        </span>,
+      ] : []),
+  ];
+  return <BoardCardShell
+    cardId={`chain:${aggregate.chainId}`}
+    chainId={aggregate.chainId}
+    route={routeFor(representative)}
+    title={title}
+    menuItems={menu(aggregate, representative, memberTaskIds, handlers, t)}
+    menuLabel={t("tasks.aggregate.actionsFor", { name: title })}
+    metaRows={metaRows}
+    failure={aggregate.frontier.failureReason === null
+      ? undefined
+      : <span data-chain-failure="">{aggregate.frontier.failureReason}</span>}
+    footer={<>
       <span>{t("tasks.aggregate.cost", { amount: aggregateCost(aggregate.totalCost) })}</span>
       <span className="flex-1" />
       <span>{timeAgo(aggregate.createdAt)}</span>
-    </div>
-  </article>;
+    </>}
+  />;
 };

--- a/apps/web/src/components/desktop-board.tsx
+++ b/apps/web/src/components/desktop-board.tsx
@@ -5,10 +5,11 @@ import { useT } from "../lib/i18n";
 import { storage } from "../lib/storage";
 import type { BoardTask, TaskStatus } from "../lib/types";
 import { cn } from "../lib/utils";
+import { type ChainAggregateActions } from "./chain-aggregate-card";
+import { PaginatedBoardEntries } from "./paginated-board-entries";
+import { type CardActions } from "./task-card";
 import { COUNT } from "./ui";
 import { Button } from "./ui/button";
-import { ChainAggregateCard, type ChainAggregateActions } from "./chain-aggregate-card";
-import { type CardActions, TaskCard } from "./task-card";
 
 /**
  * The board is one scroll surface, in both directions.
@@ -59,7 +60,6 @@ const COLUMN_HEAD = "sticky top-0 z-[2] flex h-[36px] flex-none items-center gap
 const COLUMN_BODY = "grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)] content-start gap-[10px] rounded-xl border border-[color:var(--border-soft)] bg-[color-mix(in_srgb,var(--foreground)_1%,transparent)] p-[10px]";
 const COLUMN_BODY_OVER = "border-[color:var(--primary-soft)] bg-[color-mix(in_srgb,var(--primary)_4%,transparent)]";
 const COLUMN_EMPTY = "px-0 py-[26px] text-center text-[12px] text-[color:var(--faint)]";
-const COLUMN_PAGER = "flex items-center justify-center gap-[8px] pt-[2px]";
 
 export { CARD_PAGE_SIZE };
 
@@ -80,16 +80,6 @@ export const BoardColumn = ({ column, tasks, loading, dragOver, onDragOver, onDr
 }): ReactNode => {
   const t = useT();
   const entries = normalizeBoardEntries(tasks);
-  const [page, setPage] = useState(0);
-  const lastPage = Math.max(0, Math.ceil(entries.length / CARD_PAGE_SIZE) - 1);
-  const visiblePage = Math.min(page, lastPage);
-  const start = visiblePage * CARD_PAGE_SIZE;
-  const visibleTasks = entries.slice(start, start + CARD_PAGE_SIZE);
-  const nextCount = Math.min(CARD_PAGE_SIZE, Math.max(0, entries.length - start - CARD_PAGE_SIZE));
-  const previousCount = Math.min(CARD_PAGE_SIZE, start);
-  useEffect(() => {
-    if (page > lastPage) setPage(lastPage);
-  }, [lastPage, page]);
   return <div className={COLUMN}>
     <div className={COLUMN_HEAD}>
       {t(column.labelKey)}<span className={COUNT}>{entries.length}</span>
@@ -113,23 +103,7 @@ export const BoardColumn = ({ column, tasks, loading, dragOver, onDragOver, onDr
         onDrop(event.dataTransfer.getData("text/plain"), column.status);
       }}
     >
-      {visibleTasks.map((entry) => entry.kind === "chain"
-        ? <ChainAggregateCard key={entry.id} aggregate={entry.aggregate} members={entry.members} representativeTaskId={entry.representativeTaskId} actions={aggregateActions} />
-        : <TaskCard key={entry.id} task={entry.task} actions={actions} draggable={entry.task.moveTargets.length > 0} />)}
-      {previousCount > 0 || nextCount > 0 ? (
-        <div className={COLUMN_PAGER}>
-          {previousCount > 0 ? (
-            <Button type="button" variant="legacy" size="legacySmall" className="shadow-none" onClick={() => setPage(visiblePage - 1)}>
-              {t("tasks.column.previous", { n: previousCount })}
-            </Button>
-          ) : null}
-          {nextCount > 0 ? (
-            <Button type="button" variant="legacy" size="legacySmall" className="shadow-none" onClick={() => setPage(visiblePage + 1)}>
-              {t("tasks.column.more", { n: nextCount })}
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
+      <PaginatedBoardEntries entries={entries} actions={actions} aggregateActions={aggregateActions} draggable />
       {/* Every column gets the same invitation, Backlog included (E16). */}
       {entries.length === 0 ? <div className={COLUMN_EMPTY}>{t(loading ? "common.loading" : "tasks.column.drop")}</div> : null}
     </div>

--- a/apps/web/src/components/mobile-task-list.tsx
+++ b/apps/web/src/components/mobile-task-list.tsx
@@ -1,13 +1,14 @@
-import { type ReactNode, useEffect, useState } from "react";
+import type { ReactNode } from "react";
 
-import { CARD_PAGE_SIZE, COLUMNS, type BoardEntry, type Counts, normalizeBoardEntries } from "../lib/board";
+import { COLUMNS, type BoardEntry, type Counts, normalizeBoardEntries } from "../lib/board";
 import { useT } from "../lib/i18n";
 import type { BoardTask, TaskStatus } from "../lib/types";
 import { cn } from "../lib/utils";
+import { type ChainAggregateActions } from "./chain-aggregate-card";
+import { PaginatedBoardEntries } from "./paginated-board-entries";
+import { type CardActions } from "./task-card";
 import { COUNT } from "./ui";
 import { Button } from "./ui/button";
-import { ChainAggregateCard, type ChainAggregateActions } from "./chain-aggregate-card";
-import { type CardActions, TaskCard } from "./task-card";
 
 /**
  * The board below 901px: status tabs and one column of cards.
@@ -29,7 +30,6 @@ const TAB_ON = "border-border bg-accent text-foreground";
 const LIST = "mt-[14px] grid grid-cols-[minmax(0,1fr)] gap-[10px]";
 const LIST_EMPTY = "px-0 py-[40px] text-center text-[12.5px] text-[color:var(--faint)]";
 const LIST_TOOLBAR = "mt-[14px] flex items-center gap-[10px]";
-const LIST_PAGER = "flex items-center justify-center gap-[8px]";
 
 export const MobileTaskList = ({ tab, counts, tasks, loading, onSelectTab, onArchiveDone, actions, aggregateActions, listRef }: {
   tab: TaskStatus;
@@ -44,17 +44,6 @@ export const MobileTaskList = ({ tab, counts, tasks, loading, onSelectTab, onArc
 }): ReactNode => {
   const t = useT();
   const entries = normalizeBoardEntries(tasks);
-  const [page, setPage] = useState(0);
-  const lastPage = Math.max(0, Math.ceil(entries.length / CARD_PAGE_SIZE) - 1);
-  const visiblePage = Math.min(page, lastPage);
-  const start = visiblePage * CARD_PAGE_SIZE;
-  const visibleTasks = entries.slice(start, start + CARD_PAGE_SIZE);
-  const nextCount = Math.min(CARD_PAGE_SIZE, Math.max(0, entries.length - start - CARD_PAGE_SIZE));
-  const previousCount = Math.min(CARD_PAGE_SIZE, start);
-  useEffect(() => { setPage(0); }, [tab]);
-  useEffect(() => {
-    if (page > lastPage) setPage(lastPage);
-  }, [lastPage, page]);
   return <>
     {/* A tablist, not five buttons: it is the page's primary navigation and the
         arrow keys are what a screen reader user reaches for. */}
@@ -105,23 +94,7 @@ export const MobileTaskList = ({ tab, counts, tasks, loading, onSelectTab, onArc
     >
       {/* No `draggable`: HTML5 drag does not fire on touch, and a card that
           looks draggable and is not is worse than one that does not (K15). */}
-      {visibleTasks.map((entry) => entry.kind === "chain"
-        ? <ChainAggregateCard key={entry.id} aggregate={entry.aggregate} members={entry.members} representativeTaskId={entry.representativeTaskId} actions={aggregateActions} />
-        : <TaskCard key={entry.id} task={entry.task} actions={actions} />)}
-      {previousCount > 0 || nextCount > 0 ? (
-        <div className={LIST_PAGER}>
-          {previousCount > 0 ? (
-            <Button type="button" variant="legacy" size="legacySmall" className="shadow-none" onClick={() => setPage(visiblePage - 1)}>
-              {t("tasks.column.previous", { n: previousCount })}
-            </Button>
-          ) : null}
-          {nextCount > 0 ? (
-            <Button type="button" variant="legacy" size="legacySmall" className="shadow-none" onClick={() => setPage(visiblePage + 1)}>
-              {t("tasks.column.more", { n: nextCount })}
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
+      <PaginatedBoardEntries key={tab} entries={entries} actions={actions} aggregateActions={aggregateActions} />
       {entries.length === 0 ? <div className={LIST_EMPTY}>{t(loading ? "common.loading" : "tasks.column.nothing")}</div> : null}
     </div>
   </>;

--- a/apps/web/src/components/paginated-board-entries.tsx
+++ b/apps/web/src/components/paginated-board-entries.tsx
@@ -1,0 +1,50 @@
+import { type ReactNode, useEffect, useState } from "react";
+
+import { CARD_PAGE_SIZE, type BoardEntry } from "../lib/board";
+import { useT } from "../lib/i18n";
+import { ChainAggregateCard, type ChainAggregateActions } from "./chain-aggregate-card";
+import { type CardActions, TaskCard } from "./task-card";
+import { Button } from "./ui/button";
+
+const PAGER = "flex items-center justify-center gap-[8px] pt-[2px]";
+
+/** One bounded board-entry list, including page state, clamping, cards, and controls. */
+export const PaginatedBoardEntries = ({ entries, actions, aggregateActions, draggable = false }: {
+  entries: readonly BoardEntry[];
+  actions: CardActions;
+  aggregateActions?: ChainAggregateActions | undefined;
+  draggable?: boolean;
+}): ReactNode => {
+  const t = useT();
+  const [page, setPage] = useState(0);
+  const lastPage = Math.max(0, Math.ceil(entries.length / CARD_PAGE_SIZE) - 1);
+  const visiblePage = Math.min(page, lastPage);
+  const start = visiblePage * CARD_PAGE_SIZE;
+  const visibleEntries = entries.slice(start, start + CARD_PAGE_SIZE);
+  const nextCount = Math.min(CARD_PAGE_SIZE, Math.max(0, entries.length - start - CARD_PAGE_SIZE));
+  const previousCount = Math.min(CARD_PAGE_SIZE, start);
+
+  useEffect(() => {
+    if (page > lastPage) setPage(lastPage);
+  }, [lastPage, page]);
+
+  return <>
+    {visibleEntries.map((entry) => entry.kind === "chain"
+      ? <ChainAggregateCard key={entry.id} aggregate={entry.aggregate} members={entry.members} representativeTaskId={entry.representativeTaskId} actions={aggregateActions} />
+      : <TaskCard key={entry.id} task={entry.task} actions={actions} draggable={draggable && entry.task.moveTargets.length > 0} />)}
+    {previousCount > 0 || nextCount > 0 ? (
+      <div className={PAGER}>
+        {previousCount > 0 ? (
+          <Button type="button" variant="legacy" size="legacySmall" className="shadow-none" onClick={() => setPage(visiblePage - 1)}>
+            {t("tasks.column.previous", { n: previousCount })}
+          </Button>
+        ) : null}
+        {nextCount > 0 ? (
+          <Button type="button" variant="legacy" size="legacySmall" className="shadow-none" onClick={() => setPage(visiblePage + 1)}>
+            {t("tasks.column.more", { n: nextCount })}
+          </Button>
+        ) : null}
+      </div>
+    ) : null}
+  </>;
+};

--- a/apps/web/src/components/run-line.tsx
+++ b/apps/web/src/components/run-line.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+
+import { duration } from "../lib/format";
+import { useT } from "../lib/i18n";
+import { mergeBadge } from "../lib/merge-outcome";
+import { isActiveRunStatus } from "../lib/board";
+import type { BoardLatestRun, MergeOutcome, RunStatus } from "../lib/types";
+import { cn } from "../lib/utils";
+import { Badge } from "./ui/badge";
+
+export const DOT = "size-[7px] rounded-full bg-[color:var(--faint)]";
+export const DOT_TONE = {
+  on: "bg-[color:var(--status-green-fg)] shadow-[0_0_8px_color-mix(in_srgb,var(--status-green-fg)_55%,transparent)]",
+  off: "bg-destructive",
+  green: "bg-[color:var(--status-green-fg)]",
+  amber: "bg-[color:var(--status-amber-fg)]",
+  red: "bg-[color:var(--destructive-fg)]",
+} as const;
+
+type RunTone = "green" | "amber" | "red" | "grey" | "accent";
+type RunPresentation = { tone: RunTone; key: string };
+
+const PILL_TONE: Record<RunStatus, RunTone> = {
+  QUEUED: "grey", CLAIMED: "amber", PROVISIONING: "amber", RUNNING: "amber", WAITING_INBOX: "accent",
+  SUCCEEDED: "green", FAILED: "red", TIMED_OUT: "red", CANCELLED: "grey", LOST: "red",
+};
+
+const runPresentation = (
+  status: RunStatus,
+  mergeOutcome?: MergeOutcome | null | undefined,
+): RunPresentation => {
+  const badge = mergeBadge(mergeOutcome);
+  return badge ?? { tone: PILL_TONE[status], key: `status.run.${status}` };
+};
+
+const dotTone = (status: RunStatus, mergeOutcome?: MergeOutcome | null | undefined): keyof typeof DOT_TONE => {
+  const badge = mergeBadge(mergeOutcome);
+  if (badge) return badge.tone;
+  if (status === "SUCCEEDED") return "green";
+  if (status === "FAILED" || status === "TIMED_OUT" || status === "LOST") return "red";
+  return "amber";
+};
+
+/** The sole board rendering of a Run: number, dot tone, status word, and merge override. */
+export const RunLine = ({
+  run,
+  mergeOutcome,
+  showElapsed = false,
+}: {
+  run: BoardLatestRun;
+  mergeOutcome?: MergeOutcome | null | undefined;
+  showElapsed?: boolean;
+}): ReactNode => {
+  const t = useT();
+  const presentation = runPresentation(run.status, mergeOutcome);
+  const elapsed = showElapsed && isActiveRunStatus(run.status) && run.startedAt !== null
+    ? t("tasks.card.runningDuration", { duration: duration(run.startedAt, null) })
+    : null;
+  return (
+    <span data-run-line="" className="inline-flex min-w-0 items-center gap-[6px] whitespace-nowrap">
+      <span className={cn(DOT, DOT_TONE[dotTone(run.status, mergeOutcome)])} />
+      <span className="text-primary">{t("tasks.card.run", { n: run.runNumber })}</span>
+      <span className="overflow-hidden text-ellipsis text-[color:var(--faint)]">
+        {` · ${t(presentation.key)}${elapsed === null ? "" : ` · ${elapsed}`}`}
+      </span>
+    </span>
+  );
+};
+
+/** The detail/list form crosses the same status-to-presentation seam as RunLine. */
+export const RunPill = ({ status, mergeOutcome }: {
+  status: RunStatus;
+  mergeOutcome?: MergeOutcome | null | undefined;
+}): ReactNode => {
+  const t = useT();
+  const presentation = runPresentation(status, mergeOutcome);
+  return <Badge variant="outline" shape="pill" tone={presentation.tone}>{t(presentation.key)}</Badge>;
+};

--- a/apps/web/src/components/task-card.tsx
+++ b/apps/web/src/components/task-card.tsx
@@ -1,70 +1,17 @@
-import { type DragEvent, type MouseEvent, type ReactNode, memo, useEffect, useState } from "react";
+import { type ReactNode, memo, useEffect, useState } from "react";
 
 import { chainPositionMarker } from "../lib/chain";
 import { duration, money, timeAgo, usageCostLabel } from "../lib/format";
 import { chainBinding, chainBindingLabel, retryable, scheduleLabel, statusLabel } from "../lib/board";
 import { type Translate, useT } from "../lib/i18n";
-import { mergeBadge } from "../lib/merge-outcome";
-import { navigate } from "../lib/router";
 import type { BoardTask, TaskStatus } from "../lib/types";
 import { cn } from "../lib/utils";
+import { BoardCardShell } from "./board-card-shell";
 import { IconRobot, IconUser } from "./icons";
-import { DOT, DOT_TONE, Pill, ROW, RowMenu, type RowMenuEntry } from "./ui";
+import { RunLine } from "./run-line";
+import { Pill, ROW, type RowMenuEntry } from "./ui";
 
-/* The card's geometry, stated once for both layout shells.
- *
- * Every free-text field on this card is bounded. Measured before that was true:
- * one 2,228-character `failureReason` produced a 1,792px card, a long path in
- * another overflowed its card by 193px sideways and was clipped by the column,
- * and 21 of 112 cards carried one. A board card answers "which task, how is it
- * doing"; the full text belongs to the task page, and `Copy error` in the menu
- * hands over the exact string.
- *
- * The card is deliberately *not* a fixed height (K10): a chain-less card with a
- * short title has no business reserving space for rows it does not have. */
-const TASK_CARD = "relative cursor-pointer rounded-xl border border-border bg-card px-[14px] py-[13px] hover:border-[color:var(--border-hover)] has-[a:focus-visible]:border-[color:var(--primary)]";
-const TASK_TITLE = "line-clamp-3 text-foreground [overflow-wrap:anywhere] hover:underline focus-visible:underline";
-/** `grid-cols-[minmax(0,1fr)]` is the whole reason this is bounded. A grid with
- *  no declared columns sizes its implicit one by `auto`, whose *minimum* is the
- *  widest item's min-content — and a `whitespace-nowrap` schedule line has no
- *  min-content smaller than itself. Measured, "At 09:00 AM, only on Monday
- *  (Asia/Shanghai)" made a 196px card 312px wide and the column clipped it. */
-const TASK_META = "mt-[9px] grid grid-cols-[minmax(0,1fr)] gap-[6px] text-[11.5px] text-muted-foreground";
-/** `min-h-[20px]`: the first meta row is plain text on most cards and text plus
- *  a pill on some, and a pill is 20px against text's 17.25px. Left alone, the
- *  same row changes height by 6.75px depending on whether a task happens to
- *  carry an approval gate, and the board's vertical rhythm stutters card by
- *  card. The pills are pulled down to that same 20px rather than the rows being
- *  pushed up to 24px — 112 cards is the wrong place to spend 4px each. */
-const TASK_META_ROW = "flex min-h-[20px] flex-wrap items-center gap-[8px]";
 const TASK_PILL = "py-0";
-/** Three lines, then stop. Any character may break, because these strings are
- *  mostly paths and URLs and `word-break: normal` cannot break them at all. */
-const TASK_FAILURE = "line-clamp-3 text-[var(--destructive-fg)] [overflow-wrap:anywhere]";
-/** `size-[13px]`, not the button base's `[&_svg]:size-4`. */
-const TASK_FOOT = "mt-[10px] flex items-center gap-[10px] text-[11.5px] text-muted-foreground [&_svg]:size-[13px] [&_svg]:flex-none [&_svg]:opacity-85";
-
-// The board card keeps the run line light — a status dot plus text, as in
-// kanban-tasks-board-t1560.jpg; pills are reserved for the task detail header.
-const runLabel = (task: BoardTask, t: Translate): ReactNode => {
-  const run = task.latestRun;
-  // A card with no run says nothing about runs. "no runs" is what every fresh
-  // card said, and a row that is a constant is a row that is not read.
-  if (!run) return null;
-  // §SF-1. The card's whole run line is one status word, so a mechanical merge
-  // that stopped has nowhere else to say so: SUCCEEDED here reads as a merge
-  // that happened. The badge is bound server-side to this very run.
-  const badge = mergeBadge(task.mergeOutcome);
-  const tone = badge?.tone
-    ?? (run.status === "SUCCEEDED" ? "green" : run.status === "FAILED" || run.status === "TIMED_OUT" || run.status === "LOST" ? "red" : "amber");
-  return (
-    <span className="inline-flex items-center gap-[6px] whitespace-nowrap">
-      <span className={cn(DOT, DOT_TONE[tone])} />
-      <span className="text-primary">{t("tasks.card.run", { n: run.runNumber })}</span>
-      <span className="text-[color:var(--faint)]"> · {badge ? t(badge.key) : t(`status.run.${run.status}`)}</span>
-    </span>
-  );
-};
 
 /**
  * The assignee, one line, with the rest of the name a keypress away.
@@ -109,20 +56,6 @@ export type CardProps = {
    *  exist on touch, and a card that looks draggable and is not is worse than
    *  one that does not. */
   draggable?: boolean;
-};
-
-/**
- * Should a click on the card body open the task?
- *
- * The card stays clickable anywhere (K12) but must not steal the three gestures
- * that live inside it: following the title link, working the menu, and selecting
- * text. A drag that ends inside the card also arrives here as a click.
- */
-const opensTask = (event: MouseEvent<HTMLElement>): boolean => {
-  if (event.defaultPrevented) return false;
-  const target = event.target;
-  if (target instanceof Element && target.closest("a, button, [role='menuitem'], [role='menu']") !== null) return false;
-  return (window.getSelection()?.toString() ?? "") === "";
 };
 
 export const cardTitle = (task: BoardTask): string => {
@@ -181,7 +114,6 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
   const assignee = task.assigneeAgent?.title ?? null;
   const schedule = scheduleLabel(task);
   const hasScheduleRow = schedule !== null || task.approvalGate || task.source === "CRON" || task.source === "WEBHOOK";
-  const run = runLabel(task, t);
   const model = cardModel(task);
   const taskCostLabel = usageCostLabel(task.taskCost);
   const hasTokenFallback = task.taskCost !== null && task.taskCost.costUsd === null;
@@ -189,24 +121,8 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
   const chain = chainBinding(task);
   const chainLabel = chain === null ? null : chainBindingLabel(chain);
   const repair = task.repairOf ?? null;
-  return <article
-    data-card={task.id}
-    className={TASK_CARD}
-    draggable={draggable}
-    onDragStart={(event: DragEvent<HTMLElement>) => event.dataTransfer.setData("text/plain", task.id)}
-    onClick={(event) => { if (opensTask(event)) navigate(`/tasks/${task.id}`); }}
-  >
-    <div className={cn(ROW, "items-start")}>
-      {/* A real link, not an onClick: it is what makes the card reachable by
-          keyboard, opens in a new tab on the modifier click every operator
-          tries, and gives the card an accessible name it did not have. */}
-      <h3 className="min-w-0 flex-1 text-[13px] leading-[1.45]">
-        <a data-card-title="" href={`#/tasks/${task.id}`} className={TASK_TITLE}>{title}</a>
-      </h3>
-      <RowMenu items={menu(task, actions, t)} label={t("tasks.card.actionsFor", { name: task.name })} />
-    </div>
-    <div className={TASK_META}>
-      {hasScheduleRow ? <div data-card-schedule="" className={TASK_META_ROW}>
+  const metaRows: ReactNode[] = [
+    ...(hasScheduleRow ? [<span data-card-schedule="" className="contents">
         {/* Two lines, not one ellipsized one. Measured in a 170px content box:
             "Waiting for previous step" came out as "Waiting for previous st…"
             and a cron's prose as "At 09:00 AM, only on M…". This line is the
@@ -219,21 +135,14 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
         {/* MANUAL renders nothing: most tasks are manual, and a pill on every
             card would be noise rather than provenance ([A8]). */}
         {task.source === "CRON" ? <Pill tone="grey" className={TASK_PILL}>{t("tasks.pill.cron")}</Pill> : task.source === "WEBHOOK" ? <Pill tone="accent" className={TASK_PILL}>{t("tasks.pill.webhook")}</Pill> : null}
-      </div> : null}
-      {task.blockedOn ? (
-        <div data-card-blocked-on="" className={TASK_META_ROW}>
-          <span className="line-clamp-2 min-w-0 [overflow-wrap:anywhere]">
-            {t("tasks.card.blockedOn", { name: task.blockedOn.taskName })}
-          </span>
-        </div>
-      ) : null}
-      {/* No placeholder for a chain-less card (K4). A merge-tail repair task is
-          chain-less in its own columns but not in fact, so the row is driven by
-          the binding rather than by the chain progress a detached task has none
-          of — otherwise the repair card sits on the board with nothing saying
-          which chain it belongs to. */}
-      {chainLabel === null ? null : (
-        <div className={cn(TASK_META_ROW, "overflow-hidden text-ellipsis whitespace-nowrap")}>
+      </span>] : []),
+    ...(task.blockedOn ? [<span data-card-blocked-on="" className="line-clamp-2 min-w-0 [overflow-wrap:anywhere]">
+      {t("tasks.card.blockedOn", { name: task.blockedOn.taskName })}
+    </span>] : []),
+    // A detached merge-tail repair still carries a Chain binding, so this row
+    // follows the binding rather than the persisted chain columns.
+    ...(chainLabel === null ? [] : [
+        <span className="contents">
           <button
             type="button"
             className="max-w-full overflow-hidden text-ellipsis rounded-full border border-border bg-secondary px-[7px] py-[1px] text-secondary-foreground hover:text-foreground"
@@ -252,19 +161,14 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
           {/* The board needs only the task's ordinal. Execution layers are a
               scheduling concept rendered by the chain detail page. */}
           <span>{chainPositionMarker(task.chainProgress)}</span>
-        </div>
-      )}
-      {run === null ? null : <div className={TASK_META_ROW}>{run}</div>}
-      {model === null ? null : (
-        <div className={TASK_META_ROW}>
-          <span className="min-w-0 [overflow-wrap:anywhere]" aria-label={t("tasks.card.model", { model })}>
-            {model}
-          </span>
-        </div>
-      )}
-      {task.failureReason === null ? null : <div className={cn(TASK_META_ROW, TASK_FAILURE)}>{task.failureReason}</div>}
-    </div>
-    <div className={TASK_FOOT}>
+        </span>,
+    ]),
+    ...(task.latestRun === null ? [] : [<RunLine run={task.latestRun} mergeOutcome={task.mergeOutcome} />]),
+    ...(model === null ? [] : [<span className="min-w-0 [overflow-wrap:anywhere]" aria-label={t("tasks.card.model", { model })}>
+      {model}
+    </span>]),
+  ];
+  const footer = <>
       {/* Human ownership is complete without an agent name. A missing agent on
           an AGENT task is different: it is a misconfiguration worth naming. */}
       <span
@@ -288,13 +192,24 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
           ? <RunningCardTime task={task} t={t} />
           : cardTime(task, t)}
       </span>
-    </div>
-    {hasTokenFallback ? (
+  </>;
+  const after = hasTokenFallback ? (
       <div data-task-cost-fallback="" className="mt-[6px] max-w-full whitespace-normal text-[11.5px] leading-[1.45] text-muted-foreground [overflow-wrap:anywhere]">
         {taskCostLabel}
       </div>
-    ) : null}
-  </article>;
+    ) : null;
+  return <BoardCardShell
+    cardId={task.id}
+    route={`/tasks/${task.id}`}
+    title={title}
+    menuItems={menu(task, actions, t)}
+    menuLabel={t("tasks.card.actionsFor", { name: task.name })}
+    metaRows={metaRows}
+    failure={task.failureReason ?? undefined}
+    footer={footer}
+    after={after}
+    dragId={draggable ? task.id : undefined}
+  />;
 };
 
 /** A card re-renders only when its own row changed.

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -11,11 +11,12 @@ import {
 } from "./ui/dropdown-menu";
 import { Switch } from "./ui/switch";
 import { titleCase } from "../lib/format";
-import { mergeBadge } from "../lib/merge-outcome";
 import { useT, useTNodes } from "../lib/i18n";
 import { cn } from "../lib/utils";
-import type { Agent, GoalStatus, InboxStatus, MergeOutcome, RunStatus, TaskStatus } from "../lib/types";
+import type { Agent, GoalStatus, InboxStatus, TaskStatus } from "../lib/types";
 import { IconChevron, IconDots, IconRobot, IconUser } from "./icons";
+
+export { DOT, DOT_TONE, RunPill } from "./run-line";
 
 /* ------------------------------------------------------------------ layout
  *
@@ -54,17 +55,6 @@ export const TOOLBAR = "mb-[16px] flex items-center gap-[10px]";
 export const FIELD = "grid grid-cols-[minmax(0,1fr)] gap-[6px]";
 export const FIELD_LABEL = "text-[12.5px] text-secondary-foreground";
 export const FIELD_ROW = "grid grid-cols-[repeat(auto-fit,minmax(190px,1fr))] items-start gap-[14px]";
-
-/** The status dot and its tones, as a lookup rather than a built class string
- *  (plan B13). `.dot.on` carries a glow; `.dot.green` deliberately does not. */
-export const DOT = "size-[7px] rounded-full bg-[color:var(--faint)]";
-export const DOT_TONE = {
-  on: "bg-[color:var(--status-green-fg)] shadow-[0_0_8px_color-mix(in_srgb,var(--status-green-fg)_55%,transparent)]",
-  off: "bg-destructive",
-  green: "bg-[color:var(--status-green-fg)]",
-  amber: "bg-[color:var(--status-amber-fg)]",
-  red: "bg-[color:var(--destructive-fg)]",
-} as const;
 
 export const CARD_TITLE = "mb-[14px] flex items-center gap-[9px] text-[13.5px]";
 export const COUNT = "inline-grid h-[19px] min-w-[20px] place-items-center rounded-md bg-accent px-[6px] text-[11.5px] text-muted-foreground";
@@ -120,10 +110,6 @@ export const Pill = ({ tone, className, children }: { tone: PillTone; className?
 /** Status semantics follow ui-notes §0: green = succeeded, amber = a human or a
  *  runner is still owed something, red = danger, grey = inert. */
 const taskTones: Record<TaskStatus, PillTone> = { BACKLOG: "grey", TODO: "grey", DOING: "amber", REVIEW: "accent", DONE: "green" };
-const runTones: Record<RunStatus, PillTone> = {
-  QUEUED: "grey", CLAIMED: "amber", PROVISIONING: "amber", RUNNING: "amber", WAITING_INBOX: "accent",
-  SUCCEEDED: "green", FAILED: "red", TIMED_OUT: "red", CANCELLED: "grey", LOST: "red",
-};
 /* No `STOPPED_*` entries: see `GoalStatus` in lib/types.ts — the server has no
  * writer for those states, so a red pill for them is a legend for nothing. */
 const goalTones: Record<GoalStatus, PillTone> = {
@@ -140,17 +126,6 @@ const inboxTones: Record<InboxStatus, PillTone> = { OPEN: "amber", ANSWERED: "gr
 export const TaskPill = ({ status }: { status: TaskStatus }): ReactNode => {
   const t = useT();
   return <Pill tone={taskTones[status]}>{t(`status.task.${status}`)}</Pill>;
-};
-
-/** `mergeOutcome` is §SF-1: a mechanical merge that stopped ends its run
- *  SUCCEEDED, so the run's own status is not what an operator needs to read
- *  here. Absent on every other run, and then this is the pill it always was. */
-export const RunPill = ({ status, mergeOutcome }: { status: RunStatus; mergeOutcome?: MergeOutcome | null | undefined }): ReactNode => {
-  const t = useT();
-  const badge = mergeBadge(mergeOutcome);
-  return badge
-    ? <Pill tone={badge.tone}>{t(badge.key)}</Pill>
-    : <Pill tone={runTones[status]}>{t(`status.run.${status}`)}</Pill>;
 };
 
 export const GoalPill = ({ status }: { status: GoalStatus }): ReactNode => {

--- a/apps/web/src/lib/board.ts
+++ b/apps/web/src/lib/board.ts
@@ -229,7 +229,12 @@ export const orderColumn = <T extends BoardTask | BoardEntry>(status: TaskStatus
 
 /* -------------------------------------------------------------- the actions */
 
-const ACTIVE_RUN: RunStatus[] = ["QUEUED", "CLAIMED", "PROVISIONING", "RUNNING"];
+export const ACTIVE_RUN_STATUSES = [
+  "QUEUED", "CLAIMED", "PROVISIONING", "RUNNING", "WAITING_INBOX",
+] as const satisfies readonly RunStatus[];
+
+export const isActiveRunStatus = (status: RunStatus): boolean =>
+  ACTIVE_RUN_STATUSES.includes(status as (typeof ACTIVE_RUN_STATUSES)[number]);
 
 /**
  * A retry only lands once the last run is terminal; the API rejects the rest.
@@ -244,7 +249,7 @@ export const retryable = (
   run: { status: RunStatus } | null | undefined,
 ): boolean => {
   if (!run) return false;
-  if (ACTIVE_RUN.includes(run.status)) return false;
+  if (isActiveRunStatus(run.status)) return false;
   return task.status === "REVIEW" || task.failureReason !== null || run.status !== "SUCCEEDED";
 };
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -3,6 +3,9 @@
 
 import type {
   AssigneeType,
+  BoardCard as BoardContractCard,
+  BoardChainAggregate as BoardContractChainAggregate,
+  BoardChainFrontier as BoardContractChainFrontier,
   ChainControl,
   ChainProgress,
   ChainStep,
@@ -18,17 +21,11 @@ import type {
 
 export type {
   AssigneeType,
-  BoardCard,
   BoardChainActivationState,
-  BoardChainAggregate,
-  BoardChainFrontier,
   BoardLatestRun,
   BoardMoveTarget,
-  BoardTask,
-  ChainAggregate,
   ChainAggregateState,
   ChainControl,
-  ChainFrontier,
   ChainProgress,
   ChainStep,
   ExecutionOwner,
@@ -41,6 +38,19 @@ export type {
   TaskStatus,
   UsageCost,
 } from "@anneal/db/board-contract";
+
+export type ChainFrontier<DateTime = string> = BoardContractChainFrontier<DateTime> & {
+  mergeOutcome: MergeOutcome | null;
+};
+export type BoardChainFrontier<DateTime = string> = ChainFrontier<DateTime>;
+export type ChainAggregate<DateTime = string> = Omit<BoardContractChainAggregate<DateTime>, "frontier"> & {
+  frontier: ChainFrontier<DateTime>;
+};
+export type BoardChainAggregate<DateTime = string> = ChainAggregate<DateTime>;
+export type BoardCard<DateTime = string> = Omit<BoardContractCard<DateTime>, "chainAggregate"> & {
+  chainAggregate: ChainAggregate<DateTime> | null;
+};
+export type BoardTask = BoardCard<string>;
 
 export type RunnerKind = "CLAUDE" | "CODEX" | "PI";
 export type RunnerPreference = RunnerKind | "AUTO" | "INHERIT";

--- a/apps/web/src/pages/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail.tsx
@@ -17,7 +17,7 @@ import {
   STAT_PILL, STAT_PILLS, TABLE_NAME, TABLE_SUB, TABLE_TIGHT,
   Card, EmptyState, ErrorNotice, KeyValue, Markdown, MarkdownClamp, Page, Pill, RunPill, TaskPill, Toggle,
 } from "../components/ui";
-import { retryable } from "../lib/board";
+import { isActiveRunStatus, retryable } from "../lib/board";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Select } from "../components/ui/select";
@@ -340,7 +340,7 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
   // `app.ts` orders runs `runNumber desc`, so the newest run is the head.
   const newest = runs[0];
   const newestIsActive = task.executionOwner === "agent" && newest !== undefined
-    && ["QUEUED", "CLAIMED", "PROVISIONING", "RUNNING", "WAITING_INBOX"].includes(newest.status);
+    && isActiveRunStatus(newest.status);
   const newestIsCancelling = newestIsActive && newest.cancelRequestedAt !== null && newest.cancelAcknowledgedAt === null;
   const newestBranch = newest?.branch ?? newest?.targetBranch ?? null;
   const newestBranchUrl = branchUrl(task.repo?.remoteUrl, newestBranch);

--- a/apps/web/src/tests/board.test.tsx
+++ b/apps/web/src/tests/board.test.tsx
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  chainBinding, chainBindingLabel, chainParked, clampScroll, columnStep, countByStatus, defaultTab, edgeState,
-  focusAfterMove, orderColumn, parseStatus, retryable, sameEdges, scheduleLabel, storedScroll,
+  ACTIVE_RUN_STATUSES, chainBinding, chainBindingLabel, chainParked, clampScroll, columnStep, countByStatus, defaultTab, edgeState,
+  focusAfterMove, isActiveRunStatus, orderColumn, parseStatus, retryable, sameEdges, scheduleLabel, storedScroll,
 } from "../lib/board";
 import type { BoardTask, ChainProgress } from "../lib/types";
 
@@ -169,8 +169,17 @@ test("a retry waits for the last run to be terminal", () => {
   assert.equal(retryable(task(), null), false, "a task with no runs cannot be retried");
   assert.equal(retryable(task(), { status: "RUNNING" }), false);
   assert.equal(retryable(task(), { status: "QUEUED" }), false);
+  assert.equal(retryable(task(), { status: "WAITING_INBOX" }), false);
   assert.equal(retryable(task(), { status: "SUCCEEDED" }), false);
   assert.equal(retryable(task({ status: "REVIEW" }), { status: "SUCCEEDED" }), true);
+});
+
+test("the active Run statuses include suspended Inbox work and exclude every terminal status", () => {
+  assert.deepEqual(ACTIVE_RUN_STATUSES, ["QUEUED", "CLAIMED", "PROVISIONING", "RUNNING", "WAITING_INBOX"]);
+  for (const status of ACTIVE_RUN_STATUSES) assert.equal(isActiveRunStatus(status), true, status);
+  for (const status of ["SUCCEEDED", "FAILED", "TIMED_OUT", "CANCELLED", "LOST"] as const) {
+    assert.equal(isActiveRunStatus(status), false, status);
+  }
 });
 
 /* -------------------------------------------------------------- the focus */

--- a/apps/web/src/tests/chain-aggregate-board.test.tsx
+++ b/apps/web/src/tests/chain-aggregate-board.test.tsx
@@ -25,7 +25,7 @@ const aggregate = (overrides: Partial<ChainAggregate> = {}): ChainAggregate => (
   chainId: "chain-1", chainName: "Release", stepCount: 12,
   detailTaskId: "step-1",
   statusCounts: { BACKLOG: 0, TODO: 10, DOING: 0, REVIEW: 0, DONE: 2 }, status: "TODO",
-  frontier: { taskId: "step-3", title: "Implement release", status: "TODO", latestRun: null, failureReason: null, position: 3 },
+  frontier: { taskId: "step-3", title: "Implement release", status: "TODO", latestRun: null, mergeOutcome: null, failureReason: null, position: 3 },
   activation: { state: "running", predecessor: null, taskId: "step-1" }, totalCost: null,
   createdAt: "2026-08-28T00:00:00.000Z", updatedAt: "2026-08-28T01:00:00.000Z", ...overrides,
 });
@@ -68,7 +68,7 @@ test("aggregate placement follows API-derived frontier status and counts entries
     const projection = aggregate({
       status,
       statusCounts: { BACKLOG: 0, TODO: status === "TODO" ? 12 : 0, DOING: status === "DOING" ? 1 : 0, REVIEW: status === "REVIEW" ? 1 : 0, DONE: status === "DONE" ? 12 : 0 },
-      frontier: { taskId: "frontier", title: "Frontier", status, latestRun: null, failureReason: null, position: 3 },
+      frontier: { taskId: "frontier", title: "Frontier", status, latestRun: null, mergeOutcome: null, failureReason: null, position: 3 },
     });
     const rows = Array.from({ length: 12 }, (_, index) => chainStep(`step-${index}`, index + 1, status === "DONE" ? "DONE" : index === 2 ? status : "TODO", projection));
     const grouped = boardEntriesByStatus(boardEntries(rows));
@@ -92,8 +92,33 @@ test("aggregate card exposes progress, frontier, activation/lock state, and no d
   assert.doesNotMatch(waitingMarkup, />Activate<\/button>/);
 });
 
+test("the shared card shell does not navigate a Chain card while text is selected", async () => {
+  const { dom, container } = installDom();
+  let selection = "Release";
+  Object.defineProperty(dom.window, "getSelection", {
+    configurable: true,
+    value: () => ({ toString: () => selection }),
+  });
+  const root = (await reactDom()).createRoot(container);
+  try {
+    dom.window.location.hash = "#/tasks/origin";
+    await act(async () => root.render(<ChainAggregateCard aggregate={aggregate()} />));
+    const progress = container.querySelector("[data-chain-progress]");
+    assert.ok(progress);
+    await act(async () => progress.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
+    assert.equal(dom.window.location.hash, "#/tasks/origin");
+
+    selection = "";
+    await act(async () => progress.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
+    assert.equal(dom.window.location.hash, "#/tasks/step-3");
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+  }
+});
+
 test("mobile and desktop receive the same aggregate entry list", () => {
-  const projection = aggregate({ status: "DOING", frontier: { taskId: "step-1", title: "Implement release", status: "DOING", latestRun: null, failureReason: null, position: 1 } });
+  const projection = aggregate({ status: "DOING", frontier: { taskId: "step-1", title: "Implement release", status: "DOING", latestRun: null, mergeOutcome: null, failureReason: null, position: 1 } });
   const entries = boardEntries([chainStep("step-1", 1, "DOING", projection), chainStep("step-2", 2, "TODO", projection)]);
   assert.equal(entries.length, 1);
   const grouped = boardEntriesByStatus(entries);

--- a/apps/web/src/tests/merge-outcome.test.tsx
+++ b/apps/web/src/tests/merge-outcome.test.tsx
@@ -2,12 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { ChainAggregateCard } from "../components/chain-aggregate-card";
 import { RunPill } from "../components/ui";
 import { TaskCard } from "../components/task-card";
 import { translate } from "../lib/i18n-core";
-import { mergeBadge } from "../lib/merge-outcome";
 import { lifecycleStat, sessionPill } from "../pages/Sessions";
-import type { BoardTask, MergeOutcome, RunStatus } from "../lib/types";
+import type { BoardTask, ChainAggregate, MergeOutcome, RunStatus } from "../lib/types";
 
 /**
  * §SF-1 — the merge integrator's outcome as an operator reads it.
@@ -78,6 +78,35 @@ test("a pre-merge stop reads amber Stopped in all four run-centric surfaces", ()
   assert.ok(!markup.includes(en("status.run.SUCCEEDED")), markup);
 });
 
+test("a succeeded frontier Run with a stopped merge outcome does not render the Chain as succeeded", () => {
+  const aggregate: ChainAggregate = {
+    chainId: "chain-1",
+    chainName: "Release",
+    stepCount: 1,
+    detailTaskId: "merge-step",
+    statusCounts: { BACKLOG: 0, TODO: 0, DOING: 0, REVIEW: 0, DONE: 1 },
+    status: "DONE",
+    frontier: {
+      taskId: "merge-step",
+      title: "Merge execution",
+      status: "DONE",
+      latestRun: boardTask().latestRun,
+      mergeOutcome: STOPPED,
+      failureReason: null,
+      position: 1,
+    },
+    activation: { state: "settled", predecessor: null, taskId: "merge-step" },
+    totalCost: null,
+    createdAt: "2026-08-17T00:00:00.000Z",
+    updatedAt: "2026-08-18T00:00:00.000Z",
+  };
+  const markup = renderToStaticMarkup(<ChainAggregateCard aggregate={aggregate} />);
+
+  assert.ok(markup.includes(en("status.merge.stopped")), markup);
+  assert.ok(markup.includes(AMBER_DOT), markup);
+  assert.ok(!markup.includes(en("status.run.SUCCEEDED")), markup);
+});
+
 /* ------------------------------------------------------- the post-merge incident */
 
 test("a post-merge incident reads red Incident in all four run-centric surfaces", () => {
@@ -94,19 +123,6 @@ test("a post-merge incident reads red Incident in all four run-centric surfaces"
   const markup = card({ mergeOutcome: INCIDENT });
   assert.ok(markup.includes(label), markup);
   assert.ok(markup.includes(RED_DOT), markup);
-});
-
-test("both post-merge conditions are incidents and the other stops are not", () => {
-  // The projection carries the classification; the client only reads the flag,
-  // so this asserts the two surfaces agree about which flag means which colour.
-  for (const condition of ["base-drift-post-merge", "changed-underneath-me"]) {
-    const badge = mergeBadge({ outcome: "stopped", condition, incident: true });
-    assert.deepEqual(badge, { tone: "red", key: "status.merge.incident" }, condition);
-  }
-  for (const condition of ["head-drift", "target-unresolvable", "no-authorization"]) {
-    const badge = mergeBadge({ outcome: "stopped", condition, incident: false });
-    assert.deepEqual(badge, { tone: "amber", key: "status.merge.stopped" }, condition);
-  }
 });
 
 /* ------------------------------------------------------------------ regression */
@@ -135,13 +151,4 @@ test("a failed run is untouched by the merge projection", () => {
   assert.ok(row.includes(RED), row);
   assert.deepEqual(sessionPill("FAILED"), { tone: "red", label: en("status.session.FAILED") });
   assert.deepEqual(lifecycleStat("FAILED"), { tone: "red", label: en("sessions.lifecycle.failed") });
-});
-
-test("a merged outcome adds no badge at all", () => {
-  assert.equal(mergeBadge(MERGED), null);
-  assert.equal(mergeBadge(null), null);
-  assert.equal(mergeBadge(undefined), null);
-  // `malformed` never reaches the client — the server projection returns null
-  // for any output that is not a `merge-result` — and is inert if it ever does.
-  assert.equal(mergeBadge({ outcome: "malformed", condition: "missing-or-malformed-result", incident: false }), null);
 });

--- a/apps/web/src/tests/task-detail.test.tsx
+++ b/apps/web/src/tests/task-detail.test.tsx
@@ -24,9 +24,7 @@ test("the Runs section is rendered before the Chain section", () => {
 });
 
 test("active Runs expose cancellation and an outstanding intent renders Cancelling", () => {
-  for (const status of ["QUEUED", "CLAIMED", "PROVISIONING", "RUNNING", "WAITING_INBOX"]) {
-    assert.match(source, new RegExp(`"${status}"`, "u"));
-  }
+  assert.match(source, /isActiveRunStatus\(newest\.status\)/u);
   assert.match(source, /newest\.cancelRequestedAt !== null/u);
   assert.match(source, /newest\.cancelAcknowledgedAt === null/u);
   assert.match(source, /taskDetail\.cancel\.cancelling/u);

--- a/apps/web/src/tests/tasks-board.test.tsx
+++ b/apps/web/src/tests/tasks-board.test.tsx
@@ -6,8 +6,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { InfoNotice } from "../components/ui";
 import { BOARD, BOARD_GRID, CARD_PAGE_SIZE, BoardArrows, BoardColumn, BoardNavigation, FRAME, dragEdgeStep } from "../components/desktop-board";
 import { MobileTaskList } from "../components/mobile-task-list";
+import { PaginatedBoardEntries } from "../components/paginated-board-entries";
 import { cardModel, cardTime, cardTitle, TaskCard } from "../components/task-card";
-import { COLUMNS, columnStep, countByStatus } from "../lib/board";
+import { COLUMNS, columnStep, countByStatus, taskBoardEntry } from "../lib/board";
 import { translate } from "../lib/i18n-core";
 import { ProjectProvider } from "../lib/project";
 import { storage } from "../lib/storage";
@@ -349,7 +350,7 @@ test("Archive All confirms the project-wide Done scope even while one chain is v
   const settledAggregate = (chainId: string, chainName: string, taskId: string) => ({
     chainId, chainName, detailTaskId: taskId, stepCount: 1,
     statusCounts: { BACKLOG: 0, TODO: 0, DOING: 0, REVIEW: 0, DONE: 1 }, status: "DONE" as const,
-    frontier: { taskId, title: "Review", status: "DONE" as const, latestRun: null, failureReason: null, position: 1 },
+    frontier: { taskId, title: "Review", status: "DONE" as const, latestRun: null, mergeOutcome: null, failureReason: null, position: 1 },
     activation: { state: "settled" as const, predecessor: null, taskId }, totalCost: null,
     createdAt: "2026-08-15T00:00:00.000Z", updatedAt: "2026-08-16T00:00:00.000Z",
   });
@@ -792,22 +793,28 @@ test("TaskCard is memoized", () => {
   assert.equal((TaskCard as unknown as { $$typeof: symbol }).$$typeof, Symbol.for("react.memo"));
 });
 
-test("desktop columns mount one fixed page as completed history grows", () => {
-  for (const total of [CARD_PAGE_SIZE + 1, CARD_PAGE_SIZE * 20]) {
-    const rows = Array.from({ length: total }, (_, index) => task({ id: `done-${index}`, status: "DONE" }));
-    const markup = column("DONE", rows);
-    assert.equal((markup.match(/data-card=/gu) ?? []).length, CARD_PAGE_SIZE);
-    assert.match(markup, new RegExp(`Done<span[^>]*>${total}</span>`));
-    assert.match(markup, new RegExp(`Show ${Math.min(CARD_PAGE_SIZE, total - CARD_PAGE_SIZE)} more`));
-  }
-});
+test("the shared paginated entry list owns page controls and clamps after shrink", async () => {
+  const { dom, container } = installDom();
+  const rows = Array.from({ length: CARD_PAGE_SIZE * 2 + 1 }, (_, index) => (
+    taskBoardEntry(task({ id: `done-${index}`, status: "DONE" }))
+  ));
+  const root = (await reactDom()).createRoot(container);
+  try {
+    await act(async () => root.render(<PaginatedBoardEntries entries={rows} actions={ACTIONS} />));
+    assert.equal(container.querySelectorAll("[data-card]").length, CARD_PAGE_SIZE);
+    const more = [...container.querySelectorAll("button")].find((button) => button.textContent === `Show ${CARD_PAGE_SIZE} more`);
+    assert.ok(more);
+    await act(async () => more.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
+    assert.equal(container.querySelectorAll("[data-card]").length, CARD_PAGE_SIZE);
+    assert.match(container.textContent ?? "", new RegExp(en("tasks.column.previous", { n: CARD_PAGE_SIZE })));
 
-test("mobile task lists mount one fixed page as completed history grows", () => {
-  const total = CARD_PAGE_SIZE * 20;
-  const rows = Array.from({ length: total }, (_, index) => task({ id: `done-${index}`, status: "DONE" }));
-  const markup = mobile("DONE", rows, rows);
-  assert.equal((markup.match(/data-card=/gu) ?? []).length, CARD_PAGE_SIZE);
-  assert.match(markup, new RegExp(`Show ${CARD_PAGE_SIZE} more`));
+    await act(async () => root.render(<PaginatedBoardEntries entries={rows.slice(0, 1)} actions={ACTIONS} />));
+    assert.equal(container.querySelector("[data-card]")?.getAttribute("data-card"), "done-0");
+    assert.equal(container.querySelectorAll("button").length, 1, "only the card menu remains after pagination clamps");
+  } finally {
+    await act(async () => root.unmount());
+    dom.window.close();
+  }
 });
 
 /* -------------------------------------------------------------- the notice */

--- a/packages/api/src/board.test.ts
+++ b/packages/api/src/board.test.ts
@@ -229,7 +229,7 @@ test("chainAggregate derives primary progress and every board column from the fr
   assert.equal(allTodo.stepCount, 3);
   assert.deepEqual(allTodo.statusCounts, { BACKLOG: 0, TODO: 3, DOING: 0, REVIEW: 0, DONE: 0 });
   assert.deepEqual(allTodo.frontier, {
-    taskId: "step-1", title: "Build", status: "TODO", latestRun: null, failureReason: null, position: 1,
+    taskId: "step-1", title: "Build", status: "TODO", latestRun: null, mergeOutcome: null, failureReason: null, position: 1,
   });
   assert.deepEqual(allTodo.activation, { state: "parked-unactivated", predecessor: null, taskId: "step-1" });
 
@@ -249,7 +249,7 @@ test("chainAggregate derives primary progress and every board column from the fr
   assert.equal(review.status, "REVIEW");
   assert.equal(review.activation.state, "idle");
   assert.deepEqual(review.frontier, {
-    taskId: "step-2", title: "Step 1", status: "REVIEW", latestRun: null, failureReason: "needs approval", position: 2,
+    taskId: "step-2", title: "Step 1", status: "REVIEW", latestRun: null, mergeOutcome: null, failureReason: "needs approval", position: 2,
   });
 
   const done = chainAggregate("c1", "Release", [
@@ -310,10 +310,28 @@ test("chainAggregate sums member usage and groups a detached repair without infl
   assert.deepEqual(aggregate.frontier, {
     taskId: "repair", title: "Merge-tail repair", status: "TODO", latestRun: {
       id: "run-2", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5", costUsd: "0.50", startedAt: null, endedAt: null,
-    }, failureReason: null,
+    }, mergeOutcome: null, failureReason: null,
   });
   assert.equal(aggregate.activation.state, "idle");
   assert.equal(aggregate.totalCost?.costUsd, "1.75");
+});
+
+test("the Chain frontier projects a stopped merge outcome only for the Run it shows", () => {
+  const stopped = JSON.stringify({ outcome: "stopped", condition: "head-drift", evidence: "live head changed" });
+  const frontierRun = {
+    id: "run-2", runNumber: 2, status: "SUCCEEDED" as const,
+    model: "claude-opus-5", budgetGrants: 0, session: null,
+  };
+  const projection = (runId: string) => chainAggregate("c1", "Release", [member({
+    status: "DONE",
+    runs: [frontierRun],
+    stepOutput: { kind: "merge-result", body: stopped, runId },
+  })], []);
+
+  assert.deepEqual(projection("run-2").frontier.mergeOutcome, {
+    outcome: "stopped", condition: "head-drift", incident: false,
+  });
+  assert.equal(projection("run-1").frontier.mergeOutcome, null);
 });
 
 test("blockedOn is projected from the resolved predecessor without storing its status", () => {

--- a/packages/api/src/board.ts
+++ b/packages/api/src/board.ts
@@ -63,11 +63,17 @@ import { operatorStatusTransitionRefusal } from "./task-patch.js";
  * point of the shape is that its cost is legible.
  */
 export type BoardMoveTarget = BoardContractMoveTarget;
-export type BoardCard = BoardContractCard<Date>;
+export type BoardChainFrontier = BoardContractChainFrontier<Date> & {
+  mergeOutcome: BoardContractCard<Date>["mergeOutcome"];
+};
+export type BoardChainAggregate = Omit<BoardContractChainAggregate<Date>, "frontier"> & {
+  frontier: BoardChainFrontier;
+};
+export type BoardCard = Omit<BoardContractCard<Date>, "chainAggregate"> & {
+  chainAggregate: BoardChainAggregate | null;
+};
 export type BoardLatestRun = BoardContractLatestRun<Date>;
 export type BoardChainActivationState = BoardContractChainActivationState;
-export type BoardChainFrontier = BoardContractChainFrontier<Date>;
-export type BoardChainAggregate = BoardContractChainAggregate<Date>;
 export type RepairBinding = BoardContractRepairBinding;
 
 type JsonSerialized<T> = T extends Date
@@ -192,6 +198,7 @@ export type BoardChainMember = {
   updatedAt: Date;
   templateStep: { name: string } | null;
   runs: BoardRow["runs"];
+  stepOutput?: BoardRow["stepOutput"];
 };
 
 const latestRunProjection = (runs: readonly BoardRow["runs"][number][] | null | undefined): BoardLatestRun | null => {
@@ -207,6 +214,17 @@ const latestRunProjection = (runs: readonly BoardRow["runs"][number][] | null | 
         startedAt: run.session?.startedAt ?? null,
         endedAt: run.session?.endedAt ?? null,
       } satisfies BoardLatestRun);
+};
+
+/** Bind a merge result to the newest Run displayed beside it. */
+const latestRunMergeOutcome = (
+  runs: readonly Pick<BoardRow["runs"][number], "id">[] | null | undefined,
+  stepOutput: BoardRow["stepOutput"],
+): BoardCard["mergeOutcome"] => {
+  const run = runs?.[0];
+  return run !== undefined && runOwnsMergeOutcome(stepOutput, run.id, run.id)
+    ? projectMergeOutcome(stepOutput)
+    : null;
 };
 
 const memberUsageCost = (member: Pick<BoardChainMember, "runs">): UsageCost | null =>
@@ -326,6 +344,7 @@ export const chainAggregate = (
       title: memberTitle(frontierMember),
       status: frontierMember.status,
       latestRun: latestRunProjection(frontierMember.runs),
+      mergeOutcome: latestRunMergeOutcome(frontierMember.runs, frontierMember.stepOutput),
       failureReason: frontierMember.failureReason,
       ...(frontierPosition >= 0 ? { position: frontierPosition + 1 } : {}),
     },
@@ -399,7 +418,6 @@ export const boardCard = (
   predecessor: BoardBlockedOnTask | null = null,
   repairOf: RepairBinding | null = null,
 ): BoardCard => {
-  const run = row.runs[0];
   const taskCost = sumUsageCosts(row.runs.flatMap((item) => item.session === null
     ? []
     : [runSessionUsageCost(item)!]));
@@ -452,9 +470,7 @@ export const boardCard = (
     taskCost: serializeUsageCost(taskCost),
     // Bound to the run the card actually shows: a stop recorded by run 1 is not
     // run 2's outcome, and the card's only run line is the newest run's.
-    mergeOutcome: run !== undefined && runOwnsMergeOutcome(row.stepOutput, run.id, run.id)
-      ? projectMergeOutcome(row.stepOutput)
-      : null,
+    mergeOutcome: latestRunMergeOutcome(row.runs, row.stepOutput),
     repairOf,
     chainAggregate: null,
   } satisfies BoardCard;
@@ -699,6 +715,7 @@ const boardChainRows = async (
       createdAt: true,
       updatedAt: true,
       templateStep: { select: { name: true } },
+      stepOutput: { select: { kind: true, body: true, runId: true } },
       runs: {
         orderBy: { runNumber: "desc" },
         select: {


### PR DESCRIPTION
## Summary
- project merge outcomes onto Chain frontiers and render them through one Run line
- route task and Chain cards through one card shell with guarded click delegation
- share pagination and active Run semantics across board surfaces

## Verification
- npm run lint
- targeted web tests: 111 passed
- packages/api/src/board.test.ts: 33 passed