### PR TITLE
refactor(db): share operator wire contracts

### DIFF
--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -18,6 +18,20 @@ import type {
   TaskStatus,
   UsageCost,
 } from "@anneal/db/board-contract";
+import type {
+  Agent,
+  CodexServiceTier,
+  FailureClass,
+  GoalStatus,
+  InboxDeliveryStatus,
+  InboxKind,
+  InboxStatus,
+  Repo,
+  RepoPermission,
+  RunnerKind,
+  RunnerPreference,
+  SessionExecutionStatus,
+} from "@anneal/db/wire-contract";
 
 export type {
   AssigneeType,
@@ -38,6 +52,28 @@ export type {
   TaskStatus,
   UsageCost,
 } from "@anneal/db/board-contract";
+export type {
+  Agent,
+  AgentRepoAccess,
+  CodexServiceTier,
+  Environment,
+  FailureClass,
+  FilesystemGrant,
+  GoalStatus,
+  InboxDeliveryStatus,
+  InboxKind,
+  InboxStatus,
+  MCPConnection,
+  Project,
+  Repo,
+  RepoPermission,
+  RunnerKind,
+  RunnerPreference,
+  Secret,
+  SecretPurpose,
+  SessionExecutionStatus,
+  Skill,
+} from "@anneal/db/wire-contract";
 
 export type ChainFrontier<DateTime = string> = BoardContractChainFrontier<DateTime> & {
   mergeOutcome: MergeOutcome | null;
@@ -51,144 +87,6 @@ export type BoardCard<DateTime = string> = Omit<BoardContractCard<DateTime>, "ch
   chainAggregate: ChainAggregate<DateTime> | null;
 };
 export type BoardTask = BoardCard<string>;
-
-export type RunnerKind = "CLAUDE" | "CODEX" | "PI";
-export type RunnerPreference = RunnerKind | "AUTO" | "INHERIT";
-export type CodexServiceTier = "DEFAULT" | "FAST";
-export type SessionExecutionStatus =
-  | "REQUESTED" | "PROVISIONING" | "RUNNING" | "WAITING_INBOX"
-  | "SUCCEEDED" | "FAILED" | "TIMED_OUT" | "CANCELLED" | "LOST";
-export type FailureClass =
-  | "BINARY_NOT_FOUND" | "AUTH_REQUIRED" | "RATE_LIMITED" | "CANCELLED_OR_TIMED_OUT"
-  | "TOOL_FAILED" | "TRANSIENT_PROVIDER" | "PROTOCOL_ERROR" | "TASK_FAILED" | "BUDGET_EXCEEDED";
-export type InboxStatus = "OPEN" | "ANSWERED" | "CLOSED";
-export type InboxKind = "TEXT" | "MULTIPLE_CHOICE";
-export type InboxDeliveryStatus = "PENDING" | "SENDING" | "DELIVERED" | "FAILED";
-/* Three of the six `GoalStatus` values in `schema.prisma` are missing on purpose.
- * `STOPPED_SPEND`, `STOPPED_TIME` and `STOPPED_STUCK` are the stops an execution
- * model would set, and no such model is wired: the API writes only ACTIVE (or
- * COMPLETED) on approve-dod and PAUSED on pause, and nothing else in this
- * repository writes `Goal.status` at all. Naming them here would put a tone, a
- * label and a legend in the console for a state the server cannot produce. When
- * the stops are wired, adding them back is a type error at every render site,
- * which is the point of narrowing rather than hiding. */
-export type GoalStatus = "ACTIVE" | "PAUSED" | "COMPLETED";
-export type SecretPurpose = "MCP" | "REPO" | "ENV" | "WEBHOOK";
-export type RepoPermission = "GIT_READ" | "GIT_WRITE";
-
-export type Project = {
-  id: string;
-  name: string;
-  slug: string;
-  yamlDocument: string;
-  maxDurationMin: number;
-  stallTimeoutMin: number;
-  maxSessionsPerTask: number;
-  spendCap: string | null;
-  createdAt: string;
-  updatedAt: string;
-};
-
-export type Agent = {
-  id: string;
-  projectId: string;
-  environmentId: string;
-  name: string;
-  title: string;
-  model: string;
-  codexServiceTier: CodexServiceTier;
-  foundationalPrompt: string;
-  rolePrompt: string;
-  runnerPreference: RunnerPreference;
-  inboxAccess: boolean;
-  /** Denied tools, not allowed ones. Empty is the default and means "no restriction". */
-  disabledTools: string[];
-  createdAt: string;
-  updatedAt: string;
-  archivedAt: string | null;
-  /** Present only when the control plane starts including binding tables. */
-  skills?: Array<{ skillId: string; skill?: Skill }>;
-  mcpConnections?: Array<{ mcpConnectionId: string; mcpConnection?: MCPConnection }>;
-  repoAccess?: AgentRepoAccess[];
-  secretGrants?: Array<{ secretId: string; envVar: string; secret?: Secret }>;
-  filesystemGrants?: FilesystemGrant[];
-  collaborators?: Array<{ allowedAgentId: string }>;
-};
-
-export type AgentRepoAccess = {
-  agentId: string;
-  repoId: string;
-  projectId: string;
-  mountPath: string;
-  permissions: RepoPermission;
-};
-
-export type FilesystemGrant = {
-  id: string;
-  agentId: string;
-  folderPath: string;
-  canRead: boolean;
-  canWrite: boolean;
-  canDelete: boolean;
-};
-
-export type Skill = {
-  id: string;
-  projectId: string;
-  name: string;
-  slug: string;
-  kind: "PROMPT" | "FILE";
-  body: string | null;
-  filePath: string | null;
-  updatedAt: string;
-};
-
-export type MCPConnection = {
-  id: string;
-  projectId: string;
-  credentialSecretId: string | null;
-  name: string;
-  transport: string;
-  config: unknown;
-  allowedOperations: string[];
-  createdAt: string;
-  updatedAt: string;
-  agents?: Array<{ agentId: string }>;
-};
-
-export type Environment = {
-  id: string;
-  projectId: string;
-  name: string;
-  networking: "OPEN" | "LIMITED";
-  allowedHosts: string[];
-};
-
-export type Repo = {
-  id: string;
-  projectId: string;
-  credentialSecretId: string | null;
-  name: string;
-  remoteUrl: string;
-  mountPath: string;
-  defaultBranch: string;
-  createdAt: string;
-  updatedAt: string;
-};
-
-export type Secret = {
-  id: string;
-  name: string;
-  purpose: SecretPurpose;
-  description: string | null;
-  ciphertextVersion: number;
-  keyId: string;
-  rotatedAt: string | null;
-  disabledAt: string | null;
-  createdAt: string;
-  updatedAt: string;
-  agentGrants?: Array<{ agentId: string; envVar: string; agent?: { id: string; name: string } }>;
-};
 
 export type Session = {
   id: string;

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -69,6 +69,17 @@ import {
   resumeChain,
 } from "@anneal/db";
 import type { ChainStep as ChainStepContract } from "@anneal/db/board-contract";
+import type {
+  Agent as AgentContract,
+  AgentRepoAccess as AgentRepoAccessContract,
+  Environment as EnvironmentContract,
+  FilesystemGrant as FilesystemGrantContract,
+  MCPConnection as MCPConnectionContract,
+  Project as ProjectContract,
+  Repo as RepoContract,
+  Secret as SecretContract,
+  Skill as SkillContract,
+} from "@anneal/db/wire-contract";
 import { Hono, type Context } from "hono";
 import { cors } from "hono/cors";
 import { bodyLimit } from "hono/body-limit";
@@ -826,6 +837,13 @@ const goalInclude = {
   progressLog: { orderBy: { createdAt: "asc" as const } },
 };
 
+type ProjectResponse = ProjectContract<Date, Prisma.Decimal>;
+type AgentResponse = AgentContract<Date>;
+type SecretResponse = SecretContract<Date>;
+type SkillResponse = SkillContract<Date>;
+type MCPConnectionResponse = MCPConnectionContract<Date>;
+type RepoResponse = RepoContract<Date>;
+
 export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEnvironment> => {
   const app = new Hono<AppEnvironment>();
   const releaseChainLease = options.releaseMergeLease ?? releaseMergeLease;
@@ -1076,16 +1094,18 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return context.json(result.installation, 201);
   });
 
-  app.get("/projects", async (context) => validated(context, await db.project.findMany({ orderBy: { createdAt: "asc" } })));
-  app.post("/projects", async (context) => context.json(await db.project.create({ data: await readJson(context.req.raw, projectInput) }), 201));
+  app.get("/projects", async (context) => validated(context,
+    (await db.project.findMany({ orderBy: { createdAt: "asc" } })) satisfies ProjectResponse[]));
+  app.post("/projects", async (context) => context.json(
+    (await db.project.create({ data: await readJson(context.req.raw, projectInput) })) satisfies ProjectResponse, 201));
   app.get("/projects/:projectId", async (context) => {
     const project = await db.project.findUnique({ where: { id: id.parse(context.req.param("projectId")) } });
-    return project ? context.json(project) : context.json({ error: "Project not found" }, 404);
+    return project ? context.json(project satisfies ProjectResponse) : context.json({ error: "Project not found" }, 404);
   });
-  app.patch("/projects/:projectId", async (context) => context.json(await db.project.update({
+  app.patch("/projects/:projectId", async (context) => context.json((await db.project.update({
     where: { id: id.parse(context.req.param("projectId")) },
     data: withoutUndefined(await readJson(context.req.raw, projectPatch)) as Prisma.ProjectUpdateInput,
-  })));
+  })) satisfies ProjectResponse));
   app.delete("/projects/:projectId", async (context) => {
     await db.project.delete({ where: { id: id.parse(context.req.param("projectId")) } });
     return context.body(null, 204);
@@ -1108,36 +1128,36 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return context.json(await readProjectCosts(db, id.parse(context.req.param("projectId")), days, timeZone));
   });
 
-  app.get("/projects/:projectId/environments", async (context) => context.json(await db.environment.findMany({
+  app.get("/projects/:projectId/environments", async (context) => context.json((await db.environment.findMany({
     where: { projectId: id.parse(context.req.param("projectId")) },
     orderBy: { createdAt: "asc" },
-  })));
-  app.post("/projects/:projectId/environments", async (context) => context.json(await db.environment.create({
+  })) satisfies EnvironmentContract[]));
+  app.post("/projects/:projectId/environments", async (context) => context.json((await db.environment.create({
     data: { projectId: id.parse(context.req.param("projectId")), ...await readJson(context.req.raw, environmentInput) },
-  }), 201));
+  })) satisfies EnvironmentContract, 201));
   app.get("/environments/:environmentId", async (context) => {
     const environment = await db.environment.findUnique({
       where: { id: id.parse(context.req.param("environmentId")) },
       include: { secrets: { include: { secret: { select: secretPublicSelect } } } },
     });
-    return environment ? context.json(environment) : context.json({ error: "Environment not found" }, 404);
+    return environment ? context.json(environment satisfies EnvironmentContract) : context.json({ error: "Environment not found" }, 404);
   });
-  app.patch("/environments/:environmentId", async (context) => context.json(await db.environment.update({
+  app.patch("/environments/:environmentId", async (context) => context.json((await db.environment.update({
     where: { id: id.parse(context.req.param("environmentId")) },
     data: withoutUndefined(await readJson(context.req.raw, environmentPatch)),
-  })));
+  })) satisfies EnvironmentContract));
   app.delete("/environments/:environmentId", async (context) => {
     await db.environment.delete({ where: { id: id.parse(context.req.param("environmentId")) } });
     return context.body(null, 204);
   });
 
-  app.get("/secrets", async (context) => context.json(await db.secret.findMany({
+  app.get("/secrets", async (context) => context.json((await db.secret.findMany({
     select: {
       ...secretPublicSelect,
       agentGrants: { include: { agent: { select: { id: true, name: true, title: true, projectId: true } } } },
     },
     orderBy: { createdAt: "asc" },
-  })));
+  })) satisfies SecretResponse[]));
   app.post("/secrets", async (context) => {
     const body = await readJson(context.req.raw, secretInput);
     const secret = await db.secret.create({
@@ -1149,7 +1169,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       },
       select: secretPublicSelect,
     });
-    return context.json(secret, 201);
+    return context.json(secret satisfies SecretResponse, 201);
   });
   app.get("/secrets/:secretId", async (context) => {
     const secret = await db.secret.findUnique({
@@ -1159,19 +1179,19 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         agentGrants: { include: { agent: { select: { id: true, name: true, title: true, projectId: true } } } },
       },
     });
-    return secret ? context.json(secret) : context.json({ error: "Secret not found" }, 404);
+    return secret ? context.json(secret satisfies SecretResponse) : context.json({ error: "Secret not found" }, 404);
   });
   app.patch("/secrets/:secretId", async (context) => {
     const body = await readJson(context.req.raw, secretPatch);
     const { value, ...fields } = body;
-    return context.json(await db.secret.update({
+    return context.json((await db.secret.update({
       where: { id: id.parse(context.req.param("secretId")) },
       data: {
         ...withoutUndefined(fields),
         ...(value === undefined ? {} : { encryptedValue: encryptSecret(value), rotatedAt: new Date() }),
       },
       select: secretPublicSelect,
-    }));
+    })) satisfies SecretResponse);
   });
   app.delete("/secrets/:secretId", async (context) => {
     await db.secret.delete({ where: { id: id.parse(context.req.param("secretId")) } });
@@ -1189,7 +1209,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   })).map((agent) => {
     const mechanical = agent.name === INTEGRATOR_AGENT_NAME;
     return { ...agent, mechanical, assignable: !mechanical };
-  })));
+  }) satisfies AgentResponse[]));
   app.post("/projects/:projectId/agents", async (context) => {
     const projectId = id.parse(context.req.param("projectId"));
     const body = await readJson(context.req.raw, agentInput);
@@ -1205,7 +1225,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     if (foundationalPrompt === undefined) {
       return context.json({ error: "This project has no foundation yet. Run npm run db:seed." }, 400);
     }
-    return context.json(await db.agent.create({ data: { ...body, foundationalPrompt, projectId } }), 201);
+    return context.json((await db.agent.create({
+      data: { ...body, foundationalPrompt, projectId },
+    })) satisfies AgentResponse, 201);
   });
   app.get("/agents/:agentId", async (context) => {
     const agent = await db.agent.findUnique({
@@ -1220,7 +1242,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         collaborators: { include: { allowedAgent: true } },
       },
     });
-    return agent ? context.json(agent) : context.json({ error: "Agent not found" }, 404);
+    return agent ? context.json(agent satisfies AgentResponse) : context.json({ error: "Agent not found" }, 404);
   });
   app.patch("/agents/:agentId", async (context) => {
     const agentId = id.parse(context.req.param("agentId"));
@@ -1251,7 +1273,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       }) };
     });
     if ("message" in result) return refusalJson(context, result);
-    return context.json(result.agent);
+    return context.json(result.agent satisfies AgentResponse);
   });
   app.post("/agents/:agentId/reset-runtime-config", async (context) => {
     const agentId = id.parse(context.req.param("agentId"));
@@ -1284,7 +1306,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       }) };
     });
     if ("message" in result) return refusalJson(context, result);
-    return context.json(result.agent);
+    return context.json(result.agent satisfies AgentResponse);
   });
   app.delete("/agents/:agentId", async (context) => {
     try {
@@ -1318,17 +1340,17 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     // Unchanged sweep: rows archived before this protocol existed — or queued by
     // a writer that committed first — still get their explanatory activity.
     await noteArchivedQueuedRuns(db, { agentId });
-    return context.json(result.agent);
+    return context.json(result.agent satisfies AgentResponse);
   });
   app.post("/agents/:agentId/unarchive", async (context) => {
     const agentId = id.parse(context.req.param("agentId"));
     const agent = await db.agent.findUnique({ where: { id: agentId } });
     if (!agent) return context.json({ error: "Agent not found" }, 404);
-    if (!agent.archivedAt) return context.json(agent);
-    return context.json(await db.agent.update({
+    if (!agent.archivedAt) return context.json(agent satisfies AgentResponse);
+    return context.json((await db.agent.update({
       where: { id: agentId },
       data: { archivedAt: null },
-    }));
+    })) satisfies AgentResponse);
   });
 
   app.get("/agents/:agentId/secret-grants", async (context) => context.json(await db.agentSecretGrant.findMany({
@@ -1362,9 +1384,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return context.body(null, 204);
   });
 
-  app.get("/agents/:agentId/filesystem-grants", async (context) => context.json(await db.filesystemGrant.findMany({
+  app.get("/agents/:agentId/filesystem-grants", async (context) => context.json((await db.filesystemGrant.findMany({
     where: { agentId: id.parse(context.req.param("agentId")) }, orderBy: { folderPath: "asc" },
-  })));
+  })) satisfies FilesystemGrantContract[]));
   /**
    * Two spellings of one physical folder must not become two grants. On a case- and
    * normalization-insensitive volume `protected` and `Protected` are the same directory,
@@ -1396,11 +1418,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const body = await readJson(context.req.raw, filesystemGrantInput);
     const aliased = await aliasingGrant(agentId, body.folderPath);
     if (aliased !== null) return aliasConflict(context, body.folderPath, aliased);
-    return context.json(await db.filesystemGrant.upsert({
+    return context.json((await db.filesystemGrant.upsert({
       where: { agentId_folderPath: { agentId, folderPath: body.folderPath } },
       create: { agentId, ...body },
       update: body,
-    }), 201);
+    })) satisfies FilesystemGrantContract, 201);
   });
   app.patch("/agents/:agentId/filesystem-grants/:grantId", async (context) => {
     const agentId = id.parse(context.req.param("agentId"));
@@ -1412,10 +1434,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       const aliased = await aliasingGrant(agentId, patch.folderPath, grantId);
       if (aliased !== null) return aliasConflict(context, patch.folderPath, aliased);
     }
-    return context.json(await db.filesystemGrant.update({
+    return context.json((await db.filesystemGrant.update({
       where: { id: grantId },
       data: withoutUndefined(patch) as Prisma.FilesystemGrantUncheckedUpdateInput,
-    }));
+    })) satisfies FilesystemGrantContract);
   });
   app.delete("/agents/:agentId/filesystem-grants/:grantId", async (context) => {
     const deleted = await db.filesystemGrant.deleteMany({ where: {
@@ -1443,16 +1465,16 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return deleted.count === 1 ? context.body(null, 204) : context.json({ error: "Collaboration binding not found" }, 404);
   });
 
-  app.get("/projects/:projectId/skills", async (context) => context.json(await db.skill.findMany({
+  app.get("/projects/:projectId/skills", async (context) => context.json((await db.skill.findMany({
     where: { projectId: id.parse(context.req.param("projectId")) },
     include: { agents: true },
     orderBy: { createdAt: "asc" },
-  })));
+  })) satisfies SkillResponse[]));
   app.post("/projects/:projectId/skills", async (context) => {
     const body = await readJson(context.req.raw, skillInput);
-    return context.json(await db.skill.create({
+    return context.json((await db.skill.create({
       data: { projectId: id.parse(context.req.param("projectId")), ...body },
-    }), 201);
+    })) satisfies SkillResponse, 201);
   });
   app.post("/agents/:agentId/skills", async (context) => {
     const agentId = id.parse(context.req.param("agentId"));
@@ -1475,11 +1497,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return deleted.count === 1 ? context.body(null, 204) : context.json({ error: "Skill binding not found" }, 404);
   });
 
-  app.get("/projects/:projectId/mcp-connections", async (context) => context.json(await db.mCPConnection.findMany({
+  app.get("/projects/:projectId/mcp-connections", async (context) => context.json((await db.mCPConnection.findMany({
     where: { projectId: id.parse(context.req.param("projectId")) },
     include: { agents: true },
     orderBy: { createdAt: "asc" },
-  })));
+  })) satisfies MCPConnectionResponse[]));
   app.post("/projects/:projectId/mcp-connections", async (context) => {
     const projectId = id.parse(context.req.param("projectId"));
     const body = await readJson(context.req.raw, mcpConnectionInput);
@@ -1487,9 +1509,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       const secret = await db.secret.findFirst({ where: { id: body.credentialSecretId, disabledAt: null } });
       if (!secret) return context.json({ error: "MCP credential secret is unavailable" }, 400);
     }
-    return context.json(await db.mCPConnection.create({
+    return context.json((await db.mCPConnection.create({
       data: { ...body, config: jsonValue(body.config), projectId },
-    }), 201);
+    })) satisfies MCPConnectionResponse, 201);
   });
   app.post("/agents/:agentId/mcp-connections", async (context) => {
     const agentId = id.parse(context.req.param("agentId"));
@@ -1512,10 +1534,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return deleted.count === 1 ? context.body(null, 204) : context.json({ error: "MCP binding not found" }, 404);
   });
 
-  app.get("/projects/:projectId/repos", async (context) => validated(context, await db.repo.findMany({
+  app.get("/projects/:projectId/repos", async (context) => validated(context, (await db.repo.findMany({
     where: { projectId: id.parse(context.req.param("projectId")) },
     orderBy: { createdAt: "asc" },
-  })));
+  })) satisfies RepoResponse[]));
   app.post("/projects/:projectId/repos", async (context) => {
     const projectId = id.parse(context.req.param("projectId"));
     const body = await readJson(context.req.raw, repoInput);
@@ -1523,7 +1545,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       const secret = await db.secret.findFirst({ where: { id: body.credentialSecretId, disabledAt: null } });
       if (!secret) return context.json({ error: "Repo credential secret is unavailable" }, 400);
     }
-    return context.json(await db.repo.create({ data: { ...body, projectId } }), 201);
+    return context.json((await db.repo.create({ data: { ...body, projectId } })) satisfies RepoResponse, 201);
   });
   app.patch("/repos/:repoId", async (context) => {
     const body = await readJson(context.req.raw, repoPatch);
@@ -1531,9 +1553,9 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
       const secret = await db.secret.findFirst({ where: { id: body.credentialSecretId, disabledAt: null } });
       if (!secret) return context.json({ error: "Repo credential secret is unavailable" }, 400);
     }
-    return context.json(await db.repo.update({
+    return context.json((await db.repo.update({
       where: { id: id.parse(context.req.param("repoId")) }, data: withoutUndefined(body),
-    }));
+    })) satisfies RepoResponse);
   });
   app.delete("/repos/:repoId", async (context) => {
     await db.repo.delete({ where: { id: id.parse(context.req.param("repoId")) } });
@@ -1549,11 +1571,11 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     ]);
     if (!agent || !repo) return context.json({ error: "Agent or Repo not found" }, 404);
     if (agent.projectId !== repo.projectId) return context.json({ error: "Agent and Repo belong to different projects" }, 400);
-    return context.json(await db.agentRepoAccess.upsert({
+    return context.json((await db.agentRepoAccess.upsert({
       where: { agentId_repoId: { agentId, repoId } },
       create: { agentId, repoId, projectId: agent.projectId, ...body },
       update: body,
-    }), 201);
+    })) satisfies AgentRepoAccessContract, 201);
   });
   app.delete("/agents/:agentId/repos/:repoId/access", async (context) => {
     const agentId = id.parse(context.req.param("agentId"));

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -22,6 +22,10 @@
       "types": "./src/board-contract.ts",
       "import": "./dist/board-contract.js"
     },
+    "./wire-contract": {
+      "types": "./src/wire-contract.ts",
+      "import": "./dist/wire-contract.js"
+    },
     "./service-lock": {
       "types": "./src/service-maintenance-lock.ts",
       "import": "./dist/service-maintenance-lock.js"

--- a/packages/db/src/wire-contract.ts
+++ b/packages/db/src/wire-contract.ts
@@ -1,0 +1,174 @@
+/**
+ * Browser-safe serialized contracts for operator configuration resources.
+ *
+ * Prisma is imported as types only: browser consumers receive no generated
+ * client code, while persisted enum widening becomes a compile-time change at
+ * this seam. `DateTime` and `DecimalValue` default to their JSON wire forms;
+ * server projections instantiate them with their native values before Hono
+ * serializes the response.
+ */
+
+import type {
+  CodexServiceTier as PrismaCodexServiceTier,
+  FailureClass as PrismaFailureClass,
+  GoalStatus as PrismaGoalStatus,
+  InboxDeliveryStatus as PrismaInboxDeliveryStatus,
+  InboxKind as PrismaInboxKind,
+  InboxStatus as PrismaInboxStatus,
+  NetworkingMode as PrismaNetworkingMode,
+  RepoPermission as PrismaRepoPermission,
+  RunnerKind as PrismaRunnerKind,
+  RunnerPreference as PrismaRunnerPreference,
+  SecretPurpose as PrismaSecretPurpose,
+  SessionExecutionStatus as PrismaSessionExecutionStatus,
+  SkillKind as PrismaSkillKind,
+} from "@prisma/client";
+
+export type RunnerKind = PrismaRunnerKind;
+export type RunnerPreference = PrismaRunnerPreference;
+export type CodexServiceTier = PrismaCodexServiceTier;
+export type SessionExecutionStatus = PrismaSessionExecutionStatus;
+export type FailureClass = PrismaFailureClass;
+export type InboxStatus = PrismaInboxStatus;
+export type InboxKind = PrismaInboxKind;
+export type InboxDeliveryStatus = PrismaInboxDeliveryStatus;
+export type SecretPurpose = PrismaSecretPurpose;
+export type RepoPermission = PrismaRepoPermission;
+type NetworkingMode = PrismaNetworkingMode;
+type SkillKind = PrismaSkillKind;
+
+type WiredGoalStatus = Extract<PrismaGoalStatus, "ACTIVE" | "PAUSED" | "COMPLETED">;
+type UnwiredGoalStatus =
+  | "STOPPED_SPEND"
+  | "STOPPED_TIME"
+  | "STOPPED_STUCK"
+  | "FAILED"
+  | "CANCELLED";
+type GoalStatusCoverage =
+  Exclude<PrismaGoalStatus, WiredGoalStatus | UnwiredGoalStatus> extends never
+    ? Exclude<UnwiredGoalStatus, PrismaGoalStatus> extends never
+      ? unknown
+      : never
+    : never;
+
+/* Five of the eight `GoalStatus` values in `schema.prisma` are missing on
+ * purpose. The three `STOPPED_*` states are not wired to an execution model,
+ * and FAILED/CANCELLED likewise have no writer in this repository. Naming
+ * them here would put a tone, label and legend in the console for states the
+ * server cannot produce. `GoalStatusCoverage` makes any persisted widening or
+ * removal a type error until this deliberate narrowing is reconsidered. */
+export type GoalStatus = WiredGoalStatus & GoalStatusCoverage;
+
+export type Project<DateTime = string, DecimalValue = string> = {
+  id: string;
+  name: string;
+  slug: string;
+  yamlDocument: string;
+  maxDurationMin: number;
+  stallTimeoutMin: number;
+  maxSessionsPerTask: number;
+  spendCap: DecimalValue | null;
+  createdAt: DateTime;
+  updatedAt: DateTime;
+};
+
+export type Agent<DateTime = string> = {
+  id: string;
+  projectId: string;
+  environmentId: string;
+  name: string;
+  title: string;
+  model: string;
+  codexServiceTier: CodexServiceTier;
+  foundationalPrompt: string;
+  rolePrompt: string;
+  runnerPreference: RunnerPreference;
+  inboxAccess: boolean;
+  /** Denied tools, not allowed ones. Empty means no restriction. */
+  disabledTools: string[];
+  createdAt: DateTime;
+  updatedAt: DateTime;
+  archivedAt: DateTime | null;
+  /** Binding tables are present on the detail route and absent on list rows. */
+  skills?: Array<{ skillId: string; skill?: Skill<DateTime> }>;
+  mcpConnections?: Array<{ mcpConnectionId: string; mcpConnection?: MCPConnection<DateTime> }>;
+  repoAccess?: AgentRepoAccess[];
+  secretGrants?: Array<{ secretId: string; envVar: string; secret?: Secret<DateTime> }>;
+  filesystemGrants?: FilesystemGrant[];
+  collaborators?: Array<{ allowedAgentId: string }>;
+};
+
+export type AgentRepoAccess = {
+  agentId: string;
+  repoId: string;
+  projectId: string;
+  mountPath: string;
+  permissions: RepoPermission;
+};
+
+export type FilesystemGrant = {
+  id: string;
+  agentId: string;
+  folderPath: string;
+  canRead: boolean;
+  canWrite: boolean;
+  canDelete: boolean;
+};
+
+export type Skill<DateTime = string> = {
+  id: string;
+  projectId: string;
+  name: string;
+  slug: string;
+  kind: SkillKind;
+  body: string | null;
+  filePath: string | null;
+  updatedAt: DateTime;
+};
+
+export type MCPConnection<DateTime = string> = {
+  id: string;
+  projectId: string;
+  credentialSecretId: string | null;
+  name: string;
+  transport: string;
+  config: unknown;
+  allowedOperations: string[];
+  createdAt: DateTime;
+  updatedAt: DateTime;
+  agents?: Array<{ agentId: string }>;
+};
+
+export type Environment = {
+  id: string;
+  projectId: string;
+  name: string;
+  networking: NetworkingMode;
+  allowedHosts: string[];
+};
+
+export type Repo<DateTime = string> = {
+  id: string;
+  projectId: string;
+  credentialSecretId: string | null;
+  name: string;
+  remoteUrl: string;
+  mountPath: string;
+  defaultBranch: string;
+  createdAt: DateTime;
+  updatedAt: DateTime;
+};
+
+export type Secret<DateTime = string> = {
+  id: string;
+  name: string;
+  purpose: SecretPurpose;
+  description: string | null;
+  ciphertextVersion: number;
+  keyId: string;
+  rotatedAt: DateTime | null;
+  disabledAt: DateTime | null;
+  createdAt: DateTime;
+  updatedAt: DateTime;
+  agentGrants?: Array<{ agentId: string; envVar: string; agent?: { id: string; name: string } }>;
+};


### PR DESCRIPTION
## Summary
- add a browser-safe shared wire contract for operator configuration resources
- derive browser enum types from generated Prisma types while preserving the deliberate GoalStatus narrowing
- pin matching API response projections and remove the web-side mirrors

## Verification
- npm run lint
- targeted web tests: 22 passed
- capability-routes.dbtest.ts: 1 passed