### PR TITLE
refactor(runner): name consumed claim slices

### DIFF
--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -157,6 +157,14 @@ export type ClaimedTask = {
   regressionRepairHandoff: RegressionRepairHandoff | null;
 };
 
+/** The fenced Run identity consumed by runner-to-control-plane writes. */
+export type ControlPlaneRunClaim = Pick<ClaimedTask, "fencingToken"> & {
+  run: Pick<ClaimedTask["run"], "id">;
+};
+
+/** The session principal consumed by session-authenticated control-plane writes. */
+export type ControlPlaneSessionClaim = ControlPlaneRunClaim & Pick<ClaimedTask, "sessionToken">;
+
 export type SessionEventPayload = {
   seq: number;
   at?: string;
@@ -232,7 +240,7 @@ export const claimTask = async (config: RunnerConfig): Promise<ClaimedTask | nul
 
 export const startRun = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: ControlPlaneRunClaim,
   snapshot: Record<string, unknown> & { promptHash: string },
 ): Promise<void> => {
   await request(config, `/runner/runs/${claim.run.id}/start`, {
@@ -247,7 +255,7 @@ export const startRun = async (
 
 export const heartbeat = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: ControlPlaneRunClaim,
   state: { processAlive: boolean; lastProgressEventAt: Date | null; inFlightTool: Record<string, unknown> | null },
 ): Promise<HeartbeatResult> => {
   const response = await request(config, `/runner/runs/${claim.run.id}/heartbeat`, {
@@ -267,7 +275,7 @@ export const heartbeat = async (
 
 export const acknowledgeCancellation = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: ControlPlaneRunClaim,
   cancellation: CancellationRequest,
   workspace?: { path: string; branch: string; baseSha: string } | null,
   containment: { worktreeContainmentViolations?: string[] } = {},
@@ -304,7 +312,7 @@ export type SessionTaskOutput = {
  * never needs control-plane network access or session credentials. */
 export const persistSessionTaskOutput = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: ControlPlaneSessionClaim,
   output: SessionTaskOutput,
 ): Promise<void> => {
   await request(config, `/session/runs/${claim.run.id}/output`, {
@@ -318,7 +326,7 @@ export const persistSessionTaskOutput = async (
  * late for recovery: by then the provider process and workspace are gone. */
 export const readSessionTaskOutputStatus = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: ControlPlaneSessionClaim,
 ): Promise<SessionTaskOutputStatus | null> => {
   const response = await request(config, `/session/runs/${claim.run.id}/status`, {
     method: "GET",
@@ -356,7 +364,7 @@ export const readSessionTaskOutputStatus = async (
  * work, cleanup, or process loss may happen after publication. */
 export const recordPublishedBranch = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: ControlPlaneRunClaim,
   pushedBranch: string,
 ): Promise<void> => {
   await request(config, `/runner/runs/${claim.run.id}/publication`, {
@@ -374,7 +382,7 @@ export const recordPublishedBranch = async (
  * run; unlike completion, it carries no authority over run outcome. */
 export const recordLeaseIndependentCleanup = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: ControlPlaneRunClaim,
   cleanup: { cleanupStatus: CleanupStatus; cleanupFailureReason?: string; workspaceRetained: boolean },
 ): Promise<void> => {
   await request(config, `/runner/runs/${claim.run.id}/cleanup`, {
@@ -389,7 +397,7 @@ export const recordLeaseIndependentCleanup = async (
 
 export const appendEvents = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: ControlPlaneRunClaim,
   events: SessionEventPayload[],
   providerConversationId?: string | null,
 ): Promise<void> => {
@@ -407,7 +415,7 @@ export const appendEvents = async (
 
 export const appendActivity = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: ControlPlaneRunClaim,
   body: string,
   metadata: Record<string, unknown> = {},
 ): Promise<void> => {
@@ -464,7 +472,11 @@ export type Completion = {
   failureEnvelope?: FailureEnvelope;
 };
 
-export const completeRun = async (config: RunnerConfig, claim: ClaimedTask, completion: Completion): Promise<void> => {
+export const completeRun = async (
+  config: RunnerConfig,
+  claim: ControlPlaneRunClaim,
+  completion: Completion,
+): Promise<void> => {
   await request(config, `/runner/runs/${claim.run.id}/complete`, {
     method: "POST",
     body: JSON.stringify({ runnerId: config.runnerId, fencingToken: claim.fencingToken, ...completion }),

--- a/packages/runner/src/delivery.test.ts
+++ b/packages/runner/src/delivery.test.ts
@@ -2,19 +2,27 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { ExitEvidence } from "./adapters.js";
-import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
-import { deliverFailedWorkspace, deliverWorkspace, pullRequestTitle, type CommandExecutor } from "./delivery.js";
+import {
+  deliverWorkspace, pullRequestTitle, salvageWorkspace,
+  type CommandExecutor, type DeliveryClaim,
+} from "./delivery.js";
 import { completionEnvelope } from "./envelope.js";
 import { CommandTimeoutError, KILL_OVERHEAD_MS } from "./exec.js";
 import { deliveryDeadline, NETWORK_COMMAND_TIMEOUT_MS } from "./network-retry.js";
 
 const config = { runAsPrefix: [], path: "/fake/bin", home: "/fake/home" } as unknown as RunnerConfig;
 const claim = {
-  task: { id: "task-1", name: "Feature" },
+  task: { id: "task-1", name: "Feature", templateStep: null },
   repo: { remoteUrl: "https://github.com/acme/app.git", defaultBranch: "main" },
-  run: { id: "run-2", runNumber: 2 },
-} as ClaimedTask;
+  run: {},
+} satisfies DeliveryClaim;
+const salvageIdentity = {
+  taskId: "task-1",
+  runId: "run-2",
+  runNumber: 2,
+  remoteUrl: "https://github.com/acme/app.git",
+};
 const workspace = { path: "/fake/work", branch: "feature/test", baseSha: "base" };
 
 test("delivery fails loudly with the gh probe error when gh is unavailable", async () => {
@@ -25,7 +33,7 @@ test("delivery fails loudly with the gh probe error when gh is unavailable", asy
     if (executable === "gh") throw probeError;
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake);
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake });
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.pushedBranch, workspace.branch);
   assert.equal(result.failure?.operation, "gh --version");
@@ -39,7 +47,7 @@ test("delivery records a pushed branch without invoking gh for a non-GitHub remo
   const fake: CommandExecutor = async (executable, args) => { calls.push(`${executable} ${args.join(" ")}`); return ""; };
   const result = await deliverWorkspace(config, {
     ...claim, repo: { ...claim.repo, remoteUrl: "ssh://git@example.test/acme/app.git" },
-  }, workspace, fake);
+  }, workspace, { command: fake });
   assert.equal(result.pushStatus, "SUCCEEDED");
   assert.equal(result.failure, undefined);
   assert.match(result.deliveryInstructions ?? "", /not hosted on GitHub/);
@@ -53,7 +61,7 @@ test("a chain step reuses the open pull request on its shared head branch", asyn
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/7", number: 7 }]);
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake);
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake });
   assert.equal(result.pullRequestNumber, 7);
   assert.equal(calls.some((call) => call.startsWith("gh pr create")), false);
 });
@@ -64,7 +72,7 @@ test("a failed initial pull-request lookup fails delivery with the lookup error"
     if (executable === "gh" && args[1] === "list") throw lookupError;
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake);
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake });
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.pushedBranch, workspace.branch);
   assert.equal(result.failure?.operation, "gh pr list");
@@ -86,8 +94,8 @@ test("delivery opens one pull request titled after the chain, not the step", asy
   const chained = {
     ...claim,
     task: { ...claim.task, name: "lines subcommand: Write spec", templateStep: { name: "Write spec" } },
-  } as ClaimedTask;
-  const result = await deliverWorkspace(config, chained, workspace, fake);
+  } satisfies DeliveryClaim;
+  const result = await deliverWorkspace(config, chained, workspace, { command: fake });
   assert.equal(result.pullRequestNumber, 8);
   assert.equal(pullRequestTitle(chained.task), "lines subcommand");
   assert.ok(calls.some((call) => call.includes("--title lines subcommand")));
@@ -104,8 +112,8 @@ test("a custom chain base is preserved in gh pr create", async () => {
     }
     return "";
   };
-  const custom = { ...claim, run: { ...claim.run, pullRequestBase: "release/1.x" } } as ClaimedTask;
-  const result = await deliverWorkspace(config, custom, workspace, fake);
+  const custom = { ...claim, run: { ...claim.run, pullRequestBase: "release/1.x" } } satisfies DeliveryClaim;
+  const result = await deliverWorkspace(config, custom, workspace, { command: fake });
   assert.equal(result.pullRequestNumber, 10);
   assert.ok(calls.some((call) => call.includes("--base release/1.x")));
 });
@@ -117,7 +125,10 @@ test("publication is acknowledged immediately after push and before GitHub work"
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/7", number: 7 }]);
     return "";
   };
-  await deliverWorkspace(config, claim, workspace, fake, async (branch) => { calls.push(`ack ${branch}`); });
+  await deliverWorkspace(config, claim, workspace, {
+    command: fake,
+    recordPublication: async (branch) => { calls.push(`ack ${branch}`); },
+  });
   assert.deepEqual(calls.slice(0, 3), [
     "git push --set-upstream origin feature/test",
     "ack feature/test",
@@ -135,7 +146,7 @@ test("a pull request created between list and create is confirmed and reused", a
     if (executable === "gh" && args[1] === "create") throw new Error("a pull request already exists for head");
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake);
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake });
   assert.equal(listCalls, 2);
   assert.equal(result.pushStatus, "SUCCEEDED");
   assert.equal(result.pullRequestNumber, 7);
@@ -153,7 +164,7 @@ test("transient push failures succeed on the third attempt", async () => {
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(pushes, 3);
   assert.equal(result.pushStatus, "SUCCEEDED");
 });
@@ -167,7 +178,7 @@ test("deterministic authentication failures are not retried", async () => {
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(pushes, 1);
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.failureClass, "AUTH_REQUIRED");
@@ -187,7 +198,7 @@ test("an EOF after PR creation is resolved by head lookup without duplicate crea
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(createCalls, 1);
   assert.equal(result.pullRequestNumber, 12);
   assert.equal(result.pushStatus, "SUCCEEDED");
@@ -214,7 +225,7 @@ test("a read-back that cannot be completed preserves its typed failure and never
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(createCalls, 1, "the create was resent without a read-back that found nothing");
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.pushedBranch, workspace.branch);
@@ -254,7 +265,7 @@ test("a deterministic create failure is read back once and never resent", async 
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(createCalls, 1);
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.failure?.operation, "gh pr create");
@@ -271,7 +282,7 @@ test("gh names the pull request it made, so a confirmed create needs no lookup a
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(result.pullRequestNumber, 42);
   assert.equal(result.pullRequestUrl, "https://github.com/acme/app/pull/42");
   // One `gh pr list` — the one before creation. The read-after-write is gone,
@@ -299,7 +310,7 @@ test("a create that succeeded and a lookup that failed never asks for a second c
     if (executable === "gh" && args[1] === "create") { createCalls += 1; return ""; }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(createCalls, 1);
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.pushedBranch, workspace.branch);
@@ -319,7 +330,7 @@ test("a successful but unnamed create fails when no open pull request can be fou
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(listCalls, 2);
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.pushedBranch, workspace.branch);
@@ -347,7 +358,7 @@ test("a bare EOF is a lost response, so a read-back that finds nothing earns exa
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(createCalls, 2, "the confirmed absence did not earn a resend");
   assert.equal(result.pullRequestNumber, 21);
   // Sends are gated on read-backs: one before creation, one confirming the loss.
@@ -370,10 +381,13 @@ test("a resend is not started with less budget than one attempt needs", async ()
     clock += 27_000;
     throw new Error("Post https://api.github.com/graphql: unexpected EOF");
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, undefined, {
+  const result = await deliverWorkspace(config, claim, workspace, {
+    command: fake,
+    retryOptions: {
     deadline: deliveryDeadline(0, 60, 0),
     now: () => clock,
     wait: async () => { clock += 1_000; },
+    },
   });
   assert.equal(createCalls, 1);
   assert.equal(result.pushStatus, "FAILED");
@@ -391,7 +405,7 @@ test("a pushed branch remains published when PR retries are exhausted, but deliv
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(createCalls, 6);
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.pushedBranch, workspace.branch);
@@ -409,7 +423,7 @@ test("git's Author identity error is a tool failure, not an auth failure", async
     }
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, async () => undefined, { wait: async () => undefined });
+  const result = await deliverWorkspace(config, claim, workspace, { command: fake, retryOptions: { wait: async () => undefined } });
   assert.equal(pushes, 1);
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.failureClass, "TOOL_FAILED");
@@ -422,7 +436,7 @@ test("a failed run commits uncommitted changes, pushes them as WIP, and opens no
     if (executable === "git" && args[0] === "status") return "M tracked.ts\n?? new.ts";
     return executable === "git" && args[0] === "rev-parse" ? "salvage-sha" : "";
   };
-  const result = await deliverFailedWorkspace(config, claim, workspace, fake);
+  const result = await salvageWorkspace(config, salvageIdentity, workspace, { command: fake });
   assert.equal(result?.pushStatus, "SUCCEEDED");
   assert.equal(result?.headSha, "salvage-sha");
   assert.equal(result?.failureClass, undefined);
@@ -444,7 +458,7 @@ test("a failed run with no new commit is not pushed at all", async () => {
     calls.push(`${executable} ${args.join(" ")}`);
     return executable === "git" && args[0] === "rev-parse" ? workspace.baseSha : "";
   };
-  assert.equal(await deliverFailedWorkspace(config, claim, workspace, fake), null);
+  assert.equal(await salvageWorkspace(config, salvageIdentity, workspace, { command: fake }), null);
   assert.deepEqual(calls, ["git add -A", "git status --porcelain", "git rev-parse HEAD"]);
 });
 
@@ -454,7 +468,7 @@ test("a failed run still pushes commits the agent made before crashing", async (
     calls.push(`${executable} ${args.join(" ")}`);
     return executable === "git" && args[0] === "rev-parse" ? "agent-commit-sha" : "";
   };
-  const result = await deliverFailedWorkspace(config, claim, workspace, fake);
+  const result = await salvageWorkspace(config, salvageIdentity, workspace, { command: fake });
   assert.equal(result?.headSha, "agent-commit-sha");
   assert.equal(calls.some((call) => call.includes(" commit ")), false);
   assert.equal(calls.at(-1), "git push origin HEAD:refs/heads/agentos/task-1/run-2");
@@ -462,12 +476,11 @@ test("a failed run still pushes commits the agent made before crashing", async (
 
 // --- one branch and one PR per chain -----------------------------------------
 //
-// The six tests above stay unmodified on purpose, and their passing is itself a
-// regression pin: the `claim` fixture omits `opensPullRequest` entirely, so they
-// prove that a claim payload from a *stale API build* still opens a pull request
-// rather than silently never opening one again.
+// The `claim` fixture omits `opensPullRequest` entirely, so the tests above pin
+// that a claim payload from a stale API build still opens a pull request rather
+// than silently never opening one again.
 
-const noPrClaim = { ...claim, run: { ...claim.run, opensPullRequest: false } } as ClaimedTask;
+const noPrClaim = { ...claim, run: { ...claim.run, opensPullRequest: false } } satisfies DeliveryClaim;
 
 test("a step that does not open pull requests still pushes its branch", async () => {
   const calls: string[] = [];
@@ -476,7 +489,7 @@ test("a step that does not open pull requests still pushes its branch", async ()
     if (executable === "gh" && args[1] === "list") return "[]";
     return "";
   };
-  const result = await deliverWorkspace(config, noPrClaim, workspace, fake);
+  const result = await deliverWorkspace(config, noPrClaim, workspace, { command: fake });
   assert.equal(result.pushStatus, "SUCCEEDED");
   // The push is what the *next* step of the chain clones, so it is unconditional.
   assert.ok(calls.includes("git push --set-upstream origin feature/test"));
@@ -486,7 +499,7 @@ test("a step that does not open pull requests still pushes its branch", async ()
 
 test("a step that does not open pull requests says so instead of failing", async () => {
   const fake: CommandExecutor = async (executable, args) => (executable === "gh" && args[1] === "list" ? "[]" : "");
-  const result = await deliverWorkspace(config, noPrClaim, workspace, fake);
+  const result = await deliverWorkspace(config, noPrClaim, workspace, { command: fake });
   assert.equal(result.pullRequestUrl, undefined);
   assert.match(result.deliveryInstructions ?? "", /Branch 'feature\/test' was pushed/);
   assert.match(result.deliveryInstructions ?? "", /does not open a pull request/);
@@ -499,7 +512,7 @@ test("a late documentation step reports the chain's existing pull request", asyn
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/7", number: 7 }]);
     return "";
   };
-  const result = await deliverWorkspace(config, noPrClaim, workspace, fake);
+  const result = await deliverWorkspace(config, noPrClaim, workspace, { command: fake });
   // The lookup is deliberately kept ahead of the flag check: a documentation
   // step running after the implementation step still shows the chain's PR.
   assert.equal(result.pullRequestNumber, 7);
@@ -508,7 +521,7 @@ test("a late documentation step reports the chain's existing pull request", asyn
 
 test("no gh and no pull request by design reads as design, not as a degraded path", async () => {
   const fake: CommandExecutor = async (executable) => { if (executable === "gh") throw new Error("ENOENT"); return ""; };
-  const result = await deliverWorkspace(config, noPrClaim, workspace, fake);
+  const result = await deliverWorkspace(config, noPrClaim, workspace, { command: fake });
   assert.match(result.deliveryInstructions ?? "", /does not open a pull request/);
   assert.doesNotMatch(result.deliveryInstructions ?? "", /manually/);
 });
@@ -523,7 +536,7 @@ test("a failed pull-request lookup does not fail a step that opens no pull reque
     if (executable === "gh" && args[1] === "list") throw new Error("gh: API rate limit exceeded");
     return "";
   };
-  const result = await deliverWorkspace(config, noPrClaim, workspace, fake);
+  const result = await deliverWorkspace(config, noPrClaim, workspace, { command: fake });
   assert.equal(result.pushStatus, "SUCCEEDED");
   assert.equal(result.failureClass, undefined);
   assert.match(result.deliveryInstructions ?? "", /does not open a pull request/);
@@ -542,14 +555,14 @@ test("the ref that was actually pushed is recorded on every path that pushed", a
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/9", number: 9 }]);
     return "";
   };
-  assert.equal((await deliverWorkspace(config, claim, workspace, created)).pushedBranch, "feature/test");
+  assert.equal((await deliverWorkspace(config, claim, workspace, { command: created })).pushedBranch, "feature/test");
 
   const prFails: CommandExecutor = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") return "[]";
     if (executable === "gh" && args[1] === "create") throw new Error("gh: API rate limit exceeded");
     return "";
   };
-  const failed = await deliverWorkspace(config, claim, workspace, prFails);
+  const failed = await deliverWorkspace(config, claim, workspace, { command: prFails });
   assert.equal(failed.pushStatus, "FAILED");
   assert.equal(failed.pushedBranch, "feature/test");
 
@@ -557,13 +570,13 @@ test("the ref that was actually pushed is recorded on every path that pushed", a
     if (executable === "git" && args[0] === "push") throw new Error("remote rejected");
     return "";
   };
-  assert.equal((await deliverWorkspace(config, claim, workspace, pushFails)).pushedBranch, undefined);
+  assert.equal((await deliverWorkspace(config, claim, workspace, { command: pushFails })).pushedBranch, undefined);
 
   const salvage: CommandExecutor = async (executable, args) => {
     if (executable === "git" && args[0] === "status") return "M tracked.ts";
     return executable === "git" && args[0] === "rev-parse" ? "salvage-sha" : "";
   };
-  const salvaged = await deliverFailedWorkspace(config, claim, workspace, salvage);
+  const salvaged = await salvageWorkspace(config, salvageIdentity, workspace, { command: salvage });
   assert.equal(salvaged?.pushedBranch, "agentos/task-1/run-2");
   assert.notEqual(salvaged?.pushedBranch, workspace.branch);
 });
@@ -581,10 +594,13 @@ test("a hung push is timed out and reported as a transient failure, not a lease-
     clock += (options?.timeoutMs ?? 0) + KILL_OVERHEAD_MS;
     throw new CommandTimeoutError("git", ["push"], options?.timeoutMs ?? 0);
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, undefined, {
+  const result = await deliverWorkspace(config, claim, workspace, {
+    command: fake,
+    retryOptions: {
     deadline: deliveryDeadline(0, 60, 0),
     now: () => clock,
     wait: async () => { clock += 1_000; },
+    },
   });
   assert.equal(result.pushStatus, "FAILED");
   assert.match(result.pushError ?? "", /timed out after/);
@@ -618,10 +634,13 @@ test("a hung push arrives at the API as a typed timeout, not as a failed task", 
     clock += (options?.timeoutMs ?? 0) + KILL_OVERHEAD_MS;
     throw new CommandTimeoutError("git", ["push"], options?.timeoutMs ?? 0);
   };
-  const delivery = await deliverWorkspace(config, claim, workspace, fake, undefined, {
+  const delivery = await deliverWorkspace(config, claim, workspace, {
+    command: fake,
+    retryOptions: {
     deadline: deliveryDeadline(0, 60, 0),
     now: () => clock,
     wait: async () => { clock += 1_000; },
+    },
   });
   assert.equal(delivery.pushStatus, "FAILED");
   assert.ok(delivery.failure, "delivery must keep its failure structured, not only as a message");
@@ -708,10 +727,13 @@ test("every command of a slow delivery is capped, and the whole phase fits one l
     clock += timeoutMs;
     return "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, undefined, {
+  const result = await deliverWorkspace(config, claim, workspace, {
+    command: fake,
+    retryOptions: {
     deadline: deliveryDeadline(0, 60, 0),
     now: () => clock,
     wait: async () => { clock += 1_000; },
+    },
   });
   assert.equal(result.pullRequestNumber, 9);
   assert.deepEqual(calls, ["git push --set-upstream", "gh --version", "gh pr list", "gh pr create", "gh pr list"]);
@@ -733,10 +755,13 @@ test("a hung pull-request creation and its probe cannot open a second budget", a
     clock += (options?.timeoutMs ?? 0) + KILL_OVERHEAD_MS;
     throw new CommandTimeoutError("gh", ["pr"], options?.timeoutMs ?? 0);
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, undefined, {
+  const result = await deliverWorkspace(config, claim, workspace, {
+    command: fake,
+    retryOptions: {
     deadline: deliveryDeadline(0, 60, 0),
     now: () => clock,
     wait: async () => { clock += 1_000; },
+    },
   });
   // The push already succeeded, so publication is retained even though the
   // delivery step fails and preserves the typed timeout.
@@ -769,10 +794,13 @@ test("retries across the delivery chain cannot stack into more than one lease", 
     clock += timeoutMs;
     return args[1] === "list" ? "[]" : "";
   };
-  const result = await deliverWorkspace(config, claim, workspace, fake, undefined, {
+  const result = await deliverWorkspace(config, claim, workspace, {
+    command: fake,
+    retryOptions: {
     deadline: deliveryDeadline(0, 60, 0),
     now: () => clock,
     wait: async () => { clock += 1_000; },
+    },
   });
   assert.equal(result.pushStatus, "FAILED");
   assert.equal(result.pushedBranch, "feature/test");

--- a/packages/runner/src/delivery.ts
+++ b/packages/runner/src/delivery.ts
@@ -57,6 +57,23 @@ export type CommandExecutor = (
   options?: CommandOptions,
 ) => Promise<string>;
 
+export type DeliveryClaim = {
+  task: Pick<ClaimedTask["task"], "id" | "name" | "templateStep">;
+  repo: Pick<ClaimedTask["repo"], "remoteUrl" | "defaultBranch">;
+  run: Partial<Pick<ClaimedTask["run"], "opensPullRequest" | "pullRequestBase">>;
+};
+
+export type DeliverWorkspaceDependencies = {
+  command?: CommandExecutor;
+  recordPublication?: (branch: string) => Promise<void>;
+  retryOptions?: RetryOptions;
+};
+
+export type SalvageWorkspaceDependencies = {
+  command?: CommandExecutor;
+  retryOptions?: RetryOptions;
+};
+
 export const executeCommand = (config: RunnerConfig): CommandExecutor => (
   executable,
   args,
@@ -156,7 +173,9 @@ const pullRequestFromUrl = (stdout: string): { url: string; number: number } | n
 };
 
 // A chain step is named "<chain>: <step>"; the PR is the chain's, not the step's.
-export const pullRequestTitle = (task: ClaimedTask["task"]): string => {
+export const pullRequestTitle = (
+  task: Pick<ClaimedTask["task"], "name" | "templateStep">,
+): string => {
   const step = task.templateStep?.name;
   const suffix = step ? `: ${step}` : null;
   return suffix && task.name.endsWith(suffix) && task.name.length > suffix.length
@@ -166,21 +185,21 @@ export const pullRequestTitle = (task: ClaimedTask["task"]): string => {
 
 export const deliverWorkspace = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: DeliveryClaim,
   workspace: Workspace,
-  command: CommandExecutor = executeCommand(config),
-  recordPublication: (branch: string) => Promise<void> = async () => undefined,
-  retryOptions: RetryOptions = {},
+  dependencies: DeliverWorkspaceDependencies = {},
 ): Promise<DeliveryResult> => {
+  const command = dependencies.command ?? executeCommand(config);
+  const recordPublication = dependencies.recordPublication ?? (async () => undefined);
+  const retryOptions = dependencies.retryOptions ?? {};
   const env = workspaceEnvironment(config);
   const remote = claim.repo.remoteUrl;
   // `!== false`, not a truthiness test, and the difference is the whole point.
-  // The field is required in ClaimedTask so our own code cannot omit it; the
-  // comparison is what makes a *stale API build* that omits it from the claim
-  // payload degrade to today's behaviour (open the PR) instead of to the
-  // expensive failure (never open one again, silently). Read from `run`, not
-  // `task`: the run carries the snapshot taken when it was created, so an
-  // operator's PATCH cannot change a run that is already queued.
+  // ClaimedTask requires the field, while this interface keeps it optional so
+  // a stale API build that omits it degrades to today's behaviour (open the PR)
+  // instead of to the expensive failure (never open one again, silently). Read
+  // from `run`, not `task`: the run carries the snapshot taken when it was
+  // created, so an operator's PATCH cannot change a run that is already queued.
   // No step name, output kind or task name is consulted here or anywhere in
   // this package.
   const opensPullRequest = claim.run.opensPullRequest !== false;
@@ -430,9 +449,10 @@ export const salvageWorkspace = async (
   config: RunnerConfig,
   identity: { taskId: string; runId: string; runNumber: number; remoteUrl?: string },
   workspace: Workspace,
-  command: CommandExecutor = executeCommand(config),
-  retryOptions: RetryOptions = {},
+  dependencies: SalvageWorkspaceDependencies = {},
 ): Promise<DeliveryResult | null> => {
+  const command = dependencies.command ?? executeCommand(config);
+  const retryOptions = dependencies.retryOptions ?? {};
   const env = workspaceEnvironment(config);
   const remote = identity.remoteUrl ?? "origin";
   const branch = `agentos/${identity.taskId}/run-${identity.runNumber}`;
@@ -469,16 +489,3 @@ export const salvageWorkspace = async (
     return { pushStatus: "FAILED", pushRemote: remote, pushError: `WIP salvage failed: ${message}` };
   }
 };
-
-export const deliverFailedWorkspace = async (
-  config: RunnerConfig,
-  claim: ClaimedTask,
-  workspace: Workspace,
-  command: CommandExecutor = executeCommand(config),
-  retryOptions: RetryOptions = {},
-): Promise<DeliveryResult | null> => salvageWorkspace(config, {
-  taskId: claim.task.id,
-  runId: claim.run.id,
-  runNumber: claim.run.runNumber,
-  remoteUrl: claim.repo.remoteUrl,
-}, workspace, command, retryOptions);

--- a/packages/runner/src/dependency-cache.test.ts
+++ b/packages/runner/src/dependency-cache.test.ts
@@ -8,7 +8,6 @@ import { platform, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
-import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import {
   DEPENDENCY_CACHE_ENTRY_LIMIT, DependencyCacheInputMissError, deriveDependencyCacheKey,
@@ -16,7 +15,7 @@ import {
   type DependencyCacheProgress, type DependencyCacheToolchain, type DependencyCommandExecutor,
 } from "./dependency-cache.js";
 import { CommandTimeoutError, runCommand } from "./exec.js";
-import { provisionWorkspace, workspaceEnvironment } from "./workspace.js";
+import { provisionWorkspace, workspaceEnvironment, type WorkspaceProvisionClaim } from "./workspace.js";
 
 const TOOLCHAIN: DependencyCacheToolchain = {
   node: "v24.0.0",
@@ -838,12 +837,30 @@ test("branch and pinned-detached provisioning materialize a usable scratch repos
       return realExecutor(runnerConfig, executable, args, cwd, env, options);
     };
     const branchClaim = {
-      task: { id: "cache-task" },
+      executionMode: "agent",
+      runner: "CODEX",
+      specificationMaterialization: null,
+      task: { id: "cache-task", chainId: null, chainIndex: null, templateStep: null },
       repo: { remoteUrl: remote, defaultBranch: "main" },
-      run: { id: "branch-run", runNumber: 1, targetBranch: "main", branch: "cache-feature" },
-    } as ClaimedTask;
+      run: {
+        id: "branch-run",
+        runNumber: 1,
+        targetBranch: "main",
+        targetBranchPublished: false,
+        branch: "cache-feature",
+        pinnedBaseSha: null,
+        implementationBaseSha: null,
+        implementationHeadSha: null,
+      },
+    } satisfies WorkspaceProvisionClaim;
     const branchWorkspace = await provisionWorkspace(
-      configured, branchClaim, execute, { attempts: 1 }, { report: () => undefined },
+      configured,
+      branchClaim,
+      {
+        execute,
+        retryOptions: { attempts: 1 },
+        dependencyCacheOptions: { report: () => undefined },
+      },
     );
     assert.equal(installs, 1);
     assert.equal(
@@ -856,20 +873,30 @@ test("branch and pinned-detached provisioning materialize a usable scratch repos
     const cachedPackageLock = join(root, "cache/entries", cacheEntries[0]!, "trees/node_modules/.package-lock.json");
     const cachedBefore = digest(await readFile(cachedPackageLock, "utf8"));
     const pinnedClaim = {
-      task: { id: "cache-review" },
+      executionMode: "agent",
+      runner: "CODEX",
+      specificationMaterialization: null,
+      task: { id: "cache-review", chainId: null, chainIndex: null, templateStep: null },
       repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
         id: "pinned-run",
         runNumber: 1,
         targetBranch: head,
+        targetBranchPublished: false,
         branch: "cache-feature",
         pinnedBaseSha: head,
         implementationBaseSha: head,
         implementationHeadSha: head,
       },
-    } as ClaimedTask;
+    } satisfies WorkspaceProvisionClaim;
     const pinnedWorkspace = await provisionWorkspace(
-      configured, pinnedClaim, execute, { attempts: 1 }, { report: () => undefined },
+      configured,
+      pinnedClaim,
+      {
+        execute,
+        retryOptions: { attempts: 1 },
+        dependencyCacheOptions: { report: () => undefined },
+      },
     );
     assert.equal(installs, 1, "pinned provisioning must restore instead of invoking npm");
     assert.equal(await git(pinnedWorkspace.path, "branch", "--show-current"), "");

--- a/packages/runner/src/dispose-workspace.test.ts
+++ b/packages/runner/src/dispose-workspace.test.ts
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { access, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import {
-  disposeWorkspace, type WorkspaceDisposalIdentity,
+  disposeWorkspace, type WorkspaceDisposalClaim, type WorkspaceDisposalIdentity,
 } from "./dispose-workspace.js";
 import { createControlPlaneDouble } from "./test-control-plane.js";
 
@@ -31,12 +31,24 @@ const config = (workspaceRoot: string): RunnerConfig => ({
   binaries: { CLAUDE: "claude", CODEX: "codex", PI: "pi" },
 });
 
+const runnerClaim = (runId: string): WorkspaceDisposalClaim => ({
+  fencingToken: `fence-${runId}`,
+  task: { id: "task-1" },
+  run: { id: runId, runNumber: 2 },
+  repo: { remoteUrl: "origin" },
+});
+
+const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, {
+  cwd,
+  encoding: "utf8",
+}).trim();
+
 const cases: Array<{ label: string; identity: WorkspaceDisposalIdentity }> = [
   {
     label: "runner cleanup",
     identity: {
       source: "runner",
-      claim: { run: { id: "runner-run" } } as ClaimedTask,
+      claim: runnerClaim("runner-run"),
     },
   },
   {
@@ -78,3 +90,38 @@ for (const { label, identity } of cases) {
     await assert.rejects(access(workspacePath));
   });
 }
+
+test("runner disposal salvages unfinished work through the production path before cleanup", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agentos-dispose-salvage-"));
+  const remote = join(root, "origin.git");
+  const workspacePath = join(root, "workspace");
+  git(root, "init", "--bare", remote);
+  git(root, "init", "--initial-branch=main", workspacePath);
+  git(workspacePath, "config", "user.name", "Runner Test");
+  git(workspacePath, "config", "user.email", "runner@example.invalid");
+  await writeFile(join(workspacePath, "tracked.txt"), "base\n");
+  git(workspacePath, "add", "tracked.txt");
+  git(workspacePath, "commit", "-m", "base");
+  const baseSha = git(workspacePath, "rev-parse", "HEAD");
+  git(workspacePath, "remote", "add", "origin", remote);
+  await writeFile(join(workspacePath, "tracked.txt"), "unfinished\n");
+  const controlPlane = createControlPlaneDouble();
+  const claim = { ...runnerClaim("run-2"), repo: { remoteUrl: remote } };
+
+  const result = await disposeWorkspace(config(root), { source: "runner", claim }, {
+    path: workspacePath,
+    branch: "feature/shared",
+    baseSha,
+    pinnedBaseSha: null,
+  }, {
+    alreadyDurable: false,
+    retain: false,
+  }, controlPlane.controlPlane);
+
+  assert.equal(result.cleanupStatus, "SUCCEEDED");
+  assert.equal(result.workspaceRetained, false);
+  assert.equal(result.salvage?.pushedBranch, "agentos/task-1/run-2");
+  assert.equal(git(remote, "rev-parse", "refs/heads/agentos/task-1/run-2"), result.salvage?.headSha);
+  assert.deepEqual(controlPlane.publishedBranches, ["agentos/task-1/run-2"]);
+  await assert.rejects(access(workspacePath));
+});

--- a/packages/runner/src/dispose-workspace.ts
+++ b/packages/runner/src/dispose-workspace.ts
@@ -1,13 +1,19 @@
 import {
-  controlPlane as defaultControlPlane,
-  type ClaimedTask, type CleanupStatus, type ControlPlane,
+  controlPlane as defaultControlPlane, type ClaimedTask, type CleanupStatus,
+  type ControlPlane, type ControlPlaneRunClaim,
 } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { salvageWorkspace, type DeliveryResult } from "./delivery.js";
 import { captureWorkspaceResult, cleanupWorkspace, type Workspace } from "./workspace.js";
 
+export type WorkspaceDisposalClaim = ControlPlaneRunClaim & {
+  task: Pick<ClaimedTask["task"], "id">;
+  run: ControlPlaneRunClaim["run"] & Pick<ClaimedTask["run"], "runNumber">;
+  repo: Pick<ClaimedTask["repo"], "remoteUrl">;
+};
+
 export type WorkspaceDisposalIdentity =
-  | { source: "runner"; claim: ClaimedTask }
+  | { source: "runner"; claim: WorkspaceDisposalClaim }
   | { source: "reclaim"; runId: string; taskId: string | null; runNumber: number | undefined };
 
 export type DisposableWorkspace = {

--- a/packages/runner/src/git-provenance.ts
+++ b/packages/runner/src/git-provenance.ts
@@ -5,6 +5,12 @@ import type { ClaimedTask } from "./api.js";
 import type { GitIdentity, RunnerConfig } from "./config.js";
 import type { CommandOptions } from "./exec.js";
 
+/** The run and Chain identity used to author commit provenance. */
+export type GitProvenanceClaim = Pick<ClaimedTask, "executionMode" | "runner"> & {
+  task: Pick<ClaimedTask["task"], "chainId" | "chainIndex" | "templateStep">;
+  run: Pick<ClaimedTask["run"], "id">;
+};
+
 export type GitCommandExecutor = (
   config: RunnerConfig,
   executable: string,
@@ -46,7 +52,7 @@ export const resolveRunnerGitIdentity = async (
 
 const safeTrailerValue = (value: string): boolean => value.trim().length > 0 && !/[\0\r\n]/u.test(value);
 
-const provenanceFor = (claim: ClaimedTask): { step: string; provider: "codex" | "claude" | "pi" } | null => {
+const provenanceFor = (claim: GitProvenanceClaim): { step: string; provider: "codex" | "claude" | "pi" } | null => {
   const stepName = claim.task.templateStep?.name;
   const provider = claim.runner === "CODEX" ? "codex"
     : claim.runner === "CLAUDE" ? "claude"
@@ -67,7 +73,7 @@ const provenanceFor = (claim: ClaimedTask): { step: string; provider: "codex" | 
 const shellLiteral = (value: string): string => `'${value.replaceAll("'", `'"'"'`)}'`;
 
 const hookBody = (
-  claim: ClaimedTask,
+  claim: GitProvenanceClaim,
   workspacePath: string,
   commonDir: string,
   provenance: NonNullable<ReturnType<typeof provenanceFor>>,
@@ -143,7 +149,7 @@ ANNEAL_PROVENANCE
  * so a retained workspace cannot mislabel a later human commit. */
 export const configureWorkspaceGit = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: GitProvenanceClaim,
   workspacePath: string,
   identity: GitIdentity,
   env: NodeJS.ProcessEnv,

--- a/packages/runner/src/lease.test.ts
+++ b/packages/runner/src/lease.test.ts
@@ -1,13 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { ControlPlaneError, type ClaimedTask } from "./api.js";
+import { ControlPlaneError } from "./api.js";
 import type { RunnerConfig } from "./config.js";
-import { deliverUnderLease, openDeliveryLease, type LeaseHeartbeat } from "./lease.js";
+import {
+  deliverUnderLease, openDeliveryLease, type DeliveryLeaseClaim, type LeaseHeartbeat,
+} from "./lease.js";
 import { DELIVERY_LEASE_RESERVE_MS, MIN_DELIVERY_BUDGET_MS } from "./network-retry.js";
 
 const config = { leaseSeconds: 60, heartbeatIntervalMs: 30_000 } as unknown as RunnerConfig;
-const claim = { run: { id: "run-1" } } as ClaimedTask;
+const claim = { run: { id: "run-1" }, fencingToken: "fence-1" } satisfies DeliveryLeaseClaim;
 
 const rejection = (status: number, code?: string): Error => new ControlPlaneError(status, "rejected", code);
 

--- a/packages/runner/src/lease.ts
+++ b/packages/runner/src/lease.ts
@@ -4,12 +4,15 @@ import {
   heartbeat as sendHeartbeat,
   type Authority,
   type CancellationRequest,
-  type ClaimedTask,
+  type ControlPlaneRunClaim,
 } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { deliveryDeadline, type RetryOptions } from "./network-retry.js";
 
 export type LeaseHeartbeat = typeof sendHeartbeat;
+
+/** The fenced Run identity renewed during delivery. */
+export type DeliveryLeaseClaim = ControlPlaneRunClaim;
 
 /**
  * The runner's authority over a run during the phase that follows the agent
@@ -46,7 +49,7 @@ export type DeliveryLease = {
  */
 export const openDeliveryLease = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: DeliveryLeaseClaim,
   lastKnownRenewalAt: number,
   options: {
     send?: LeaseHeartbeat;

--- a/packages/runner/src/provision-failure.test.ts
+++ b/packages/runner/src/provision-failure.test.ts
@@ -142,14 +142,16 @@ test("a transient mirror fetch failure escapes provisioning as a transient error
   const escaped = await provisionWorkspace(
     config(root),
     claim("https://example.test/repo.git"),
-    async (executorConfig, executable, args, cwd, env) => {
-      // Only git is faked: the mirror's own filesystem bookkeeping is real work
-      // in a temporary directory, and the retry under test rides on the fetch.
-      if (executable === "/bin/sh") return runCommand(executorConfig.runAsPrefix, executable, args, cwd, env, {});
-      if (args[0] === "fetch") throw new Error(message);
-      return "";
+    {
+      execute: async (executorConfig, executable, args, cwd, env) => {
+        // Only git is faked: the mirror's own filesystem bookkeeping is real work
+        // in a temporary directory, and the retry under test rides on the fetch.
+        if (executable === "/bin/sh") return runCommand(executorConfig.runAsPrefix, executable, args, cwd, env, {});
+        if (args[0] === "fetch") throw new Error(message);
+        return "";
+      },
+      retryOptions: { attempts: 1 },
     },
-    { attempts: 1 },
   ).then(() => null, (error: unknown) => error);
   assert.ok(escaped instanceof Error, "the fetch failure must escape provisioning, not be swallowed");
 

--- a/packages/runner/src/regression-output-handoff.test.ts
+++ b/packages/runner/src/regression-output-handoff.test.ts
@@ -7,9 +7,10 @@ import test from "node:test";
 
 import { REGRESSION_VERIFICATION_OUTPUT_KIND } from "@anneal/db";
 
-import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
-import { readRegressionOutputHandoff } from "./regression-output-handoff.js";
+import {
+  readRegressionOutputHandoff, type RegressionHandoffClaim,
+} from "./regression-output-handoff.js";
 import type { Workspace } from "./workspace.js";
 
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, {
@@ -44,12 +45,12 @@ const runnerConfig = (root: string): RunnerConfig => ({
   binaries: { CLAUDE: "claude", CODEX: "codex", PI: "pi" },
 });
 
-const claim = (runId = "run-1"): ClaimedTask => ({
+const claim = (runId = "run-1"): RegressionHandoffClaim => ({
   task: {
-    templateStep: { name: "Regression verification", outputKind: REGRESSION_VERIFICATION_OUTPUT_KIND },
+    templateStep: { outputKind: REGRESSION_VERIFICATION_OUTPUT_KIND },
   },
   run: { id: runId },
-} as ClaimedTask);
+});
 
 const setup = async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-regression-handoff-"));

--- a/packages/runner/src/regression-output-handoff.ts
+++ b/packages/runner/src/regression-output-handoff.ts
@@ -20,6 +20,12 @@ export type RegressionOutputHandoff = {
   commitSha: string;
 };
 
+/** The exact Run and output contract used to qualify a Regression handoff. */
+export type RegressionHandoffClaim = {
+  task: { templateStep: Pick<NonNullable<ClaimedTask["task"]["templateStep"]>, "outputKind"> | null };
+  run: Pick<ClaimedTask["run"], "id">;
+};
+
 const handoffPath = (workspace: Workspace): string =>
   join(workspace.path, ".agentos", "regression-output.json");
 
@@ -72,7 +78,7 @@ cat -- "$path"
  */
 export const readRegressionOutputHandoff = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  claim: RegressionHandoffClaim,
   workspace: Workspace,
 ): Promise<RegressionOutputHandoff | null> => {
   if (claim.task.templateStep?.outputKind !== REGRESSION_VERIFICATION_OUTPUT_KIND) return null;

--- a/packages/runner/src/repo-mirror.test.ts
+++ b/packages/runner/src/repo-mirror.test.ts
@@ -5,14 +5,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { runCommand } from "./exec.js";
 import {
   mirrorRevisionsPresent, repoMirrorPath, RepoMirrorError, withRepoMirror,
   type MirrorCommandExecutor, type RepoMirrorProgress,
 } from "./repo-mirror.js";
-import { provisionWorkspace, workspaceEnvironment, type WorkspaceCommandExecutor } from "./workspace.js";
+import {
+  provisionWorkspace, workspaceEnvironment,
+  type WorkspaceCommandExecutor, type WorkspaceProvisionClaim,
+} from "./workspace.js";
 
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 
@@ -47,11 +49,23 @@ const fixture = async (label: string): Promise<Fixture> => {
   return { root, remote, seed, config, mirrorRoot, mirror: repoMirrorPath(mirrorRoot, remote) };
 };
 
-const claimFor = (remote: string, id: string): ClaimedTask => ({
-  task: { id: `task-${id}` },
+const claimFor = (remote: string, id: string): WorkspaceProvisionClaim => ({
+  executionMode: "agent",
+  runner: "CODEX",
+  specificationMaterialization: null,
+  task: { id: `task-${id}`, chainId: null, chainIndex: null, templateStep: null },
   repo: { remoteUrl: remote, defaultBranch: "main" },
-  run: { id: `run-${id}`, runNumber: 1, targetBranch: "main", branch: "main" },
-} as ClaimedTask);
+  run: {
+    id: `run-${id}`,
+    runNumber: 1,
+    targetBranch: "main",
+    targetBranchPublished: false,
+    pinnedBaseSha: null,
+    implementationBaseSha: null,
+    implementationHeadSha: null,
+    branch: "main",
+  },
+});
 
 /** The production executor, with every argv it is handed recorded. */
 const recorded = (calls: { args: string[]; cwd: string }[]): WorkspaceCommandExecutor =>
@@ -69,7 +83,7 @@ const silent = (): ((progress: RepoMirrorProgress) => void) => (): void => undef
 test("the second run reuses the machine's mirror and fetches only what changed", async () => {
   const { root, remote, seed, config, mirror } = await fixture("reuse");
   try {
-    await provisionWorkspace(config, claimFor(remote, "one"), undefined, {}, {}, { report: silent() });
+    await provisionWorkspace(config, claimFor(remote, "one"), { mirrorOptions: { report: silent() } });
     const created = (await stat(mirror)).birthtimeMs;
 
     await writeFile(join(seed, "tree.txt"), "second\n");
@@ -79,7 +93,9 @@ test("the second run reuses the machine's mirror and fetches only what changed",
 
     const calls: { args: string[]; cwd: string }[] = [];
     const workspace = await provisionWorkspace(
-      config, claimFor(remote, "two"), recorded(calls), {}, {}, { report: silent() },
+      config,
+      claimFor(remote, "two"),
+      { execute: recorded(calls), mirrorOptions: { report: silent() } },
     );
 
     // Same mirror directory, not a rebuilt one, and the run sees the commit
@@ -107,7 +123,7 @@ test("the mirror carries branches and tags but not the remote's other refs", asy
     // would make every fetch pay for the repository's whole review history.
     git(seed, "push", "origin", "HEAD:refs/pull/7/head");
 
-    await provisionWorkspace(config, claimFor(remote, "refspec"), undefined, {}, {}, { report: silent() });
+    await provisionWorkspace(config, claimFor(remote, "refspec"), { mirrorOptions: { report: silent() } });
 
     const refs = git(mirror, "for-each-ref", "--format=%(refname)").split("\n");
     assert.equal(refs.includes("refs/heads/main"), true);
@@ -121,11 +137,13 @@ test("the mirror carries branches and tags but not the remote's other refs", asy
 test("a mirror pointing at a different remote is refused instead of quietly re-cloning", async () => {
   const { root, remote, config, mirror } = await fixture("mismatch");
   try {
-    await provisionWorkspace(config, claimFor(remote, "first"), undefined, {}, {}, { report: silent() });
+    await provisionWorkspace(config, claimFor(remote, "first"), { mirrorOptions: { report: silent() } });
     git(mirror, "remote", "set-url", "origin", "https://github.com/acme/somewhere-else.git");
 
     const failure = await provisionWorkspace(
-      config, claimFor(remote, "second"), undefined, {}, {}, { report: silent() },
+      config,
+      claimFor(remote, "second"),
+      { mirrorOptions: { report: silent() } },
     ).then(() => null, (error: unknown) => error);
     assert.equal(failure instanceof RepoMirrorError, true);
     assert.equal((failure as RepoMirrorError).condition, "remote-url-mismatch");
@@ -142,7 +160,9 @@ test("a mirror that is not a readable git repository is refused, not rebuilt", a
     await writeFile(join(mirror, "not-a-repository"), "\n");
 
     const failure = await provisionWorkspace(
-      config, claimFor(remote, "corrupt"), undefined, {}, {}, { report: silent() },
+      config,
+      claimFor(remote, "corrupt"),
+      { mirrorOptions: { report: silent() } },
     ).then(() => null, (error: unknown) => error);
     assert.equal(failure instanceof RepoMirrorError, true);
     assert.equal((failure as RepoMirrorError).condition, "not-a-readable-git-repository");
@@ -235,7 +255,7 @@ test("the mirror is private to the account that runs the tasks", async () => {
   const { root, remote, config, mirror, mirrorRoot } = await fixture("private");
   const previous = process.umask(0o022);
   try {
-    await provisionWorkspace(config, claimFor(remote, "private"), undefined, {}, {}, { report: silent() });
+    await provisionWorkspace(config, claimFor(remote, "private"), { mirrorOptions: { report: silent() } });
     // The mirror carries the same history as the run workspace and lives in the
     // task account's own home. Nothing outside that account has business
     // reading it, and a permissive umask must not decide otherwise.
@@ -260,7 +280,7 @@ test("every mirror command runs through the run-as prefix, so the account with t
     const isolated = { ...config, runAsPrefix: [launcher] } as RunnerConfig;
     await mkdir(config.workspaceRoot, { recursive: true });
 
-    await provisionWorkspace(isolated, claimFor(remote, "run-as"), undefined, {}, {}, { report: silent() });
+    await provisionWorkspace(isolated, claimFor(remote, "run-as"), { mirrorOptions: { report: silent() } });
 
     const argv = await readFile(log, "utf8");
     assert.match(argv, /git init --bare/u);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -703,9 +703,10 @@ export const executeClaim = async (
           config,
           claim,
           delivered,
-          undefined,
-          (branch) => controlPlane.recordPublishedBranch(config, claim, branch),
-          retryOptions,
+          {
+            recordPublication: (branch) => controlPlane.recordPublishedBranch(config, claim, branch),
+            retryOptions,
+          },
         ));
     }
     const primaryDelivery = delivery;

--- a/packages/runner/src/telemetry.test.ts
+++ b/packages/runner/src/telemetry.test.ts
@@ -4,7 +4,7 @@ import { createRequire } from "node:module";
 import type { AddressInfo } from "node:net";
 import test from "node:test";
 
-import { claimRequestBody, heartbeat, runnerTelemetryBody, type ClaimedTask } from "./api.js";
+import { claimRequestBody, heartbeat, runnerTelemetryBody, type ControlPlaneRunClaim } from "./api.js";
 import { loadRunnerConfig } from "./config.js";
 
 const require = createRequire(import.meta.url);
@@ -58,7 +58,7 @@ test("a control-plane call that connects but never answers fails instead of hold
     apiUrl: `http://127.0.0.1:${address.port}`,
     apiTimeoutMs: 300,
   };
-  const claim = { run: { id: "run-1" }, fencingToken: 1 } as unknown as ClaimedTask;
+  const claim = { run: { id: "run-1" }, fencingToken: "fence-1" } satisfies ControlPlaneRunClaim;
   try {
     const started = Date.now();
     await assert.rejects(

--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -5,14 +5,13 @@ import { tmpdir } from "node:os";
 import { dirname, join, sep } from "node:path";
 import test from "node:test";
 
-import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { CLONE_COMMAND_TIMEOUT_MS } from "./network-retry.js";
 import { runCommand } from "./exec.js";
 import {
   cleanupAgentScratch, provisionAgentScratch, provisionSessionConfig, provisionWorkspace, sessionConfigBaselineRoot,
   workspaceEnvironment, writeSessionCredentials,
-  type WorkspaceCommandExecutor,
+  type WorkspaceCommandExecutor, type WorkspaceProvisionClaim,
 } from "./workspace.js";
 
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -28,6 +27,32 @@ const realShell = async (
 ): Promise<string | null> => (executable === "/bin/sh"
   ? runCommand(config.runAsPrefix, executable, args, cwd, env, {})
   : null);
+
+type WorkspaceClaimFixture = {
+  task: Pick<WorkspaceProvisionClaim["task"], "id">;
+  repo: WorkspaceProvisionClaim["repo"];
+  run: Pick<WorkspaceProvisionClaim["run"], "id" | "runNumber" | "targetBranch" | "branch">
+    & Partial<Pick<
+      WorkspaceProvisionClaim["run"],
+      "targetBranchPublished" | "pinnedBaseSha" | "implementationBaseSha" | "implementationHeadSha"
+    >>;
+  specificationMaterialization?: WorkspaceProvisionClaim["specificationMaterialization"];
+};
+
+const workspaceClaim = (fixture: WorkspaceClaimFixture): WorkspaceProvisionClaim => ({
+  executionMode: "agent",
+  runner: "CODEX",
+  specificationMaterialization: fixture.specificationMaterialization ?? null,
+  task: { ...fixture.task, chainId: null, chainIndex: null, templateStep: null },
+  repo: fixture.repo,
+  run: {
+    targetBranchPublished: false,
+    pinnedBaseSha: null,
+    implementationBaseSha: null,
+    implementationHeadSha: null,
+    ...fixture.run,
+  },
+});
 
 test("provisioning trusts an already-published intended head after its database ACK was lost", async () => {
   const root = await mkdtemp(join(tmpdir(), "agentos-workspace-publication-"));
@@ -57,7 +82,7 @@ test("provisioning trusts an already-published intended head after its database 
       home: root,
       gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
     } as unknown as RunnerConfig;
-    const claim = {
+    const claim = workspaceClaim({
       task: { id: "task-1" },
       repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
@@ -68,7 +93,7 @@ test("provisioning trusts an already-published intended head after its database 
         targetBranch: "main",
         branch: "agentos/chain/demo-deadbeef",
       },
-    } as ClaimedTask;
+    });
 
     const workspace = await provisionWorkspace(config, claim);
     assert.equal(workspace.branch, "agentos/chain/demo-deadbeef");
@@ -104,7 +129,7 @@ test("provisioning commits the server-prepared direct specification before the a
     } as unknown as RunnerConfig;
     const branch = "feature/platform-spec";
     const specificationPath = `.chain/${branch}/spec.md`;
-    const claim = {
+    const claim = workspaceClaim({
       task: { id: "task-specification" },
       repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
@@ -118,7 +143,7 @@ test("provisioning commits the server-prepared direct specification before the a
         path: specificationPath,
         body: "authoritative brief",
       },
-    } as ClaimedTask;
+    });
 
     const workspace = await provisionWorkspace(config, claim);
     assert.equal(await readFile(join(workspace.path, specificationPath), "utf8"), "authoritative brief");
@@ -154,7 +179,7 @@ test("prepared specification refuses a repository symlink that would escape the 
       gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
     } as unknown as RunnerConfig;
     const branch = "feature/platform-spec";
-    const claim = {
+    const claim = workspaceClaim({
       task: { id: "task-specification-symlink" },
       repo: { remoteUrl: remote, defaultBranch: "main" },
       run: { id: "run-specification-symlink", runNumber: 1, targetBranch: "main", branch },
@@ -163,7 +188,7 @@ test("prepared specification refuses a repository symlink that would escape the 
         path: `.chain/${branch}/spec.md`,
         body: "must stay inside",
       },
-    } as ClaimedTask;
+    });
 
     await assert.rejects(provisionWorkspace(config, claim), /Prepared specification parent .* is a symlink/u);
     await assert.rejects(readFile(join(escaped, branch, "spec.md")), /ENOENT/u);
@@ -201,14 +226,14 @@ test("a resolver-confirmed newer salvage base outranks an existing declared head
       path: process.env.PATH ?? "/usr/bin:/bin", home: root,
       gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
     } as unknown as RunnerConfig;
-    const claim = {
+    const claim = workspaceClaim({
       task: { id: "task-1" },
       repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
         id: "run-3", runNumber: 3, targetBranch: salvage,
         targetBranchPublished: true, branch: declared,
       },
-    } as ClaimedTask;
+    });
     const workspace = await provisionWorkspace(config, claim);
     assert.equal(workspace.branch, declared);
     assert.equal(workspace.baseSha, salvageSha);
@@ -253,7 +278,7 @@ test("a pinned workspace fetches only the recorded commit and never creates the 
       home: root,
       gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
     } as unknown as RunnerConfig;
-    const claim = {
+    const claim = workspaceClaim({
       task: { id: "task-blind" },
       repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
@@ -265,7 +290,7 @@ test("a pinned workspace fetches only the recorded commit and never creates the 
         implementationHeadSha: pinnedBaseSha,
         branch: chainBranch,
       },
-    } as ClaimedTask;
+    });
 
     const workspace = await provisionWorkspace(config, claim);
     assert.equal(workspace.baseSha, pinnedBaseSha);
@@ -297,11 +322,11 @@ test("the mirror fetch retries two transient failures and succeeds on the third 
       home: root,
       gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
     } as unknown as RunnerConfig;
-    const claim = {
+    const claim = workspaceClaim({
       task: { id: "task-retry" },
       repo: { remoteUrl: "https://github.com/acme/app.git", defaultBranch: "main" },
       run: { id: "run-retry", runNumber: 1, targetBranch: "main", branch: "main" },
-    } as ClaimedTask;
+    });
     const fake = async (config: RunnerConfig, executable: string, args: string[], cwd: string, env: NodeJS.ProcessEnv): Promise<string> => {
       const shell = await realShell(config, executable, args, cwd, env);
       if (shell !== null) return shell;
@@ -314,7 +339,10 @@ test("the mirror fetch retries two transient failures and succeeds on the third 
       if (executable === "git" && args[0] === "rev-parse") return "base-sha";
       return "";
     };
-    const workspace = await provisionWorkspace(config, claim, fake, { wait: async () => undefined });
+    const workspace = await provisionWorkspace(config, claim, {
+      execute: fake,
+      retryOptions: { wait: async () => undefined },
+    });
     // The retried operation is now the mirror's fetch. The clone that follows
     // reads local disk, so retrying it would only repeat a failure that no
     // amount of waiting can change.
@@ -348,11 +376,11 @@ test("the mirror's remote fetch carries a per-command ceiling while local git co
       home: root,
       gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
     } as unknown as RunnerConfig;
-    const claim = {
+    const claim = workspaceClaim({
       task: { id: "task-timeout" },
       repo: { remoteUrl: "https://github.com/acme/app.git", defaultBranch: "main" },
       run: { id: "run-timeout", runNumber: 1, targetBranch: "main", branch: "agentos/task-timeout/run-1" },
-    } as ClaimedTask;
+    });
     const calls: RecordedCommand[] = [];
     // Only main is published: the intended head's probe finds nothing, exactly
     // as the `ls-remote` round trip it replaced used to report.
@@ -361,7 +389,10 @@ test("the mirror's remote fetch carries a per-command ceiling while local git co
       if (args[0] === "rev-parse") return "base-sha";
       return "";
     });
-    await provisionWorkspace(config, claim, fake, { wait: async () => undefined });
+    await provisionWorkspace(config, claim, {
+      execute: fake,
+      retryOptions: { wait: async () => undefined },
+    });
     const ceiling = (name: string): number | undefined => calls.find(({ args }) => args[0] === name)?.timeoutMs;
     // The only command still talking to GitHub is the mirror's fetch, and a
     // hung one is what nothing else bounds before the agent starts.
@@ -397,7 +428,7 @@ test("the pinned range is fetched out of the mirror, and only the mirror's own f
       home: root,
       gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
     } as unknown as RunnerConfig;
-    const claim = {
+    const claim = workspaceClaim({
       task: { id: "task-pinned-timeout" },
       repo: { remoteUrl: "https://github.com/acme/app.git", defaultBranch: "main" },
       run: {
@@ -409,14 +440,17 @@ test("the pinned range is fetched out of the mirror, and only the mirror's own f
         implementationBaseSha: "impl-base-sha",
         implementationHeadSha: "pinned-sha",
       },
-    } as ClaimedTask;
+    });
     const calls: RecordedCommand[] = [];
     const fake = recordingExecutor(calls, (args) => {
       if (args[0] === "cat-file") return "impl-base-sha commit\npinned-sha commit";
       if (args[0] === "rev-parse") return "pinned-sha";
       return "";
     });
-    await provisionWorkspace(config, claim, fake, { wait: async () => undefined });
+    await provisionWorkspace(config, claim, {
+      execute: fake,
+      retryOptions: { wait: async () => undefined },
+    });
     const remoteFetch = calls.find(({ args }) => args[0] === "fetch" && args.includes("origin"));
     const rangeFetch = calls.find(({ args }) => args[0] === "fetch" && args.includes("pinned-sha"));
     assert.equal(remoteFetch?.timeoutMs, CLONE_COMMAND_TIMEOUT_MS);
@@ -456,7 +490,7 @@ test("session credentials are created through the run-as prefix, with the token 
       run: { id: "run-1" },
       sessionToken: "session-token-never-in-argv",
       fencingToken: "fencing-token-never-in-argv",
-    } as ClaimedTask;
+    };
 
     const path = await writeSessionCredentials(config, claim, { path: workspacePath, branch: "topic", baseSha: "base" });
 
@@ -533,11 +567,11 @@ test("a run-as workspace is provisioned by the launched account and cannot be en
       home: root,
       gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
     } as unknown as RunnerConfig;
-    const claim = {
+    const claim = workspaceClaim({
       task: { id: "task-prefix" },
       repo: { remoteUrl: remote, defaultBranch: "main" },
       run: { id: "run-prefix", runNumber: 1, targetBranch: "main", branch: "main" },
-    } as ClaimedTask;
+    });
 
     const workspace = await provisionWorkspace(config, claim);
 

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -10,7 +10,9 @@ import type { SessionConfigOptions } from "./adapters/session-config.js";
 import { defaultSessionConfigBaselineRoot, type RunnerConfig, type RunnerKind } from "./config.js";
 import { materializeWorkspaceDependencies, type DependencyCacheOptions } from "./dependency-cache.js";
 import { platformCommitArgs, runCommand, type CommandOptions } from "./exec.js";
-import { configureWorkspaceGit, resolveRunnerGitIdentity } from "./git-provenance.js";
+import {
+  configureWorkspaceGit, resolveRunnerGitIdentity, type GitProvenanceClaim,
+} from "./git-provenance.js";
 import { type RetryOptions } from "./network-retry.js";
 import {
   ensureMirrorRevisions, mirrorHasBranch, withRepoMirror, type RepoMirrorOptions,
@@ -54,12 +56,11 @@ const assertMaterializationPathIsPlain = async (workspace: string, path: string)
 
 const materializePreparedSpecification = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
+  prepared: ClaimedTask["specificationMaterialization"],
   workspace: Workspace,
   execute: WorkspaceCommandExecutor,
   env: NodeJS.ProcessEnv,
 ): Promise<Workspace> => {
-  const prepared = claim.specificationMaterialization;
   if (!prepared) return workspace;
   if (workspace.pinnedBaseSha) throw new Error("Pinned review workspace cannot materialize a direct implementation specification");
   const expectedPath = `.chain/${workspace.branch}/spec.md`;
@@ -99,6 +100,35 @@ export type WorkspaceCommandExecutor = (
   env: NodeJS.ProcessEnv,
   options?: CommandOptions,
 ) => Promise<string>;
+
+export type WorkspaceProvisionClaim = GitProvenanceClaim & Pick<ClaimedTask, "specificationMaterialization"> & {
+  task: GitProvenanceClaim["task"] & Pick<ClaimedTask["task"], "id">;
+  repo: Pick<ClaimedTask["repo"], "remoteUrl" | "defaultBranch">;
+  run: GitProvenanceClaim["run"] & Pick<
+    ClaimedTask["run"],
+    | "runNumber"
+    | "targetBranch"
+    | "targetBranchPublished"
+    | "pinnedBaseSha"
+    | "implementationBaseSha"
+    | "implementationHeadSha"
+    | "branch"
+  >;
+};
+
+export type WorkspaceReuseClaim = GitProvenanceClaim & {
+  run: GitProvenanceClaim["run"] & Pick<
+    ClaimedTask["run"],
+    "workspacePath" | "branch" | "baseSha" | "pinnedBaseSha"
+  >;
+};
+
+export type ProvisionWorkspaceDependencies = {
+  execute?: WorkspaceCommandExecutor;
+  retryOptions?: RetryOptions;
+  dependencyCacheOptions?: DependencyCacheOptions;
+  mirrorOptions?: RepoMirrorOptions;
+};
 
 /**
  * Every workspace mutation runs through here so that, when RUNNER_RUN_AS_PREFIX
@@ -250,12 +280,13 @@ export const provisionSessionConfig = async (
 
 export const provisionWorkspace = async (
   config: RunnerConfig,
-  claim: ClaimedTask,
-  execute: WorkspaceCommandExecutor = command,
-  retryOptions: RetryOptions = {},
-  dependencyCacheOptions: DependencyCacheOptions = {},
-  mirrorOptions: RepoMirrorOptions = {},
+  claim: WorkspaceProvisionClaim,
+  dependencies: ProvisionWorkspaceDependencies = {},
 ): Promise<Workspace> => {
+  const execute = dependencies.execute ?? command;
+  const retryOptions = dependencies.retryOptions ?? {};
+  const dependencyCacheOptions = dependencies.dependencyCacheOptions ?? {};
+  const mirrorOptions = dependencies.mirrorOptions ?? {};
   const root = resolve(config.workspaceRoot);
   const workspace = resolve(root, claim.run.id);
   if (!inside(root, workspace)) throw new Error("Resolved workspace escaped the controlled root");
@@ -377,7 +408,13 @@ export const provisionWorkspace = async (
         return { path: workspace, branch, baseSha, ...(commitHooksPath ? { commitHooksPath } : {}) };
       },
     );
-    const materialized = await materializePreparedSpecification(config, claim, provisioned, execute, env);
+    const materialized = await materializePreparedSpecification(
+      config,
+      claim.specificationMaterialization,
+      provisioned,
+      execute,
+      env,
+    );
     await materializeWorkspaceDependencies(config, workspace, env, execute, dependencyCacheOptions);
     return materialized;
   } catch (error: unknown) {
@@ -386,7 +423,7 @@ export const provisionWorkspace = async (
   }
 };
 
-export const reuseWorkspace = async (config: RunnerConfig, claim: ClaimedTask): Promise<Workspace> => {
+export const reuseWorkspace = async (config: RunnerConfig, claim: WorkspaceReuseClaim): Promise<Workspace> => {
   if (!claim.run.workspacePath || !claim.run.branch || !claim.run.baseSha) throw new Error("Resumed Run is missing workspace metadata");
   const root = resolve(config.workspaceRoot);
   const workspace = resolve(claim.run.workspacePath);
@@ -416,7 +453,7 @@ export const reuseWorkspace = async (config: RunnerConfig, claim: ClaimedTask): 
  */
 export const writeSessionCredentials = async (
   config: Pick<RunnerConfig, "apiUrl" | "path" | "home" | "runAsPrefix">,
-  claim: ClaimedTask,
+  claim: Pick<ClaimedTask, "sessionToken" | "fencingToken"> & { run: Pick<ClaimedTask["run"], "id"> },
   workspace: Workspace,
 ): Promise<string> => {
   const directory = join(workspace.path, ".agentos");


### PR DESCRIPTION
## Summary

- expose named claim slices at runner module interfaces
- replace positional test collaborators with named dependency bundles
- delete deliverFailedWorkspace and test salvage through the production disposal path
- replace runner test claim casts with honest literals

## Verification

- npm run lint
- targeted runner tests: 145 passed, 2 skipped, 0 failed