### PR TITLE
docs: acknowledge Linux Do community

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,6 @@ Copyright (c) 2026 Matt Pocock) supply working text for the chain's
 prompts; see [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md). This
 snapshot is licensed under the [MIT License](LICENSE), with its
 boundary defined by [`public-snapshot.json`](public-snapshot.json).
+
+Community link: [LINUX DO](https://linux.do/) — sincere, friendly,
+united, and professional.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -161,3 +161,5 @@ Copyright (c) 2026 Matt Pocock）中的五个技能，见
 [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。本快照以
 [MIT License](LICENSE) 许可，快照边界由
 [`public-snapshot.json`](public-snapshot.json) 定义。
+
+社区友链：[LINUX DO](https://linux.do/)——真诚、友善、团结、专业。


### PR DESCRIPTION
## Summary

- add a LINUX DO community link at the end of the English README
- add the corresponding Chinese community link at the end of the Chinese README

## Verification

- `git diff --check`
- `node --test scripts/deploy/launchd-service-wrapper.test.mjs` under Node.js 22.17.0: 11/11 passed
- full `scripts/merge-gate.sh --expect-head 2d453b0b0fba6219e8844a1b67e250cdc02a6dc6` was run twice under Node.js 22.17.0; both runs were blocked by the unrelated concurrent quiet-window auto-deploy harness test `the real web invocation starts from a read-only release without writing into it` (the same test passes when run alone)

The PR remains unmerged because the repository requires an exact `MERGE GATE: PASS` for the commit.