### PR TITLE
refactor(api): remove project-scoped goal action aliases

### DIFF
--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -676,28 +676,12 @@ curl -X DELETE "$BASE_URL/goals/$GOAL_ID" -H "Authorization: Bearer $OPERATOR_TO
 curl -X POST "$BASE_URL/goals/$GOAL_ID/approve-dod" -H "Authorization: Bearer $OPERATOR_TOKEN"
 ```
 
-### POST `/projects/:projectId/goals/:goalId/approve-dod`
-
-- Required path parameters: `projectId`, `goalId`.
-
-```sh
-curl -X POST "$BASE_URL/projects/$PROJECT_ID/goals/$GOAL_ID/approve-dod" -H "Authorization: Bearer $OPERATOR_TOKEN"
-```
-
 ### POST `/goals/:goalId/pause`
 
 - Required path parameter: `goalId`.
 
 ```sh
 curl -X POST "$BASE_URL/goals/$GOAL_ID/pause" -H "Authorization: Bearer $OPERATOR_TOKEN"
-```
-
-### POST `/projects/:projectId/goals/:goalId/pause`
-
-- Required path parameters: `projectId`, `goalId`.
-
-```sh
-curl -X POST "$BASE_URL/projects/$PROJECT_ID/goals/$GOAL_ID/pause" -H "Authorization: Bearer $OPERATOR_TOKEN"
 ```
 
 ### GET `/goals/:goalId/definition-of-done`

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1666,7 +1666,6 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     }));
   };
   app.post("/goals/:goalId/approve-dod", approveGoalDod);
-  app.post("/projects/:projectId/goals/:goalId/approve-dod", approveGoalDod);
 
   const pauseGoal = async (context: Context<AppEnvironment, string>) => {
     const goalId = id.parse(context.req.param("goalId"));
@@ -1679,7 +1678,6 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return context.json(await db.goal.findUniqueOrThrow({ where: { id: goalId }, include: goalInclude }));
   };
   app.post("/goals/:goalId/pause", pauseGoal);
-  app.post("/projects/:projectId/goals/:goalId/pause", pauseGoal);
 
   app.get("/goals/:goalId/definition-of-done", async (context) => context.json(await db.goalDefinitionItem.findMany({
     where: { goalId: id.parse(context.req.param("goalId")) }, orderBy: { itemIndex: "asc" },

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1645,9 +1645,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
 
   const approveGoalDod = async (context: Context<AppEnvironment, string>) => {
     const goalId = id.parse(context.req.param("goalId"));
-    const projectId = context.req.param("projectId");
-    const goal = await db.goal.findFirst({
-      where: { id: goalId, ...(projectId ? { projectId: id.parse(projectId) } : {}) },
+    const goal = await db.goal.findUnique({
+      where: { id: goalId },
       include: { definitionOfDone: true },
     });
     if (!goal) return context.json({ error: "Goal not found" }, 404);
@@ -1669,9 +1668,8 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
 
   const pauseGoal = async (context: Context<AppEnvironment, string>) => {
     const goalId = id.parse(context.req.param("goalId"));
-    const projectId = context.req.param("projectId");
     const updated = await db.goal.updateMany({
-      where: { id: goalId, ...(projectId ? { projectId: id.parse(projectId) } : {}), status: GoalStatus.ACTIVE },
+      where: { id: goalId, status: GoalStatus.ACTIVE },
       data: { status: GoalStatus.PAUSED },
     });
     if (updated.count !== 1) return context.json({ error: "Only an active Goal can be paused" }, 409);

--- a/packages/api/src/goals.test.ts
+++ b/packages/api/src/goals.test.ts
@@ -68,7 +68,7 @@ test("approved Goals advance ACTIVE → COMPLETED and reopen when a DoD item is 
     };
     const items = [{ id: "item-1", goalId: goal.id, itemIndex: 0, text: "Tests pass", done: false }];
     const goalDelegate = {
-      findFirst: async () => ({ ...goal, definitionOfDone: items.map((item) => ({ ...item })) }),
+      findUnique: async () => ({ ...goal, definitionOfDone: items.map((item) => ({ ...item })) }),
       findUniqueOrThrow: async () => ({ ...goal }),
       update: async ({ data }: { data: Partial<typeof goal> }) => {
         Object.assign(goal, data);

--- a/packages/api/src/goals.test.ts
+++ b/packages/api/src/goals.test.ts
@@ -112,6 +112,35 @@ test("approved Goals advance ACTIVE → COMPLETED and reopen when a DoD item is 
   });
 });
 
+test("Goal action routes keep canonical forms and remove project-scoped aliases", async () => {
+  await withOperatorToken(async () => {
+    const app = createApp({} as PrismaClient);
+    const inventory = app.routes.map(({ method, path }) => `${method} ${path}`);
+    const removed = [
+      "POST /projects/:projectId/goals/:goalId/approve-dod",
+      "POST /projects/:projectId/goals/:goalId/pause",
+    ];
+    const retained = [
+      "POST /goals/:goalId/approve-dod",
+      "POST /goals/:goalId/pause",
+    ];
+    assert.deepEqual(inventory.filter((route) => removed.includes(route)), []);
+    for (const route of retained) assert.ok(inventory.includes(route), `${route} is not registered`);
+
+    for (const [method, path] of removed.map((route) => route.split(" ") as [string, string])) {
+      const response = await app.request(path, {
+        method,
+        headers: {
+          Authorization: "Bearer goals-test-operator",
+          "Content-Type": "application/json",
+        },
+      });
+      assert.equal(response.status, 404, `${method} ${path}`);
+      assert.deepEqual(await response.json(), { error: "Not found" });
+    }
+  });
+});
+
 test("a DoD write returns 503 after its Serializable retry budget is exhausted", async () => {
   await withOperatorToken(async () => {
     let attempts = 0;


### PR DESCRIPTION
## Summary
- remove the project-scoped Goals approve-dod and pause aliases
- retain canonical Goal action routes and document only those routes
- cover route inventory and 404 behavior in the focused Goals tests

## Validation
- RUNNER_WORKSPACE_ROOT=$(mktemp -d) node --import tsx --test packages/api/src/goals.test.ts
- npm run typecheck -w @anneal/api
- npm run test:operator-api-docs

Breaking removal approved for the next minor release.