### PR TITLE
refactor(web): remove unused UI parts

### DIFF
--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -15,48 +15,4 @@ function Card({ className, ...props }: React.ComponentProps<"section">) {
   )
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-header"
-      className={cn("flex flex-col space-y-1.5 p-6", className)}
-      {...props}
-    />
-  )
-}
-
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-title"
-      className={cn("font-semibold leading-none tracking-tight", className)}
-      {...props}
-    />
-  )
-}
-
-function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-description"
-      className={cn("text-sm text-muted-foreground", className)}
-      {...props}
-    />
-  )
-}
-
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="card-content" className={cn("p-6 pt-0", className)} {...props} />
-}
-
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="card-footer"
-      className={cn("flex items-center p-6 pt-0", className)}
-      {...props}
-    />
-  )
-}
-
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export { Card }

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -7,7 +7,7 @@ import { X } from "lucide-react"
 import { useT } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 
-/** The four Radix aliases below render no DOM node of their own, so `data-slot`
+/** The two Radix aliases below render no DOM node of their own, so `data-slot`
  *  is inert there at runtime. They are still written as v4 wrappers rather than
  *  bare assignments: a half-migrated file is the thing this generation change
  *  exists to prevent, and the attribute is asserted in source by
@@ -16,16 +16,8 @@ function Dialog(props: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
-function DialogTrigger(props: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
-}
-
 function DialogPortal(props: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
-}
-
-function DialogClose(props: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
 function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
@@ -103,25 +95,12 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
   )
 }
 
-function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
-  return (
-    <DialogPrimitive.Description
-      data-slot="dialog-description"
-      className={cn("text-sm text-muted-foreground", className)}
-      {...props}
-    />
-  )
-}
-
 export {
   Dialog,
   DialogPortal,
   DialogOverlay,
-  DialogTrigger,
-  DialogClose,
   DialogContent,
   DialogHeader,
   DialogFooter,
   DialogTitle,
-  DialogDescription,
 }

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -2,8 +2,9 @@ import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { cn } from "@/lib/utils"
 
-/** The two Radix aliases below render no DOM node of their own, so `data-slot` is
- *  inert there at runtime; see the same note in `dialog.tsx`. */
+/** The Root alias renders no DOM node of its own. The Trigger alias renders a
+ *  `Primitive.button`; its isolated generation test is source-only because it
+ *  needs Root context. */
 function DropdownMenu(props: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
 }

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,10 +1,8 @@
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { Check, ChevronRight, Circle } from "lucide-react"
-
 import { cn } from "@/lib/utils"
 
-/** The six Radix aliases below render no DOM node of their own, so `data-slot` is
+/** The two Radix aliases below render no DOM node of their own, so `data-slot` is
  *  inert there at runtime; see the same note in `dialog.tsx`. */
 function DropdownMenu(props: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
@@ -12,57 +10,6 @@ function DropdownMenu(props: React.ComponentProps<typeof DropdownMenuPrimitive.R
 
 function DropdownMenuTrigger(props: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
   return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
-}
-
-function DropdownMenuGroup(props: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
-  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
-}
-
-function DropdownMenuPortal(props: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
-}
-
-function DropdownMenuSub(props: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
-}
-
-function DropdownMenuRadioGroup(props: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
-  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />
-}
-
-function DropdownMenuSubTrigger({
-  className,
-  inset,
-  children,
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & { inset?: boolean }) {
-  return (
-    <DropdownMenuPrimitive.SubTrigger
-      data-slot="dropdown-menu-sub-trigger"
-      className={cn(
-        "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-        inset && "pl-8",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <ChevronRight className="ml-auto" />
-    </DropdownMenuPrimitive.SubTrigger>
-  )
-}
-
-function DropdownMenuSubContent({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
-  return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",
-        className
-      )}
-      {...props}
-    />
-  )
 }
 
 function DropdownMenuContent({
@@ -103,56 +50,6 @@ function DropdownMenuItem({
   )
 }
 
-function DropdownMenuCheckboxItem({
-  className,
-  children,
-  checked,
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
-  return (
-    <DropdownMenuPrimitive.CheckboxItem
-      data-slot="dropdown-menu-checkbox-item"
-      className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-        className
-      )}
-      {...(checked === undefined ? {} : { checked })}
-      {...props}
-    >
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <Check className="h-4 w-4" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
-      {children}
-    </DropdownMenuPrimitive.CheckboxItem>
-  )
-}
-
-function DropdownMenuRadioItem({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
-  return (
-    <DropdownMenuPrimitive.RadioItem
-      data-slot="dropdown-menu-radio-item"
-      className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-        className
-      )}
-      {...props}
-    >
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <Circle className="h-2 w-2 fill-current" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
-      {children}
-    </DropdownMenuPrimitive.RadioItem>
-  )
-}
-
 function DropdownMenuLabel({
   className,
   inset,
@@ -181,30 +78,11 @@ function DropdownMenuSeparator({ className, ...props }: React.ComponentProps<typ
   )
 }
 
-function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
-  return (
-    <span
-      data-slot="dropdown-menu-shortcut"
-      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
-      {...props}
-    />
-  )
-}
-
 export {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuCheckboxItem,
-  DropdownMenuRadioItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuShortcut,
-  DropdownMenuGroup,
-  DropdownMenuPortal,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
 }

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -41,19 +41,6 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
   )
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
-  return (
-    <tfoot
-      data-slot="table-footer"
-      className={cn(
-        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-        className
-      )}
-      {...props}
-    />
-  )
-}
-
 function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
   return (
     <tr
@@ -93,23 +80,11 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   )
 }
 
-function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
-  return (
-    <caption
-      data-slot="table-caption"
-      className={cn("mt-4 text-sm text-muted-foreground", className)}
-      {...props}
-    />
-  )
-}
-
 export {
   Table,
   TableHeader,
   TableBody,
-  TableFooter,
   TableHead,
   TableRow,
   TableCell,
-  TableCaption,
 }

--- a/apps/web/src/tests/component-generation.test.tsx
+++ b/apps/web/src/tests/component-generation.test.tsx
@@ -6,10 +6,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "../components/ui/card";
+import { Card } from "../components/ui/card";
 import { Input } from "../components/ui/input";
 import { Select } from "../components/ui/select";
-import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "../components/ui/table";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../components/ui/table";
 import { Textarea } from "../components/ui/textarea";
 
 const read = (file: string): string =>
@@ -34,25 +34,22 @@ const code = (file: string): string =>
 const PARTS: Record<string, string[]> = {
   "badge.tsx": ["Badge"],
   "button.tsx": ["Button"],
-  "card.tsx": ["Card", "CardHeader", "CardFooter", "CardTitle", "CardDescription", "CardContent"],
+  "card.tsx": ["Card"],
   "checkbox.tsx": ["Checkbox"],
   "dialog.tsx": [
-    "Dialog", "DialogPortal", "DialogOverlay", "DialogTrigger", "DialogClose",
-    "DialogContent", "DialogHeader", "DialogFooter", "DialogTitle", "DialogDescription",
+    "Dialog", "DialogPortal", "DialogOverlay", "DialogContent", "DialogHeader",
+    "DialogFooter", "DialogTitle",
   ],
   "dropdown-menu.tsx": [
     "DropdownMenu", "DropdownMenuTrigger", "DropdownMenuContent", "DropdownMenuItem",
-    "DropdownMenuCheckboxItem", "DropdownMenuRadioItem", "DropdownMenuLabel",
-    "DropdownMenuSeparator", "DropdownMenuShortcut", "DropdownMenuGroup",
-    "DropdownMenuPortal", "DropdownMenuSub", "DropdownMenuSubContent",
-    "DropdownMenuSubTrigger", "DropdownMenuRadioGroup",
+    "DropdownMenuLabel", "DropdownMenuSeparator",
   ],
   "hover-card.tsx": ["HoverCard", "HoverCardTrigger", "HoverCardContent"],
   "input.tsx": ["Input"],
   "progress.tsx": ["Progress"],
   "select.tsx": ["Select"],
   "switch.tsx": ["Switch"],
-  "table.tsx": ["Table", "TableHeader", "TableBody", "TableFooter", "TableHead", "TableRow", "TableCell", "TableCaption"],
+  "table.tsx": ["Table", "TableHeader", "TableBody", "TableHead", "TableRow", "TableCell"],
   "textarea.tsx": ["Textarea"],
 };
 
@@ -61,10 +58,10 @@ const NOT_A_PART = ["badgeVariants", "buttonVariants"];
 const kebab = (name: string): string =>
   name.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 
-test("the 12 migrated files plus hover-card carry 50 parts, and the plan's count is pinned", () => {
+test("the 12 migrated files plus hover-card carry 31 parts, and the plan's count is pinned", () => {
   const migrated = Object.entries(PARTS).filter(([file]) => file !== "hover-card.tsx");
   assert.equal(migrated.length, 12);
-  assert.equal(migrated.reduce((total, [, parts]) => total + parts.length, 0), 47);
+  assert.equal(migrated.reduce((total, [, parts]) => total + parts.length, 0), 28);
   assert.equal(PARTS["hover-card.tsx"]!.length, 3);
 });
 
@@ -123,22 +120,15 @@ test("the DOM-rendering parts emit the attribute, not just declare it", () => {
     ["badge", <Badge />],
     ["button", <Button />],
     ["card", <Card />],
-    ["card-header", <CardHeader />],
-    ["card-title", <CardTitle />],
-    ["card-description", <CardDescription />],
-    ["card-content", <CardContent />],
-    ["card-footer", <CardFooter />],
     ["input", <Input />],
     ["select", <Select />],
     ["textarea", <Textarea />],
     ["table", <Table />],
     ["table-header", <table><TableHeader /></table>],
     ["table-body", <table><TableBody /></table>],
-    ["table-footer", <table><TableFooter /></table>],
     ["table-row", <table><tbody><TableRow /></tbody></table>],
     ["table-head", <table><thead><tr><TableHead /></tr></thead></table>],
     ["table-cell", <table><tbody><tr><TableCell /></tr></tbody></table>],
-    ["table-caption", <table><TableCaption /></table>],
   ];
   const missing = cases
     .filter(([slot, element]) => !renderToStaticMarkup(element).includes(`data-slot="${slot}"`))


### PR DESCRIPTION
## Summary
- remove 19 UI wrappers with no production consumers
- narrow the component-generation inventory, count, and DOM cases to the retained 31-part surface

## Verification
- focused component-generation test: 9/9
- npm run typecheck -w @anneal/web
- npm run build -w @anneal/db (workspace prerequisite)
- npm run build -w @anneal/web

No full merge gate was run.