### PR TITLE
docs: reconcile published documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,11 +165,6 @@ SCHEDULER_POLL_INTERVAL_MS=30000
 # overlap, and warns while RUNNER_RUN_AS_PREFIX is empty (the shipped default), because
 # that is exactly the configuration in which the backstop for that gap is absent.
 
-# Run budget defaults (spendCap is stored but not applicable to subscription CLIs)
-SESSION_MAX_DURATION_MIN=240
-STALL_TIMEOUT_MIN=10
-MAX_SESSIONS_PER_TASK=3
-
 # --- Merge Integrator v1.1 (issue #100) --------------------------------------
 # Every value below is empty by default and every default is fail-closed: an
 # unconfigured deployment produces no merge authorization and claims no

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ chain into a workflow for your own team of agents.
 | 7 | Blind code review | `review-coordinator-opus` | Reviews the same diff again, blind to step 6's findings | Claude | Claude Opus 5 · high |
 | 8 | Apply review fixes | `senior-dev` | Dispositions every finding from both reviews and applies the adopted ones | Codex | GPT-5.6 Sol · high |
 | 9 | Documentation | `librarian` | Updates internal documentation to match the delivered code | Pi | GPT-5.6 Luna · xhigh |
-| 10 | Regression verification | `regression-verifier` | Refreshes onto the target branch and reruns the regressions | Codex | GPT-5.6 Luna · max |
+| 10 | Regression verification | `regression-verifier` | Refreshes onto the target branch and reruns the regressions | Codex | GPT-5.6 Luna · xhigh |
 | 11 | Merge readiness | — | Recomputes the head, requires every open review to clear, emits an exact-head authorization | — | mechanical, no model run |
 | 12 | Merge execution | `merge-integrator` | Re-verifies every precondition against the live pull request, then merges | — | mechanical, no model run |
 
@@ -127,7 +127,8 @@ board column semantics in the
 You need:
 
 - an Apple Silicon Mac
-- Node.js `22.17.0` (from `.nvmrc`) and npm 10.9.2+
+- Node.js satisfying `^20.19.0 || ^22.13.0 || >=24`; use `22.17.0` from
+  `.nvmrc`, with npm 10.9.2+
 - Docker Compose and Git
 - the official Codex CLI signed in under the same macOS account
   (Claude Code and Pi optional)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -82,7 +82,7 @@ trailer，你可以直接在 git log 里核对哪些提交出自链。
 | 7 | 盲评 | `review-coordinator-opus` | 对同一 diff 再评一次，看不到第 6 步的发现 | Claude | Claude Opus 5 · high |
 | 8 | 落地评审修复 | `senior-dev` | 裁决两轮评审的全部发现并落地采纳项 | Codex | GPT-5.6 Sol · high |
 | 9 | 文档 | `librarian` | 让内部文档与交付代码保持一致 | Pi | GPT-5.6 Luna · xhigh |
-| 10 | 回归验证 | `regression-verifier` | 刷新到目标分支并重跑回归 | Codex | GPT-5.6 Luna · max |
+| 10 | 回归验证 | `regression-verifier` | 刷新到目标分支并重跑回归 | Codex | GPT-5.6 Luna · xhigh |
 | 11 | 合并就绪 | — | 重算 head，要求所有评审清零，签发精确到 head 的授权 | — | 机械步骤，无模型运行 |
 | 12 | 合并执行 | `merge-integrator` | 对照线上 pull request 复核全部前置条件后合并 | — | 机械步骤，无模型运行 |
 
@@ -110,7 +110,8 @@ merge-tail 修复。</sub>
 你需要：
 
 - Apple Silicon 的 Mac
-- Node.js `22.17.0`（见 `.nvmrc`）与 npm 10.9.2+
+- Node.js 满足 `^20.19.0 || ^22.13.0 || >=24`；使用 `.nvmrc` 指定的
+  `22.17.0`，并配合 npm 10.9.2+
 - Docker Compose 与 Git
 - 在同一 macOS 账户下已登录的官方 Codex CLI（Claude Code 与 Pi 可选）
 

--- a/docs/demos/templates-release-demo.md
+++ b/docs/demos/templates-release-demo.md
@@ -1,21 +1,18 @@
 # Templates release demo
 
-This page describes the retained OSS-C **legacy release demo**, not the current
-canonical workflow. Its harness and evidence schema expect the former
-twelve-node Full Assurance shape: agent steps 1-10, server-side mechanical
-readiness at step 11, and the mechanical `merge-integrator` at step 12.
-
-Current canonical workflows are an eight-node/seven-layer Direct chain and a
-twelve-node/eleven-layer Full Assurance chain. Full Assurance has parallel Sol
-and blind Opus review siblings whose findings the fix node adjudicates itself;
-its readiness and integrator are nodes 11 and 12. Do not use the OSS-C harness
-as current-template acceptance evidence until its implementation is migrated to
-that graph. The canonical source of the current workflow is
+This page describes the retained OSS-C release demo. Its harness loads the
+current canonical `compound-engineer-workflow` and requires its twelve-node Full
+Assurance shape: agent steps 1-10, server-side mechanical readiness at step 11,
+and the mechanical `merge-integrator` at step 12. The canonical Direct and Full
+Assurance graphs are documented in
 [`agents/README.md`](../../agents/README.md).
 
-The harness proves one serial template execution against exact Anneal and
-synthetic-target commits. It does not prove fresh installation, universal
-provider compatibility, production readiness, or general template authoring.
+The harness records one template execution against exact Anneal and
+synthetic-target commits. It verifies task completion and output kinds, the two
+mechanical tail positions, and automatic pull-request delivery in public mode.
+It does not inspect the target diff or command output independently, and it does
+not prove fresh installation, universal provider compatibility, production
+readiness, or general template authoring.
 An approved OSS-B artifact separately authorizes fresh-install wording. An
 approved CP-A artifact separately authorizes the named provider path.
 
@@ -36,9 +33,11 @@ approved CP-A artifact separately authorizes the named provider path.
   artifact, a human-created public GitHub repository, working `gh` auth, no
   existing demo branch, and no open pull request from that branch.
 
-The synthetic target baseline and authorized change are fixed in the harness.
-The only changed files may be `src/cli.mjs`, `test/cli.test.mjs`, and
-`README.md`; the example must print `{"lines":3,"words":5}` followed by LF.
+The synthetic target baseline and requested change are fixed in the harness.
+The task description tells the chain to change only `src/cli.mjs`,
+`test/cli.test.mjs`, and `README.md`, and to print
+`{"lines":3,"words":5}` followed by LF for the example. Those are task
+instructions, not assertions repeated by the evidence verifier.
 
 ## Commands
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -112,10 +112,12 @@ root-owned service adoption to the matching runbook profile.
 ## Templates release demo
 
 `npm run demo:templates -- preflight|setup|instantiate|capture|verify|reset`
-drives the retained v0.2 twelve-node release-demo workflow; it is not evidence
-for the current layered canonical templates. The demo's limits and exact
-commands are in [`docs/demos/templates-release-demo.md`](demos/templates-release-demo.md).
-The current Direct and Full Assurance graphs are documented in
+drives the retained OSS-C release-demo protocol over the current canonical
+twelve-node Full Assurance template. It records exact-commit chain evidence but
+does not independently inspect the target diff or command output. The demo's
+limits and exact commands are in
+[`docs/demos/templates-release-demo.md`](demos/templates-release-demo.md). The
+current Direct and Full Assurance graphs are documented in
 [`agents/README.md`](../agents/README.md). A rehearsal or one provider run proves
 neither universal provider compatibility nor a fresh install.
 

--- a/docs/release/license-and-assets.md
+++ b/docs/release/license-and-assets.md
@@ -29,19 +29,27 @@ failure rather than a silent inclusion.
 | Category | Count | Provenance |
 | --- | --- | --- |
 | First-party source, tests, configuration and manifests | the majority | Written for this repository. MIT, per `LICENSE`. |
-| Third-party source, vendored | 14 files | shadcn/ui. See below. |
+| Third-party source, vendored | 13 files | shadcn/ui. See below. |
 | Chain prompts carrying upstream text | `agents/roles/`, `agents/templates/` | mattpocock/skills. See below. |
 | Data fixtures | 5 files | See below. |
-| Images, fonts, audio, video, icons, compiled binaries, archives | **0** | There are none. |
+| Binary media | 3 files | First-party README captures. See below. |
 
-### There are no binary assets
+### Binary README assets
 
-The published set contains **zero binary files**. No image, no font, no icon
-file, no compiled artifact, no archive. That is not a claim about what we
-remembered to check — it is a property of the file set, and it is re-checked
-mechanically: `scripts/public-snapshot-scan.mjs` classifies a file as binary when
-its first 8 KiB contain a NUL byte or more than 10% control characters, and the
-scan reports any binary in scope.
+The published set contains three first-party media files used by the bilingual
+README pair. `public-snapshot.json` includes each file and records its reviewed
+`binary-material` finding by exact path.
+
+| Path | Media type | SHA-256 | Bytes | Provenance |
+| --- | --- | --- | --- | --- |
+| `docs/media/agents.png` | `image/png` | `f248b0a9ecc543a0ec438024272073022d570e9f9588e0e71c9882bb9917f2d5` | 341236 | Capture of Anneal's Agents view. |
+| `docs/media/chain.png` | `image/png` | `b51111e47afb1ec62caa2164e0eb50f9e4fc55ad025446d85a0ae437e80563c3` | 417380 | Capture of an Anneal Full Assurance chain. |
+| `docs/media/parallel-tasks.gif` | `image/gif` | `b38e64f16fe36cc13c5e845ca9263748ed4195a84eddb72add81228fa6f5cd6c` | 447169 | Capture of Anneal running multiple tasks on its board. |
+
+All three captures come from this repository's own application, are owned by
+Moson Lab, and are covered by `LICENSE`. The scanner classifies a file as binary
+when its first 8 KiB contain a NUL byte or more than 10% control characters and
+reports every binary in scope; no other binary file is published.
 
 To re-derive it from a clean checkout:
 
@@ -49,8 +57,8 @@ To re-derive it from a clean checkout:
 npm run snapshot:scan
 ```
 
-The consequence for licensing is that there is no unprovenanced media in this
-release, and no asset whose origin has to be taken on trust.
+The consequence for licensing is that every published media asset has explicit
+provenance rather than relying on an assumed zero-binary inventory.
 
 ## Third-party source carried in the tree
 

--- a/docs/release/security.md
+++ b/docs/release/security.md
@@ -20,9 +20,10 @@ to face a network.
   bind. Compose shorthand with no bind emits a notice because it publishes on
   every interface, while the migration target URL must still name literal
   loopback.
-- The web console is served at `http://127.0.0.1:5173` and its dev/preview
-  server decides per request that the caller is its own loopback origin before
-  it will attach the operator's authority.
+- The web console is served at `http://127.0.0.1:5173` by the development
+  server and at `http://127.0.0.1:4173` by the deployed preview server. In
+  either mode, the server decides per request that the caller is its own
+  loopback origin before it will attach the operator's authority.
 
 **Exposing any of this beyond the loopback interface is unsupported.** There is
 no authentication design for a remote caller here — no login, no per-user

--- a/scripts/deploy/launchd-service-wrapper.test.mjs
+++ b/scripts/deploy/launchd-service-wrapper.test.mjs
@@ -261,7 +261,8 @@ test("the real web invocation starts from a read-only release without writing in
   child.stderr.on("data", (chunk) => { output += chunk; });
 
   let response = null;
-  for (let attempt = 0; attempt < 50; attempt += 1) {
+  const readinessDeadline = Date.now() + 30_000;
+  while (Date.now() < readinessDeadline) {
     if (child.exitCode !== null) break;
     try {
       response = await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(250) });


### PR DESCRIPTION
## Summary
- remove undocumented environment budget knobs and align README runtime/model facts
- update the templates release-demo boundary to match the current canonical workflow
- record the three published binary media assets and correct release security ports

## Verification
- npm run lint
- npm run test:snapshot-scan
- npm run test:release-docs
- npm run test:demo-templates
- npm run test:setup-local
- npm run snapshot:scan