### PR TITLE
refactor(deploy): deepen deployment attempt seam

### DIFF
--- a/scripts/deploy/deploy-phases.mjs
+++ b/scripts/deploy/deploy-phases.mjs
@@ -6,11 +6,8 @@ const phase = (scope, name, hostMethod, mutating, ledgerState = null) => Object.
   ledgerState,
 });
 
-/**
- * The declaration is ordered across the main prefix and the host upgrade. A
- * prefix entry names the main operation that owns the boundary; an upgrade
- * entry names the production-host method that executes it.
- */
+/** The full ordered deployment. Every row names a host method that receives
+ * the DeploymentAttempt and returns the facts it established. */
 export const DEPLOY_PHASES = Object.freeze([
   phase("prefix", "parse-arguments", "parseArgs", false),
   phase("prefix", "check-escalation", "checkEscalation", false),

--- a/scripts/deploy/deployment-attempt.mjs
+++ b/scripts/deploy/deployment-attempt.mjs
@@ -1,0 +1,99 @@
+const hasOwn = (value, key) => Object.prototype.hasOwnProperty.call(value, key);
+
+export class DeploymentAttempt {
+  #facts = new Map();
+  #resources = [];
+  #released = false;
+
+  constructor({ deployRoot, targetCommit, transactionId }) {
+    if (typeof deployRoot !== "string" || deployRoot === "") throw new TypeError("deployment-attempt-deploy-root-required");
+    if (typeof targetCommit !== "string" || targetCommit === "") throw new TypeError("deployment-attempt-target-commit-required");
+    if (typeof transactionId !== "string" || transactionId === "") throw new TypeError("deployment-attempt-transaction-id-required");
+    this.deployRoot = deployRoot;
+    this.targetCommit = targetCommit;
+    this.transactionId = transactionId;
+    Object.freeze(this);
+  }
+
+  fact(name) {
+    return this.#facts.get(name);
+  }
+
+  requireFact(name) {
+    if (!this.#facts.has(name)) throw new TypeError(`deployment-attempt-fact-missing:${name}`);
+    return this.#facts.get(name);
+  }
+
+  establish(facts) {
+    if (facts === undefined || facts === null) return;
+    if (typeof facts !== "object" || Array.isArray(facts)) throw new TypeError("deployment-attempt-facts-invalid");
+    if (hasOwn(facts, "resources")) {
+      if (!Array.isArray(facts.resources)) throw new TypeError("deployment-attempt-resources-invalid");
+      for (const resource of facts.resources) {
+        if (typeof resource?.release !== "function") throw new TypeError("deployment-attempt-resource-release-missing");
+        this.#resources.push(resource);
+      }
+    }
+    for (const [name, value] of Object.entries(facts)) {
+      if (name !== "resources") this.#facts.set(name, value);
+    }
+  }
+
+  ledgerMetadata(metadata = {}) {
+    const revisions = this.fact("revisions");
+    const preparedRelease = this.fact("verifiedRelease") ?? this.fact("preparedRelease");
+    const backup = this.fact("backup");
+    const migration = this.fact("migration");
+    const publication = this.fact("publication");
+    const verification = this.fact("serviceVerification");
+    return {
+      targetCommit: revisions?.to ?? this.targetCommit,
+      ...(preparedRelease?.buildStamp ? { activatedBuildStamp: preparedRelease.buildStamp } : {}),
+      ...(preparedRelease?.releaseName ? { releaseDirectoryIdentity: preparedRelease.releaseName } : {}),
+      ...(backup?.backupIdentity ? { backupIdentity: backup.backupIdentity } : {}),
+      ...(migration ? {
+        migrationTailBefore: migration.migrationTailBefore ?? null,
+        migrationTailAfter: migration.migrationTailAfter ?? null,
+      } : {}),
+      ...(publication?.releaseDirectoryIdentity
+        ? { releaseDirectoryIdentity: publication.releaseDirectoryIdentity }
+        : publication?.releaseIdentity?.name
+          ? { releaseDirectoryIdentity: publication.releaseIdentity.name }
+          : {}),
+      ...(publication?.pointerOldTarget !== undefined ? { pointerOldTarget: publication.pointerOldTarget } : {}),
+      ...(publication?.pointerNewTarget !== undefined ? { pointerNewTarget: publication.pointerNewTarget } : {}),
+      ...(publication?.releaseIdentity ? { releaseIdentity: publication.releaseIdentity } : {}),
+      ...(publication?.pointerTransition ? { pointerTransition: publication.pointerTransition } : {}),
+      ...(verification?.activatedBuildStamp ? { activatedBuildStamp: verification.activatedBuildStamp } : {}),
+      ...(this.fact("rollbackPointerOutcome") ? { rollbackPointerOutcome: this.fact("rollbackPointerOutcome") } : {}),
+      ...metadata,
+    };
+  }
+
+  async release() {
+    if (this.#released) return;
+    this.#released = true;
+    const failures = [];
+    for (const resource of this.#resources.reverse()) {
+      try {
+        await resource.release();
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    if (failures.length > 0) throw new AggregateError(failures, "deployment-attempt-resource-release-failed");
+  }
+}
+
+export const openDeploymentAttempt = (identity) => new DeploymentAttempt(identity);
+
+export const parseReleaseArtifactReceipt = (output) => {
+  const receiptLine = output.trim().split("\n").findLast((line) => line.startsWith("RELEASE-ARTIFACT "));
+  if (!receiptLine) return null;
+  try {
+    const receipt = JSON.parse(receiptLine.slice("RELEASE-ARTIFACT ".length));
+    return typeof receipt?.releaseName === "string" && receipt.releaseName !== "" ? receipt : null;
+  } catch {
+    return null;
+  }
+};

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -36,6 +36,7 @@ import {
   pruneDeployHistory,
 } from "./deploy-preflight.mjs";
 import { createProductionHost } from "./quiet-window-host.mjs";
+import { openDeploymentAttempt, parseReleaseArtifactReceipt } from "./deployment-attempt.mjs";
 import { runCommandWithRetry } from "./quiet-window-retry.mjs";
 import { verifyBackupConfiguration } from "./install-launchd.mjs";
 import { backupConfigurationFromEnvironment, writePgDumpBackup } from "./quiet-window-backup.mjs";
@@ -563,6 +564,239 @@ const makeWritable = (root) => {
   visit(root);
 };
 
+const createDeployHost = () => createProductionHost({
+  parseArgs: async () => ({ options: parseArgs(process.argv.slice(2)) }),
+  checkEscalation: async () => {
+    if (!existsSync(ESCALATION_PATH)) return;
+    await retryEscalationNotification();
+    log(`STOP escalation-active path=${ESCALATION_PATH}`);
+    return { skip: "escalation-active", exitCode: 2 };
+  },
+  acquireLock: async () => {
+    const lock = await acquireLock();
+    if (lock === null) {
+      log("SKIP concurrent-run lock-held");
+      return { skip: "lock-held" };
+    }
+    if (lock.recovered) {
+      await lock.release();
+      throw new DeployFailure(
+        "stale-deploy-owner-recovered",
+        `pid-${lock.recovered.pid ?? "unknown"}`,
+      );
+    }
+    return { lock, resources: [lock] };
+  },
+  readRevisions: async (attempt) => ({
+    revisions: { from: readDeployedRevision(), to: attempt.targetCommit },
+  }),
+  checkAlreadyDeployed: async (attempt) => {
+    const revisions = attempt.requireFact("revisions");
+    if (revisions.from !== revisions.to) return;
+    pruneHistory();
+    log(`NOOP already-deployed revision=${revisions.from}`);
+    return { skip: "already-deployed" };
+  },
+  startDeploymentLedger: async (attempt) => ({
+    ledger: createDeploymentLedger({
+      stateDir: STATE_DIR,
+      deploymentId: attempt.transactionId,
+      targetCommit: attempt.targetCommit,
+    }),
+  }),
+  prepareReleaseArtifact: async (attempt) => {
+    const built = await checked(
+      "release-artifact-build-failed",
+      loadBinaries().node,
+      [join(SCRIPT_DIR, "build-release-artifact.mjs"), attempt.targetCommit],
+      { capture: true },
+    );
+    const hasReceipt = built.stdout.trim().split("\n").some((line) => line.startsWith("RELEASE-ARTIFACT "));
+    const receipt = parseReleaseArtifactReceipt(built.stdout);
+    if (!receipt) fail("release-artifact-build-failed", hasReceipt ? "builder-receipt-invalid" : "builder-receipt-missing");
+    const preparedRelease = verifyReleaseArtifact({
+      deployRoot: attempt.deployRoot,
+      revision: attempt.targetCommit,
+      releaseName: receipt.releaseName,
+    });
+    return { preparedRelease };
+  },
+  verifyArtifact: async (attempt) => {
+    const preparedRelease = attempt.requireFact("preparedRelease");
+    return {
+      verifiedRelease: verifyReleaseArtifact({
+        deployRoot: attempt.deployRoot,
+        revision: attempt.targetCommit,
+        releaseName: preparedRelease.releaseName,
+      }),
+    };
+  },
+  waitForQuiet: async () => {
+    const barrier = await waitForQuiet();
+    return { barrier, resources: [barrier] };
+  },
+  prepareWorkspace: async (attempt) => {
+    const release = attempt.requireFact("verifiedRelease");
+    const operationWorkspace = join(STATE_DIR, `operation-${attempt.transactionId}`);
+    try {
+      cpSync(release.releaseDirectory, operationWorkspace, { recursive: true, errorOnExist: true });
+      makeWritable(operationWorkspace);
+    } catch (error) {
+      if (existsSync(operationWorkspace)) {
+        makeWritable(operationWorkspace);
+        rmSync(operationWorkspace, { recursive: true, force: true });
+      }
+      fail("operation-workspace-preparation-failed", error?.code ?? "copy-failed");
+    }
+    return {
+      operationWorkspace,
+      resources: [{
+        release: async () => {
+          if (!existsSync(operationWorkspace)) return;
+          makeWritable(operationWorkspace);
+          rmSync(operationWorkspace, { recursive: true, force: true });
+        },
+      }],
+    };
+  },
+  verifyStableServicePaths: async () => {
+    await verifyStableServicePaths();
+  },
+  backup: async (attempt) => {
+    const revisions = attempt.requireFact("revisions");
+    const backupDirectory = join(STATE_DIR, "backups");
+    mkdirSync(backupDirectory, { recursive: true, mode: 0o700 });
+    const output = join(backupDirectory, `${new Date().toISOString().replace(/[:.]/gu, "-")}-${revisions.from.slice(0, 12)}-${revisions.to.slice(0, 12)}.dump`);
+    try {
+      await writePgDumpBackup({
+        configuration: loadBinaries().backup,
+        databaseUrl: process.env.DATABASE_URL,
+        output,
+        signal: interruptController.signal,
+      });
+    } catch (error) {
+      throwIfInterrupted();
+      fail("database-backup-failed", error instanceof Error ? error.message : String(error));
+    }
+    return { backup: { backupIdentity: basename(output) } };
+  },
+  guardedMigration: async (attempt) => {
+    const operationWorkspace = attempt.requireFact("operationWorkspace");
+    const migrationTailBefore = await migrationTail();
+    await checked("guarded-migration-refused", loadBinaries().node, ["node_modules/tsx/dist/cli.mjs", "packages/db/prisma/preflight-goal-execution.ts"], {
+      cwd: operationWorkspace,
+    });
+    await checked("guarded-migration-refused", loadBinaries().node, [
+      "node_modules/prisma/build/index.js",
+      "migrate",
+      "deploy",
+      "--schema",
+      "packages/db/prisma/schema.prisma",
+    ], {
+      cwd: operationWorkspace,
+    });
+    const migrationTailAfter = await migrationTail();
+    return { migration: { migrationTailBefore, migrationTailAfter } };
+  },
+  generatePrismaClient: (attempt) => checked("prisma-client-generation-refused", loadBinaries().node, [
+    "node_modules/prisma/build/index.js",
+    "generate",
+    "--schema",
+    "packages/db/prisma/schema.prisma",
+  ], { cwd: attempt.requireFact("operationWorkspace") }),
+  syncCanonicalPrompts: (attempt) => checked("canonical-prompt-sync-refused", loadBinaries().node, [
+    "node_modules/tsx/dist/cli.mjs",
+    "packages/db/prisma/sync-canonical-prompts.ts",
+  ], { cwd: attempt.requireFact("operationWorkspace") }),
+  verifyRuntimePrismaClient: async (attempt) => {
+    if (!generatedPrismaClientIsComplete(attempt.requireFact("operationWorkspace"))) {
+      fail("runtime-prisma-client-missing", "operation-generated-client-is-absent");
+    }
+  },
+  assertQuietBeforeRestart: async (attempt) => {
+    if (!await attempt.requireFact("barrier").verify()) fail("deploy-barrier-lost", "exclusive-session-lock-not-held");
+    const blockers = await blockingRuns();
+    if (blockers.length > 0) fail("quiet-window-lost", `blockers-${blockers.length}`);
+  },
+  publishBuild: async (attempt) => {
+    const release = attempt.requireFact("verifiedRelease");
+    const verifiedRelease = verifyReleaseArtifact({
+      deployRoot: attempt.deployRoot,
+      revision: attempt.targetCommit,
+      releaseName: release.releaseName,
+    });
+    const activated = activateReleasePointer({ root: attempt.deployRoot, release: verifiedRelease.releaseName });
+    const relativeTarget = (target) => target === null ? null : `releases/${target}`;
+    const pointerTransition = Object.freeze({
+      oldTarget: relativeTarget(activated.oldTarget),
+      newTarget: relativeTarget(activated.newTarget),
+      previousTarget: relativeTarget(activated.previousTarget),
+    });
+    return {
+      verifiedRelease,
+      publication: {
+        releaseDirectoryIdentity: verifiedRelease.releaseName,
+        releaseIdentity: {
+          name: verifiedRelease.releaseName,
+          commit: verifiedRelease.revision,
+          digest: verifiedRelease.digest,
+        },
+        pointerOldTarget: pointerTransition.oldTarget,
+        pointerNewTarget: pointerTransition.newTarget,
+        pointerTransition,
+        rollback: async () => rollbackReleasePointer({ root: attempt.deployRoot }),
+      },
+    };
+  },
+  restartServices: async () => {
+    for (const label of SERVICE_LABELS) await launchctl("service-restart-failed", ["kickstart", "-k", `${domain()}/${label}`]);
+  },
+  verifyServices: async (attempt) => {
+    const revisions = attempt.requireFact("revisions");
+    const deadline = Date.now() + 30_000;
+    let lastReason = "not-ready";
+    while (Date.now() < deadline) {
+      const state = await serviceState();
+      if (!state.ok) lastReason = `launchd-unavailable-${state.unavailable.join(",")}`;
+      else {
+        try {
+          const port = process.env.API_PORT ?? "3000";
+          const health = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(2_000) });
+          const version = await fetch(`http://127.0.0.1:${port}/version`, { signal: AbortSignal.timeout(2_000) });
+          const payload = version.ok ? await version.json() : {};
+          if (health.ok && version.ok && payload.commit === revisions.to && payload.dirty === false) {
+            throwIfInterrupted();
+            return {
+              serviceVerification: {
+                activatedBuildStamp: {
+                  packageName: payload.packageName,
+                  commit: payload.commit,
+                  dirty: payload.dirty,
+                },
+              },
+            };
+          }
+          lastReason = `health-${health.status}-version-${version.status}-commit-${String(payload.commit ?? "unknown")}`;
+        } catch (error) {
+          if (error instanceof DeployFailure) throw error;
+          lastReason = error instanceof Error ? error.name : "probe-failed";
+        }
+      }
+      await sleep(1_000);
+    }
+    fail("service-verification-failed", lastReason);
+  },
+  restorePreviousServices: async () => {
+    for (const label of SERVICE_LABELS) {
+      await launchctl("previous-service-restore-failed", ["kickstart", "-k", `${domain()}/${label}`], { allowAfterInterrupt: true });
+    }
+  },
+  escalate: writeEscalation,
+  markEscalationNotified,
+  notify,
+  log,
+});
+
 const main = async () => {
   const options = parseArgs(process.argv.slice(2));
   if (!Number.isSafeInteger(POLL_MS) || POLL_MS < 1_000) fail("environment-invalid", "QUIET_WINDOW_POLL_SECONDS-must-be-a-positive-integer");
@@ -589,231 +823,23 @@ const main = async () => {
     return 2;
   }
 
-  return runLocked({ acquireLock, log }, async () => {
-    let from = "unknown";
-    let to = "unknown";
-    try {
-      from = readDeployedRevision();
-      to = await remoteMainRevision();
-    } catch (error) {
-      const failure = failureOf(error);
-      await persistAndNotifyFailure(failure, from, to);
-      return { ok: false, reason: failure.reason };
-    }
-    if (from === to) {
-      pruneHistory();
-      log(`NOOP already-deployed revision=${from}`);
-      return { ok: true, skipped: "already-deployed" };
-    }
+  let targetCommit = "unknown";
+  try {
+    targetCommit = await remoteMainRevision();
+  } catch (error) {
+    const failure = failureOf(error);
+    await persistAndNotifyFailure(failure, "unknown", targetCommit);
+    return 1;
+  }
 
-    let operationWorkspace = null;
-    let preparedRelease = null;
-    let barrier = null;
-    let ledger = null;
-    const transactionId = randomUUID();
-    const backupDirectory = join(STATE_DIR, "backups");
-    try {
-      ledger = createDeploymentLedger({ stateDir: STATE_DIR, deploymentId: transactionId, targetCommit: to });
-      ledger.start({ targetCommit: to });
-      const built = await checked(
-        "release-artifact-build-failed",
-        loadBinaries().node,
-        [join(SCRIPT_DIR, "build-release-artifact.mjs"), to],
-        { capture: true },
-      );
-      const receiptLine = built.stdout.trim().split("\n").findLast((line) => line.startsWith("RELEASE-ARTIFACT "));
-      if (!receiptLine) fail("release-artifact-build-failed", "builder-receipt-missing");
-      let receipt;
-      try { receipt = JSON.parse(receiptLine.slice("RELEASE-ARTIFACT ".length)); }
-      catch { fail("release-artifact-build-failed", "builder-receipt-invalid"); }
-      preparedRelease = verifyReleaseArtifact({
-        deployRoot: REPOSITORY_ROOT,
-        revision: to,
-        releaseName: receipt.releaseName,
-      });
-      ledger.record("ARTIFACT_PREPARED", {
-        targetCommit: to,
-        releaseDirectoryIdentity: preparedRelease.releaseName,
-        activatedBuildStamp: preparedRelease.buildStamp,
-      });
-    } catch (error) {
-      const failure = failureOf(error);
-      if (ledger && failure.reason !== "deployment-ledger-write-failed") {
-        try { ledger.record("FAILED", { targetCommit: to, reasonCode: failure.reason }); }
-        catch (ledgerError) { log(`STOP deployment-ledger-write-failed detail=${ledgerError instanceof Error ? ledgerError.name : "unknown"}`); }
-      }
-      if (!shouldPersistFailure({ dryRun: false, reason: failure.reason, upgradeStarted: false })) {
-        log(`STOP ${failure.reason}${failure.detail ? ` detail=${failure.detail}` : ""}; no-upgrade-started`);
-        return { ok: false, reason: failure.reason };
-      }
-      await persistAndNotifyFailure(failure, from, to);
-      return { ok: false, reason: failure.reason };
-    }
-    const host = createProductionHost({
-      verifyArtifact: async (target) => {
-        if (!preparedRelease) fail("release-artifact-missing", target);
-        preparedRelease = verifyReleaseArtifact({
-          deployRoot: REPOSITORY_ROOT,
-          revision: target,
-          releaseName: preparedRelease.releaseName,
-        });
-        return preparedRelease;
-      },
-      waitForQuiet: async () => {
-        barrier = await waitForQuiet();
-      },
-      prepareWorkspace: async () => {
-        operationWorkspace = join(STATE_DIR, `operation-${transactionId}`);
-        try {
-          cpSync(preparedRelease.releaseDirectory, operationWorkspace, { recursive: true, errorOnExist: true });
-          makeWritable(operationWorkspace);
-        } catch (error) {
-          fail("operation-workspace-preparation-failed", error?.code ?? "copy-failed");
-        }
-      },
-      backup: async () => {
-        mkdirSync(backupDirectory, { recursive: true, mode: 0o700 });
-        const output = join(backupDirectory, `${new Date().toISOString().replace(/[:.]/gu, "-")}-${from.slice(0, 12)}-${to.slice(0, 12)}.dump`);
-        try {
-          await writePgDumpBackup({
-            configuration: loadBinaries().backup,
-            databaseUrl: process.env.DATABASE_URL,
-            output,
-            signal: interruptController.signal,
-          });
-        } catch (error) {
-          throwIfInterrupted();
-          fail("database-backup-failed", error instanceof Error ? error.message : String(error));
-        }
-        return { backupIdentity: basename(output) };
-      },
-      guardedMigration: async () => {
-        const migrationTailBefore = await migrationTail();
-        await checked("guarded-migration-refused", loadBinaries().node, ["node_modules/tsx/dist/cli.mjs", "packages/db/prisma/preflight-goal-execution.ts"], {
-          cwd: operationWorkspace,
-        });
-        await checked("guarded-migration-refused", loadBinaries().node, [
-          "node_modules/prisma/build/index.js",
-          "migrate",
-          "deploy",
-          "--schema",
-          "packages/db/prisma/schema.prisma",
-        ], {
-          cwd: operationWorkspace,
-        });
-        const migrationTailAfter = await migrationTail();
-        return { migrationTailBefore, migrationTailAfter };
-      },
-      generatePrismaClient: () => checked("prisma-client-generation-refused", loadBinaries().node, [
-        "node_modules/prisma/build/index.js",
-        "generate",
-        "--schema",
-        "packages/db/prisma/schema.prisma",
-      ], { cwd: operationWorkspace }),
-      syncCanonicalPrompts: () => checked("canonical-prompt-sync-refused", loadBinaries().node, [
-        "node_modules/tsx/dist/cli.mjs",
-        "packages/db/prisma/sync-canonical-prompts.ts",
-      ], { cwd: operationWorkspace }),
-      verifyRuntimePrismaClient: async () => {
-        if (!generatedPrismaClientIsComplete(operationWorkspace)) {
-          fail("runtime-prisma-client-missing", "operation-generated-client-is-absent");
-        }
-      },
-      verifyStableServicePaths: async () => {
-        await verifyStableServicePaths();
-      },
-      assertQuietBeforeRestart: async () => {
-        if (!await barrier.verify()) fail("deploy-barrier-lost", "exclusive-session-lock-not-held");
-        const blockers = await blockingRuns();
-        if (blockers.length > 0) fail("quiet-window-lost", `blockers-${blockers.length}`);
-      },
-      publishBuild: async () => {
-        if (!preparedRelease) fail("release-artifact-missing", "verified-release-not-prepared");
-        preparedRelease = verifyReleaseArtifact({
-          deployRoot: REPOSITORY_ROOT,
-          revision: to,
-          releaseName: preparedRelease.releaseName,
-        });
-        const activated = activateReleasePointer({ root: REPOSITORY_ROOT, release: preparedRelease.releaseName });
-        const relativeTarget = (target) => target === null ? null : `releases/${target}`;
-        const pointerTransition = Object.freeze({
-          oldTarget: relativeTarget(activated.oldTarget),
-          newTarget: relativeTarget(activated.newTarget),
-          previousTarget: relativeTarget(activated.previousTarget),
-        });
-        return {
-          releaseDirectoryIdentity: preparedRelease.releaseName,
-          releaseIdentity: {
-            name: preparedRelease.releaseName,
-            commit: preparedRelease.revision,
-            digest: preparedRelease.digest,
-          },
-          pointerOldTarget: pointerTransition.oldTarget,
-          pointerNewTarget: pointerTransition.newTarget,
-          pointerTransition,
-          rollback: async () => rollbackReleasePointer({ root: REPOSITORY_ROOT }),
-          commit: async () => undefined,
-        };
-      },
-      restartServices: async () => {
-        for (const label of SERVICE_LABELS) await launchctl("service-restart-failed", ["kickstart", "-k", `${domain()}/${label}`]);
-      },
-      verifyServices: async (revisions) => {
-        const deadline = Date.now() + 30_000;
-        let lastReason = "not-ready";
-        while (Date.now() < deadline) {
-          const state = await serviceState();
-          if (!state.ok) lastReason = `launchd-unavailable-${state.unavailable.join(",")}`;
-          else {
-            try {
-              const port = process.env.API_PORT ?? "3000";
-              const health = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(2_000) });
-              const version = await fetch(`http://127.0.0.1:${port}/version`, { signal: AbortSignal.timeout(2_000) });
-              const payload = version.ok ? await version.json() : {};
-              if (health.ok && version.ok && payload.commit === revisions.to && payload.dirty === false) {
-                throwIfInterrupted();
-                return {
-                  activatedBuildStamp: {
-                    packageName: payload.packageName,
-                    commit: payload.commit,
-                    dirty: payload.dirty,
-                  },
-                };
-              }
-              lastReason = `health-${health.status}-version-${version.status}-commit-${String(payload.commit ?? "unknown")}`;
-            } catch (error) {
-              if (error instanceof DeployFailure) throw error;
-              lastReason = error instanceof Error ? error.name : "probe-failed";
-            }
-          }
-          await sleep(1_000);
-        }
-        fail("service-verification-failed", lastReason);
-      },
-      restorePreviousServices: async () => {
-        for (const label of SERVICE_LABELS) {
-          await launchctl("previous-service-restore-failed", ["kickstart", "-k", `${domain()}/${label}`], { allowAfterInterrupt: true });
-        }
-      },
-      escalate: writeEscalation,
-      markEscalationNotified,
-      notify,
-      log,
-      cleanupWorkspace: async () => {
-        try {
-          if (operationWorkspace && existsSync(operationWorkspace)) {
-            makeWritable(operationWorkspace);
-            rmSync(operationWorkspace, { recursive: true, force: true });
-          }
-        } finally {
-          if (barrier) await barrier.release();
-        }
-      },
-    });
-    const result = await executeUpgrade(host, { from, to }, { ledger, ledgerStarted: true });
-    if (result.ok) pruneHistory();
-    return result.ok ? { ok: true } : { ok: false, reason: result.failure.reason };
-  }).then((result) => result.ok ? 0 : 1);
+  const attempt = openDeploymentAttempt({
+    deployRoot: REPOSITORY_ROOT,
+    targetCommit,
+    transactionId: randomUUID(),
+  });
+  const result = await executeUpgrade(createDeployHost(), attempt);
+  if (result.ok && !result.skipped) pruneHistory();
+  return result.ok ? (attempt.fact("exitCode") ?? 0) : 1;
 };
 
 for (const [signal, code] of [["SIGINT", 130], ["SIGTERM", 143]]) {

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -4,7 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { PREFIX_DEPLOY_PHASES, UPGRADE_DEPLOY_PHASES } from "./deploy-phases.mjs";
+import { DEPLOY_PHASES, UPGRADE_DEPLOY_PHASES } from "./deploy-phases.mjs";
+import { openDeploymentAttempt, parseReleaseArtifactReceipt } from "./deployment-attempt.mjs";
 import {
   DeployFailure,
   SERVICE_LABELS,
@@ -26,8 +27,30 @@ import { assembleReleaseDirectory } from "./release-directory.mjs";
 import { buildReleaseArtifact, findReleaseArtifact, verifyReleaseArtifact } from "./release-artifact.mjs";
 
 const revisions = { from: "a".repeat(40), to: "b".repeat(40) };
+const EXPECTED_PHASES = [
+  "parse-arguments",
+  "check-escalation",
+  "acquire-deploy-lock",
+  "read-revisions",
+  "check-already-deployed",
+  "start-deployment-ledger",
+  "prepare-release-artifact",
+  "verify-release-artifact",
+  "acquire-quiet-window",
+  "prepare-operation-workspace",
+  "verify-stable-service-paths",
+  "backup",
+  "guarded-migration",
+  "generate-prisma-client",
+  "canonical-prompt-sync",
+  "verify-runtime-prisma-client",
+  "assert-quiet-before-restart",
+  "publish-build",
+  "restart-services",
+  "verify-services",
+];
 
-const fixture = (failure = null) => {
+const fixture = ({ failure = null, builderOutput = null } = {}) => {
   const calls = [];
   const phaseCalls = [];
   const records = [];
@@ -43,39 +66,102 @@ const fixture = (failure = null) => {
     return work(...args);
   };
   const releaseName = `${revisions.to}-${"c".repeat(64)}`;
-  const phaseWork = {
-    verifyArtifact: async () => ({
-      releaseDirectoryIdentity: releaseName,
-      buildStamp: { packageName: "@anneal/api", commit: revisions.to, dirty: false },
-    }),
-    backup: async () => ({ backupIdentity: "fixture.dump" }),
-    guardedMigration: async () => ({ migrationTailBefore: "before", migrationTailAfter: "after" }),
-    publishBuild: async () => {
-      state.serving = "candidate";
-      return {
-        releaseDirectoryIdentity: releaseName,
-        releaseIdentity: { name: releaseName, commit: revisions.to, digest: "c".repeat(64) },
-        rollback: async () => { calls.push("rollback-build"); state.serving = "previous"; },
-        commit: async () => { calls.push("commit-build"); },
-      };
-    },
+  const release = {
+    releaseName,
+    releaseDirectory: `/fixture/releases/${releaseName}`,
+    revision: revisions.to,
+    digest: "c".repeat(64),
+    buildStamp: { packageName: "@anneal/api", commit: revisions.to, dirty: false },
   };
-  const host = {
-    ...Object.fromEntries(UPGRADE_DEPLOY_PHASES.map(({ name, hostMethod }) => [
-      hostMethod,
-      step(name, phaseWork[hostMethod]),
-    ])),
-    restorePreviousServices: support("restore-services"),
-    escalate: async (record) => { calls.push("escalate"); state.escalated = record; },
-    notify: async (record) => { calls.push(`notify-${record.outcome}`); },
-    cleanupWorkspace: async () => { calls.push("cleanup-workspace"); },
-  };
+  const resource = (name, extra = {}) => ({
+    ...extra,
+    release: async () => { calls.push(name); },
+  });
+  const lock = resource("release-lock");
+  const barrier = resource("release-barrier", { verify: async () => true });
   const ledger = {
     start: (metadata) => { records.push({ state: "STARTED", metadata }); },
     record: (name, metadata) => { records.push({ state: name, metadata }); },
   };
+  const host = {
+    parseArgs: step("parse-arguments", async () => ({ options: {} })),
+    checkEscalation: step("check-escalation"),
+    acquireLock: step("acquire-deploy-lock", async () => ({ lock, resources: [lock] })),
+    readRevisions: step("read-revisions", async (attempt) => ({
+      revisions: { from: revisions.from, to: attempt.targetCommit },
+    })),
+    checkAlreadyDeployed: step("check-already-deployed", async (attempt) => {
+      assert.equal(attempt.requireFact("revisions").to, revisions.to);
+    }),
+    startDeploymentLedger: step("start-deployment-ledger", async () => ({ ledger })),
+    prepareReleaseArtifact: step("prepare-release-artifact", async () => {
+      if (builderOutput !== null && parseReleaseArtifactReceipt(builderOutput) === null) {
+        throw new DeployFailure("release-artifact-build-failed", "builder-receipt-invalid");
+      }
+      return { preparedRelease: release };
+    }),
+    verifyArtifact: step("verify-release-artifact", async (attempt) => {
+      assert.equal(attempt.requireFact("preparedRelease"), release);
+      return { verifiedRelease: release };
+    }),
+    waitForQuiet: step("acquire-quiet-window", async () => ({ barrier, resources: [barrier] })),
+    prepareWorkspace: step("prepare-operation-workspace", async (attempt) => {
+      assert.equal(attempt.requireFact("verifiedRelease"), release);
+      return {
+        operationWorkspace: "/fixture/operation",
+        resources: [resource("release-workspace")],
+      };
+    }),
+    verifyStableServicePaths: step("verify-stable-service-paths"),
+    backup: step("backup", async (attempt) => {
+      assert.equal(attempt.requireFact("operationWorkspace"), "/fixture/operation");
+      return { backup: { backupIdentity: "fixture.dump" } };
+    }),
+    guardedMigration: step("guarded-migration", async (attempt) => {
+      assert.equal(attempt.requireFact("backup").backupIdentity, "fixture.dump");
+      return { migration: { migrationTailBefore: "before", migrationTailAfter: "after" } };
+    }),
+    generatePrismaClient: step("generate-prisma-client", async (attempt) => {
+      assert.equal(attempt.requireFact("operationWorkspace"), "/fixture/operation");
+    }),
+    syncCanonicalPrompts: step("canonical-prompt-sync", async (attempt) => {
+      assert.equal(attempt.requireFact("operationWorkspace"), "/fixture/operation");
+    }),
+    verifyRuntimePrismaClient: step("verify-runtime-prisma-client", async (attempt) => {
+      assert.equal(attempt.requireFact("operationWorkspace"), "/fixture/operation");
+    }),
+    assertQuietBeforeRestart: step("assert-quiet-before-restart", async (attempt) => {
+      assert.equal(await attempt.requireFact("barrier").verify(), true);
+    }),
+    publishBuild: step("publish-build", async (attempt) => {
+      assert.equal(attempt.requireFact("verifiedRelease"), release);
+      state.serving = "candidate";
+      return {
+        publication: {
+          releaseDirectoryIdentity: releaseName,
+          releaseIdentity: { name: releaseName, commit: revisions.to, digest: "c".repeat(64) },
+          rollback: async () => { calls.push("rollback-build"); state.serving = "previous"; },
+        },
+      };
+    }),
+    restartServices: step("restart-services", async (attempt) => {
+      assert.equal(attempt.requireFact("publication").releaseDirectoryIdentity, releaseName);
+    }),
+    verifyServices: step("verify-services", async () => ({
+      serviceVerification: { activatedBuildStamp: release.buildStamp },
+    })),
+    restorePreviousServices: support("restore-services"),
+    escalate: async (record) => { calls.push("escalate"); state.escalated = record; },
+    notify: async (record) => { calls.push(`notify-${record.outcome}`); },
+  };
   return { host, calls, phaseCalls, records, state, ledger };
 };
+
+const attempt = () => openDeploymentAttempt({
+  deployRoot: "/fixture",
+  targetCommit: revisions.to,
+  transactionId: "fixture-transaction",
+});
 
 const minimalBuildTree = (root, revision) => {
   const dist = join(root, "packages/api/dist");
@@ -122,9 +208,9 @@ test("deployed build stamps require an exact clean commit", () => {
   assert.equal(deployedBuildStampRefusal({ packageName: "@other/api", commit: revisions.to, dirty: false }), "unexpected-package-name");
 });
 
-test("production host requires the artifact-only mechanisms", () => {
-  assert.throws(() => createProductionHost({}), /production-host-adapter-missing:verifyArtifact/u);
-  for (const { hostMethod } of UPGRADE_DEPLOY_PHASES) {
+test("production host requires every deploy phase", () => {
+  assert.throws(() => createProductionHost({}), /production-host-adapter-missing:parseArgs/u);
+  for (const { hostMethod } of DEPLOY_PHASES) {
     const { host } = fixture();
     delete host[hostMethod];
     assert.throws(
@@ -132,18 +218,6 @@ test("production host requires the artifact-only mechanisms", () => {
       new RegExp(`production-host-adapter-missing:${hostMethod}`, "u"),
     );
   }
-});
-
-test("main prefix phase order declares the current artifact deployment boundaries", () => {
-  assert.deepEqual(PREFIX_DEPLOY_PHASES.map(({ name }) => name), [
-    "parse-arguments",
-    "check-escalation",
-    "acquire-deploy-lock",
-    "read-revisions",
-    "check-already-deployed",
-    "start-deployment-ledger",
-    "prepare-release-artifact",
-  ]);
 });
 
 test("release artifact inventory includes deploy runtime and workspace dependencies", () => {
@@ -161,48 +235,55 @@ test("release artifact inventory includes deploy runtime and workspace dependenc
   rmSync(root, { recursive: true, force: true });
 });
 
-test("successful activation verifies artifact before acquiring the quiet window", async () => {
-  const { host, calls, records, ledger } = fixture();
-  assert.deepEqual(await executeUpgrade(host, revisions, { ledger }), { ok: true });
+test("fixture executes the whole deploy sequence with explicit attempt facts", async () => {
+  const { host, calls, phaseCalls, records } = fixture();
+  assert.deepEqual(await executeUpgrade(host, attempt()), { ok: true });
+  assert.deepEqual(phaseCalls, EXPECTED_PHASES);
   assert.deepEqual(calls, [
-    "verify-release-artifact", "acquire-quiet-window", "prepare-operation-workspace", "verify-stable-service-paths", "backup",
-    "guarded-migration", "generate-prisma-client", "canonical-prompt-sync", "verify-runtime-prisma-client",
-    "assert-quiet-before-restart", "publish-build", "restart-services", "verify-services", "notify-success", "commit-build",
-    "cleanup-workspace",
+    ...EXPECTED_PHASES,
+    "notify-success",
+    "release-workspace",
+    "release-barrier",
+    "release-lock",
   ]);
   assert.deepEqual(records.map(({ state }) => state), [
-    "STARTED", "ARTIFACT_VERIFIED", "BACKED_UP", "SCHEMA_ADVANCED", "ACTIVATED", "VERIFIED", "SUCCEEDED",
+    "STARTED", "ARTIFACT_PREPARED", "ARTIFACT_VERIFIED", "BACKED_UP", "SCHEMA_ADVANCED", "ACTIVATED", "VERIFIED", "SUCCEEDED",
   ]);
 });
 
 test("missing artifact records FAILED without quiet-window, build, or activation", async () => {
-  const { host, calls, records, ledger } = fixture();
-  host.verifyArtifact = async () => {
-    calls.push("verify-release-artifact");
-    throw new DeployFailure("release-artifact-missing", revisions.to);
-  };
-  const result = await executeUpgrade(host, revisions, { ledger });
+  const { host, calls, records } = fixture({ failure: "verify-release-artifact" });
+  const result = await executeUpgrade(host, attempt());
   assert.equal(result.ok, false);
-  assert.equal(result.failure.reason, "release-artifact-missing");
+  assert.equal(result.failure.reason, "verify-release-artifact-failed");
   assert.equal(calls.includes("acquire-quiet-window"), false);
   assert.equal(calls.includes("publish-build"), false);
   assert.equal(calls.some((call) => /dependencies|install/u.test(call)), false);
   assert.equal(records.at(-1).state, "FAILED");
 });
 
-test("each declared upgrade phase stops execution at its first failure", async () => {
-  const phaseNames = UPGRADE_DEPLOY_PHASES.map(({ name }) => name);
-  for (const [index, name] of phaseNames.entries()) {
-    const { host, phaseCalls } = fixture(name);
-    const result = await executeUpgrade(host, revisions);
+test("malformed builder receipt records FAILED before the quiet window opens", async () => {
+  const { host, calls, records } = fixture({ builderOutput: "RELEASE-ARTIFACT {not-json}\n" });
+  const result = await executeUpgrade(host, attempt());
+  assert.equal(result.ok, false);
+  assert.equal(result.failure.reason, "release-artifact-build-failed");
+  assert.equal(result.failure.detail, "builder-receipt-invalid");
+  assert.deepEqual(records.map(({ state }) => state), ["STARTED", "FAILED"]);
+  assert.equal(calls.includes("acquire-quiet-window"), false);
+});
+
+test("each independently listed deploy phase stops execution at its first failure", async () => {
+  for (const [index, name] of EXPECTED_PHASES.entries()) {
+    const { host, phaseCalls } = fixture({ failure: name });
+    const result = await executeUpgrade(host, attempt());
     assert.equal(result.ok, false, name);
-    assert.deepEqual(phaseCalls, phaseNames.slice(0, index + 1), name);
+    assert.deepEqual(phaseCalls, EXPECTED_PHASES.slice(0, index + 1), name);
   }
 });
 
 test("service verification failure rolls back before restoring services", async () => {
-  const { host, calls, state } = fixture("verify-services");
-  const result = await executeUpgrade(host, revisions);
+  const { host, calls, state } = fixture({ failure: "verify-services" });
+  const result = await executeUpgrade(host, attempt());
   assert.equal(result.ok, false);
   assert.equal(state.serving, "previous");
   assert.ok(calls.indexOf("rollback-build") < calls.indexOf("restore-services"));
@@ -284,7 +365,7 @@ test("artifact verification reports content digest mismatch distinctly", () => {
 test("dry-run reports artifact readiness and performs no mutation", async () => {
   const calls = [];
   const execution = fixture();
-  assert.deepEqual(await executeUpgrade(execution.host, revisions, { ledger: execution.ledger }), { ok: true });
+  assert.deepEqual(await executeUpgrade(execution.host, attempt()), { ok: true });
   const result = await dryRunDecision({
     revisions: async () => ({ from: revisions.from, to: revisions.to }),
     blockingRuns: async () => [],
@@ -297,14 +378,7 @@ test("dry-run reports artifact readiness and performs no mutation", async () => 
   const plannedPhases = result.lines
     .filter((line) => line.startsWith("DRY-RUN plan step="))
     .map((line) => line.match(/^DRY-RUN plan step=([^ ]+) mutation=skipped$/u)?.[1]);
-  assert.deepEqual(plannedPhases, execution.phaseCalls);
-});
-
-test("deploy source has no install/build fallback, checkout mutation, or legacy publication", () => {
-  const source = readFileSync(new URL("./quiet-window-deploy.mjs", import.meta.url), "utf8");
-  assert.doesNotMatch(source, /npm[^\n]*(?:ci|run["', ]+build)/u);
-  assert.doesNotMatch(source, /worktree|fast-forward|assertProductionCheckout|inspectGitPreflight/u);
-  assert.match(source, /process\.env\.AGENTOS_REPOSITORY_ROOT/u);
+  assert.deepEqual(plannedPhases, EXPECTED_PHASES.slice(7));
 });
 
 test("deploy history prunes recognized backups and leaves unrelated entries", () => {
@@ -323,7 +397,7 @@ test("deploy history prunes recognized backups and leaves unrelated entries", ()
   rmSync(stateDir, { recursive: true, force: true });
 });
 
-test("deployment ledger accepts the artifact verification boundary", () => {
+test("deployment ledger accepts the artifact verification seam", () => {
   assert.ok(DEPLOYMENT_LEDGER_STATES.includes("ARTIFACT_PREPARED"));
   assert.ok(DEPLOYMENT_LEDGER_STATES.includes("ARTIFACT_VERIFIED"));
   const stateDir = mkdtempSync(join(tmpdir(), "anneal-deploy-ledger-"));

--- a/scripts/deploy/quiet-window-host.mjs
+++ b/scripts/deploy/quiet-window-host.mjs
@@ -1,11 +1,11 @@
-import { UPGRADE_DEPLOY_PHASES } from "./deploy-phases.mjs";
+import { DEPLOY_PHASES } from "./deploy-phases.mjs";
 
-/** Import-safe production-host composition boundary used by the real job and harness. */
+/** Import-safe production adapter for the deployment host seam. */
 export const createProductionHost = (adapters) => {
-  for (const { hostMethod: method } of UPGRADE_DEPLOY_PHASES) {
+  for (const { hostMethod: method } of DEPLOY_PHASES) {
     if (typeof adapters[method] !== "function") throw new TypeError(`production-host-adapter-missing:${method}`);
   }
-  for (const method of ["restorePreviousServices", "escalate", "notify", "cleanupWorkspace"]) {
+  for (const method of ["restorePreviousServices", "escalate", "notify"]) {
     if (typeof adapters[method] !== "function") throw new TypeError(`production-host-adapter-missing:${method}`);
   }
   return Object.freeze({ ...adapters });

--- a/scripts/deploy/quiet-window-lib.mjs
+++ b/scripts/deploy/quiet-window-lib.mjs
@@ -1,4 +1,4 @@
-import { UPGRADE_DEPLOY_PHASES } from "./deploy-phases.mjs";
+import { DEPLOY_PHASES, UPGRADE_DEPLOY_PHASES } from "./deploy-phases.mjs";
 
 export const BLOCKING_RUN_STATUSES = Object.freeze(["claimed", "provisioning", "running"]);
 
@@ -47,7 +47,7 @@ export const quietWindowIsOpen = (runs) =>
 
 const DEPLOYED_API_PACKAGE_NAMES = new Set(["@anneal/api", "@agentos/api"]);
 
-/** Accept the one live rename boundary while still requiring a clean exact commit. */
+/** Accept the one live rename seam while still requiring a clean exact commit. */
 export const deployedBuildStampRefusal = (stamp) => {
   if (typeof stamp?.commit !== "string" || !/^[0-9a-f]{40}$/u.test(stamp.commit)) return "invalid-commit";
   if (stamp.dirty !== false) return "dirty-build";
@@ -62,137 +62,69 @@ export const failureOf = (error) => error instanceof DeployFailure
   ? error
   : new DeployFailure("unexpected-error", error instanceof Error ? error.message : String(error));
 
-/**
- * The mutating upgrade pipeline. The host is deliberately narrow so the test
- * harness can prove ordering and stop-on-first-failure without a live checkout,
- * launchd, or PostgreSQL.
- */
-export const executeUpgrade = async (host, initialRevisions, options = {}) => {
-  const ledger = options?.ledger ?? host.ledger;
-  const ledgerStarted = options?.ledgerStarted === true || ledger?.started === true;
-  let publication = null;
-  let revisions = initialRevisions;
+/** Execute the full deployment attempt through the host seam. Every phase
+ * receives the attempt and establishes facts for the phases that follow. */
+export const executeUpgrade = async (host, attempt) => {
   let schemaAdvanced = false;
   let activationAttempted = false;
   let activationOutcomeProven = false;
-  let candidateBuildStamp = null;
-  let context = {};
+  let upgradeStarted = false;
   const ledgerError = (operation, error) => error instanceof DeploymentLedgerError
     ? error
     : new DeploymentLedgerError(operation, error);
   const recordLedger = async (state, metadata = {}) => {
-    if (typeof ledger?.record !== "function") return;
+    const ledger = attempt.fact("ledger");
+    if (!ledger) throw new TypeError("deployment-attempt-fact-missing:ledger");
     try {
-      await ledger.record(state, {
-        targetCommit: revisions.to,
-        ...context,
-        ...metadata,
-      });
+      const record = attempt.ledgerMetadata(metadata);
+      if (state === "STARTED" && typeof ledger.start === "function") await ledger.start(record);
+      else if (typeof ledger.record === "function") await ledger.record(state, record);
+      else throw new TypeError("deployment-ledger-record-missing");
     } catch (error) {
       throw ledgerError("record", error);
     }
   };
   try {
-    if (ledger && !ledgerStarted) {
-      if (typeof ledger.start === "function") {
-        try {
-          await ledger.start({ targetCommit: revisions.to });
-        } catch (error) {
-          throw ledgerError("start", error);
-        }
-      }
-      else await recordLedger("STARTED");
-    }
-    let artifact = null;
     let publicationReady = false;
-    const executePhase = async ({ hostMethod }) => {
-      switch (hostMethod) {
-        case "verifyArtifact": {
-          artifact = await host[hostMethod](revisions.to);
-          candidateBuildStamp = artifact?.buildStamp ?? null;
-          context = {
-            ...context,
-            activatedBuildStamp: candidateBuildStamp,
-            releaseDirectoryIdentity: artifact?.releaseDirectoryIdentity ?? null,
-          };
-          break;
-        }
-        case "prepareWorkspace":
-          await host[hostMethod](artifact);
-          break;
-        case "backup": {
-          const backup = await host[hostMethod]();
-          context = { ...context, backupIdentity: backup?.backupIdentity ?? null };
-          break;
-        }
-        case "guardedMigration": {
-          const migration = await host[hostMethod]();
-          context = {
-            ...context,
-            migrationTailBefore: migration?.migrationTailBefore ?? null,
-            migrationTailAfter: migration?.migrationTailAfter ?? null,
-          };
-          schemaAdvanced = true;
-          break;
-        }
-        case "publishBuild":
-          activationAttempted = true;
-          try {
-            publication = await host[hostMethod]();
-            publicationReady = true;
-            activationOutcomeProven = publication !== null && publication !== undefined;
-          } catch (error) {
-            if (error instanceof DeployFailure && ["build-swap-failed", "release-pointer-activation-failed"].includes(error.reason)) {
-              activationOutcomeProven = true;
-            }
-            throw error;
-          }
-          context = {
-            ...context,
-            activatedBuildStamp: candidateBuildStamp,
-            ...(publication?.releaseDirectoryIdentity
-              ? { releaseDirectoryIdentity: publication.releaseDirectoryIdentity }
-              : publication?.releaseIdentity?.name
-                ? { releaseDirectoryIdentity: publication.releaseIdentity.name }
-                : {}),
-            ...(publication?.pointerOldTarget !== undefined ? { pointerOldTarget: publication.pointerOldTarget } : {}),
-            ...(publication?.pointerNewTarget !== undefined ? { pointerNewTarget: publication.pointerNewTarget } : {}),
-            ...(publication?.releaseIdentity ? { releaseIdentity: publication.releaseIdentity } : {}),
-            ...(publication?.pointerTransition ? { pointerTransition: publication.pointerTransition } : {}),
-          };
-          break;
-        case "verifyServices": {
-          const verification = await host[hostMethod](revisions);
-          context = {
-            ...context,
-            activatedBuildStamp: verification?.activatedBuildStamp ?? context.activatedBuildStamp,
-          };
-          break;
-        }
-        default:
-          await host[hostMethod]();
-      }
-    };
     try {
-      for (const phase of UPGRADE_DEPLOY_PHASES) {
-        await executePhase(phase);
+      for (const phase of DEPLOY_PHASES) {
+        if (phase.scope === "upgrade") upgradeStarted = true;
+        if (phase.hostMethod === "publishBuild") activationAttempted = true;
+        let facts;
+        try {
+          facts = await host[phase.hostMethod](attempt);
+        } catch (error) {
+          if (phase.hostMethod === "publishBuild"
+            && error instanceof DeployFailure
+            && ["build-swap-failed", "release-pointer-activation-failed"].includes(error.reason)) {
+            activationOutcomeProven = true;
+          }
+          throw error;
+        }
+        attempt.establish(facts);
+        if (phase.hostMethod === "guardedMigration") schemaAdvanced = true;
+        if (phase.hostMethod === "publishBuild") {
+          publicationReady = attempt.fact("publication") !== undefined;
+          activationOutcomeProven = publicationReady;
+        }
         if (phase.ledgerState !== null) await recordLedger(phase.ledgerState);
+        if (attempt.fact("skip")) return { ok: true, skipped: attempt.fact("skip") };
       }
       await recordLedger("SUCCEEDED");
-      await host.notify({ outcome: "success", reason: "deployed", ...revisions });
+      await host.notify({ outcome: "success", reason: "deployed", ...attempt.requireFact("revisions") });
     } catch (error) {
       if (publicationReady) {
         try {
-          const rollbackPointerOutcome = await publication.rollback();
+          const rollbackPointerOutcome = await attempt.requireFact("publication").rollback();
           if (rollbackPointerOutcome !== null && rollbackPointerOutcome !== undefined) {
             const durableOutcome = typeof rollbackPointerOutcome === "string"
               ? rollbackPointerOutcome
               : rollbackPointerOutcome.operation && rollbackPointerOutcome.oldTarget && rollbackPointerOutcome.newTarget
                 ? `${rollbackPointerOutcome.operation}:${rollbackPointerOutcome.oldTarget}->${rollbackPointerOutcome.newTarget}`
                 : String(rollbackPointerOutcome.outcome ?? rollbackPointerOutcome);
-            context = { ...context, rollbackPointerOutcome: durableOutcome };
+            attempt.establish({ rollbackPointerOutcome: durableOutcome });
           }
-          await host.restorePreviousServices();
+          await host.restorePreviousServices(attempt);
           activationOutcomeProven = true;
         } catch (recoveryError) {
           activationOutcomeProven = false;
@@ -201,11 +133,11 @@ export const executeUpgrade = async (host, initialRevisions, options = {}) => {
       }
       throw error;
     }
-    await publication.commit();
     return { ok: true };
   } catch (error) {
     const failure = failureOf(error);
     let terminalLedgerFailure = null;
+    const ledger = attempt.fact("ledger");
     if (ledger && failure.reason !== "deployment-ledger-write-failed") {
       const terminalState = schemaAdvanced && activationAttempted && !activationOutcomeProven
         ? "MANUAL_RECOVERY"
@@ -219,13 +151,18 @@ export const executeUpgrade = async (host, initialRevisions, options = {}) => {
     } else if (failure.reason === "deployment-ledger-write-failed") {
       host.log?.(`STOP ${failure.reason}${failure.detail ? ` detail=${failure.detail}` : ""}`);
     }
+    const revisions = attempt.fact("revisions") ?? { from: "unknown", to: attempt.targetCommit };
     const record = { outcome: "failure", reason: failure.reason, detail: failure.detail, ...revisions };
-    await host.escalate(record);
-    try {
-      await host.notify(record);
-      await host.markEscalationNotified?.();
-    } catch (notificationError) {
-      host.log?.(`STOP inbox-notification-pending reason=${failure.reason}`);
+    if (shouldPersistFailure({ dryRun: false, reason: failure.reason, upgradeStarted })) {
+      await host.escalate(record);
+      try {
+        await host.notify(record);
+        await host.markEscalationNotified?.();
+      } catch (notificationError) {
+        host.log?.(`STOP inbox-notification-pending reason=${failure.reason}`);
+      }
+    } else {
+      host.log?.(`STOP ${failure.reason}${failure.detail ? ` detail=${failure.detail}` : ""}; no-upgrade-started`);
     }
     return {
       ok: false,
@@ -233,7 +170,7 @@ export const executeUpgrade = async (host, initialRevisions, options = {}) => {
       ...(terminalLedgerFailure ? { ledgerFailure: terminalLedgerFailure } : {}),
     };
   } finally {
-    await host.cleanupWorkspace();
+    await attempt.release();
   }
 };
 


### PR DESCRIPTION
## What changed

- Added a DeploymentAttempt module opened with deploy root, target commit, and transaction id. It owns phase facts and releases acquired lock, quiet-window barrier, and operation workspace resources through one interface call.
- Made all twenty DEPLOY_PHASES executable through the same host seam. Production and fixture adapters receive the attempt and return established facts; createProductionHost now validates every phase.
- Removed the enclosing mutable phase state, the cleanupWorkspace adapter, and the vestigial publication commit hook.
- Replaced the source-text ordering/absence assertions with an independently written fixture adapter that executes the complete twenty-phase contract and a malformed builder receipt test that proves FAILED is recorded before the quiet window opens.

## Evidence

- npm run lint — PASS (Biome checked 591 files; ESLint exit 0).
- npm run typecheck — PASS.
- npm run test:auto-deploy — PASS (48 tests).
- node --test scripts/deploy/ — FAIL before discovery on Node v26.5.0 because the directory is treated as a module path: MODULE_NOT_FOUND scripts/deploy.
- node --test scripts/deploy/*.test.mjs — PASS (48 tests; every scripts/deploy test file).

## Reported but unfixed

- The brief command node --test scripts/deploy/ is not directory-discoverable under the current Node v26.5.0 runtime. The repository-declared test command and the explicit scripts/deploy/*.test.mjs command both pass; no test runner configuration was changed.
- No ownership fence was hit.