### PR TITLE
test(web): deepen DOM harness for page tests

### DIFF
--- a/apps/web/src/tests/agent-tools.test.tsx
+++ b/apps/web/src/tests/agent-tools.test.tsx
@@ -11,6 +11,7 @@ import type { Agent, RunnerPreference } from "../lib/types";
 import { claudeDeclaration } from "../../../../packages/runner/src/adapters/claude.js";
 import { codexDeclaration } from "../../../../packages/runner/src/adapters/codex.js";
 import { piDeclaration } from "../../../../packages/runner/src/adapters/pi.js";
+import { installFetchFunction } from "./dom-harness";
 
 const agent = (overrides: Partial<Agent> = {}): Agent => ({
   id: "a", projectId: "p", environmentId: "e", name: "senior-dev", title: "Senior Developer",
@@ -90,11 +91,10 @@ test("rapid tool toggles serialize union writes and ignore a stale poll in fligh
   const root = createRoot(container);
   const calls: RequestInit[] = [];
   const releases: Array<(response: Response) => void> = [];
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (_input: string | URL | Request, init?: RequestInit) => {
+  const fetchHarness = installFetchFunction(async (_input, init) => {
     calls.push(init ?? {});
     return await new Promise<Response>((resolve) => releases.push(resolve));
-  } });
+  });
   let saved = 0;
   const stale = agent();
   const state = (label: string): string | null => dom.window.document.querySelector(`[aria-label="${label}"]`)?.getAttribute("data-state") ?? null;
@@ -129,7 +129,7 @@ test("rapid tool toggles serialize union writes and ignore a stale poll in fligh
     });
     assert.equal(saved, 1);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    fetchHarness.dispose();
     await act(async () => root.unmount());
     dom.window.close();
   }
@@ -148,11 +148,10 @@ test("a failed tool write rolls back while a later queued intent converges from 
   const root = createRoot(container);
   const calls: RequestInit[] = [];
   const releases: Array<(response: Response) => void> = [];
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (_input: string | URL | Request, init?: RequestInit) => {
+  const fetchHarness = installFetchFunction(async (_input, init) => {
     calls.push(init ?? {});
     return await new Promise<Response>((resolve) => releases.push(resolve));
-  } });
+  });
   let saved = 0;
   const state = (label: string): string | null => dom.window.document.querySelector(`[aria-label="${label}"]`)?.getAttribute("data-state") ?? null;
   const click = async (label: string): Promise<void> => {
@@ -186,7 +185,7 @@ test("a failed tool write rolls back while a later queued intent converges from 
     assert.equal(state("Enable Bash"), "checked");
     assert.equal(state("Enable Web search"), "unchecked");
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    fetchHarness.dispose();
     await act(async () => root.unmount());
     dom.window.close();
   }

--- a/apps/web/src/tests/chain-aggregate-board.test.tsx
+++ b/apps/web/src/tests/chain-aggregate-board.test.tsx
@@ -10,7 +10,7 @@ import { COLUMNS, type BoardEntry, boardEntries, boardEntriesByStatus, countBySt
 import { translate } from "../lib/i18n-core";
 import type { BoardTask, ChainAggregate, TaskStatus } from "../lib/types";
 import { useTaskStartConfirmation } from "../pages/Tasks";
-import { installDom, reactDom } from "./dom-harness";
+import { installDom, mountPage, reactDom } from "./dom-harness";
 
 const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
   id: "task-1", name: "Release: Build", displayName: "Build", status: "TODO", moveTargets: [], failureReason: null,
@@ -158,14 +158,11 @@ const AggregateActivationHarness = (): ReactNode => {
 };
 
 test("aggregate Activate starts step zero and keeps a stale-view 4xx visible", async () => {
-  const { dom, container } = installDom();
-  const originalFetch = globalThis.fetch;
   const requests: Array<{ method: string; path: string }> = [];
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (input: string, init?: RequestInit) => {
+  const page = await mountPage(<AggregateActivationHarness />, { "*": ({ input, method }) => {
     const path = String(input);
-    const method = init?.method ?? "GET";
     requests.push({ method, path });
-    if (path === "/api/tasks/step-1/startability") return Response.json({
+    if (path === "/api/tasks/step-1/startability") return {
       startable: true,
       checklist: {
         repoBound: true, agentAssignee: true, repoAccessGrant: true,
@@ -175,35 +172,19 @@ test("aggregate Activate starts step zero and keeps a stale-view 4xx visible", a
         id: "step-1", name: "Release: Build", agent: { id: "a1", title: "Senior dev" },
         repo: { id: "r1", name: "product" }, targetBranch: "main",
       },
-    });
+    };
     if (path === "/api/tasks/step-1/start" && method === "POST") {
       return Response.json({ error: "This chain was already activated." }, { status: 409 });
     }
     return Response.json([], { status: 404 });
   } });
-  const root = (await reactDom()).createRoot(container);
-  const settle = async (): Promise<void> => {
-    for (let round = 0; round < 3; round += 1) {
-      await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
-    }
-  };
-  const press = async (label: string): Promise<void> => {
-    const button = [...dom.window.document.querySelectorAll<HTMLButtonElement>("button")]
-      .find((candidate) => candidate.textContent?.trim() === label);
-    assert.ok(button, `no ${label} button`);
-    await act(async () => button.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
-    await settle();
-  };
   try {
-    await act(async () => root.render(<AggregateActivationHarness />));
-    await press("Activate");
-    assert.ok(container.querySelector("[data-aggregate-confirmation]"));
-    await press("Confirm activation");
+    await page.press("Activate");
+    assert.ok(page.container.querySelector("[data-aggregate-confirmation]"));
+    await page.press("Confirm activation");
     assert.equal(requests.filter(({ method, path }) => method === "POST" && path === "/api/tasks/step-1/start").length, 1);
-    assert.match(container.textContent ?? "", /already activated/u);
+    assert.match(page.container.textContent ?? "", /already activated/u);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
   }
 });

--- a/apps/web/src/tests/conditional-poll.test.tsx
+++ b/apps/web/src/tests/conditional-poll.test.tsx
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { ApiError, api } from "../lib/api";
+import { installFetchFunction } from "./dom-harness";
 
 type Call = { url: string; init: RequestInit };
 
@@ -11,12 +12,9 @@ const withFetch = async (
   work: () => Promise<void>,
 ): Promise<Call[]> => {
   const calls: Call[] = [];
-  const original = globalThis.fetch;
   let index = 0;
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (url: string, init: RequestInit) => {
-      calls.push({ url, init });
+  const fetchHarness = installFetchFunction(async (url, init = {}) => {
+      calls.push({ url: String(url), init });
       const scripted = responses[index++] ?? { status: 500 };
       const headers = new Headers();
       if (scripted.etag !== null && scripted.etag !== undefined) headers.set("ETag", scripted.etag);
@@ -24,12 +22,11 @@ const withFetch = async (
         status: scripted.status,
         headers,
       });
-    },
   });
   try {
     await work();
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: original });
+    fetchHarness.dispose();
   }
   return calls;
 };

--- a/apps/web/src/tests/costs.test.tsx
+++ b/apps/web/src/tests/costs.test.tsx
@@ -1,9 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { act } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { installDom, reactDom } from "./dom-harness";
+import { mountPage } from "./dom-harness";
 
 import {
   COSTS_COLUMNS, COSTS_RANGES, ChartLegend, DailySpendChart, ModelBar, SERIES_SLOTS, axisDates,
@@ -173,20 +172,13 @@ const report = (overrides: Partial<CostsReport> = {}): CostsReport => ({
   ...overrides,
 });
 
-const settle = async (): Promise<void> => {
-  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 10)); });
-};
-
 /** Mounts the page against a scripted control plane, reads it, and unmounts.
  *  The unmount is not tidiness: `usePoll` holds a `setInterval`, and a root left
  *  mounted keeps the test process alive forever. */
 const readPage = async (body: CostsReport): Promise<{ text: string; html: string; requested: string[] }> => {
-  const { container } = installDom("http://127.0.0.1:5173/costs");
-  const [{ createRoot }, { CostsPage }, { ProjectProvider }] = await Promise.all([
-    reactDom(), import("../pages/Costs"), import("../lib/project"),
-  ]);
+  const [{ CostsPage }, { ProjectProvider }] = await Promise.all([import("../pages/Costs"), import("../lib/project")]);
   const requested: string[] = [];
-  globalThis.fetch = (async (input: string | URL | Request) => {
+  const page = await mountPage(<ProjectProvider><CostsPage /></ProjectProvider>, { "*": ({ input }) => {
     const url = String(input).replace(/^.*\/api/, "");
     requested.push(url);
     if (url === "/projects") {
@@ -194,17 +186,11 @@ const readPage = async (body: CostsReport): Promise<{ text: string; html: string
     }
     if (url.startsWith("/projects/p1/costs")) return new Response(JSON.stringify(body), { status: 200 });
     return new Response("[]", { status: 200 });
-  }) as typeof fetch;
-  const root = createRoot(container);
+  } }, "http://127.0.0.1:5173/costs");
   try {
-    act(() => root.render(<ProjectProvider><CostsPage /></ProjectProvider>));
-    // Two settles: the first resolves `/projects`, which is what gives the page
-    // a project id to ask for costs with.
-    await settle();
-    await settle();
-    return { text: container.textContent ?? "", html: container.innerHTML, requested };
+    return { text: page.container.textContent ?? "", html: page.container.innerHTML, requested };
   } finally {
-    act(() => root.unmount());
+    await page.dispose();
   }
 };
 

--- a/apps/web/src/tests/dom-harness.ts
+++ b/apps/web/src/tests/dom-harness.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
+import { act, type ReactElement } from "react";
 
 /**
  * A jsdom the React DOM client believes in, and the client loaded against it.
@@ -19,6 +20,7 @@ export const installDom = (url = "http://127.0.0.1:5173/"): { dom: JSDOM; contai
     window: dom.window, document: dom.window.document, navigator: dom.window.navigator,
     HTMLElement: dom.window.HTMLElement, HTMLButtonElement: dom.window.HTMLButtonElement,
     HTMLFormElement: dom.window.HTMLFormElement, HTMLInputElement: dom.window.HTMLInputElement,
+    HTMLSelectElement: dom.window.HTMLSelectElement, HTMLTextAreaElement: dom.window.HTMLTextAreaElement,
     Element: dom.window.Element, Node: dom.window.Node, MutationObserver: dom.window.MutationObserver,
     // React compares dispatched events against the *global* constructors, so a
     // window whose Event/InputEvent/MouseEvent are not the global ones has its
@@ -42,4 +44,226 @@ export const reactDom = async (): Promise<typeof import("react-dom/client")> => 
   assert.ok(globalThis.document !== undefined, "installDom() runs before reactDom()");
   client ??= import("react-dom/client");
   return await client;
+};
+
+export type PageRequest = {
+  input: string | URL | Request;
+  init: RequestInit;
+  method: string;
+  path: string;
+  requestIndex: number;
+  routeIndex: number;
+};
+
+export type PageRouteResult = Response | string | number | boolean | null | readonly unknown[] | { [key: string]: unknown };
+export type PageRoute = PageRouteResult | ((request: PageRequest) => PageRouteResult | Promise<PageRouteResult>);
+export type PageRoutes = Record<string, PageRoute>;
+export type FetchImplementation = (input: string | URL | Request, init?: RequestInit) => Response | Promise<Response>;
+
+export type FetchHarness = {
+  requests: PageRequest[];
+  settle: () => Promise<void>;
+  dispose: () => void;
+};
+
+export type PageHarness = FetchHarness & {
+  dom: JSDOM;
+  container: Element;
+  press: (label: string) => Promise<void>;
+  dispose: () => Promise<void>;
+};
+
+const descriptor = (key: PropertyKey): PropertyDescriptor | undefined =>
+  Object.getOwnPropertyDescriptor(globalThis, key);
+
+const restore = (key: PropertyKey, previous: PropertyDescriptor | undefined): void => {
+  if (previous === undefined) Reflect.deleteProperty(globalThis, key);
+  else Object.defineProperty(globalThis, key, previous);
+};
+
+const requestPath = (input: string | URL | Request): string => {
+  const address = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+  const location = globalThis.window?.location.href;
+  const base = location?.startsWith("http://") || location?.startsWith("https://") ? location : "http://127.0.0.1/";
+  const url = new URL(address, base);
+  const path = `${url.pathname}${url.search}`;
+  return path.startsWith("/api/") ? path.slice(4) : path;
+};
+
+const routeKeys = (method: string, path: string): string[] => {
+  const pathname = path.split("?", 1)[0]!;
+  return [`${method} ${path}`, path, `${method} ${pathname}`, pathname, "*"];
+};
+
+const responseFrom = (value: unknown): Response => {
+  if (value instanceof Response || (
+    typeof value === "object" && value !== null && "ok" in value && "status" in value &&
+    "text" in value && typeof value.text === "function"
+  )) return value as Response;
+  return Response.json(value);
+};
+
+/**
+ * Installs the test-side fetch seam and observes when its work becomes quiet.
+ *
+ * Route keys are a path, `METHOD path`, or `*`; paths are relative to `/api`.
+ * Values are JSON responses unless the route returns a `Response` itself.
+ */
+export const installFetch = (routes: PageRoutes): FetchHarness => {
+  const previousFetch = descriptor("fetch");
+  const requests: PageRequest[] = [];
+  const routeCounts = new Map<string, number>();
+  const observedResponses = new WeakSet<object>();
+  let activity = 0;
+  let disposed = false;
+
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    writable: true,
+    value: async (input: string | URL | Request, suppliedInit?: RequestInit): Promise<Response> => {
+      const init = suppliedInit ?? (input instanceof Request ? {
+        method: input.method,
+        headers: input.headers,
+        body: input.body,
+        signal: input.signal,
+      } : {});
+      const method = (init.method ?? "GET").toUpperCase();
+      const path = requestPath(input);
+      const routeKey = routeKeys(method, path).find((key) => Object.hasOwn(routes, key));
+      assert.ok(routeKey, `unhandled fetch route: ${method} ${path}`);
+      const routeIndex = (routeCounts.get(routeKey) ?? 0) + 1;
+      routeCounts.set(routeKey, routeIndex);
+      const request = { input, init, method, path, requestIndex: requests.length + 1, routeIndex };
+      requests.push(request);
+      activity += 1;
+      try {
+        const route = routes[routeKey];
+        const response = responseFrom(typeof route === "function" ? await route(request) : route);
+        if (!observedResponses.has(response)) {
+          observedResponses.add(response);
+          for (const name of ["text", "json", "arrayBuffer", "blob", "formData"] as const) {
+            const bodyReader = response[name];
+            if (typeof bodyReader !== "function") continue;
+            Object.defineProperty(response, name, {
+              configurable: true,
+              value: async () => {
+                activity += 1;
+                try {
+                  return await bodyReader.call(response);
+                } finally {
+                  activity += 1;
+                }
+              },
+            });
+          }
+        }
+        return response;
+      } finally {
+        activity += 1;
+      }
+    },
+  });
+
+  return {
+    requests,
+    settle: async () => {
+      let previousActivity: number | null = null;
+      for (let guard = 0; guard < 100; guard += 1) {
+        await act(async () => { await Promise.resolve(); });
+        if (activity === previousActivity) return;
+        previousActivity = activity;
+      }
+      assert.fail("fetch did not become quiet after 100 observed state changes");
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      restore("fetch", previousFetch);
+    },
+  };
+};
+
+/** Adapts a protocol-level fetch double for tests that exercise the client itself. */
+export const installFetchFunction = (implementation: FetchImplementation): FetchHarness =>
+  installFetch({ "*": ({ input, init }) => implementation(input, init) });
+
+/** Runs work with a fetch route table and always restores the global seam. */
+export const withFetch = async <T>(routes: PageRoutes, work: (fetch: FetchHarness) => Promise<T>): Promise<T> => {
+  const harness = installFetch(routes);
+  try {
+    return await work(harness);
+  } finally {
+    harness.dispose();
+  }
+};
+
+/** Mounts an element and returns it only after fetch and DOM activity is quiet. */
+export const mountPage = async (
+  element: ReactElement,
+  routes: PageRoutes,
+  url = "http://127.0.0.1:5173/",
+  prepareDom?: (dom: JSDOM) => void,
+): Promise<PageHarness> => {
+  const globalKeys = [
+    "window", "document", "navigator", "HTMLElement", "HTMLButtonElement", "HTMLFormElement",
+    "HTMLInputElement", "HTMLSelectElement", "HTMLTextAreaElement", "Element", "Node", "MutationObserver", "Event", "InputEvent", "MouseEvent",
+    "IS_REACT_ACT_ENVIRONMENT",
+  ] as const;
+  const previousGlobals = new Map(globalKeys.map((key) => [key, descriptor(key)]));
+  const { dom, container } = installDom(url);
+  prepareDom?.(dom);
+  const fetch = installFetch(routes);
+  const root = (await reactDom()).createRoot(container);
+  let mutations = 0;
+  let disposed = false;
+  const observer = new dom.window.MutationObserver(() => { mutations += 1; });
+  observer.observe(container, { attributes: true, childList: true, characterData: true, subtree: true });
+
+  const settle = async (): Promise<void> => {
+    let previousSnapshot: string | null = null;
+    for (let guard = 0; guard < 100; guard += 1) {
+      await fetch.settle();
+      const snapshot = `${fetch.requests.length}:${mutations}`;
+      if (snapshot === previousSnapshot) return;
+      previousSnapshot = snapshot;
+    }
+    assert.fail("page did not become quiet after 100 observed state changes");
+  };
+
+  const dispose = async (): Promise<void> => {
+    if (disposed) return;
+    disposed = true;
+    try {
+      await act(async () => root.unmount());
+    } finally {
+      observer.disconnect();
+      fetch.dispose();
+      dom.window.close();
+      for (const key of globalKeys) restore(key, previousGlobals.get(key));
+    }
+  };
+
+  try {
+    await act(async () => root.render(element));
+    await settle();
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
+
+  return {
+    dom,
+    container,
+    requests: fetch.requests,
+    settle,
+    press: async (label: string) => {
+      const button = [...container.querySelectorAll("button")].find((node) => (
+        node.textContent?.trim() === label || node.getAttribute("aria-label") === label
+      ));
+      assert.ok(button, `missing button ${label}: ${container.innerHTML}`);
+      await act(async () => button.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
+      await settle();
+    },
+    dispose,
+  };
 };

--- a/apps/web/src/tests/event-stream.test.tsx
+++ b/apps/web/src/tests/event-stream.test.tsx
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { JSDOM } from "jsdom";
+import type { JSDOM } from "jsdom";
 import { act } from "react";
-import { createRoot } from "react-dom/client";
 
 import { BACKOFF_CEILING_MS, EVENT_PAGE_CEILING, nextIntervalMs, toEnvelope } from "../lib/use-event-stream";
 import type { SessionEvent } from "../lib/types";
+import { installDom, installFetchFunction, reactDom } from "./dom-harness";
 
 const row = (seq: number): SessionEvent => ({
   id: `e${seq}`, sessionId: "s1", runId: "r1", seq, at: "2026-08-16T00:00:00.000Z",
@@ -54,26 +54,15 @@ const withHook = async (
     setTerminal: (value: boolean) => Promise<void>;
   }) => Promise<void>,
 ): Promise<void> => {
-  const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { pretendToBeVisual: true });
-  const globals = {
-    window: dom.window, document: dom.window.document, navigator: dom.window.navigator,
-    HTMLElement: dom.window.HTMLElement, Element: dom.window.Element, Node: dom.window.Node,
-    MutationObserver: dom.window.MutationObserver,
-  };
-  for (const [key, value] of Object.entries(globals)) Object.defineProperty(globalThis, key, { configurable: true, value });
-  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  const { dom, container } = installDom();
 
   const requests: string[] = [];
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       requests.push(path);
       const result = respond(path);
       if (result instanceof Error) throw result;
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(result) } as unknown as Response;
-    },
   });
 
   // A tiny hand-rolled clock: node:test's mock timers do not survive React's
@@ -98,15 +87,10 @@ const withHook = async (
     return null;
   };
 
-  const container = dom.window.document.querySelector("#root");
-  assert.ok(container);
-  const root = createRoot(container);
+  const root = (await reactDom()).createRoot(container);
   rerender = () => root.render(<Probe isTerminal={terminal} />);
 
-  // Let every microtask-resolved fetch settle before asserting.
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 12; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   const advance = async (ms: number): Promise<void> => {
     const target = now + ms;
     for (let guard = 0; guard < 200; guard += 1) {
@@ -138,7 +122,7 @@ const withHook = async (
   } finally {
     await act(async () => root.unmount());
     Object.defineProperty(dom.window, "setTimeout", { configurable: true, value: realSetTimeout });
-    if (originalFetch) Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    fetchHarness.dispose();
     dom.window.close();
   }
 };

--- a/apps/web/src/tests/foundation.test.tsx
+++ b/apps/web/src/tests/foundation.test.tsx
@@ -1,32 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { JSDOM } from "jsdom";
 import { act } from "react";
-import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { contentRevision } from "../lib/format";
 import type { Agent } from "../lib/types";
 import { AgentDetailPage, NewAgent } from "../pages/Agents";
+import { installDom, installFetchFunction, reactDom } from "./dom-harness";
 
 const value: Agent = {
   id: "a", projectId: "p", environmentId: "e", name: "senior-dev", title: "Senior Developer",
   model: "claude-opus-5:high", codexServiceTier: "DEFAULT", runnerPreference: "CLAUDE", inboxAccess: false, disabledTools: [],
   foundationalPrompt: "the canonical foundation", rolePrompt: "role", createdAt: "2026-08-16T00:00:00.000Z",
   updatedAt: "2026-08-16T00:00:00.000Z", archivedAt: null,
-};
-
-const installDom = (): { dom: JSDOM; container: Element } => {
-  const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { pretendToBeVisual: true, url: "http://localhost/agents/a" });
-  for (const [key, item] of Object.entries({
-    window: dom.window, document: dom.window.document, navigator: dom.window.navigator,
-    HTMLElement: dom.window.HTMLElement, HTMLButtonElement: dom.window.HTMLButtonElement, HTMLFormElement: dom.window.HTMLFormElement,
-    Element: dom.window.Element, Node: dom.window.Node, MutationObserver: dom.window.MutationObserver,
-  })) Object.defineProperty(globalThis, key, { configurable: true, value: item });
-  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
-  const container = dom.window.document.querySelector("#root");
-  assert.ok(container);
-  return { dom, container };
 };
 
 test("foundation content revisions are stable, distinct and exactly seven hex characters", () => {
@@ -41,14 +27,13 @@ test("the create form has no Foundation field or request key", async () => {
   assert.equal((staticMarkup.match(/<textarea/gu) ?? []).length, 1, "only the role prompt remains");
   assert.doesNotMatch(staticMarkup, /Anneal foundation/iu);
 
-  const { dom, container } = installDom();
-  const root = createRoot(container);
-  const originalFetch = globalThis.fetch;
+  const { dom, container } = installDom("http://localhost/agents/a");
+  const root = (await reactDom()).createRoot(container);
   const requests: RequestInit[] = [];
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (_input: string | URL | Request, init?: RequestInit) => {
+  const fetchHarness = installFetchFunction(async (_input, init) => {
     requests.push(init ?? {});
     return new Response(JSON.stringify(init?.method === "POST" ? value : []), { status: init?.method === "POST" ? 201 : 200 });
-  } });
+  });
   try {
     await act(async () => {
       root.render(<NewAgent projectId="p" onClose={() => undefined} onCreated={() => undefined}
@@ -66,22 +51,21 @@ test("the create form has no Foundation field or request key", async () => {
     const body = JSON.parse(String(post.body)) as Record<string, unknown>;
     assert.equal("foundationalPrompt" in body, false);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    fetchHarness.dispose();
     await act(async () => root.unmount());
     dom.window.close();
   }
 });
 
 test("edit mode keeps Foundation read-only and the save payload omits it", async () => {
-  const { dom, container } = installDom();
-  const root = createRoot(container);
-  const originalFetch = globalThis.fetch;
+  const { dom, container } = installDom("http://localhost/agents/a");
+  const root = (await reactDom()).createRoot(container);
   const requests: RequestInit[] = [];
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (input: string | URL | Request, init?: RequestInit) => {
+  const fetchHarness = installFetchFunction(async (input, init) => {
     requests.push(init ?? {});
     const body = String(input).endsWith("/agents/a") ? value : [];
     return new Response(JSON.stringify(body), { status: 200 });
-  } });
+  });
   const button = (text: string): HTMLButtonElement => {
     const match = [...dom.window.document.querySelectorAll("button")].find((candidate) => candidate.textContent?.trim() === text);
     assert.ok(match, text);
@@ -111,7 +95,7 @@ test("edit mode keeps Foundation read-only and the save payload omits it", async
     assert.deepEqual(Object.keys(body).sort(), ["codexServiceTier", "inboxAccess", "model", "name", "rolePrompt", "runnerPreference", "title"]);
     assert.equal("foundationalPrompt" in body, false);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    fetchHarness.dispose();
     await act(async () => root.unmount());
     dom.window.close();
   }

--- a/apps/web/src/tests/inbox-artifact.test.tsx
+++ b/apps/web/src/tests/inbox-artifact.test.tsx
@@ -1,9 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { act } from "react";
-
-import { installDom, reactDom } from "./dom-harness";
+import { mountPage } from "./dom-harness";
 import type { InboxMessage, TaskStepOutput } from "../lib/types";
 
 const now = "2026-08-25T00:00:00.000Z";
@@ -27,62 +25,44 @@ const artifact: TaskStepOutput = {
   body: "FULL ARTIFACT TAIL", createdAt: now, updatedAt: now,
 };
 
-const settle = async (): Promise<void> => {
-  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 10)); });
-};
-
 test("an approval gate shows the producing step's full artifact, not just the card's truncated preview", async () => {
-  const { container } = installDom("http://127.0.0.1:5173/inbox/gate-1");
-  const [{ createRoot }, { InboxThreadPage }, { ProjectProvider }] = await Promise.all([
-    reactDom(), import("../pages/Inbox"), import("../lib/project"),
-  ]);
+  const [{ InboxThreadPage }, { ProjectProvider }] = await Promise.all([import("../pages/Inbox"), import("../lib/project")]);
 
   const requested: string[] = [];
-  globalThis.fetch = (async (input: string | URL | Request) => {
+  const page = await mountPage(<ProjectProvider><InboxThreadPage messageId="gate-1" /></ProjectProvider>, { "*": ({ input }) => {
     const url = String(input).replace(/^.*\/api/, "");
     requested.push(url);
     if (url === "/inbox/messages") return new Response(JSON.stringify([gateCard()]), { status: 200 });
     if (url === "/tasks/producing-task/output") return new Response(JSON.stringify(artifact), { status: 200 });
     return new Response("[]", { status: 200 });
-  }) as typeof fetch;
-
-  const root = createRoot(container);
+  } }, "http://127.0.0.1:5173/inbox/gate-1");
   try {
-    act(() => root.render(<ProjectProvider><InboxThreadPage messageId="gate-1" /></ProjectProvider>));
-    await settle();
-    const text = container.textContent ?? "";
+    const text = page.container.textContent ?? "";
     assert.match(text, /PREVIEW HEAD/);
     // The point of the card: the part the preview cut off is on screen.
     assert.match(text, /FULL ARTIFACT TAIL/);
     // And the producing step is reachable, where before only the gate step was.
-    assert.ok(container.querySelector("a[href='#/tasks/producing-task']"));
+    assert.ok(page.container.querySelector("a[href='#/tasks/producing-task']"));
     assert.ok(requested.includes("/tasks/producing-task/output"));
   } finally {
-    act(() => root.unmount());
+    await page.dispose();
   }
 });
 
 test("a card that is not an approval gate polls no artifact at all", async () => {
-  const { container } = installDom("http://127.0.0.1:5173/inbox/plain-1");
-  const [{ createRoot }, { InboxThreadPage }, { ProjectProvider }] = await Promise.all([
-    reactDom(), import("../pages/Inbox"), import("../lib/project"),
-  ]);
+  const [{ InboxThreadPage }, { ProjectProvider }] = await Promise.all([import("../pages/Inbox"), import("../lib/project")]);
 
   const requested: string[] = [];
   const plain: InboxMessage = { ...gateCard(), id: "plain-1", kind: "TEXT", gateTaskId: null, artifactTaskId: null, choices: null, body: "A plain question" };
-  globalThis.fetch = (async (input: string | URL | Request) => {
+  const page = await mountPage(<ProjectProvider><InboxThreadPage messageId="plain-1" /></ProjectProvider>, { "*": ({ input }) => {
     const url = String(input).replace(/^.*\/api/, "");
     requested.push(url);
     if (url === "/inbox/messages") return new Response(JSON.stringify([plain]), { status: 200 });
     return new Response("[]", { status: 200 });
-  }) as typeof fetch;
-
-  const root = createRoot(container);
+  } }, "http://127.0.0.1:5173/inbox/plain-1");
   try {
-    act(() => root.render(<ProjectProvider><InboxThreadPage messageId="plain-1" /></ProjectProvider>));
-    await settle();
     assert.ok(!requested.some((url) => url.endsWith("/output")));
   } finally {
-    act(() => root.unmount());
+    await page.dispose();
   }
 });

--- a/apps/web/src/tests/inbox-badge.test.tsx
+++ b/apps/web/src/tests/inbox-badge.test.tsx
@@ -1,11 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { act } from "react";
 
 import { App } from "../App";
 import { LocaleProvider } from "../lib/i18n";
 import { ThemeProvider } from "../lib/theme";
-import { installDom, reactDom } from "./dom-harness";
+import { mountPage } from "./dom-harness";
 
 /**
  * What the sidebar badge costs every page.
@@ -19,32 +18,22 @@ import { installDom, reactDom } from "./dom-harness";
  * nobody.
  */
 const mounted = async (routes: Record<string, string>): Promise<{ paths: string[]; markup: string }> => {
-  const { dom, container } = installDom();
   const paths: string[] = [];
-  const original = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (url: string) => {
-    const path = String(url);
+  const page = await mountPage(
+    <ThemeProvider><LocaleProvider initialLocale="en"><App /></LocaleProvider></ThemeProvider>,
+    { "*": ({ input }) => {
+    const path = String(input);
     paths.push(path);
     const body = routes[path];
     return body === undefined
       ? new Response('{"error":"not found"}', { status: 404 })
       : new Response(body, { status: 200, headers: { "Content-Type": "application/json" } });
-  } });
-  const root = (await reactDom()).createRoot(container);
+    } },
+  );
   try {
-    await act(async () => root.render(
-      <ThemeProvider><LocaleProvider initialLocale="en"><App /></LocaleProvider></ThemeProvider>,
-    ));
-    // Twice: one tick resolves the bootstrap, the next lets the Shell that
-    // mounted because of it run its own first poll.
-    for (let round = 0; round < 2; round += 1) {
-      await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
-    }
-    return { paths, markup: dom.window.document.body.innerHTML };
+    return { paths, markup: page.dom.window.document.body.innerHTML };
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: original });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
   }
 };
 

--- a/apps/web/src/tests/inbox-lanes.test.tsx
+++ b/apps/web/src/tests/inbox-lanes.test.tsx
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { act } from "react";
 
-import { installDom, reactDom } from "./dom-harness";
+import { mountPage } from "./dom-harness";
 import type { InboxMessage } from "../lib/types";
 
 const now = "2026-08-26T00:00:00.000Z";
@@ -29,10 +29,6 @@ const deployed = card({
   body: "[auto-deploy] success: cd63e56186022274da18288bfd7ef36bd6b318ea -> cb46e4a003c3296fbd2f9ee49d6450ae7b7b3b3b; reason=deployed",
 });
 
-const settle = async (): Promise<void> => {
-  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 10)); });
-};
-
 const serve = (messages: InboxMessage[], posted: string[] = []): typeof fetch =>
   (async (input: string | URL | Request, init?: RequestInit) => {
     const url = String(input).replace(/^.*\/api/, "");
@@ -42,15 +38,9 @@ const serve = (messages: InboxMessage[], posted: string[] = []): typeof fetch =>
   }) as typeof fetch;
 
 const renderInbox = async (messages: InboxMessage[], posted: string[] = []) => {
-  const { container } = installDom("http://127.0.0.1:5173/inbox");
-  const [{ createRoot }, { InboxPage }, { ProjectProvider }] = await Promise.all([
-    reactDom(), import("../pages/Inbox"), import("../lib/project"),
-  ]);
-  globalThis.fetch = serve(messages, posted);
-  const root = createRoot(container);
-  act(() => root.render(<ProjectProvider><InboxPage /></ProjectProvider>));
-  await settle();
-  return { container, root };
+  const [{ InboxPage }, { ProjectProvider }] = await Promise.all([import("../pages/Inbox"), import("../lib/project")]);
+  const page = await mountPage(<ProjectProvider><InboxPage /></ProjectProvider>, { "*": ({ input, init }) => serve(messages, posted)(input, init) }, "http://127.0.0.1:5173/inbox");
+  return { container: page.container, page };
 };
 
 const lane = (container: Element, label: RegExp): HTMLButtonElement => {
@@ -60,7 +50,7 @@ const lane = (container: Element, label: RegExp): HTMLButtonElement => {
 };
 
 test("the active lane holds only cards that owe a reply; a detached notification is not one", async () => {
-  const { container, root } = await renderInbox([gate, notice, deployed]);
+  const { container, page } = await renderInbox([gate, notice, deployed]);
   try {
     const text = container.textContent ?? "";
     assert.match(text, /合并 PR/);
@@ -68,19 +58,19 @@ test("the active lane holds only cards that owe a reply; a detached notification
     // nothing from them — that is what made the badge read 145.
     assert.doesNotMatch(text, /merge tail stopped/);
   } finally {
-    act(() => root.unmount());
+    await page.dispose();
   }
 });
 
 test("the notices lane lists the detached notification and dismisses it without a decision", async () => {
   const posted: string[] = [];
-  const { container, root } = await renderInbox([gate, notice, deployed], posted);
+  const { container, page } = await renderInbox([gate, notice, deployed], posted);
   try {
     // The lane's own count tells the operator there is something there without
     // spending the sidebar badge on it.
     assert.match(lane(container, /^Notices/).textContent ?? "", /^Notices 1$/);
     act(() => { lane(container, /^Notices/).click(); });
-    await settle();
+    await page.settle();
     const text = container.textContent ?? "";
     assert.match(text, /merge tail stopped/);
     assert.doesNotMatch(text, /合并 PR/);
@@ -89,22 +79,22 @@ test("the notices lane lists the detached notification and dismisses it without 
       .find((button) => (button.textContent ?? "").trim() === "Dismiss");
     assert.ok(dismiss, "the notices lane offers a row-level dismiss");
     act(() => { (dismiss as HTMLButtonElement).click(); });
-    await settle();
+    await page.settle();
     assert.deepEqual(posted, ["/inbox/messages/notice-1/close"]);
   } finally {
-    act(() => root.unmount());
+    await page.dispose();
   }
 });
 
 test("a deploy that succeeded reports where production is, without occupying a lane", async () => {
-  const { container, root } = await renderInbox([deployed]);
+  const { container, page } = await renderInbox([deployed]);
   try {
     const text = container.textContent ?? "";
     assert.match(text, /cb46e4a/);
     // Archived on write, so it is not in the active lane it is rendered above.
     assert.match(text, /Nothing waiting on you/);
   } finally {
-    act(() => root.unmount());
+    await page.dispose();
   }
 });
 

--- a/apps/web/src/tests/model-picker.test.tsx
+++ b/apps/web/src/tests/model-picker.test.tsx
@@ -1,8 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { JSDOM } from "jsdom";
 import { act } from "react";
-import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { ModelLabel, ModelPicker, modelForSave } from "../components/model-picker";
@@ -10,19 +8,7 @@ import { LocaleProvider } from "../lib/i18n";
 import type { Agent } from "../lib/types";
 import { AgentDetailPage, NewAgent } from "../pages/Agents";
 import { NewGoal } from "../pages/Goals";
-
-const installDom = (url = "http://localhost/agents/a"): { dom: JSDOM; container: Element } => {
-  const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { pretendToBeVisual: true, url });
-  for (const [key, value] of Object.entries({
-    window: dom.window, document: dom.window.document, navigator: dom.window.navigator,
-    HTMLElement: dom.window.HTMLElement, HTMLSelectElement: dom.window.HTMLSelectElement, HTMLFormElement: dom.window.HTMLFormElement,
-    Element: dom.window.Element, Node: dom.window.Node, MutationObserver: dom.window.MutationObserver,
-  })) Object.defineProperty(globalThis, key, { configurable: true, value });
-  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
-  const container = dom.window.document.querySelector("#root");
-  assert.ok(container);
-  return { dom, container };
-};
+import { installDom, installFetchFunction, reactDom } from "./dom-harness";
 
 test("catalog models render a default effort without rewriting a bare stored value", () => {
   let changes = 0;
@@ -39,7 +25,7 @@ test("catalog models render a default effort without rewriting a bare stored val
 
 test("catalog selection retains a supported effort, falls back otherwise, and writes a concrete runner", async () => {
   const { dom, container } = installDom();
-  const root = createRoot(container);
+  const root = (await reactDom()).createRoot(container);
   const seen: Array<{ model: string; runnerPreference: string }> = [];
   try {
     await act(async () => root.render(
@@ -115,19 +101,18 @@ test("the real Create button blocks a contradictory model and runner pair", () =
 
 test("the real detail Save button blocks a stored contradiction until the picker repairs it", async () => {
   const { dom, container } = installDom();
-  const root = createRoot(container);
+  const root = (await reactDom()).createRoot(container);
   const agent: Agent = {
     id: "a", projectId: "p", environmentId: "e", name: "senior-dev", title: "Senior Developer",
     model: "gpt-5.6-luna:high", codexServiceTier: "DEFAULT", runnerPreference: "CLAUDE", inboxAccess: false, disabledTools: [],
     foundationalPrompt: "foundation", rolePrompt: "role", createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(), archivedAt: null,
   };
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (input: string | URL | Request) => {
+  const fetchHarness = installFetchFunction(async (input) => {
     const path = String(input);
     const body = path.endsWith("/agents/a") ? agent : [];
     return new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } });
-  } });
+  });
   try {
     await act(async () => {
       root.render(<AgentDetailPage agentId="a" />);
@@ -146,7 +131,7 @@ test("the real detail Save button blocks a stored contradiction until the picker
     await act(async () => model.dispatchEvent(new dom.window.Event("change", { bubbles: true })));
     assert.equal(save.disabled, false);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    fetchHarness.dispose();
     await act(async () => root.unmount());
     dom.window.close();
   }
@@ -154,20 +139,19 @@ test("the real detail Save button blocks a stored contradiction until the picker
 
 test("the executioner Setup page has no legacy subprocess profile controls", async () => {
   const { dom, container } = installDom();
-  const root = createRoot(container);
+  const root = (await reactDom()).createRoot(container);
   const agent: Agent = {
     id: "a", projectId: "p", environmentId: "e", name: "implementation-plan-executioner", title: "Implementation Plan Executioner",
     model: "gpt-5.6-sol:high", codexServiceTier: "DEFAULT", runnerPreference: "CODEX", inboxAccess: true, disabledTools: [],
     foundationalPrompt: "foundation", rolePrompt: "role", createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(), archivedAt: null,
   };
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (input: string | URL | Request) => {
+  const fetchHarness = installFetchFunction(async (input) => {
     const path = String(input);
     return new Response(JSON.stringify(path.endsWith("/agents/a") ? agent : [agent]), {
       status: 200, headers: { "Content-Type": "application/json" },
     });
-  } });
+  });
   try {
     await act(async () => {
       root.render(<AgentDetailPage agentId="a" />);
@@ -183,7 +167,7 @@ test("the executioner Setup page has no legacy subprocess profile controls", asy
     assert.ok(canonicalName);
     assert.equal(canonicalName.disabled, true);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    fetchHarness.dispose();
     await act(async () => root.unmount());
     dom.window.close();
   }

--- a/apps/web/src/tests/onboarding.test.tsx
+++ b/apps/web/src/tests/onboarding.test.tsx
@@ -13,7 +13,7 @@ import { ThemeProvider } from "../lib/theme";
 import { isValidBranchName, isValidSlug, remoteRejection, slugify, STARTER_MOUNT_PATH } from "../lib/onboarding";
 import { storage } from "../lib/storage";
 import { OnboardingPage, stepProblem } from "../pages/Onboarding";
-import { installDom, reactDom } from "./dom-harness";
+import { mountPage } from "./dom-harness";
 
 /**
  * The first-run wizard (plan Step 5; evidence rows E9/E10 on the browser side).
@@ -131,15 +131,8 @@ const withWizard = async (
   },
   walk: (wizard: Wizard) => Promise<void>,
 ): Promise<{ posts: Array<Record<string, unknown>>; paths: string[]; markup: string; hash: string }> => {
-  const { dom, container } = installDom(script.url);
-  if (script.freezeClock) {
-    let frozen = 0;
-    Object.defineProperty(dom.window, "setTimeout", { configurable: true, value: () => { frozen += 1; return frozen; } });
-    Object.defineProperty(dom.window, "clearTimeout", { configurable: true, value: () => undefined });
-  }
   const posts: Array<Record<string, unknown>> = [];
   const paths: string[] = [];
-  const original = globalThis.fetch;
   let projectIndex = 0;
   let postIndex = 0;
   const answer = (scripted: Scripted | undefined, fallback: Scripted): Response => {
@@ -147,10 +140,12 @@ const withWizard = async (
     if ("throws" in chosen) throw new TypeError("Failed to fetch");
     return new Response(chosen.body ?? "", { status: chosen.status, headers: { "Content-Type": "application/json" } });
   };
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (url: string, init?: RequestInit) => {
-    const path = String(url);
+  const page = await mountPage(
+    <ThemeProvider><LocaleProvider initialLocale="en">{subject()}</LocaleProvider></ThemeProvider>,
+    { "*": ({ input, init, method }) => {
+    const path = String(input);
     paths.push(path);
-    if (path === "/api/onboarding" && init?.method === "POST") {
+    if (path === "/api/onboarding" && method === "POST") {
       posts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
       return answer(script.post?.[Math.min(postIndex++, (script.post?.length ?? 1) - 1)], { status: 201, body: INSTALLATION_BODY });
     }
@@ -161,19 +156,19 @@ const withWizard = async (
       // script: after the gate succeeds the provider is polling the same
       // control plane.
       const length = script.projects?.length ?? 1;
-      const at = init?.cache === "no-store" ? Math.max(0, projectIndex - 1) : projectIndex++;
+      const at = init.cache === "no-store" ? Math.max(0, projectIndex - 1) : projectIndex++;
       return answer(script.projects?.[Math.min(at, length - 1)], { status: 200, body: "[]" });
     }
     return new Response("[]", { status: 404 });
-  } });
-  const root = (await reactDom()).createRoot(container);
-  const settle = async (): Promise<void> => {
-    // Twice: one tick lets the request resolve, the next lets whatever mounted
-    // because of it run its own first effect.
-    for (let round = 0; round < 2; round += 1) {
-      await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
-    }
-  };
+    } },
+    script.url,
+    script.freezeClock ? (dom) => {
+      let frozen = 0;
+      Object.defineProperty(dom.window, "setTimeout", { configurable: true, value: () => { frozen += 1; return frozen; } });
+      Object.defineProperty(dom.window, "clearTimeout", { configurable: true, value: () => undefined });
+    } : undefined,
+  );
+  const { dom } = page;
   const button = (label: string): HTMLButtonElement => {
     const found = [...dom.window.document.querySelectorAll("button")]
       .find((candidate) => candidate.textContent?.trim() === label || candidate.getAttribute("aria-label") === label);
@@ -181,10 +176,8 @@ const withWizard = async (
     return found as HTMLButtonElement;
   };
   try {
-    await act(async () => root.render(<ThemeProvider><LocaleProvider initialLocale="en">{subject()}</LocaleProvider></ThemeProvider>));
-    await settle();
     await walk({
-      dom, posts, paths, settle,
+      dom, posts, paths, settle: page.settle,
       markup: () => dom.window.document.body.innerHTML,
       disabled: (label) => button(label).hasAttribute("disabled"),
       fill: async (label, value) => {
@@ -200,27 +193,25 @@ const withWizard = async (
       },
       press: async (label) => {
         await act(async () => button(label).dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
-        await settle();
+        await page.settle();
       },
       check: async (label) => {
         await act(async () => button(label).dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
-        await settle();
+        await page.settle();
       },
       wait: async (ms) => {
         await act(async () => { await new Promise((resolve) => setTimeout(resolve, ms)); });
-        await settle();
+        await page.settle();
       },
       visible: async (value) => {
         Object.defineProperty(dom.window.document, "hidden", { configurable: true, value: !value });
         await act(async () => { dom.window.document.dispatchEvent(new dom.window.Event("visibilitychange")); });
-        await settle();
+        await page.settle();
       },
     });
     return { posts, paths, markup: dom.window.document.body.innerHTML, hash: dom.window.location.hash };
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: original });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
   }
 };
 

--- a/apps/web/src/tests/request-timeout.test.ts
+++ b/apps/web/src/tests/request-timeout.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from "node:net";
 import test from "node:test";
 
 import { ApiError, REQUEST_TIMEOUT_MS, api } from "../lib/api";
+import { installFetchFunction } from "./dom-harness";
 
 /**
  * Every control-plane request is bounded.
@@ -20,19 +21,15 @@ const withFetch = async (
   work: () => Promise<void>,
 ): Promise<Call[]> => {
   const calls: Call[] = [];
-  const original = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (url: string, init: RequestInit) => {
-      const call = { url, init };
+  const fetchHarness = installFetchFunction(async (url, init = {}) => {
+      const call = { url: String(url), init };
       calls.push(call);
       return await answer(call);
-    },
   });
   try {
     await work();
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: original });
+    fetchHarness.dispose();
   }
   return calls;
 };
@@ -141,10 +138,7 @@ test("a response that sends headers and then stalls its body is translated to a 
     configurable: true,
     value: () => originalTimeout(100),
   });
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: (_url: string, init: RequestInit) => originalFetch(`http://127.0.0.1:${port}/projects`, init),
-  });
+  const fetchHarness = installFetchFunction((_url, init = {}) => originalFetch(`http://127.0.0.1:${port}/projects`, init));
   try {
     await assert.rejects(() => api.get("/projects"), (reason: unknown) => {
       assert.ok(reason instanceof ApiError);
@@ -153,7 +147,7 @@ test("a response that sends headers and then stalls its body is translated to a 
       return true;
     });
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    fetchHarness.dispose();
     Object.defineProperty(AbortSignal, "timeout", { configurable: true, value: originalTimeout });
     server.closeAllConnections();
     await new Promise<void>((resolve) => { server.close(() => resolve()); });

--- a/apps/web/src/tests/runner-status.test.tsx
+++ b/apps/web/src/tests/runner-status.test.tsx
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { JSDOM } from "jsdom";
+import type { JSDOM } from "jsdom";
 import { act } from "react";
-import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import {
@@ -10,6 +9,7 @@ import {
 } from "../components/runner-status";
 import { LocaleProvider } from "../lib/i18n";
 import type { RunnersResponse } from "../lib/types";
+import { installDom, installFetchFunction, reactDom } from "./dom-harness";
 
 const now = new Date();
 const payload = (overrides: Partial<RunnersResponse> = {}): RunnersResponse => ({
@@ -113,18 +113,11 @@ const withProvider = async (
   respond: (path: string, count: number) => { ok: boolean; body: unknown },
   operation: (context: { dom: JSDOM; requests: string[]; advance: (ms: number) => Promise<void>; latest: () => ReturnType<typeof useRunners> }) => Promise<void>,
 ): Promise<void> => {
-  const dom = new JSDOM("<!doctype html><html><body><div id='root'></div></body></html>", { pretendToBeVisual: true });
-  for (const [key, value] of Object.entries({
-    window: dom.window, document: dom.window.document, navigator: dom.window.navigator,
-    HTMLElement: dom.window.HTMLElement, Element: dom.window.Element, Node: dom.window.Node,
-    MutationObserver: dom.window.MutationObserver,
-  })) Object.defineProperty(globalThis, key, { configurable: true, value });
-  Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { configurable: true, value: true });
+  const { dom, container } = installDom();
 
   const requests: string[] = [];
   const counts = new Map<string, number>();
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
     const path = String(input);
     requests.push(path);
     const count = (counts.get(path) ?? 0) + 1;
@@ -136,7 +129,7 @@ const withProvider = async (
       headers: new Headers(),
       text: async () => JSON.stringify(response.body),
     } as Response;
-  } });
+  });
 
   let clock = now.getTime();
   let handle = 0;
@@ -158,10 +151,8 @@ const withProvider = async (
 
   let snapshot: ReturnType<typeof useRunners> | null = null;
   const Probe = () => { snapshot = useRunners(); return null; };
-  const container = dom.window.document.querySelector("#root");
-  assert.ok(container);
-  const root = createRoot(container);
-  const flush = async (): Promise<void> => { await act(async () => { for (let turn = 0; turn < 10; turn += 1) await Promise.resolve(); }); };
+  const root = (await reactDom()).createRoot(container);
+  const flush = fetchHarness.settle;
   const advance = async (ms: number): Promise<void> => {
     const target = clock + ms;
     for (let guard = 0; guard < 100; guard += 1) {
@@ -182,7 +173,7 @@ const withProvider = async (
     await operation({ dom, requests, advance, latest: () => { assert.ok(snapshot); return snapshot; } });
   } finally {
     await act(async () => root.unmount());
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
+    fetchHarness.dispose();
     Object.defineProperty(Date, "now", { configurable: true, value: originalDateNow });
     dom.window.close();
   }

--- a/apps/web/src/tests/sessions.test.tsx
+++ b/apps/web/src/tests/sessions.test.tsx
@@ -14,6 +14,7 @@ import { isSessionUnseen, sessionSeenKey } from "../lib/session-list";
 import { storage } from "../lib/storage";
 import { TEXT_NODE_MAX_LINES, TOOL_OUTPUT_MAX_LINES } from "../lib/session-stream";
 import type { Session, SessionEvent, SessionExecutionStatus } from "../lib/types";
+import { installFetchFunction } from "./dom-harness";
 
 // Radix chooses useLayoutEffect or useEffect when its module is first loaded.
 // Seed a browser global before importing Sessions so portaled hover-card content
@@ -312,26 +313,22 @@ test("sessions are grouped by day, capped at five, and expandable in both locale
   const sessions = [...today, yesterday, older];
 
   const { ProjectProvider } = await import("../lib/project");
-  const originalFetch = globalThis.fetch;
   try {
     for (const locale of ["en", "zh"] as const) {
       const dom = jsdom();
       const container = dom.window.document.querySelector("#root");
       assert.ok(container);
-      Object.defineProperty(globalThis, "fetch", {
-        configurable: true,
-        value: async (input: string) => {
+      const fetchHarness = installFetchFunction(async (input) => {
           const path = String(input);
           const payload = path.includes("/projects") ? [{ id: "p1", name: "Demo" }] : sessions;
           return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-        },
       });
       const root = createRoot(container);
       try {
         await act(async () => {
           root.render(<LocaleProvider initialLocale={locale}><ProjectProvider><SessionsPage /></ProjectProvider></LocaleProvider>);
         });
-        for (let turn = 0; turn < 20; turn += 1) await act(async () => { await Promise.resolve(); });
+        await fetchHarness.settle();
 
         const dayGroups = [...dom.window.document.querySelectorAll<HTMLElement>("[data-session-day]")];
         assert.equal(dayGroups.length, 3, container.innerHTML);
@@ -353,12 +350,12 @@ test("sessions are grouped by day, capped at five, and expandable in both locale
         await click(dom, expand);
         assert.equal(dom.window.document.querySelectorAll("[data-session-row]").length, 7);
       } finally {
+        fetchHarness.dispose();
         await act(async () => root.unmount());
         dom.window.close();
       }
     }
   } finally {
-    globalThis.fetch = originalFetch;
     setFormatLocale("en", (key, vars) => translate("en", key, vars));
   }
 });
@@ -376,16 +373,12 @@ test("day expansion resets when the Project scope changes", async () => {
   const dom = jsdom();
   const container = dom.window.document.querySelector("#root");
   assert.ok(container);
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       const payload = path.includes("/projects")
         ? [{ id: "p1", name: "One" }, { id: "p2", name: "Two" }]
         : path.includes("projectId=p2") ? byProject.p2 : byProject.p1;
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
   const { ProjectProvider, useProjectScope } = await import("../lib/project");
   const ScopeProbe = (): ReactNode => {
@@ -393,9 +386,7 @@ test("day expansion resets when the Project scope changes", async () => {
     return <button type="button" data-switch-project onClick={() => scope.select("p2")}>Switch project</button>;
   };
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 24; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   try {
     await act(async () => {
       root.render(<LocaleProvider initialLocale="en"><ProjectProvider><ScopeProbe /><SessionsPage /></ProjectProvider></LocaleProvider>);
@@ -415,7 +406,7 @@ test("day expansion resets when the Project scope changes", async () => {
   } finally {
     await act(async () => root.unmount());
     dom.window.close();
-    globalThis.fetch = originalFetch;
+    fetchHarness.dispose();
   }
 });
 
@@ -441,24 +432,18 @@ test("agent and status filters show loaded-only copy and localized choices", asy
     session({ id: "done-other", task: { id: "task-done", name: "Done other" }, agentId: "agent-other", agent: { id: "agent-other", title: "Agent Other" }, executionStatus: "SUCCEEDED" }),
     session({ id: "failed-match", task: { id: "task-failed", name: "Failed match" }, agentId: "agent-match", agent: { id: "agent-match", title: "Agent Match" }, executionStatus: "FAILED" }),
   ];
-  const originalFetch = globalThis.fetch;
   try {
     for (const locale of ["en", "zh"] as const) {
       const dom = jsdom();
       const container = dom.window.document.querySelector("#root");
       assert.ok(container);
-      Object.defineProperty(globalThis, "fetch", {
-        configurable: true,
-        value: async (input: string) => {
+      const fetchHarness = installFetchFunction(async (input) => {
           const payload = String(input).includes("/projects") ? [{ id: "p1", name: "Demo" }] : sessions;
           return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-        },
       });
       const { ProjectProvider } = await import("../lib/project");
       const root = createRoot(container);
-      const flush = async (): Promise<void> => {
-        await act(async () => { for (let turn = 0; turn < 20; turn += 1) await Promise.resolve(); });
-      };
+      const flush = fetchHarness.settle;
       const choose = async (selector: string, value: string): Promise<void> => {
         const select = dom.window.document.querySelector<HTMLSelectElement>(selector);
         assert.ok(select, `${selector} not found in ${container.innerHTML}`);
@@ -496,12 +481,12 @@ test("agent and status filters show loaded-only copy and localized choices", asy
         assert.match(container.textContent ?? "", locale === "en" ? /No sessions match the selected filters\./u : /没有会话符合所选筛选条件。/u);
         assert.doesNotMatch(container.textContent ?? "", locale === "en" ? /No sessions yet\./u : /还没有会话。/u);
       } finally {
+        fetchHarness.dispose();
         await act(async () => root.unmount());
         dom.window.close();
       }
     }
   } finally {
-    globalThis.fetch = originalFetch;
     setFormatLocale("en", (key, vars) => translate("en", key, vars));
   }
 });
@@ -512,17 +497,13 @@ test("agent and status filters reset when the Project scope changes", async () =
     id: `${projectId}-session`, projectId, agentId: `${projectId}-agent`,
     agent: { id: `${projectId}-agent`, title: `${projectId} Agent` }, executionStatus: "RUNNING",
   })];
-  const originalFetch = globalThis.fetch;
   const dom = jsdom();
   const container = dom.window.document.querySelector("#root");
   assert.ok(container);
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       const payload = path.includes("/projects") ? projects : path.includes("projectId=p2") ? sessionsFor("p2") : sessionsFor("p1");
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
   const { ProjectProvider, useProjectScope } = await import("../lib/project");
   const ScopeProbe = (): ReactNode => {
@@ -530,9 +511,7 @@ test("agent and status filters reset when the Project scope changes", async () =
     return <button type="button" data-switch-project onClick={() => scope.select("p2")}>Switch project</button>;
   };
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 24; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   const choose = async (selector: string, value: string): Promise<void> => {
     const select = dom.window.document.querySelector<HTMLSelectElement>(selector);
     assert.ok(select);
@@ -560,7 +539,7 @@ test("agent and status filters reset when the Project scope changes", async () =
   } finally {
     await act(async () => root.unmount());
     dom.window.close();
-    globalThis.fetch = originalFetch;
+    fetchHarness.dispose();
   }
 });
 
@@ -576,10 +555,7 @@ test("opening a Session marks it opened, and returning to the list clears its do
   const detail = session({ projectId: "p-open", executionStatus: "SUCCEEDED", endedAt: "2026-08-21T01:00:00.000Z" });
   const seenKey = sessionSeenKey("p-open");
   storage.set(seenKey, JSON.stringify({ since: "2026-08-20T00:00:00.000Z", opened: {} }));
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       const payload = path.includes("/runs/")
         ? { events: [], nextAfterSeq: null, hasMore: false, total: 0 }
@@ -587,14 +563,11 @@ test("opening a Session marks it opened, and returning to the list clears its do
           ? [{ id: "p-open", name: "Open project" }]
           : path.includes("/sessions/session-1") ? detail : [detail];
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
   const { SessionDetailPage } = await import("../pages/Sessions");
   const { ProjectProvider } = await import("../lib/project");
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 24; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   try {
     await act(async () => { root.render(<SessionDetailPage sessionId="session-1" />); });
     await flush();
@@ -607,7 +580,7 @@ test("opening a Session marks it opened, and returning to the list clears its do
   } finally {
     await act(async () => root.unmount());
     dom.window.close();
-    globalThis.fetch = originalFetch;
+    fetchHarness.dispose();
   }
 });
 
@@ -618,22 +591,16 @@ test("a Session finishing while its detail page is open is marked opened again",
   let detail = session({ projectId: "p-transition", executionStatus: "RUNNING", endedAt: null });
   const seenKey = sessionSeenKey("p-transition");
   storage.set(seenKey, JSON.stringify({ since: "2026-08-20T00:00:00.000Z", opened: {} }));
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       const payload = path.includes("/runs/")
         ? { events: [], nextAfterSeq: null, hasMore: false, total: 0 }
         : detail;
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
   const { SessionDetailPage } = await import("../pages/Sessions");
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 24; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   try {
     await act(async () => { root.render(<SessionDetailPage sessionId="session-1" />); });
     await flush();
@@ -655,7 +622,7 @@ test("a Session finishing while its detail page is open is marked opened again",
   } finally {
     await act(async () => root.unmount());
     dom.window.close();
-    globalThis.fetch = originalFetch;
+    fetchHarness.dispose();
   }
 });
 
@@ -960,16 +927,13 @@ test("Load more keeps page one and dedupes it against the live head", async () =
 
   let headRows = head(Array.from({ length: 50 }, (_, index) => `new-${index}`));
   const requests: string[] = [];
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       requests.push(path);
       const payload = path.includes("/projects") ? [{ id: "p1", name: "Demo" }]
         : path.includes("before=") ? older
           : headRows;
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
 
   const { ProjectProvider } = await import("../lib/project");
@@ -977,9 +941,7 @@ test("Load more keeps page one and dedupes it against the live head", async () =
   const container = dom.window.document.querySelector("#root");
   assert.ok(container);
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 20; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   await act(async () => { root.render(<ProjectProvider><SessionsPage /></ProjectProvider>); });
   await flush();
 
@@ -1007,6 +969,7 @@ test("Load more keeps page one and dedupes it against the live head", async () =
 
   await act(async () => root.unmount());
   dom.window.close();
+  fetchHarness.dispose();
 });
 
 test("an applied filter remains active across Refresh and Load more", async () => {
@@ -1027,22 +990,16 @@ test("an applied filter remains active across Refresh and Load more", async () =
   const older = [listRow("older-match", 60, "agent-match"), ...Array.from({ length: 49 }, (_, index) => listRow(`older-other-${index}`, index + 61, "agent-other"))];
   let headRows = initialHead;
   const requests: string[] = [];
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       requests.push(path);
       const payload = path.includes("/projects") ? [{ id: "p1", name: "Demo" }]
         : path.includes("before=") ? older : headRows;
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
   const { ProjectProvider } = await import("../lib/project");
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 20; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   const chooseAgent = async (): Promise<void> => {
     const select = dom.window.document.querySelector<HTMLSelectElement>("[data-session-filter-agent]");
     assert.ok(select);
@@ -1077,7 +1034,7 @@ test("an applied filter remains active across Refresh and Load more", async () =
   } finally {
     await act(async () => root.unmount());
     dom.window.close();
-    globalThis.fetch = originalFetch;
+    fetchHarness.dispose();
   }
 });
 
@@ -1096,9 +1053,7 @@ test("the detail page does not call the initial drain `N new`", async () => {
     payload: { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: `line ${index}` }] } },
   }));
   const detail = session({ executionStatus: "SUCCEEDED", endedAt: "2026-08-16T00:10:00.000Z" });
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       // Two pages, so the flag has to survive an intermediate render.
       const payload = path.includes("/events")
@@ -1107,7 +1062,6 @@ test("the detail page does not call the initial drain `N new`", async () => {
           : { events: events.slice(0, 6), nextAfterSeq: 6, hasMore: true, total: 12 }
         : detail;
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
 
   const { SessionDetailPage } = await import("../pages/Sessions");
@@ -1116,8 +1070,8 @@ test("the detail page does not call the initial drain `N new`", async () => {
   const root = createRoot(container);
   try {
     await act(async () => { root.render(<SessionDetailPage sessionId="session-1" />); });
-    for (let turn = 0; turn < 6; turn += 1) {
-      await act(async () => { for (let inner = 0; inner < 20; inner += 1) await Promise.resolve(); });
+    for (let guard = 0; guard < 100 && !/line 5/u.test(container.innerHTML); guard += 1) {
+      await fetchHarness.settle();
       await act(async () => { await new Promise((resolve) => dom.window.setTimeout(resolve, 0)); });
     }
     assert.match(container.innerHTML, /line 5/, "both pages drained into the visible merged node");
@@ -1127,6 +1081,7 @@ test("the detail page does not call the initial drain `N new`", async () => {
     // path the runner never sees the event loop drain and the file hangs.
     await act(async () => root.unmount());
     dom.window.close();
+    fetchHarness.dispose();
   }
 });
 
@@ -1146,9 +1101,7 @@ test("the live stream counts a call added to the tail tool group as one new node
   ];
   let current = initial;
   const detail = session({ executionStatus: "RUNNING" });
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       const payload = path.includes("/runs/")
         ? path.includes("afterSeq=2")
@@ -1156,16 +1109,13 @@ test("the live stream counts a call added to the tail tool group as one new node
           : { events: current, nextAfterSeq: current.at(-1)?.seq ?? null, hasMore: false, total: current.length }
         : detail;
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
 
   const { SessionDetailPage } = await import("../pages/Sessions");
   const container = dom.window.document.querySelector("#root");
   assert.ok(container);
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 30; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   try {
     await act(async () => { root.render(<SessionDetailPage sessionId="session-1" />); });
     await flush();
@@ -1188,6 +1138,7 @@ test("the live stream counts a call added to the tail tool group as one new node
   } finally {
     await act(async () => root.unmount());
     dom.window.close();
+    fetchHarness.dispose();
   }
 });
 
@@ -1201,24 +1152,19 @@ test("a live stream at the bottom auto-scrolls after its initial drain", async (
   });
   let current = [initial];
   const detail = session({ executionStatus: "RUNNING" });
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       const payload = path.includes("/runs/")
         ? { events: current, nextAfterSeq: current.at(-1)?.seq ?? null, hasMore: false, total: current.length }
         : detail;
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
 
   const { SessionDetailPage } = await import("../pages/Sessions");
   const container = dom.window.document.querySelector("#root");
   assert.ok(container);
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 30; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   try {
     await act(async () => { root.render(<SessionDetailPage sessionId="session-1" />); });
     await flush();
@@ -1236,6 +1182,7 @@ test("a live stream at the bottom auto-scrolls after its initial drain", async (
   } finally {
     await act(async () => root.unmount());
     dom.window.close();
+    fetchHarness.dispose();
   }
 });
 
@@ -1247,24 +1194,19 @@ test("a live stream counts assistant prose absorbed by the tail text node", asyn
   const first = event({ id: "assistant-1", seq: 1, source: "CLAUDE", type: "MODEL_DELTA", payload: CLAUDE_TEXT_ASSISTANT });
   let current = [first];
   const detail = session({ executionStatus: "RUNNING" });
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       const payload = path.includes("/runs/")
         ? { events: current, nextAfterSeq: current.at(-1)?.seq ?? null, hasMore: false, total: current.length }
         : detail;
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(payload) } as unknown as Response;
-    },
   });
 
   const { SessionDetailPage } = await import("../pages/Sessions");
   const container = dom.window.document.querySelector("#root");
   assert.ok(container);
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 30; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   try {
     await act(async () => { root.render(<SessionDetailPage sessionId="session-1" />); });
     await flush();
@@ -1284,6 +1226,7 @@ test("a live stream counts assistant prose absorbed by the tail text node", asyn
   } finally {
     await act(async () => root.unmount());
     dom.window.close();
+    fetchHarness.dispose();
   }
 });
 
@@ -1292,9 +1235,7 @@ test("a capped stream keeps the visible event-cap notice", async () => {
   Object.defineProperty(dom.window, "scrollTo", { configurable: true, value: () => undefined });
   const detail = session({ executionStatus: "SUCCEEDED", endedAt: "2026-08-16T00:10:00.000Z" });
   let seq = 0;
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       if (!path.includes("/runs/")) {
         return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(detail) } as unknown as Response;
@@ -1307,7 +1248,6 @@ test("a capped stream keeps the visible event-cap notice", async () => {
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify({
         events: [row], nextAfterSeq: seq, hasMore: true, total: 100,
       }) } as unknown as Response;
-    },
   });
 
   const { SessionDetailPage } = await import("../pages/Sessions");
@@ -1316,8 +1256,8 @@ test("a capped stream keeps the visible event-cap notice", async () => {
   const root = createRoot(container);
   try {
     await act(async () => { root.render(<SessionDetailPage sessionId="session-1" />); });
-    for (let turn = 0; turn < 100 && seq < 40; turn += 1) {
-      await act(async () => { await Promise.resolve(); });
+    for (let guard = 0; guard < 100 && seq < 40; guard += 1) {
+      await fetchHarness.settle();
       await act(async () => { await new Promise((resolve) => dom.window.setTimeout(resolve, 0)); });
     }
     assert.equal(seq, 40);
@@ -1325,6 +1265,7 @@ test("a capped stream keeps the visible event-cap notice", async () => {
   } finally {
     await act(async () => root.unmount());
     dom.window.close();
+    fetchHarness.dispose();
   }
 });
 
@@ -1335,9 +1276,7 @@ test("a failed Load more tells the operator instead of vanishing into the consol
     return session({ id: `new-${index}`, requestedAt: at, startedAt: at });
   });
 
-  Object.defineProperty(globalThis, "fetch", {
-    configurable: true,
-    value: async (input: string) => {
+  const fetchHarness = installFetchFunction(async (input) => {
       const path = String(input);
       if (path.includes("/projects")) {
         return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify([{ id: "p1", name: "Demo" }]) } as unknown as Response;
@@ -1347,7 +1286,6 @@ test("a failed Load more tells the operator instead of vanishing into the consol
         return { ok: false, status: 503, headers: new Headers(), text: async () => JSON.stringify({ error: "Service unavailable" }) } as unknown as Response;
       }
       return { ok: true, status: 200, headers: new Headers(), text: async () => JSON.stringify(headRows) } as unknown as Response;
-    },
   });
 
   const { ProjectProvider } = await import("../lib/project");
@@ -1355,9 +1293,7 @@ test("a failed Load more tells the operator instead of vanishing into the consol
   const container = dom.window.document.querySelector("#root");
   assert.ok(container);
   const root = createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 20; turn += 1) await Promise.resolve(); });
-  };
+  const flush = fetchHarness.settle;
   await act(async () => { root.render(<ProjectProvider><SessionsPage /></ProjectProvider>); });
   await flush();
 
@@ -1374,4 +1310,5 @@ test("a failed Load more tells the operator instead of vanishing into the consol
 
   await act(async () => root.unmount());
   dom.window.close();
+  fetchHarness.dispose();
 });

--- a/apps/web/src/tests/smoke-fixture.test.tsx
+++ b/apps/web/src/tests/smoke-fixture.test.tsx
@@ -7,7 +7,7 @@ import { act } from "react";
 import { NewTask } from "../components/new-task-panel";
 import { LocaleProvider } from "../lib/i18n";
 import { translate } from "../lib/i18n-core";
-import { installDom, reactDom } from "./dom-harness";
+import { mountPage } from "./dom-harness";
 
 /**
  * The published smoke task, and the form that has to be able to send it.
@@ -46,63 +46,49 @@ const withForm = async (walk: (form: {
   press: (label: string) => Promise<void>;
   markup: () => string;
 }) => Promise<void>): Promise<Array<Record<string, unknown>>> => {
-  const { dom, container } = installDom();
   const posts: Array<Record<string, unknown>> = [];
-  const original = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (url: string, init?: RequestInit) => {
-    if (init?.method === "POST") posts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
-    return new Response(String(url).endsWith("/task-templates") ? "[]" : "{}", {
+  const page = await mountPage(
+    <LocaleProvider initialLocale="en">
+      <NewTask projectId="p1" agents={[]} repos={[]} onClose={() => undefined} onCreated={() => undefined} />
+    </LocaleProvider>,
+    { "*": ({ input, init, method }) => {
+    if (method === "POST") posts.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+    return new Response(String(input).endsWith("/task-templates") ? "[]" : "{}", {
       status: 200, headers: { "Content-Type": "application/json" },
     });
-  } });
-  const root = (await reactDom()).createRoot(container);
-  const settle = async (): Promise<void> => {
-    for (let round = 0; round < 2; round += 1) {
-      await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
-    }
-  };
+    } },
+  );
   const control = (label: string): HTMLElement => {
-    const found = [...dom.window.document.querySelectorAll("button")]
+    const found = [...page.dom.window.document.querySelectorAll("button")]
       .find((candidate) => candidate.textContent?.trim() === label || candidate.getAttribute("aria-label") === label);
     assert.ok(found, `no control labelled ${label}`);
     return found as HTMLElement;
   };
   try {
-    await act(async () => root.render(
-      <LocaleProvider initialLocale="en">
-        <NewTask projectId="p1" agents={[]} repos={[]} onClose={() => undefined} onCreated={() => undefined} />
-      </LocaleProvider>,
-    ));
-    await settle();
     await walk({
-      markup: () => dom.window.document.body.innerHTML,
+      markup: () => page.dom.window.document.body.innerHTML,
       fill: async (label, value) => {
-        const field = [...dom.window.document.querySelectorAll("label")]
+        const field = [...page.dom.window.document.querySelectorAll("label")]
           .find((candidate) => candidate.textContent?.trim() === label)
           ?.parentElement?.querySelector("input, textarea") as HTMLInputElement | null;
         assert.ok(field, `no field labelled ${label}`);
-        const prototype = field.tagName === "TEXTAREA" ? dom.window.HTMLTextAreaElement.prototype : dom.window.HTMLInputElement.prototype;
+        const prototype = field.tagName === "TEXTAREA" ? page.dom.window.HTMLTextAreaElement.prototype : page.dom.window.HTMLInputElement.prototype;
         const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
         assert.ok(setter);
         await act(async () => {
           setter.call(field, value);
-          field.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+          field.dispatchEvent(new page.dom.window.Event("input", { bubbles: true }));
         });
       },
       toggle: async (label) => {
-        await act(async () => control(label).dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
-        await settle();
+        await act(async () => control(label).dispatchEvent(new page.dom.window.MouseEvent("click", { bubbles: true })));
+        await page.settle();
       },
-      press: async (label) => {
-        await act(async () => control(label).dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
-        await settle();
-      },
+      press: page.press,
     });
     return posts;
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: original });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
   }
 };
 

--- a/apps/web/src/tests/startup-gate.test.tsx
+++ b/apps/web/src/tests/startup-gate.test.tsx
@@ -8,7 +8,7 @@ import { App } from "../App";
 import { StartupGate } from "../components/startup-gate";
 import { LocaleProvider } from "../lib/i18n";
 import { ThemeProvider } from "../lib/theme";
-import { installDom, reactDom } from "./dom-harness";
+import { mountPage } from "./dom-harness";
 
 /**
  * The first-load contract (plan Step 5, evidence row E6).
@@ -49,41 +49,27 @@ const mounted = async (
    *  without it is a gate no developer can get past. */
   strict = false,
 ): Promise<{ calls: Call[]; markup: string }> => {
-  const { dom, container } = installDom();
   const calls: Call[] = [];
-  const original = globalThis.fetch;
   let index = 0;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (url: string, init?: RequestInit) => {
-    const path = String(url);
-    calls.push({ path, polling: init?.cache === "no-store" });
+  const tree = <ThemeProvider><LocaleProvider initialLocale="en">{subject()}</LocaleProvider></ThemeProvider>;
+  const page = await mountPage(strict ? <StrictMode>{tree}</StrictMode> : tree, { "*": ({ input, init }) => {
+    const path = String(input);
+    calls.push({ path, polling: init.cache === "no-store" });
     if (path !== "/api/projects") return new Response("[]", { status: 404 });
     // A poll repeats whatever the bootstrap last answered rather than advancing
     // the script: the provider that mounts after the gate is polling the same
     // control plane, and answering it differently would be a fixture artefact.
-    const at = init?.cache === "no-store" ? Math.max(0, index - 1) : index++;
+    const at = init.cache === "no-store" ? Math.max(0, index - 1) : index++;
     const scripted = bootstrap[Math.min(at, bootstrap.length - 1)] ?? { status: 500 };
     if ("throws" in scripted) throw new TypeError("Failed to fetch");
     if ("timesOut" in scripted) throw timeoutError();
     return new Response(scripted.body ?? "", { status: scripted.status, headers: { "Content-Type": "application/json" } });
   } });
-  const root = (await reactDom()).createRoot(container);
   try {
-    const tree = <ThemeProvider><LocaleProvider initialLocale="en">{subject()}</LocaleProvider></ThemeProvider>;
-    await act(async () => root.render(strict ? <StrictMode>{tree}</StrictMode> : tree));
-    const settle = async (): Promise<void> => {
-      // Twice: one tick lets the request resolve, the next lets whatever mounted
-      // because of it run its own first effect.
-      for (let round = 0; round < 2; round += 1) {
-        await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
-      }
-    };
-    await settle();
-    await drive(dom, settle);
-    return { calls, markup: dom.window.document.body.innerHTML };
+    await drive(page.dom, page.settle);
+    return { calls, markup: page.dom.window.document.body.innerHTML };
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: original });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
   }
 };
 
@@ -183,24 +169,18 @@ test("a 500 is neither a refusal nor an outage, and says so without inventing a 
 });
 
 test("the pending state renders loading only, and never the application", async () => {
-  const { dom, container } = installDom();
-  const original = globalThis.fetch;
   let calls = 0;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async () => {
+  const page = await mountPage(<ThemeProvider><LocaleProvider initialLocale="en"><App /></LocaleProvider></ThemeProvider>, { "*": async () => {
     calls += 1;
     return await new Promise<Response>(() => undefined);
   } });
-  const root = (await reactDom()).createRoot(container);
   try {
-    await act(async () => root.render(<ThemeProvider><LocaleProvider initialLocale="en"><App /></LocaleProvider></ThemeProvider>));
-    const markup = dom.window.document.body.innerHTML;
+    const markup = page.dom.window.document.body.innerHTML;
     assert.equal(calls, 1);
     assert.match(markup, /data-startup-state="pending"/u);
     assert.doesNotMatch(markup, /data-runner-state=|Set up Anneal/u);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: original });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
   }
 });
 

--- a/apps/web/src/tests/task-detail-navigation.test.tsx
+++ b/apps/web/src/tests/task-detail-navigation.test.tsx
@@ -1,14 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { JSDOM } from "jsdom";
-import { act } from "react";
+import { act, type ReactNode, useState } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { ApiError } from "../lib/api";
 import type { Chain, Run, Task, TaskStepOutput } from "../lib/types";
-import { RunRow } from "../pages/TaskDetail";
-import { installDom, reactDom } from "./dom-harness";
+import { RunRow, TaskDetailPage, TaskOutput } from "../pages/TaskDetail";
+import { mountPage } from "./dom-harness";
 import prompts from "./fixtures/tc-ux-v1-prompts.json";
 
 const now = "2026-08-17T00:00:00.000Z";
@@ -65,37 +64,15 @@ test("a resumed run identifies Duration as wall-clock time that includes Inbox w
   assert.match(markup, /5m 0s wall-clock \(includes Inbox wait\)/);
 });
 
-const settle = async (): Promise<void> => {
-  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 10)); });
+let replaceSubject: ((subject: ReactNode) => void) | null = null;
+
+const SubjectHarness = ({ initial }: { initial: ReactNode }): ReactNode => {
+  const [subject, setSubject] = useState(initial);
+  replaceSubject = (next) => setSubject(next);
+  return subject;
 };
 
 test("task-id switches expose a clean loading shell and destination-scoped actions", async () => {
-  const dom = new JSDOM("<!doctype html><div id='root'></div>", { url: "http://localhost/tasks/a", pretendToBeVisual: true });
-  const previous = {
-    window: globalThis.window,
-    document: globalThis.document,
-    navigator: globalThis.navigator,
-    fetch: globalThis.fetch,
-  };
-  for (const [name, value] of Object.entries({
-    window: dom.window,
-    document: dom.window.document,
-    navigator: dom.window.navigator,
-    HTMLElement: dom.window.HTMLElement,
-    HTMLFormElement: dom.window.HTMLFormElement,
-    HTMLInputElement: dom.window.HTMLInputElement,
-    Node: dom.window.Node,
-    Element: dom.window.Element,
-    Event: dom.window.Event,
-    InputEvent: dom.window.InputEvent,
-    MouseEvent: dom.window.MouseEvent,
-    IS_REACT_ACT_ENVIRONMENT: true,
-  })) Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
-  const [{ createRoot }, { TaskDetailPage, TaskOutput }] = await Promise.all([
-    import("react-dom/client"),
-    import("../pages/TaskDetail"),
-  ]);
-
   const mutations: Array<{ url: string; method: string; body: string }> = [];
   let resolveB: ((response: Response) => void) | null = null;
   let resolveAActivity: ((response: Response) => void) | null = null;
@@ -103,9 +80,8 @@ test("task-id switches expose a clean loading shell and destination-scoped actio
   let firstAActivity = true;
   const tasks = { a: task("a", "Source A", 0), b: task("b", "Destination B", 1), c: task("c", "Destination C", 2, "chain-c") };
   tasks.a.runs = [sourceRun("a")];
-  globalThis.fetch = (async (input: string | URL | Request, init: RequestInit = {}) => {
+  const page = await mountPage(<SubjectHarness initial={<TaskDetailPage taskId="a" />} />, { "*": ({ input, init, method }) => {
     const url = String(input).replace(/^.*\/api/, "");
-    const method = init.method ?? "GET";
     if (method !== "GET") {
       mutations.push({ url, method, body: String(init.body ?? "") });
       return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
@@ -132,13 +108,9 @@ test("task-id switches expose a clean loading shell and destination-scoped actio
     const chain = /^\/tasks\/([^/]+)\/chain$/.exec(url);
     if (chain) return new Response(JSON.stringify(chain[1] === "c" ? chainFor("c") : emptyChain()), { status: 200 });
     return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
-  }) as typeof fetch;
-
-  const container = dom.window.document.getElementById("root")!;
-  const root = createRoot(container);
+  } }, "http://localhost/tasks/a");
+  const { dom, container } = page;
   try {
-    act(() => root.render(<TaskDetailPage taskId="a" />));
-    await settle();
     assert.match(container.textContent ?? "", /Source A/);
     assert.match(container.textContent ?? "", /revised-plan source artifact/);
 
@@ -153,14 +125,14 @@ test("task-id switches expose a clean loading shell and destination-scoped actio
     assert.match(container.textContent ?? "", /source-only-workspace/);
     assert.equal(sourceInput.value, "unsent source draft");
 
-    act(() => root.render(<TaskDetailPage taskId="b" />));
+    act(() => replaceSubject?.(<TaskDetailPage taskId="b" />));
     assert.match(container.textContent ?? "", /Loading/);
     assert.doesNotMatch(container.textContent ?? "", /Source A|revised-plan source artifact|unsent source draft|source-only-workspace/);
     assert.equal(container.querySelector("button"), null, "destination shell exposes no source action");
     assert.equal(container.querySelector("input"), null, "destination shell exposes no source draft field");
 
     resolveB!(new Response(JSON.stringify(tasks.b), { status: 200 }));
-    await settle();
+    await page.settle();
     assert.match(container.textContent ?? "", /Destination B/);
     assert.match(container.textContent ?? "", /No output recorded/);
     assert.match(container.textContent ?? "", /independently review the persisted plan/);
@@ -171,7 +143,7 @@ test("task-id switches expose a clean loading shell and destination-scoped actio
       id: "late-a", taskId: "a", actorType: "operator", actorId: null,
       body: "late source activity", metadata: null, createdAt: now,
     }]), { status: 200 }));
-    await settle();
+    await page.settle();
     assert.doesNotMatch(container.textContent ?? "", /late source activity/);
     assert.equal(destinationInput.value, "", "a late source response must not restore the source draft");
     assert.doesNotMatch(container.textContent ?? "", /source-only-workspace/);
@@ -181,28 +153,28 @@ test("task-id switches expose a clean loading shell and destination-scoped actio
       select.value = "DOING";
       select.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
     });
-    await settle();
+    await page.settle();
     const archive = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Archive"))!;
     await act(async () => { archive.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })); });
-    await settle();
+    await page.settle();
     await act(async () => {
       const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, "value")!.set!;
       setter.call(destinationInput, "destination comment");
       destinationInput.dispatchEvent(new dom.window.InputEvent("input", { bubbles: true, inputType: "insertText", data: "destination comment" }));
       destinationInput.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
     });
-    await settle();
+    await page.settle();
     const send = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Send"))!;
     assert.equal(send.disabled, false, `comment=${destinationInput.value}`);
     await act(async () => { send.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })); });
-    await settle();
+    await page.settle();
 
-    act(() => root.render(<TaskDetailPage taskId="c" />));
+    act(() => replaceSubject?.(<TaskDetailPage taskId="c" />));
     assert.doesNotMatch(container.textContent ?? "", /Destination B|destination comment/);
-    await settle();
+    await page.settle();
     const start = [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Start next step"))!;
     await act(async () => { start.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })); });
-    await settle();
+    await page.settle();
 
     assert.ok(mutations.some((item) => item.url === "/tasks/b/start" && item.method === "POST"));
     assert.ok(mutations.some((item) => item.url === "/tasks/b/archive" && item.method === "POST"));
@@ -214,48 +186,27 @@ test("task-id switches expose a clean loading shell and destination-scoped actio
       data: output("b", "same-resource artifact"), error: null, loading: false, missing: false,
       lastSuccessAt: now, reload: () => undefined,
     };
-    act(() => root.render(<TaskOutput poll={heldOutput} />));
+    act(() => replaceSubject?.(<TaskOutput poll={heldOutput} />));
     assert.match(container.textContent ?? "", /same-resource artifact/);
-    act(() => root.render(<TaskOutput poll={{
+    act(() => replaceSubject?.(<TaskOutput poll={{
       ...heldOutput, error: new ApiError(404, "/tasks/b/output", "Output not found"), missing: true,
     }} />));
     assert.match(container.textContent ?? "", /No output recorded/);
     assert.doesNotMatch(container.textContent ?? "", /same-resource artifact|Output not found/);
     for (const status of [405, 501]) {
-      act(() => root.render(<TaskOutput poll={{
+      act(() => replaceSubject?.(<TaskOutput poll={{
         ...heldOutput, data: null, error: new ApiError(status, "/tasks/b/output", `HTTP ${status}`), missing: true,
       }} />));
       assert.match(container.textContent ?? "", new RegExp(`HTTP ${status}`));
       assert.doesNotMatch(container.textContent ?? "", /No output recorded/);
     }
   } finally {
-    act(() => root.unmount());
-    globalThis.fetch = previous.fetch;
-    for (const [name, value] of Object.entries({ window: previous.window, document: previous.document, navigator: previous.navigator })) {
-      Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
-    }
-    dom.window.close();
+    replaceSubject = null;
+    await page.dispose();
   }
 });
 
 test("the task-detail Chain card reflects a completed held layer on the next poll and deduplicates Resume", async () => {
-  const previous = {
-    window: globalThis.window,
-    document: globalThis.document,
-    navigator: globalThis.navigator,
-    HTMLElement: globalThis.HTMLElement,
-    HTMLButtonElement: globalThis.HTMLButtonElement,
-    HTMLFormElement: globalThis.HTMLFormElement,
-    HTMLInputElement: globalThis.HTMLInputElement,
-    Element: globalThis.Element,
-    Node: globalThis.Node,
-    MutationObserver: globalThis.MutationObserver,
-    Event: globalThis.Event,
-    InputEvent: globalThis.InputEvent,
-    MouseEvent: globalThis.MouseEvent,
-    fetch: globalThis.fetch,
-  };
-  const { dom, container } = installDom("http://localhost/tasks/hold");
   const holdTask = task("hold", "Held task", 0, "chain-hold");
   const runningChain = chainFor("hold");
   runningChain.chainId = "chain-hold";
@@ -273,9 +224,8 @@ test("the task-detail Chain card reflects a completed held layer on the next pol
   let latestChain = runningChain;
   let chainPolls = 0;
   const mutations: Array<{ url: string; method: string; body: string }> = [];
-  globalThis.fetch = (async (input: string | URL | Request, init: RequestInit = {}) => {
+  const page = await mountPage(<TaskDetailPage taskId="hold" />, { "*": ({ input, init, method }) => {
     const url = String(input).replace(/^.*\/api/, "");
-    const method = init.method ?? "GET";
     if (method !== "GET") {
       mutations.push({ url, method, body: String(init.body ?? "") });
       return new Response("{}", { status: 200 });
@@ -293,19 +243,16 @@ test("the task-detail Chain card reflects a completed held layer on the next pol
       return new Response(JSON.stringify(latestChain), { status: 200 });
     }
     return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
-  }) as typeof fetch;
-  const { createRoot } = await reactDom();
-  const { TaskDetailPage } = await import("../pages/TaskDetail");
-  const root = createRoot(container);
+  } }, "http://localhost/tasks/hold");
+  const { dom, container } = page;
   try {
-    act(() => root.render(<TaskDetailPage taskId="hold" />));
-    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 20)); });
     assert.ok(chainPolls >= 1);
     assert.match(container.textContent ?? "", /Current execution/);
     assert.doesNotMatch(container.textContent ?? "", /Waiting for the operator to resume/);
 
     latestChain = completedChain;
     await act(async () => { await new Promise((resolve) => setTimeout(resolve, 2_600)); });
+    await page.settle();
     assert.ok(chainPolls >= 2, `expected a poll after the initial response, got ${chainPolls}`);
     assert.match(container.textContent ?? "", /Waiting for the operator to resume/);
 
@@ -315,8 +262,8 @@ test("the task-detail Chain card reflects a completed held layer on the next pol
     await act(async () => {
       toggle!.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
       toggle!.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
-      await new Promise((resolve) => setTimeout(resolve, 20));
     });
+    await page.settle();
     const resumes = mutations.filter((item) => item.url === "/tasks/hold/chain/resume");
     assert.equal(resumes.length, 1, JSON.stringify(mutations));
     assert.match(JSON.parse(resumes[0]!.body).requestId, /^[0-9a-f]{8}-[0-9a-f-]{27}$/u);
@@ -326,14 +273,12 @@ test("the task-detail Chain card reflects a completed held layer on the next pol
     await act(async () => {
       stop!.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
       stop!.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
-      await new Promise((resolve) => setTimeout(resolve, 20));
     });
+    await page.settle();
     const holds = mutations.filter((item) => item.url === "/tasks/hold/chain/hold");
     assert.equal(holds.length, 1, JSON.stringify(mutations));
     assert.match(JSON.parse(holds[0]!.body).requestId, /^[0-9a-f]{8}-[0-9a-f-]{27}$/u);
   } finally {
-    act(() => root.unmount());
-    Object.assign(globalThis, previous);
-    dom.window.close();
+    await page.dispose();
   }
 });

--- a/apps/web/src/tests/tasks-board.test.tsx
+++ b/apps/web/src/tests/tasks-board.test.tsx
@@ -14,7 +14,7 @@ import { ProjectProvider } from "../lib/project";
 import { storage } from "../lib/storage";
 import { BOARD_PAGE, ChainFilterControl, TasksPage, archiveDoneNotice, moveAction, moveNotAllowedNotice, stableRows, startabilityRefusal, tasksForChain, useTaskStartConfirmation } from "../pages/Tasks";
 import type { BoardTask, ChainProgress, TaskStartability, TaskStatus } from "../lib/types";
-import { installDom, reactDom } from "./dom-harness";
+import { installDom, mountPage, reactDom } from "./dom-harness";
 
 const en = (key: string, vars?: Record<string, string | number>): string => translate("en", key, vars);
 
@@ -141,9 +141,7 @@ const withStartFlow = async (walk: (flow: {
   requests: BoardRequest[];
   press: (label: string) => Promise<void>;
 }) => Promise<void>, startStatus = 201): Promise<void> => {
-  const { dom, container } = installDom();
   const requests: BoardRequest[] = [];
-  const originalFetch = globalThis.fetch;
   const startability = {
     startable: true,
     checklist: {
@@ -155,11 +153,10 @@ const withStartFlow = async (walk: (flow: {
       repo: { id: "r1", name: "product" }, targetBranch: "main",
     },
   };
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (url: string, init?: RequestInit) => {
-    const path = String(url);
-    const method = init?.method ?? "GET";
-    requests.push({ method, path, body: init?.body === undefined ? null : JSON.parse(String(init.body)) });
-    if (path === "/api/tasks/t1/startability") return Response.json(startability);
+  const page = await mountPage(<StartFlowHarness />, { "*": ({ input, init, method }) => {
+    const path = String(input);
+    requests.push({ method, path, body: init.body === undefined ? null : JSON.parse(String(init.body)) });
+    if (path === "/api/tasks/t1/startability") return startability;
     if (path === "/api/tasks/t1/start" && method === "POST") {
       return startStatus === 201
         ? Response.json({ runId: "run-1", runNumber: 1 }, { status: 201 })
@@ -167,27 +164,10 @@ const withStartFlow = async (walk: (flow: {
     }
     return Response.json([], { status: 404 });
   } });
-  const root = (await reactDom()).createRoot(container);
-  const settle = async (): Promise<void> => {
-    for (let round = 0; round < 3; round += 1) {
-      await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
-    }
-  };
-  const press = async (label: string): Promise<void> => {
-    const found = [...dom.window.document.querySelectorAll("button")]
-      .find((candidate) => candidate.textContent?.trim() === label || candidate.getAttribute("aria-label") === label);
-    assert.ok(found, `no button labelled ${label}`);
-    await act(async () => found.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
-    await settle();
-  };
   try {
-    await act(async () => root.render(<StartFlowHarness />));
-    await settle();
-    await walk({ dom, requests, press });
+    await walk({ dom: page.dom, requests, press: page.press });
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
   }
 };
 
@@ -345,7 +325,6 @@ test("a non-template chain uses the API-derived badge and short card title", () 
 });
 
 test("Archive All confirms the project-wide Done scope even while one chain is visible", async () => {
-  const { dom, container } = installDom();
   storage.set("agentos.projectId", "p1");
   const settledAggregate = (chainId: string, chainName: string, taskId: string) => ({
     chainId, chainName, detailTaskId: taskId, stepCount: 1,
@@ -358,51 +337,39 @@ test("Archive All confirms the project-wide Done scope even while one chain is v
     task({ id: "visible", name: "Alpha: Review", displayName: "Review", status: "DONE", chainId: "alpha", chainName: "Alpha", chainProgress: progress({ chainId: "alpha" }), chainAggregate: settledAggregate("alpha", "Alpha", "visible") }),
     task({ id: "hidden", name: "Beta: Review", displayName: "Review", status: "DONE", chainId: "beta", chainName: "Beta", chainProgress: progress({ chainId: "beta" }), chainAggregate: settledAggregate("beta", "Beta", "hidden") }),
   ];
-  const originalFetch = globalThis.fetch;
   const confirmations: string[] = [];
   const mutations: string[] = [];
-  Object.defineProperty(dom.window, "confirm", { configurable: true, value: (message: string) => { confirmations.push(message); return true; } });
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (input: string, init?: RequestInit) => {
-    const path = String(input);
-    if ((init?.method ?? "GET") === "POST") {
+  const page = await mountPage(<ProjectProvider><TasksPage /></ProjectProvider>, {
+    "GET /projects": [{ id: "p1", name: "Project One" }],
+    "GET /tasks": rows,
+    "POST /projects/p1/tasks/archive-done": ({ input }) => {
+      mutations.push(String(input));
+      return { archived: 2, skipped: 0 };
+    },
+    "*": ({ input, method }) => {
+      const path = String(input);
+      if (method === "POST") {
       mutations.push(path);
-      return Response.json({ archived: 2, skipped: 0 });
+        return { archived: 2, skipped: 0 };
+      }
+      return [];
     }
-    if (path === "/api/projects") return Response.json([{ id: "p1", name: "Project One" }]);
-    if (path.includes("/api/tasks?")) return Response.json(rows);
-    return Response.json([]);
-  } });
-  const root = (await reactDom()).createRoot(container);
-  const flush = async (): Promise<void> => {
-    await act(async () => { for (let turn = 0; turn < 20; turn += 1) await Promise.resolve(); });
-  };
-  const press = async (label: string): Promise<void> => {
-    const button = [...dom.window.document.querySelectorAll("button")].find((node) => (
-      node.textContent?.trim() === label || node.getAttribute("aria-label") === label
-    ));
-    assert.ok(button, `missing button ${label}: ${container.innerHTML}`);
-    await act(async () => button.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
-    await flush();
-  };
+  });
+  Object.defineProperty(page.dom.window, "confirm", { configurable: true, value: (message: string) => { confirmations.push(message); return true; } });
   try {
-    await act(async () => root.render(<ProjectProvider><TasksPage /></ProjectProvider>));
-    await flush();
-    await press("Show only chain Alpha");
-    assert.ok(container.querySelector('[data-card="visible"]'));
-    assert.equal(container.querySelector('[data-card="hidden"]'), null);
-    await press("Archive All");
+    await page.press("Show only chain Alpha");
+    assert.ok(page.container.querySelector('[data-card="visible"]'));
+    assert.equal(page.container.querySelector('[data-card="hidden"]'), null);
+    await page.press("Archive All");
     assert.deepEqual(confirmations, ["Archive all 2 done tasks in this project?"]);
     assert.deepEqual(mutations, ["/api/projects/p1/tasks/archive-done"]);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
     storage.remove("agentos.projectId");
   }
 });
 
 test("the board renders Backlog oldest first and leaves every other column in the API's order", async () => {
-  const { dom, container } = installDom();
   storage.set("agentos.projectId", "p1");
   // As `GET /tasks` answers: newest first, for every column.
   const rows = [
@@ -412,25 +379,18 @@ test("the board renders Backlog oldest first and leaves every other column in th
     task({ id: "done-new", status: "DONE" }),
     task({ id: "done-old", status: "DONE" }),
   ];
-  const originalFetch = globalThis.fetch;
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (input: string) => {
-    const path = String(input);
-    if (path === "/api/projects") return Response.json([{ id: "p1", name: "Project One" }]);
-    if (path.includes("/api/tasks?")) return Response.json(rows);
-    return Response.json([]);
-  } });
-  const root = (await reactDom()).createRoot(container);
+  const page = await mountPage(<ProjectProvider><TasksPage /></ProjectProvider>, {
+    "GET /projects": [{ id: "p1", name: "Project One" }],
+    "GET /tasks": rows,
+    "*": [],
+  });
   try {
-    await act(async () => root.render(<ProjectProvider><TasksPage /></ProjectProvider>));
-    await act(async () => { for (let turn = 0; turn < 20; turn += 1) await Promise.resolve(); });
-    const rendered = [...container.querySelectorAll("[data-card]")].map((node) => node.getAttribute("data-card"));
+    const rendered = [...page.container.querySelectorAll("[data-card]")].map((node) => node.getAttribute("data-card"));
     // Backlog is a queue dispatched from the top, so a numbered queue has to
     // read top-to-bottom in dispatch order; Done reports what just happened.
     assert.deepEqual(rendered, ["backlog-old", "backlog-mid", "backlog-new", "done-new", "done-old"]);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
     storage.remove("agentos.projectId");
   }
 });

--- a/apps/web/src/tests/tasks-transitions.test.tsx
+++ b/apps/web/src/tests/tasks-transitions.test.tsx
@@ -4,7 +4,7 @@ import { act, type ReactNode, useCallback, useState } from "react";
 
 import type { CardActions } from "../components/task-card";
 import type { BoardTask, TaskStatus } from "../lib/types";
-import { installDom, reactDom } from "./dom-harness";
+import { installDom, mountPage } from "./dom-harness";
 
 const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
   id: "t1", name: "Ship the thing", displayName: overrides.displayName ?? overrides.name ?? "Ship the thing", status: "TODO", moveTargets: [],
@@ -57,12 +57,6 @@ const startability = (startable: boolean) => ({
   },
 });
 
-const settle = async (): Promise<void> => {
-  await act(async () => {
-    for (let round = 0; round < 4; round += 1) await Promise.resolve();
-  });
-};
-
 const installComputedStyle = (dom: ReturnType<typeof installDom>["dom"]): void => {
   Object.defineProperty(globalThis, "getComputedStyle", {
     configurable: true,
@@ -73,7 +67,7 @@ const installComputedStyle = (dom: ReturnType<typeof installDom>["dom"]): void =
   Object.defineProperty(globalThis, "DOMRect", { configurable: true, value: dom.window.DOMRect });
 };
 
-const openDoing = async (dom: ReturnType<typeof installDom>["dom"]): Promise<HTMLElement> => {
+const openDoing = async (dom: ReturnType<typeof installDom>["dom"], settle: () => Promise<void>): Promise<HTMLElement> => {
   const trigger = dom.window.document.querySelector<HTMLButtonElement>("button[aria-label^='Actions for']");
   assert.ok(trigger, dom.window.document.body.innerHTML);
   await act(async () => trigger.dispatchEvent(new dom.window.MouseEvent("pointerdown", { bubbles: true, button: 0 })));
@@ -85,31 +79,28 @@ const openDoing = async (dom: ReturnType<typeof installDom>["dom"]): Promise<HTM
 };
 
 test("the agent menu Doing action opens confirmation and never PATCHes", async () => {
-  const { dom, container } = installDom();
-  installComputedStyle(dom);
+  const preload = installDom();
+  installComputedStyle(preload.dom);
   const { useTaskStartConfirmation } = await import("../pages/Tasks");
   const { TaskCard } = await import("../components/task-card");
-  const originalFetch = globalThis.fetch;
   const requests: Array<{ method: string; path: string }> = [];
   const mutations: TaskStatus[] = [];
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (input: string, init?: RequestInit) => {
+  const page = await mountPage(<StartMenuHarness Card={TaskCard} useStart={useTaskStartConfirmation} row={task({
+    assigneeType: "AGENT",
+    assigneeAgent: { id: "a1", title: "Senior dev", model: "gpt-5.6-luna:max" },
+    moveTargets: [{ status: "BACKLOG", via: "patch" }, { status: "DOING", via: "start" }],
+  })} onMutation={(status) => mutations.push(status)} />, { "*": ({ input, method }) => {
     const path = String(input);
-    requests.push({ method: init?.method ?? "GET", path });
+    requests.push({ method, path });
     if (path === "/api/tasks/t1/startability") return Response.json(startability(true));
     if (path === "/api/tasks/t1/start") return Response.json({ runId: "r1", runNumber: 1 }, { status: 201 });
     return Response.json([], { status: 404 });
   } });
-  const root = (await reactDom()).createRoot(container);
+  const { dom, container } = page;
   try {
-    await act(async () => root.render(<StartMenuHarness Card={TaskCard} useStart={useTaskStartConfirmation} row={task({
-      assigneeType: "AGENT",
-      assigneeAgent: { id: "a1", title: "Senior dev", model: "gpt-5.6-luna:max" },
-      moveTargets: [{ status: "BACKLOG", via: "patch" }, { status: "DOING", via: "start" }],
-    })} onMutation={(status) => mutations.push(status)} />));
-    await settle();
-    const doing = await openDoing(dom);
+    const doing = await openDoing(dom, page.settle);
     await act(async () => doing.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
-    await settle();
+    await page.settle();
     assert.ok(container.querySelector("[data-confirmation]"), container.innerHTML);
     assert.equal(requests.filter(({ method, path }) => method === "GET" && path === "/api/tasks/t1/startability").length, 1);
     assert.equal(requests.some(({ method }) => method === "PATCH"), false);
@@ -120,47 +111,42 @@ test("the agent menu Doing action opens confirmation and never PATCHes", async (
       .find((button) => button.textContent?.trim() === "Start task");
     assert.ok(confirm);
     await act(async () => confirm.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true })));
-    await settle();
+    await page.settle();
     assert.equal(requests.filter(({ method, path }) => method === "POST" && path === "/api/tasks/t1/start").length, 1);
     assert.equal(requests.some(({ method }) => method === "PATCH"), false);
     assert.equal(container.querySelector("[data-confirmation]"), null);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
+    preload.dom.window.close();
   }
 });
 
 test("a non-startable agent menu does not advertise Doing", async () => {
-  const { dom, container } = installDom();
-  installComputedStyle(dom);
+  const preload = installDom();
+  installComputedStyle(preload.dom);
   const { useTaskStartConfirmation } = await import("../pages/Tasks");
   const { TaskCard } = await import("../components/task-card");
-  const originalFetch = globalThis.fetch;
   const requests: Array<{ method: string; path: string }> = [];
   const mutations: TaskStatus[] = [];
-  Object.defineProperty(globalThis, "fetch", { configurable: true, value: async (input: string, init?: RequestInit) => {
+  const page = await mountPage(<StartMenuHarness Card={TaskCard} useStart={useTaskStartConfirmation} row={task({ assigneeType: "AGENT", assigneeAgent: { id: "a1", title: "Senior dev", model: "gpt-5.6-luna:max" } })} onMutation={(status) => mutations.push(status)} />, { "*": ({ input, method }) => {
     const path = String(input);
-    requests.push({ method: init?.method ?? "GET", path });
+    requests.push({ method, path });
     if (path === "/api/tasks/t1/startability") return Response.json(startability(false));
     return Response.json([], { status: 404 });
   } });
-  const root = (await reactDom()).createRoot(container);
+  const { dom } = page;
   try {
-    await act(async () => root.render(<StartMenuHarness Card={TaskCard} useStart={useTaskStartConfirmation} row={task({ assigneeType: "AGENT", assigneeAgent: { id: "a1", title: "Senior dev", model: "gpt-5.6-luna:max" } })} onMutation={(status) => mutations.push(status)} />));
-    await settle();
     const trigger = dom.window.document.querySelector<HTMLButtonElement>("button[aria-label^='Actions for']");
     assert.ok(trigger);
     await act(async () => trigger.dispatchEvent(new dom.window.MouseEvent("pointerdown", { bubbles: true, button: 0 })));
-    await settle();
+    await page.settle();
     assert.equal([...dom.window.document.querySelectorAll<HTMLElement>("[role='menuitem']")]
       .some((item) => item.textContent?.trim() === "Doing"), false);
     assert.equal(requests.filter(({ method, path }) => method === "GET" && path === "/api/tasks/t1/startability").length, 0);
     assert.equal(requests.some(({ method }) => method === "PATCH"), false);
     assert.deepEqual(mutations, []);
   } finally {
-    Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
-    await act(async () => root.unmount());
-    dom.window.close();
+    await page.dispose();
+    preload.dom.window.close();
   }
 });


### PR DESCRIPTION
## What changed

- Deepened the test-side DOM harness into a page harness Module. Its Interface accepts a React element and a path-to-response table, then returns a mounted, settled container with `press(label)`, `settle()`, and idempotent `dispose()` operations.
- Kept the global object as the existing fetch seam, but moved fetch installation/restoration, Response body observation, jsdom ordering, React root lifecycle, DOM mutation observation, and cleanup behind the harness Interface.
- Replaced fixed microtask-turn counts with a quiet condition over observed fetch request/response/body activity and DOM mutations. Event-stream drains retain explicit failure guards, but their success conditions are observable DOM content or the existing event ceiling.
- Migrated the owned page and client tests, including `task-detail-navigation.test.tsx`; it no longer constructs its own JSDOM. No production paths changed, and no assertion was weakened.

## Evidence

- `npm install` — PASS.
- Pre-migration fresh-worktree `RUNNER_WORKSPACE_ROOT="$(mktemp -d)" npm test --workspace @anneal/web` — 536 tests reported; 533 passed, 1 skipped, and 2 test files failed to load because the fresh worktree had no web build artifacts.
- `npm run build -w @anneal/web` — PASS. With the required artifacts present, those two files expand into their underlying cases rather than file-level failures.
- Targeted migrated callers via `node --import tsx --test ...` — PASS, 259/259.
- Final integrated head `aa5663b91ce82205ddbb805299ed2ee9d9bf2ac0`: `npm run lint` — PASS.
- Final integrated head: `npm run typecheck` — PASS.
- Final integrated head: `RUNNER_WORKSPACE_ROOT="$(mktemp -d)" npm test --workspace @anneal/web` — PASS, 541 tests; 540 passed, 1 skipped, 0 failed. The fully loaded count is five higher than the fresh pre-build report and did not drop.

## Reported but unfixed

- `apps/web/src/tests/chain-list.test.tsx` remains owned by the sibling lane and was not edited. Its five source-regex assertions over `TaskDetail.tsx` remain at lines 343, 347, and 351-353. The page harness can now replace them with mounted rendering in follow-up work.