### PR TITLE
refactor(api): unify readiness settlements

### DIFF
--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -39,12 +39,10 @@ import {
   type ReadinessInput,
 } from "./readiness-decision.js";
 import {
-  commitWithLeaseOutcome,
   LeaseReleaseDeferralRecordError,
   releaseMergeLease,
   withMergeLease,
   type HeldLeaseOutcome,
-  type LeaseOutcome,
   type ReleaseMergeLease,
   type WithMergeLease,
 } from "./merge-lease.js";
@@ -55,6 +53,13 @@ import {
   type ReadinessClaimHandle,
   type ReadinessLeaseOwnership,
 } from "./readiness-claim.js";
+import {
+  createReadinessSettlementRunner,
+  readinessSettlement,
+  type ReadinessSettlement,
+  type ReadinessSettlementApplication,
+  type ReadinessSettlementRunner,
+} from "./readiness-settlement.js";
 
 export const readinessPollIntervalMs = (): number => {
   const raw = Number(process.env.MERGE_READINESS_POLL_INTERVAL_MS);
@@ -239,86 +244,47 @@ const recoveryContextFor = async (
   return row && context ? { context, status: row.status } : null;
 };
 
-const stopReadiness = async (
-  db: PrismaClient,
+const stopReadinessSettlement = (
   input: {
     readinessTaskId: string;
     regressionTaskId: string;
     reason: string;
     recovery: RecoveryContext | null;
     refusalCode: MergeRecoveryRefusalCode | null;
+    now: Date;
   },
-  claim: ReadinessClaimHandle,
-  releaseChainLease: ReleaseMergeLease,
-): Promise<{
-  applied: boolean;
-  ownership: ReadinessLeaseOwnership;
-}> => commitWithLeaseOutcome(db, (tx) => settleReadinessStop(tx, input, claim), {
-  release: releaseChainLease,
-}).then((settlement) => {
-  if (!settlement) throw new Error("Readiness stop transaction returned no settlement");
-  return settlement;
-});
-
-const settleReadinessStop = async (
-  tx: Prisma.TransactionClient,
-  input: {
-    readinessTaskId: string;
-    regressionTaskId: string;
-    reason: string;
-    recovery: RecoveryContext | null;
-    refusalCode: MergeRecoveryRefusalCode | null;
-  },
-  claim: ReadinessClaimHandle,
-): Promise<{
-  value: { applied: boolean; ownership: ReadinessLeaseOwnership };
-  leaseOutcome: LeaseOutcome;
-}> => {
-  const settlement = await claim.settle(tx, {
-    kind: "finish",
-    at: new Date(),
-    apply: async (client) => {
-      const stopped = await stopMergeTail(client, {
-        phase: "readiness",
-        readinessTaskId: input.readinessTaskId,
-        regressionTaskId: input.regressionTaskId,
-        reason: input.reason,
-        recovery: input.recovery,
-        at: new Date(),
+): ReadinessSettlement => readinessSettlement("stop", {
+  taskId: input.regressionTaskId,
+  at: input.now,
+  apply: async (tx) => {
+    const stopped = await stopMergeTail(tx, {
+      phase: "readiness",
+      readinessTaskId: input.readinessTaskId,
+      regressionTaskId: input.regressionTaskId,
+      reason: input.reason,
+      recovery: input.recovery,
+      at: input.now,
+    });
+    if (input.recovery && input.refusalCode) {
+      const coded = await tx.mergeRecoveryAttempt.updateMany({
+        where: {
+          id: input.recovery.aggregateId,
+          status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
+          failureReason: input.reason,
+        },
+        data: { refusalCode: input.refusalCode },
       });
-      if (input.recovery && input.refusalCode) {
-        const coded = await client.mergeRecoveryAttempt.updateMany({
-          where: {
-            id: input.recovery.aggregateId,
-            status: MergeRecoveryStatus.BLOCKED_DOWNSTREAM,
-            failureReason: input.reason,
-          },
-          data: { refusalCode: input.refusalCode },
-        });
-        if (coded.count !== 1) {
-          throw new Error(`Recovery refusal code was not recorded for ${input.recovery.aggregateId}`);
-        }
+      if (coded.count !== 1) {
+        throw new Error(`Recovery refusal code was not recorded for ${input.recovery.aggregateId}`);
       }
-      return { value: stopped, ownership: "released" as const };
-    },
-  });
-  if (!settlement.settled) {
-    return {
-      value: { applied: false, ownership: settlement.ownership },
-      leaseOutcome: { kind: "continue" },
-    };
-  }
-  if (settlement.claim !== "released") throw new Error("Readiness stop retained a finished claim");
-  return {
-    value: { applied: true, ownership: settlement.ownership },
-    leaseOutcome: settlement.value.leaseOutcome,
-  };
-};
+    }
+    return { ownership: "released", leaseOutcome: stopped.leaseOutcome };
+  },
+});
 
 export type ReadinessTickResult = { claimed: number; authorized: number; requeued: number; stopped: number };
 
-const requeueRegression = async (
-  db: PrismaClient,
+const requeueRegressionSettlement = (
   input: {
     readinessTaskId: string;
     regressionTaskId: string;
@@ -328,83 +294,50 @@ const requeueRegression = async (
     now: Date;
     recovery: RecoveryContext | null;
   },
-  claim: ReadinessClaimHandle,
-  releaseChainLease: ReleaseMergeLease,
-): Promise<{ applied: boolean; ownership: ReadinessLeaseOwnership }> => commitWithLeaseOutcome(
-  db,
-  (tx) => settleRegressionRequeue(tx, input, claim),
-  { release: releaseChainLease },
-).then((settlement) => {
-  if (!settlement) throw new Error("Regression requeue transaction returned no settlement");
-  return settlement;
-});
-
-const settleRegressionRequeue = async (
-  tx: Prisma.TransactionClient,
-  input: {
-    readinessTaskId: string;
-    regressionTaskId: string;
-    staleBaseSha: string;
-    currentBaseSha: string;
-    reason: string;
-    now: Date;
-    recovery: RecoveryContext | null;
-  },
-  claim: ReadinessClaimHandle,
-): Promise<{
-  value: { applied: boolean; ownership: ReadinessLeaseOwnership };
-  leaseOutcome: LeaseOutcome;
-}> => {
-  const settlement = await claim.settle(tx, {
-    kind: "finish",
-    at: input.now,
-    apply: async (client) => {
-      // The prior Regression run succeeded; the control plane invalidated its
-      // exact-base evidence after a remote read. This retry is therefore external
-      // compensation, not another attempt charged to the agent. Without the
-      // grant, a requeue at the configured ceiling creates run N+1 with ceiling N
-      // and the runner rejects it before launch -- exactly the stuck state the
-      // readiness transition was supposed to recover.
-      if (input.recovery) {
-        await enterRepair(client, {
-          aggregateId: input.recovery.aggregateId,
+): ReadinessSettlement => readinessSettlement("requeue", {
+  taskId: input.regressionTaskId,
+  at: input.now,
+  apply: async (tx) => {
+    // The prior Regression run succeeded; the control plane invalidated its
+    // exact-base evidence after a remote read. This retry is therefore external
+    // compensation, not another attempt charged to the agent. Without the
+    // grant, a requeue at the configured ceiling creates run N+1 with ceiling N
+    // and the runner rejects it before launch -- exactly the stuck state the
+    // readiness transition was supposed to recover.
+    if (input.recovery) {
+      await enterRepair(tx, {
+        aggregateId: input.recovery.aggregateId,
+        currentBaseSha: input.currentBaseSha,
+        now: input.now,
+        readinessRequeue: { staleBaseSha: input.staleBaseSha, reason: input.reason },
+      });
+    } else {
+      await tx.task.update({
+        where: { id: input.readinessTaskId },
+        data: { status: TaskStatus.TODO, failureReason: null },
+      });
+      await tx.task.update({
+        where: { id: input.regressionTaskId },
+        data: { status: TaskStatus.TODO, failureReason: null },
+      });
+      await enqueueTaskRun(tx, input.regressionTaskId, input.now, { budgetGrant: 1 });
+      await writeMarker(tx, input.regressionTaskId, "readiness", {
+        actorType: "control-plane",
+        body: `Merge readiness returned to regression: ${input.reason}; ${input.staleBaseSha} -> ${input.currentBaseSha}`,
+        metadata: {
+          state: "requeued-regression",
+          reason: input.reason,
+          staleBaseSha: input.staleBaseSha,
           currentBaseSha: input.currentBaseSha,
-          now: input.now,
-          readinessRequeue: { staleBaseSha: input.staleBaseSha, reason: input.reason },
-        });
-      } else {
-        await client.task.update({
-          where: { id: input.readinessTaskId },
-          data: { status: TaskStatus.TODO, failureReason: null },
-        });
-        await client.task.update({
-          where: { id: input.regressionTaskId },
-          data: { status: TaskStatus.TODO, failureReason: null },
-        });
-        await enqueueTaskRun(client, input.regressionTaskId, input.now, { budgetGrant: 1 });
-        await writeMarker(client, input.regressionTaskId, "readiness", {
-          actorType: "control-plane",
-          body: `Merge readiness returned to regression: ${input.reason}; ${input.staleBaseSha} -> ${input.currentBaseSha}`,
-          metadata: {
-            state: "requeued-regression",
-            reason: input.reason,
-            staleBaseSha: input.staleBaseSha,
-            currentBaseSha: input.currentBaseSha,
-          },
-        });
-      }
-      return { value: undefined, ownership: "released" as const };
-    },
-  });
-  if (!settlement.settled) {
-    return { value: { applied: false, ownership: settlement.ownership }, leaseOutcome: { kind: "continue" } };
-  }
-  if (settlement.claim !== "released") throw new Error("Regression requeue retained a finished claim");
-  return {
-    value: { applied: true, ownership: settlement.ownership },
-    leaseOutcome: { kind: "stop", taskId: input.regressionTaskId },
-  };
-};
+        },
+      });
+    }
+    return {
+      ownership: "released",
+      leaseOutcome: { kind: "stop", taskId: input.regressionTaskId },
+    };
+  },
+});
 
 type ClaimedReadiness = {
   claimed: true;
@@ -502,25 +435,23 @@ const readReadiness = async (
   }
 };
 
-const deferReadiness = async (
-  db: PrismaClient,
+const deferReadinessSettlement = (
   readinessTaskId: string,
-  claim: ReadinessClaimHandle,
-): Promise<{ applied: boolean; ownership: ReadinessLeaseOwnership }> => db.$transaction(async (tx) => {
-  const settlement = await claim.settle(tx, {
-    kind: "finish",
-    at: new Date(),
-    apply: async (client) => {
-      await client.task.update({
-        where: { id: readinessTaskId },
-        data: { status: TaskStatus.TODO, failureReason: null },
-      });
-      return { value: undefined, ownership: "released" as const };
-    },
-  });
-  if (!settlement.settled) return { applied: false, ownership: settlement.ownership };
-  if (settlement.claim !== "released") throw new Error("Readiness defer retained a finished claim");
-  return { applied: true, ownership: settlement.ownership };
+  regressionTaskId: string,
+  now: Date,
+): ReadinessSettlement => readinessSettlement("defer", {
+  taskId: regressionTaskId,
+  at: now,
+  apply: async (tx) => {
+    await tx.task.update({
+      where: { id: readinessTaskId },
+      data: { status: TaskStatus.TODO, failureReason: null },
+    });
+    return {
+      ownership: "released",
+      leaseOutcome: { kind: "stop", taskId: regressionTaskId },
+    };
+  },
 });
 
 const recordLeaseDeferral = async (
@@ -555,77 +486,195 @@ const heldLeaseOutcome = (ownership: ReadinessLeaseOwnership, taskId: string): H
   ? { kind: "stop", taskId }
   : { kind: "continue" };
 
-type ReadinessDecisionApplication =
-  | { kind: "authorize"; decision: Extract<ReadinessDecision, { kind: "authorize" }> }
-  | { kind: "settled"; leaseOutcome: HeldLeaseOutcome; value: "settled" };
+const authorizeReadinessSettlement = (
+  read: ClaimedReadiness,
+  decision: Extract<ReadinessDecision, { kind: "authorize" }>,
+): ReadinessSettlement => {
+  const { readiness, regression, recovery } = read;
+  return readinessSettlement("authorize", {
+    taskId: regression.id,
+    at: read.input.now,
+    apply: async (tx) => {
+      await tx.task.update({
+        where: { id: readiness.id },
+        data: { status: TaskStatus.DONE, failureReason: null },
+      });
+      const binding = `mechanical:${readiness.id}:${randomUUID()}`;
+      const payload = {
+        ...decision.evidence,
+        mergeMethod: AUTHORIZED_MERGE_METHOD,
+        issuedAt: decision.issuedAt,
+        decision: {
+          channel: "mechanical" as const,
+          inboxDecisionId: binding,
+          inboxMessageId: binding,
+        },
+      };
+      if (recovery) {
+        // Recovery regression merges the current base before it proves the
+        // candidate, so its gated head may legitimately replace the head that
+        // first stopped on base drift. Adopt only the head re-read under the
+        // merge Lease and bind the CAS to the pre-Lease recovery snapshot.
+        try {
+          await adoptRecoveryHead(tx, {
+            recovery,
+            currentBaseSha: decision.evidence.baseSha,
+            authorizedHeadSha: decision.evidence.headSha,
+          });
+        } catch (error: unknown) {
+          if (!await recoveryHeadAdoptionSnapshotChanged(tx, recovery)) throw error;
+          throw new MergeRecoveryRefusalError(MergeRecoveryRefusalCode.HEAD_ADOPTION_CONFLICT, error);
+        }
+      }
+      const activity = await tx.taskActivity.create({ data: {
+        taskId: readiness.id,
+        actorType: "control-plane",
+        body: `Mechanical merge authorized for PR #${decision.prNumber} at ${decision.evidence.headSha}`,
+        metadata: {
+          ...authorizationMetadata(payload),
+          recoverySourceStopId: recovery?.sourceStopId ?? null,
+        } as Prisma.InputJsonObject,
+      } });
+      await tx.taskStepOutput.upsert({
+        where: { taskId: readiness.id },
+        create: {
+          taskId: readiness.id,
+          kind: "merge-authorization",
+          body: JSON.stringify({
+            authorizationActivityId: activity.id,
+            headSha: decision.evidence.headSha,
+          }),
+          commitSha: decision.evidence.headSha,
+        },
+        update: {
+          kind: "merge-authorization",
+          body: JSON.stringify({
+            authorizationActivityId: activity.id,
+            headSha: decision.evidence.headSha,
+          }),
+          commitSha: decision.evidence.headSha,
+        },
+      });
+      await tx.task.update({ where: { id: regression.id }, data: { failureReason: null } });
+      if (decision.auditTriggers.length > 0) {
+        await openDefenseAuditNotice(tx, {
+          readinessTaskId: readiness.id,
+          headSha: decision.headSha,
+          baseSha: decision.baseSha,
+          triggers: decision.auditTriggers,
+        });
+      }
+      await writeMarker(tx, readiness.id, "readiness", {
+        actorType: "control-plane",
+        body: `Merge readiness authorized exact head ${decision.evidence.headSha}; merge execution queued`,
+        metadata: {
+          state: "authorized",
+          headSha: decision.evidence.headSha,
+          authorizationActivityId: activity.id,
+          recoverySourceStopId: recovery?.sourceStopId ?? null,
+        },
+      });
+      let activated: { nextTaskId: string | null; gated: boolean };
+      if (recovery) {
+        const recoveryActivation = await activateRecoveryIntegratorSuccessor(tx, {
+          readinessTaskId: readiness.id,
+          integratorTaskId: recovery.integratorTaskId,
+          sourceStopId: recovery.sourceStopId,
+          recoveryRunId: recovery.recoveryRunId,
+          authorizationActivityId: activity.id,
+        }, read.input.now);
+        if (recoveryActivation.outcome === "refused") {
+          throw new MergeRecoveryRefusalError(recoveryActivation.refusalCode);
+        }
+        activated = recoveryActivation;
+      } else {
+        activated = await activateChainSuccessor(tx, readiness, {}, read.input.now);
+      }
+      const handoff = activated.nextTaskId
+        ? await tx.run.findFirst({
+          where: { taskId: activated.nextTaskId, status: RunStatus.QUEUED },
+          select: { id: true },
+          orderBy: { runNumber: "desc" },
+        })
+        : null;
+      return handoff
+        ? {
+          ownership: { retainFor: handoff.id },
+          leaseOutcome: {
+            kind: "hand-off",
+            taskId: regression.id,
+            handoffRunId: handoff.id,
+            at: read.input.now,
+          },
+        }
+        : { ownership: "released", leaseOutcome: { kind: "continue" } };
+    },
+  });
+};
 
-type DecisionLeaseContext =
-  | { position: "before-acquire"; release: ReleaseMergeLease }
-  | { position: "held" };
+type ReadinessDecisionHandlers<T> = {
+  [Kind in ReadinessDecision["kind"]]: (
+    decision: Extract<ReadinessDecision, { kind: Kind }>,
+  ) => T;
+};
+
+const dispatchReadinessDecision = <T>(
+  decision: ReadinessDecision,
+  handlers: ReadinessDecisionHandlers<T>,
+): T => {
+  const handler = handlers[decision.kind] as unknown as (
+    selected: ReadinessDecision,
+  ) => T;
+  return handler(decision);
+};
 
 const applyReadinessDecision = async (
-  db: PrismaClient,
   read: ClaimedReadiness,
   decision: ReadinessDecision,
   result: ReadinessTickResult,
-  lease: DecisionLeaseContext,
-): Promise<ReadinessDecisionApplication> => {
+  runner: ReadinessSettlementRunner,
+): Promise<ReadinessSettlementApplication> => {
   const { readiness, regression, recovery, claim } = read;
-  const underLease = lease.position === "held";
-  const settled = (leaseOutcome: HeldLeaseOutcome): ReadinessDecisionApplication => ({
-    kind: "settled",
-    leaseOutcome,
-    value: "settled",
-  });
-
-  switch (decision.kind) {
-    case "skip":
-      return settled(underLease ? { kind: "stop", taskId: regression.id } : { kind: "continue" });
-    case "defer": {
-      const deferred = await deferReadiness(db, readiness.id, claim);
-      return settled(underLease
-        ? heldLeaseOutcome(deferred.ownership, regression.id)
-        : { kind: "continue" });
-    }
-    case "stop": {
-      const input = {
+  return dispatchReadinessDecision(decision, {
+    skip: () => Promise.resolve(runner.skip(regression.id)),
+    defer: () => runner.apply(
+      deferReadinessSettlement(readiness.id, regression.id, new Date()),
+      claim,
+    ),
+    stop: async (stopping) => {
+      const application = await runner.apply(stopReadinessSettlement({
         readinessTaskId: readiness.id,
         regressionTaskId: regression.id,
-        reason: decision.evidence,
+        reason: stopping.evidence,
         recovery,
         refusalCode: null,
-      };
-      const stopped = lease.position === "held"
-        ? (await db.$transaction((tx) => settleReadinessStop(tx, input, claim))).value
-        : await stopReadiness(db, input, claim, lease.release);
-      if (stopped.applied) result.stopped += 1;
-      return settled(underLease
-        ? stopped.applied
-          ? { kind: "stop", taskId: regression.id }
-          : heldLeaseOutcome(stopped.ownership, regression.id)
-        : { kind: "continue" });
-    }
-    case "requeue-regression": {
-      const input = {
+        now: new Date(),
+      }), claim);
+      if (application.kind === "settled" && application.outcome.value.applied) {
+        result.stopped += 1;
+      }
+      return application;
+    },
+    "requeue-regression": async (requeue) => {
+      const application = await runner.apply(requeueRegressionSettlement({
         readinessTaskId: readiness.id,
         regressionTaskId: regression.id,
-        ...decision,
+        ...requeue,
         now: read.input.now,
         recovery,
-      };
-      const requeued = lease.position === "held"
-        ? (await db.$transaction((tx) => settleRegressionRequeue(tx, input, claim))).value
-        : await requeueRegression(db, input, claim, lease.release);
-      if (requeued.applied) result.requeued += 1;
-      return settled(underLease
-        ? requeued.applied
-          ? { kind: "stop", taskId: regression.id }
-          : heldLeaseOutcome(requeued.ownership, regression.id)
-        : { kind: "continue" });
-    }
-    case "authorize":
-      return { kind: "authorize", decision };
-  }
+      }), claim);
+      if (application.kind === "settled" && application.outcome.value.applied) {
+        result.requeued += 1;
+      }
+      return application;
+    },
+    authorize: async (authorization) => {
+      return runner.apply(
+        authorizeReadinessSettlement(read, authorization),
+        claim,
+      );
+    },
+  });
 };
 
 const runReadinessDecision = async (
@@ -637,13 +686,16 @@ const runReadinessDecision = async (
   runWithMergeLease: WithMergeLease,
   reader: PullRequestReader | null,
 ): Promise<void> => {
-  const { readiness, regression, recovery, claim } = read;
+  const { readiness, regression, claim } = read;
+  const preAcquireRunner = createReadinessSettlementRunner(db, {
+    kind: "pre-acquire",
+    release: releaseChainLease,
+  });
   const application = await applyReadinessDecision(
-    db,
     read,
     decision,
     result,
-    { position: "before-acquire", release: releaseChainLease },
+    preAcquireRunner,
   );
   if (application.kind === "settled") return;
 
@@ -663,157 +715,26 @@ const runReadinessDecision = async (
     // Regression evidence is durable before this short Lease window. Repeat
     // the remote decision after acquisition so a base move between the first
     // read and the Lease cannot authorize stale evidence.
+    const heldRunner = createReadinessSettlementRunner(db, {
+      kind: "held",
+      release: releaseChainLease,
+    });
+    const leasedDecision = await evaluateReadiness(reader, read.input);
     const leasedApplication = await applyReadinessDecision(
-      db,
       read,
-      await evaluateReadiness(reader, read.input),
+      leasedDecision,
       result,
-      { position: "held" },
+      heldRunner,
     );
-    if (leasedApplication.kind === "settled") return leasedApplication;
-    const leasedDecision = leasedApplication.decision;
-
-    const authorization = await commitWithLeaseOutcome(db, async (tx) => {
-      const settlement = await claim.settle(tx, {
-        kind: "finish",
-        at: read.input.now,
-        apply: async (client) => {
-        await client.task.update({
-          where: { id: readiness.id },
-          data: { status: TaskStatus.DONE, failureReason: null },
-        });
-        const binding = `mechanical:${readiness.id}:${randomUUID()}`;
-        const payload = {
-          ...leasedDecision.evidence,
-          mergeMethod: AUTHORIZED_MERGE_METHOD,
-          issuedAt: leasedDecision.issuedAt,
-          decision: {
-            channel: "mechanical" as const,
-            inboxDecisionId: binding,
-            inboxMessageId: binding,
-          },
-        };
-        if (recovery) {
-          // Recovery regression merges the current base before it proves the
-          // candidate, so its gated head may legitimately replace the head that
-          // first stopped on base drift. Adopt only the head re-read under the
-          // merge Lease and bind the CAS to the pre-Lease recovery snapshot.
-          try {
-            await adoptRecoveryHead(client, {
-              recovery,
-              currentBaseSha: leasedDecision.evidence.baseSha,
-              authorizedHeadSha: leasedDecision.evidence.headSha,
-            });
-          } catch (error: unknown) {
-            if (!await recoveryHeadAdoptionSnapshotChanged(client, recovery)) throw error;
-            throw new MergeRecoveryRefusalError(MergeRecoveryRefusalCode.HEAD_ADOPTION_CONFLICT, error);
-          }
-        }
-        const activity = await client.taskActivity.create({ data: {
-          taskId: readiness.id,
-          actorType: "control-plane",
-          body: `Mechanical merge authorized for PR #${leasedDecision.prNumber} at ${leasedDecision.evidence.headSha}`,
-          metadata: {
-            ...authorizationMetadata(payload),
-            recoverySourceStopId: recovery?.sourceStopId ?? null,
-          } as Prisma.InputJsonObject,
-        } });
-        await client.taskStepOutput.upsert({
-          where: { taskId: readiness.id },
-          create: {
-            taskId: readiness.id,
-            kind: "merge-authorization",
-            body: JSON.stringify({
-              authorizationActivityId: activity.id,
-              headSha: leasedDecision.evidence.headSha,
-            }),
-            commitSha: leasedDecision.evidence.headSha,
-          },
-          update: {
-            kind: "merge-authorization",
-            body: JSON.stringify({
-              authorizationActivityId: activity.id,
-              headSha: leasedDecision.evidence.headSha,
-            }),
-            commitSha: leasedDecision.evidence.headSha,
-          },
-        });
-        await client.task.update({ where: { id: regression.id }, data: { failureReason: null } });
-        if (leasedDecision.auditTriggers.length > 0) {
-          await openDefenseAuditNotice(client, {
-            readinessTaskId: readiness.id,
-            headSha: leasedDecision.headSha,
-            baseSha: leasedDecision.baseSha,
-            triggers: leasedDecision.auditTriggers,
-          });
-        }
-        await writeMarker(client, readiness.id, "readiness", {
-          actorType: "control-plane",
-          body: `Merge readiness authorized exact head ${leasedDecision.evidence.headSha}; merge execution queued`,
-          metadata: {
-            state: "authorized",
-            headSha: leasedDecision.evidence.headSha,
-            authorizationActivityId: activity.id,
-            recoverySourceStopId: recovery?.sourceStopId ?? null,
-          },
-        });
-        let activated: { nextTaskId: string | null; gated: boolean };
-        if (recovery) {
-          const recoveryActivation = await activateRecoveryIntegratorSuccessor(client, {
-            readinessTaskId: readiness.id,
-            integratorTaskId: recovery.integratorTaskId,
-            sourceStopId: recovery.sourceStopId,
-            recoveryRunId: recovery.recoveryRunId,
-            authorizationActivityId: activity.id,
-          }, read.input.now);
-          if (recoveryActivation.outcome === "refused") {
-            throw new MergeRecoveryRefusalError(recoveryActivation.refusalCode);
-          }
-          activated = recoveryActivation;
-        } else {
-          activated = await activateChainSuccessor(client, readiness, {}, read.input.now);
-        }
-        const handoff = activated.nextTaskId
-          ? await client.run.findFirst({
-            where: { taskId: activated.nextTaskId, status: RunStatus.QUEUED },
-            select: { id: true },
-            orderBy: { runNumber: "desc" },
-          })
-          : null;
-        return {
-          value: "authorized" as const,
-          ownership: handoff ? { retainFor: handoff.id } : "released" as const,
-        };
-        },
-      });
-      return {
-        value: settlement,
-        leaseOutcome: settlement.settled
-          && settlement.claim === "released"
-          && settlement.ownership !== "released"
-          ? {
-            kind: "hand-off",
-            taskId: regression.id,
-            handoffRunId: settlement.ownership.retainFor,
-            at: read.input.now,
-          }
-          : { kind: "continue" },
-      };
-    }, { release: releaseChainLease });
-    if (!authorization) throw new Error("Readiness authorization transaction returned no settlement");
-    if (!authorization.settled) {
-      return {
-        leaseOutcome: heldLeaseOutcome(authorization.ownership, regression.id),
-        value: "claim-lost" as const,
-      };
+    if (leasedApplication.kind === "acquire-lease") {
+      throw new Error("Held readiness settlement requested another Merge Lease");
     }
-    if (authorization.claim !== "released") throw new Error("Authorization retained a finished claim");
+    const value = leasedDecision.kind === "authorize" && leasedApplication.outcome.value.applied
+      ? "authorized" as const
+      : "settled" as const;
     return {
-      // A retained ownership was recorded atomically with authorization by
-      // commitWithLeaseOutcome. Continue leaves that Lease for its consumer;
-      // a missing successor still releases through this outer owner.
-      leaseOutcome: heldLeaseOutcome(authorization.ownership, regression.id),
-      value: authorization.value,
+      leaseOutcome: leasedApplication.outcome.leaseOutcome,
+      value,
     };
   }, db);
   if (leased.outcome === "contended") return;
@@ -846,8 +767,8 @@ export const readinessTick = async (
     if (!isMergeReadinessStep(readiness.templateStep)) continue;
 
     const read = await readReadiness(db, readiness, now);
-    const decision = await evaluateReadiness(reader, read.input);
     if (!read.claimed) continue;
+    const decision = await evaluateReadiness(reader, read.input);
     result.claimed += 1;
     try {
       await runReadinessDecision(
@@ -863,21 +784,29 @@ export const readinessTick = async (
       if (error instanceof LeaseReleaseDeferralRecordError) throw error;
       const refusalCode = error instanceof MergeRecoveryRefusalError ? error.refusalCode : null;
       const reason = `readiness evaluation failed: ${error instanceof Error ? error.message : String(error)}`;
-      const stopped = await stopReadiness(db, {
+      const runner = createReadinessSettlementRunner(db, {
+        kind: "pre-acquire",
+        release: releaseChainLease,
+      });
+      const stopped = await runner.apply(stopReadinessSettlement({
         readinessTaskId: readiness.id,
         regressionTaskId: read.regression.id,
         reason,
         recovery: read.recovery,
         refusalCode,
-      }, read.claim, releaseChainLease);
-      if (stopped.applied) {
+        now: new Date(),
+      }), read.claim);
+      if (stopped.kind === "acquire-lease") {
+        throw new Error("Readiness stop requested a Merge Lease");
+      }
+      if (stopped.outcome.value.applied) {
         result.stopped += 1;
       }
       // A failed release/hold recording can happen after stopMergeTail has
       // already committed its state transition. A second stop then returns
       // false and must not turn that failure into a successful-looking tick.
       // Surface it to the worker caller so the missing evidence is observable.
-      if (!stopped.applied) throw error;
+      if (!stopped.outcome.value.applied) throw error;
     }
   }
   return result;

--- a/packages/api/src/readiness-settlement.test.ts
+++ b/packages/api/src/readiness-settlement.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { type Prisma, type PrismaClient } from "@anneal/db";
+
+import {
+  createReadinessSettlementRunner,
+  readinessSettlement,
+  type ReadinessSettlementKind,
+} from "./readiness-settlement.js";
+import type {
+  ReadinessClaimHandle,
+  ReadinessClaimSettlement,
+  ReadinessClaimTransition,
+  ReadinessLeaseOwnership,
+} from "./readiness-claim.js";
+
+const transactionClient = {
+  task: { findUnique: async () => null },
+} as unknown as Prisma.TransactionClient;
+
+const database = {
+  $transaction: async (
+    transaction: (tx: Prisma.TransactionClient) => Promise<unknown>,
+  ) => transaction(transactionClient),
+} as unknown as PrismaClient;
+
+type ClaimCase = "settles" | "does-not-settle" | "retained";
+
+const claimHandle = (
+  claimCase: ClaimCase,
+  ownership: ReadinessLeaseOwnership = { retainFor: "successor-run" },
+): ReadinessClaimHandle => {
+  const settle = async <T>(
+    _tx: Prisma.TransactionClient,
+    transition: ReadinessClaimTransition<T>,
+  ): Promise<ReadinessClaimSettlement<T>> => {
+    if (claimCase === "does-not-settle") return { settled: false, ownership };
+    if (claimCase === "retained") {
+      return { settled: true, claim: "retained", value: undefined as T };
+    }
+    if (transition.kind === "keep") {
+      return { settled: true, claim: "retained", value: await transition.apply(transactionClient) };
+    }
+    const applied = await transition.apply(transactionClient);
+    return {
+      settled: true,
+      claim: "released",
+      value: applied.value,
+      ownership: applied.ownership,
+    };
+  };
+  return {
+    renew: async () => true,
+    settle,
+    ownershipAfterLoss: async () => ownership,
+  };
+};
+
+const kinds: ReadinessSettlementKind[] = ["stop", "requeue", "defer", "authorize"];
+const positions = ["pre-acquire", "held"] as const;
+const claimCases: ClaimCase[] = ["settles", "does-not-settle", "retained"];
+
+test("the settlement runner owns the outcome, position, and claim-state matrix", async (t) => {
+  for (const kind of kinds) {
+    for (const position of positions) {
+      for (const claimCase of claimCases) {
+        await t.test(`${kind} / ${position} / ${claimCase}`, async () => {
+          let bodyRuns = 0;
+          const settlement = readinessSettlement(kind, {
+            taskId: "regression-task",
+            at: new Date("2026-08-29T00:00:00.000Z"),
+            apply: async () => {
+              bodyRuns += 1;
+              return {
+                ownership: "released",
+                leaseOutcome: kind === "authorize"
+                  ? { kind: "continue" }
+                  : { kind: "stop", taskId: "regression-task" },
+              };
+            },
+          });
+          const runner = createReadinessSettlementRunner(database, {
+            kind: position,
+            release: async () => undefined,
+          });
+
+          if (claimCase === "retained" && !(position === "pre-acquire" && kind === "authorize")) {
+            await assert.rejects(
+              runner.apply(settlement, claimHandle(claimCase)),
+              /retained a finished claim/u,
+            );
+            assert.equal(bodyRuns, 0);
+            return;
+          }
+
+          const application = await runner.apply(settlement, claimHandle(claimCase));
+          if (position === "pre-acquire" && kind === "authorize") {
+            assert.deepEqual(application, { kind: "acquire-lease" });
+            assert.equal(bodyRuns, 0);
+            return;
+          }
+
+          assert.equal(application.kind, "settled");
+          if (application.kind !== "settled") return;
+          assert.deepEqual(application.outcome, {
+            value: { applied: claimCase === "settles" },
+            leaseOutcome: position === "held" && claimCase === "settles"
+              ? { kind: "stop", taskId: "regression-task" }
+              : { kind: "continue" },
+          });
+          assert.equal(bodyRuns, claimCase === "settles" ? 1 : 0);
+        });
+      }
+    }
+  }
+});
+
+test("a held runner releases when a lost claim reports released ownership", async () => {
+  const runner = createReadinessSettlementRunner(database, {
+    kind: "held",
+    release: async () => undefined,
+  });
+  const settlement = readinessSettlement("stop", {
+    taskId: "regression-task",
+    at: new Date("2026-08-29T00:00:00.000Z"),
+    apply: async () => ({
+      ownership: "released",
+      leaseOutcome: { kind: "stop", taskId: "regression-task" },
+    }),
+  });
+
+  const application = await runner.apply(settlement, claimHandle("does-not-settle", "released"));
+  assert.deepEqual(application, {
+    kind: "settled",
+    outcome: {
+      value: { applied: false },
+      leaseOutcome: { kind: "stop", taskId: "regression-task" },
+    },
+  });
+});

--- a/packages/api/src/readiness-settlement.ts
+++ b/packages/api/src/readiness-settlement.ts
@@ -1,0 +1,172 @@
+import { type Prisma, type PrismaClient } from "@anneal/db";
+
+import {
+  commitWithLeaseOutcome,
+  type HeldLeaseOutcome,
+  type LeaseOutcome,
+  type ReleaseMergeLease,
+  type TransactionLeaseOutcome,
+} from "./merge-lease.js";
+import {
+  type ReadinessClaimHandle,
+  type ReadinessLeaseOwnership,
+} from "./readiness-claim.js";
+
+export type ReadinessSettlementKind = "stop" | "requeue" | "defer" | "authorize";
+
+export type ReadinessSettlementBody = (
+  tx: Prisma.TransactionClient,
+  claim: ReadinessClaimHandle,
+) => Promise<TransactionLeaseOutcome<{ applied: boolean }>>;
+
+export type ReadinessSettlement = {
+  kind: ReadinessSettlementKind;
+  taskId: string;
+  body: ReadinessSettlementBody;
+};
+
+type ReadinessSettlementApply = (
+  tx: Prisma.TransactionClient,
+) => Promise<{
+  ownership: ReadinessLeaseOwnership;
+  leaseOutcome: LeaseOutcome;
+}>;
+
+export const readinessSettlement = (
+  kind: ReadinessSettlementKind,
+  input: {
+    taskId: string;
+    at: Date;
+    apply: ReadinessSettlementApply;
+  },
+): ReadinessSettlement => ({
+  kind,
+  taskId: input.taskId,
+  body: async (tx, claim) => {
+    const settlement = await claim.settle(tx, {
+      kind: "finish",
+      at: input.at,
+      apply: async (client) => {
+        const applied = await input.apply(client);
+        return { value: applied.leaseOutcome, ownership: applied.ownership };
+      },
+    });
+    if (!settlement.settled) {
+      return {
+        value: { applied: false },
+        leaseOutcome: heldLeaseOutcome(settlement.ownership, input.taskId),
+      };
+    }
+    if (settlement.claim !== "released") {
+      throw new Error("Readiness settlement retained a finished claim");
+    }
+    return {
+      value: { applied: true },
+      leaseOutcome: settlement.value,
+    };
+  },
+});
+
+export type ReadinessSettlementApplication =
+  | { kind: "acquire-lease" }
+  | {
+    kind: "settled";
+    outcome: {
+      value: { applied: boolean };
+      leaseOutcome: HeldLeaseOutcome;
+    };
+  };
+
+type ReadinessSettlementPosition =
+  | { kind: "pre-acquire"; release: ReleaseMergeLease }
+  | { kind: "held"; release: ReleaseMergeLease };
+
+export type ReadinessSettlementRunner = {
+  readonly position: ReadinessSettlementPosition["kind"];
+  apply(
+    settlement: ReadinessSettlement,
+    claim: ReadinessClaimHandle,
+  ): Promise<ReadinessSettlementApplication>;
+  skip(taskId: string): ReadinessSettlementApplication;
+};
+
+const heldLeaseOutcome = (
+  ownership: ReadinessLeaseOwnership,
+  taskId: string,
+): HeldLeaseOutcome => ownership === "released"
+  ? { kind: "stop", taskId }
+  : { kind: "continue" };
+
+const asHeldLeaseOutcome = (
+  outcome: LeaseOutcome,
+  taskId: string,
+): HeldLeaseOutcome => outcome.kind === "stop"
+  ? { kind: "stop", taskId: outcome.taskId ?? taskId }
+  : { kind: "continue" };
+
+const continueLease = (): { kind: "continue" } => ({ kind: "continue" });
+
+const preAcquireOutcome = (
+  settlement: ReadinessSettlement,
+  outcome: TransactionLeaseOutcome<{ applied: boolean }>,
+): TransactionLeaseOutcome<{ applied: boolean }> => {
+  if (!outcome.value.applied || settlement.kind === "defer") {
+    return { ...outcome, leaseOutcome: continueLease() };
+  }
+  return outcome;
+};
+
+const settled = (
+  outcome: { value: { applied: boolean }; leaseOutcome: HeldLeaseOutcome },
+): ReadinessSettlementApplication => ({ kind: "settled", outcome });
+
+/**
+ * Pre-acquire runners commit post-transaction Lease outcomes themselves. Held
+ * runners return a normalized outcome to the withMergeLease callback that owns
+ * the already-acquired Lease.
+ */
+export const createReadinessSettlementRunner = (
+  db: PrismaClient,
+  position: ReadinessSettlementPosition,
+): ReadinessSettlementRunner => ({
+  position: position.kind,
+  skip: (taskId) => settled({
+    value: { applied: false },
+    leaseOutcome: position.kind === "held"
+      ? { kind: "stop", taskId }
+      : { kind: "continue" },
+  }),
+  apply: async (settlement, claim) => {
+    if (position.kind === "pre-acquire") {
+      if (settlement.kind === "authorize") return { kind: "acquire-lease" };
+      const value = await commitWithLeaseOutcome(
+        db,
+        async (tx) => preAcquireOutcome(settlement, await settlement.body(tx, claim)),
+        { release: position.release },
+      );
+      if (!value) throw new Error("Readiness settlement transaction returned no value");
+      return settled({ value, leaseOutcome: continueLease() });
+    }
+
+    if (settlement.kind !== "authorize") {
+      const outcome = await db.$transaction((tx) => settlement.body(tx, claim));
+      return settled({
+        ...outcome,
+        leaseOutcome: asHeldLeaseOutcome(outcome.leaseOutcome, settlement.taskId),
+      });
+    }
+
+    let heldOutcome: HeldLeaseOutcome | null = null;
+    const value = await commitWithLeaseOutcome(db, async (tx) => {
+      const outcome = await settlement.body(tx, claim);
+      heldOutcome = outcome.value.applied && outcome.leaseOutcome.kind === "continue"
+        ? { kind: "stop", taskId: settlement.taskId }
+        : asHeldLeaseOutcome(outcome.leaseOutcome, settlement.taskId);
+      return outcome.value.applied
+        ? outcome
+        : { ...outcome, leaseOutcome: continueLease() };
+    }, { release: position.release });
+    if (!value || !heldOutcome) throw new Error("Readiness authorization transaction returned no value");
+    return settled({ value, leaseOutcome: heldOutcome });
+  },
+});


### PR DESCRIPTION
## What changed

- Added a readiness-settlement Module whose uniform transaction body takes the transaction client and claim Handle, then returns `TransactionLeaseOutcome<{ applied: boolean }>` for stop, requeue, defer, and authorize.
- Moved claim-loss classification, the finished-claim assertion, and pre-acquire versus held Lease application behind one runner Interface. `applyReadinessDecision` is now an outcome dispatch table and no longer receives or branches on Lease position.
- Kept ADR-0003's second repository-state decision inside the Lease window and preserved the existing Lease acquire/release timing and authorization handoff.
- Moved the first `evaluateReadiness` call after the successful claim check. The claim is a local durable CAS and gates the remote repository reads, so a candidate this worker does not own performs no decision work; the required second decision still runs after Lease acquisition.
- Added a no-Postgres matrix test covering stop/requeue/defer/authorize x pre-acquire/held x settles/does-not-settle/retained, plus released ownership after claim loss.

## Evidence

- `npm run lint` — PASS (`biome lint` checked 592 files; ESLint passed).
- `npm run typecheck` — PASS across all workspaces.
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm test --workspace @anneal/api` — PASS: 687 tests, 686 passed, 1 existing opt-in skip, 0 failed.
- With a one-use Docker PostgreSQL 16 scratch database, `AGENTOS_ALLOW_SCRATCH_DATABASES=1`, isolated `TEST_DATABASE_URL` / `TEST_DATABASE_MAINTENANCE_URL`, and a temporary `RUNNER_WORKSPACE_ROOT`: `npm run test:db -w @anneal/api -- src/merge-tail-readiness.dbtest.ts src/merge-stop-state.dbtest.ts` — PASS: 48/48.
- An initial direct targeted Node invocation failed before test execution with `ERR_MODULE_NOT_FOUND` for `@anneal/db/dist/index.js` because it bypassed the workspace `pretest` build. After building `@anneal/github-client` and `@anneal/db`, the targeted worker and settlement tests passed 28/28; the required workspace command above subsequently passed in full.

## Reported but unfixed

None.
