### PR TITLE
refactor(chain): centralize execution ordering

### DIFF
--- a/apps/web/src/components/chain-list.tsx
+++ b/apps/web/src/components/chain-list.tsx
@@ -1,5 +1,7 @@
 import { type ReactNode, useState } from "react";
 
+import { compare, denseOrdinals, layerOf } from "@anneal/db/chain-order";
+
 import { sha, titleCase } from "../lib/format";
 import { useT } from "../lib/i18n";
 import { parseRepairCycles, type RepairCycleViewModel } from "../lib/repair-subtimeline";
@@ -78,7 +80,12 @@ export type ChainLayerGroup = {
 };
 
 const executionLayer = (step: Pick<ChainStep, "layer" | "chainIndex">): number | null => (
-  step.layer ?? step.chainIndex
+  layerOf({ layer: step.layer, index: step.chainIndex })
+);
+
+const chainStepOrder = (left: ChainStep, right: ChainStep): number => compare(
+  { layer: left.layer, index: left.chainIndex, id: left.taskId },
+  { layer: right.layer, index: right.chainIndex, id: right.taskId },
 );
 
 /** The held layer is stored in the same coordinate system as each Step's
@@ -99,28 +106,23 @@ export const heldChainWaitingOnOperator = (chain: Chain): boolean => {
 };
 
 /**
- * Render order is a node concern (`position`), while execution order is a
- * layer concern. The API normally supplies a stored layer, but falling back to
- * the node ordinal keeps a legacy/expand-migration response visibly linear.
+ * Render order follows the same total execution order as the server surfaces.
  * The returned ordinal is dense so sparse, zero-based, and one-based storage
- * all have the same operator-facing numbering.
+ * all have the same operator-facing numbering; missing execution metadata is
+ * one final unknown layer rather than a layer invented from display position.
  */
 export const chainLayerGroups = (steps: readonly ChainStep[]): ChainLayerGroup[] => {
-  const effectiveLayer = (step: ChainStep): number => step.layer ?? step.chainIndex ?? step.position;
-  const values = [...new Set(steps.map(effectiveLayer))].sort((left, right) => left - right);
-  const ordinals = new Map(values.map((value, index) => [value, index + 1]));
+  const ordinals = denseOrdinals(steps.map((step) => ({ layer: step.layer, index: step.chainIndex })));
   const byLayer = new Map<number, ChainStep[]>();
   for (const step of steps) {
-    const layer = effectiveLayer(step);
+    const layer = layerOf({ layer: step.layer, index: step.chainIndex }, { missing: "last" });
     const group = byLayer.get(layer);
     if (group) group.push(step); else byLayer.set(layer, [step]);
   }
-  const groups = values.map((storedLayer) => ({
+  const groups = [...ordinals].map(([storedLayer, ordinal]) => ({
     storedLayer,
-    ordinal: ordinals.get(storedLayer) ?? 1,
-    steps: [...(byLayer.get(storedLayer) ?? [])].sort((left, right) => (
-      left.position - right.position || (left.chainIndex ?? 0) - (right.chainIndex ?? 0) || left.taskId.localeCompare(right.taskId)
-    )),
+    ordinal,
+    steps: [...(byLayer.get(storedLayer) ?? [])].sort(chainStepOrder),
     blockers: [] as ChainStep[],
   }));
   for (const [index, group] of groups.entries()) {

--- a/apps/web/src/tests/chain-list.test.tsx
+++ b/apps/web/src/tests/chain-list.test.tsx
@@ -4,7 +4,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { CHAIN_PAGE, ChainList, GATE_TITLE_KEY } from "../components/chain-list";
+import { CHAIN_PAGE, ChainList, GATE_TITLE_KEY, chainLayerGroups } from "../components/chain-list";
 import { translate } from "../lib/i18n-core";
 import { LocaleProvider } from "../lib/i18n";
 import type { Chain, ChainStep, TaskActivity } from "../lib/types";
@@ -236,6 +236,22 @@ test("sparse stored layers use dense one-based layer ordinals", () => {
     [...markup.matchAll(/aria-label="Layer (\d+)"/g)].map((match) => match[1]),
     ["1", "2", "3"],
   );
+});
+
+test("missing execution metadata forms one final layer independent of display position", () => {
+  const groups = chainLayerGroups([
+    step(30, { taskId: "unknown-b", layer: null, chainIndex: null }),
+    step(1, { taskId: "known", layer: 4, chainIndex: 9 }),
+    step(2, { taskId: "unknown-a", layer: null, chainIndex: null }),
+  ]);
+
+  assert.deepEqual(groups.map((group) => ({
+    ordinal: group.ordinal,
+    taskIds: group.steps.map((item) => item.taskId),
+  })), [
+    { ordinal: 1, taskIds: ["known"] },
+    { ordinal: 2, taskIds: ["unknown-a", "unknown-b"] },
+  ]);
 });
 
 test("a long chain shows the first fifty rows behind a Show all press", () => {

--- a/packages/api/src/board.test.ts
+++ b/packages/api/src/board.test.ts
@@ -15,6 +15,7 @@ import {
   repairBinding,
   taskChainName,
 } from "./board.js";
+import { chainProgress, type ChainRow } from "./chain.js";
 
 const session = (overrides: Partial<NonNullable<BoardRow["runs"][number]["session"]>> = {}): NonNullable<BoardRow["runs"][number]["session"]> => ({
   nativeChildUsed: false, costUsd: null, inputTokens: null, cachedInputTokens: null, outputTokens: null, startedAt: null, endedAt: null, ...overrides,
@@ -259,6 +260,31 @@ test("chainAggregate derives primary progress and every board column from the fr
   assert.equal(done.status, "DONE");
   assert.equal(done.activation.state, "settled");
   assert.equal(done.frontier.taskId, "step-2");
+});
+
+test("board aggregate and Chain detail choose the same first unfinished execution layer", () => {
+  const shared = [
+    { id: "done", name: "Completed layer", chainIndex: 1, chainLayer: 10, status: "DONE" as const },
+    { id: "later", name: "Later layer", chainIndex: 2, chainLayer: 90, status: "TODO" as const },
+    { id: "parallel-done", name: "Finished sibling", chainIndex: 3, chainLayer: 40, status: "DONE" as const },
+    { id: "frontier", name: "First unfinished layer", chainIndex: 4, chainLayer: 40, status: "TODO" as const },
+  ];
+  const aggregate = chainAggregate("c1", "Release", shared.map((item) => member({
+    ...item,
+    displayName: item.name,
+    templateStep: { name: item.name },
+  })), []);
+  const detail = chainProgress(shared.map((item): ChainRow => ({
+    ...item,
+    projectId: "p1",
+    chainId: "c1",
+    archivedAt: null,
+    templateStep: { name: item.name },
+  })));
+
+  assert.equal(aggregate.frontier.taskId, "frontier");
+  assert.equal(aggregate.frontier.title, detail?.activeStepName);
+  assert.equal(detail?.currentLayer, 2);
 });
 
 test("chainAggregate reports a predecessor-bound chain and never offers parked activation", () => {

--- a/packages/api/src/board.ts
+++ b/packages/api/src/board.ts
@@ -34,6 +34,7 @@ import type {
   RunStatus as BoardRunStatus,
   UsageCost as BoardUsageCost,
 } from "@anneal/db/board-contract";
+import { compare } from "@anneal/db/chain-order";
 
 import { chainExecutionOwner, type ChainExecutionOwner } from "./chain-execution-owner.js";
 import {
@@ -238,13 +239,9 @@ const chainStatuses = (): Record<TaskStatusType, number> => ({
   [TaskStatus.DONE]: 0,
 });
 
-const chainMemberLayer = (member: Pick<BoardChainMember, "chainLayer" | "chainIndex">): number =>
-  member.chainLayer ?? member.chainIndex ?? Number.MAX_SAFE_INTEGER;
-
-const chainMemberOrder = (left: BoardChainMember, right: BoardChainMember): number => (
-  chainMemberLayer(left) - chainMemberLayer(right)
-    || (left.chainIndex ?? Number.MAX_SAFE_INTEGER) - (right.chainIndex ?? Number.MAX_SAFE_INTEGER)
-    || left.id.localeCompare(right.id)
+const chainMemberOrder = (left: BoardChainMember, right: BoardChainMember): number => compare(
+  { layer: left.chainLayer, index: left.chainIndex, id: left.id },
+  { layer: right.chainLayer, index: right.chainIndex, id: right.id },
 );
 
 const memberTitle = (member: BoardChainMember): string => member.displayName

--- a/packages/api/src/chain.ts
+++ b/packages/api/src/chain.ts
@@ -2,7 +2,6 @@ import {
   ACTIVE_RUN_STATUSES,
   AssigneeType,
   chainControlKey,
-  executionLayer,
   readChainControlRecord,
   readChainControls,
   resumeActivationAnchor,
@@ -14,8 +13,9 @@ import {
   type PrismaClient,
   TaskStatus,
 } from "@anneal/db";
+import { compare, denseOrdinals, layerOf } from "@anneal/db/chain-order";
 
-export { executionLayer, resumeActivationAnchor, resumeActivationNeedsSourceRun };
+export { resumeActivationAnchor, resumeActivationNeedsSourceRun };
 
 import { runBudgetCeiling } from "./execution.js";
 import type { Refusal } from "./refusal.js";
@@ -70,13 +70,17 @@ export const stepName = (row: Pick<ChainRow, "name" | "templateStep">): string =
 
 const byChainIndex = (left: ChainRow, right: ChainRow): number => (left.chainIndex ?? 0) - (right.chainIndex ?? 0);
 
+const chainLayerOf = <T extends { chainLayer?: number | null; chainIndex: number | null }>(row: T): number | null => layerOf({
+  layer: row.chainLayer === undefined ? null : row.chainLayer,
+  index: row.chainIndex,
+});
+
 const byExecutionPosition = <T extends { chainLayer?: number | null; chainIndex: number | null; id: string }>(
   left: T,
   right: T,
-): number => (
-  (executionLayer(left) ?? 0) - (executionLayer(right) ?? 0)
-    || (left.chainIndex ?? 0) - (right.chainIndex ?? 0)
-    || left.id.localeCompare(right.id)
+): number => compare(
+  { layer: left.chainLayer === undefined ? null : left.chainLayer, index: left.chainIndex, id: left.id },
+  { layer: right.chainLayer === undefined ? null : right.chainLayer, index: right.chainIndex, id: right.id },
 );
 
 /**
@@ -88,24 +92,28 @@ const byExecutionPosition = <T extends { chainLayer?: number | null; chainIndex:
  */
 export const chainProgress = (rows: ChainRow[]): Omit<ChainProgress, "chainId"> | null => {
   if (rows.length === 0) return null;
-  const ordered = [...rows].sort(byChainIndex);
+  const ordered = [...rows].sort(byExecutionPosition);
   const done = ordered.filter((row) => row.status === TaskStatus.DONE).length;
   const active = ordered.find((row) => row.status !== TaskStatus.DONE) ?? ordered[ordered.length - 1]!;
   // The expand migration backfills every legacy row, but keeping the
   // chainIndex fallback makes progress safe for rows read while that migration
-  // is staged and for malformed one-row fixtures. Stored layers may be sparse,
-  // zero-based, or one-based; the board presents their dense rank instead.
-  const effectiveLayer = (row: ChainRow, index: number): number => row.chainLayer ?? row.chainIndex ?? index;
-  const layerValues = ordered.map(effectiveLayer);
-  const distinctLayers = [...new Set(layerValues)].sort((left, right) => left - right);
-  const denseLayer = new Map(distinctLayers.map((layer, index) => [layer, index + 1]));
+  // is staged. Stored layers may be sparse, zero-based, or one-based; the board
+  // presents their dense rank instead. A malformed row missing both fields is
+  // one final unknown layer rather than a layer invented from arrival order.
+  const denseLayer = denseOrdinals(ordered.map((row) => ({ layer: row.chainLayer, index: row.chainIndex })));
+  const activeLayer = layerOf(
+    { layer: active.chainLayer, index: active.chainIndex },
+    { missing: "last" },
+  );
+  const currentLayer = denseLayer.get(activeLayer);
+  if (currentLayer === undefined) throw new Error(`Active Chain row ${active.id} has no dense layer ordinal`);
   return {
     done,
     total: ordered.length,
     activeStepName: stepName(active),
     activeStatus: active.status.toLowerCase(),
-    currentLayer: denseLayer.get(effectiveLayer(active, ordered.indexOf(active))) ?? 1,
-    layerCount: distinctLayers.length,
+    currentLayer,
+    layerCount: denseLayer.size,
   };
 };
 
@@ -227,9 +235,9 @@ export const blockingPredecessor = <T extends Pick<ChainRow, "chainIndex" | "id"
   const ordered = [...rows].sort(byExecutionPosition);
   const target = ordered.find((item) => item.id === targetId);
   if (!target) return null;
-  const targetLayer = executionLayer(target);
+  const targetLayer = chainLayerOf(target);
   return ordered.find((item) => {
-    const itemLayer = executionLayer(item);
+    const itemLayer = chainLayerOf(item);
     return itemLayer !== null && targetLayer !== null
       ? itemLayer < targetLayer && item.status !== TaskStatus.DONE
       : item.id !== target.id && item.status !== TaskStatus.DONE;
@@ -331,7 +339,7 @@ export const refusalForHeldChainStep = (
 ): Refusal | null => {
   if (!control?.held || task.chainId === null
     || control.projectId !== task.projectId || control.chainId !== task.chainId) return null;
-  const taskLayer = executionLayer(task);
+  const taskLayer = chainLayerOf(task);
   // A held control is only valid with a persisted layer, but fail closed if a
   // malformed legacy row reaches admission: an unknown layer must not bypass
   // an active Chain barrier.

--- a/packages/api/src/revalidation.ts
+++ b/packages/api/src/revalidation.ts
@@ -6,6 +6,7 @@ import {
   TaskStatus,
   type PrismaClient,
 } from "@anneal/db";
+import { layerOf } from "@anneal/db/chain-order";
 
 import {
   fenceRefusalResponse,
@@ -60,9 +61,10 @@ export type RevalidationCancellation = {
   reason: string;
 } | Refusal | FenceRefusalResponse;
 
-const executionLayer = (task: { chainLayer: number | null; chainIndex: number | null }): number | null => (
-  task.chainLayer ?? task.chainIndex
-);
+const executionLayer = (task: { chainLayer: number | null; chainIndex: number | null }): number | null => layerOf({
+  layer: task.chainLayer,
+  index: task.chainIndex,
+});
 
 const callerRefusal = (message: string): Refusal => ({ reason: "forbidden", message });
 

--- a/packages/api/src/run-claim.ts
+++ b/packages/api/src/run-claim.ts
@@ -23,6 +23,7 @@ import {
   taskIsIntegratorStep,
   TaskStatus,
 } from "@anneal/db";
+import { layerOf } from "@anneal/db/chain-order";
 import { z } from "zod";
 
 import { issueSessionToken } from "./auth.js";
@@ -763,7 +764,7 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
           } },
           select: { state: true, heldLayer: true },
         });
-        const taskLayer = candidate.task.chainLayer ?? candidate.task.chainIndex;
+        const taskLayer = layerOf({ layer: candidate.task.chainLayer, index: candidate.task.chainIndex });
         if (control?.state === ChainControlState.HELD
           && (control.heldLayer === null || taskLayer === null || taskLayer > control.heldLayer)) {
           // The Chain mutex was acquired after the candidate scan. Hold may

--- a/packages/api/src/templates.ts
+++ b/packages/api/src/templates.ts
@@ -15,6 +15,7 @@ import {
   TaskStatus,
   type TriggerFireSource,
 } from "@anneal/db";
+import { layerOf } from "@anneal/db/chain-order";
 
 import { isValidBranchName } from "./branch-name.js";
 import { composeBrief } from "./task-brief.js";
@@ -107,9 +108,10 @@ const templateRefusal = (
   message: string,
 ): TemplateInstantiationRefusal => new TemplateInstantiationRefusal(code, message);
 
-const executionLayer = (task: { chainLayer: number | null; chainIndex: number | null }): number | null => (
-  task.chainLayer ?? task.chainIndex
-);
+const executionLayer = (task: { chainLayer: number | null; chainIndex: number | null }): number | null => layerOf({
+  layer: task.chainLayer,
+  index: task.chainIndex,
+});
 
 const dispatchBindingUniqueConflict = (error: unknown): boolean => {
   if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== "P2002") return false;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -22,6 +22,10 @@
       "types": "./src/board-contract.ts",
       "import": "./dist/board-contract.js"
     },
+    "./chain-order": {
+      "types": "./src/chain-order.ts",
+      "import": "./dist/chain-order.js"
+    },
     "./wire-contract": {
       "types": "./src/wire-contract.ts",
       "import": "./dist/wire-contract.js"

--- a/packages/db/src/chain-activation.ts
+++ b/packages/db/src/chain-activation.ts
@@ -8,6 +8,7 @@ import {
 } from "@prisma/client";
 
 import { readChainControl } from "./chain-control.js";
+import { compare, layerOf } from "./chain-order.js";
 import { lockAgentRepoGrant, lockAgentRow, lockChainRows } from "./locks.js";
 import { parseAuthorizationMetadata } from "./merge-integrator.js";
 import { isIntegratorBindingError, stopStateFor } from "./merge-integrator-db.js";
@@ -560,17 +561,17 @@ const parkStoppedIntegratorSuccessor = async (
   return { nextTaskId: successor.id, gated: false };
 };
 
-const layerOf = (task: { chainLayer?: number | null; chainIndex: number | null }): number | null => (
-  task.chainLayer ?? task.chainIndex
-);
+const chainLayerOf = (task: { chainLayer?: number | null; chainIndex: number | null }): number | null => layerOf({
+  layer: task.chainLayer === undefined ? null : task.chainLayer,
+  index: task.chainIndex,
+});
 
 const layerOrder = (
   left: { chainLayer?: number | null; chainIndex: number | null; id: string },
   right: { chainLayer?: number | null; chainIndex: number | null; id: string },
-): number => (
-  (layerOf(left) ?? 0) - (layerOf(right) ?? 0)
-    || (left.chainIndex ?? 0) - (right.chainIndex ?? 0)
-    || left.id.localeCompare(right.id)
+): number => compare(
+  { layer: left.chainLayer === undefined ? null : left.chainLayer, index: left.chainIndex, id: left.id },
+  { layer: right.chainLayer === undefined ? null : right.chainLayer, index: right.chainIndex, id: right.id },
 );
 
 /**
@@ -609,7 +610,7 @@ const activateChainSuccessorInternal = async (
   });
   chainRows.sort(layerOrder);
   const current = chainRows.find((row) => row.id === task.id);
-  const currentLayer = current ? layerOf(current) : layerOf(task);
+  const currentLayer = current ? chainLayerOf(current) : chainLayerOf(task);
   if (!current || currentLayer === null) {
     await tx.taskActivity.create({ data: {
       taskId: task.id,
@@ -619,7 +620,7 @@ const activateChainSuccessorInternal = async (
     return { nextTaskId: null, gated: false };
   }
 
-  const currentRows = chainRows.filter((row) => layerOf(row) === currentLayer);
+  const currentRows = chainRows.filter((row) => chainLayerOf(row) === currentLayer);
   // The full-chain lock is already held here. Read the persisted control only
   // after taking it so a completion and an operator Hold have one defined
   // winner, rather than allowing a stale pre-lock read to leak activation.
@@ -646,10 +647,10 @@ const activateChainSuccessorInternal = async (
   // history and select the first higher layer that still has work. This keeps
   // the one-node-per-layer migration linear without recursively re-entering the
   // activation routine.
-  const nextLayer = [...new Set(chainRows.map(layerOf).filter((value): value is number => value !== null))]
+  const nextLayer = [...new Set(chainRows.map(chainLayerOf).filter((value): value is number => value !== null))]
     .filter((value) => value > currentLayer)
     .sort((left, right) => left - right)
-    .find((value) => chainRows.some((row) => layerOf(row) === value && row.status !== TaskStatus.DONE));
+    .find((value) => chainRows.some((row) => chainLayerOf(row) === value && row.status !== TaskStatus.DONE));
   if (nextLayer === undefined) {
     const predecessorComplete = chainRows.every((row) => row.status === TaskStatus.DONE);
     if (!boundSuccessor || predecessorComplete) {
@@ -690,7 +691,7 @@ const activateChainSuccessorInternal = async (
     return { nextTaskId: null, gated: false };
   }
 
-  const nextRows = chainRows.filter((row) => layerOf(row) === nextLayer).sort(layerOrder);
+  const nextRows = chainRows.filter((row) => chainLayerOf(row) === nextLayer).sort(layerOrder);
   if (nextRows.some((row) => row.approvalGate) && nextRows.length > 1) {
     throw new WorkflowRefusalError("invalid-request", `Approval gate is not allowed in multi-node chain layer ${nextLayer}`);
   }
@@ -1019,7 +1020,7 @@ export const advanceTemplateTask = async (
   }
   if (task.approvalGate) {
     if (task.chainId) {
-      const layer = layerOf(task);
+      const layer = chainLayerOf(task);
       const siblingCount = layer === null ? 0 : await tx.task.count({
         where: {
           projectId: task.projectId,

--- a/packages/db/src/chain-control.ts
+++ b/packages/db/src/chain-control.ts
@@ -10,6 +10,7 @@ import {
   ACTIVE_RUN_STATUSES,
   activateChainSuccessor,
 } from "./chain-activation.js";
+import { compare, layerOf } from "./chain-order.js";
 import { lockChainRows, lockChainStructure } from "./locks.js";
 import { markerFromMetadata } from "./merge-tail-markers.js";
 
@@ -53,9 +54,14 @@ export type ChainResumeRow = {
   repoId: string | null;
 };
 
-export const executionLayer = (
-  task: { chainLayer?: number | null; chainIndex: number | null },
-): number | null => task.chainLayer ?? task.chainIndex;
+const chainLayerOf = (
+  task: Pick<ChainResumeRow, "chainLayer" | "chainIndex">,
+): number | null => layerOf({ layer: task.chainLayer, index: task.chainIndex });
+
+const chainOrder = (left: ChainResumeRow, right: ChainResumeRow): number => compare(
+  { layer: left.chainLayer, index: left.chainIndex, id: left.id },
+  { layer: right.chainLayer, index: right.chainIndex, id: right.id },
+);
 
 /**
  * Resume anchors ordinary successor activation at the highest complete layer,
@@ -66,36 +72,33 @@ export const resumeActivationAnchor = (
   heldLayer: number | null,
 ): ChainResumeRow | null => {
   if (heldLayer === null) return null;
-  const layers = [...new Set(rows.map(executionLayer).filter((layer): layer is number => layer !== null))];
-  const heldRows = rows.filter((row) => executionLayer(row) === heldLayer);
+  const layers = [...new Set(rows.map(chainLayerOf).filter((layer): layer is number => layer !== null))];
+  const heldRows = rows.filter((row) => chainLayerOf(row) === heldLayer);
   if (heldRows.length === 0 || !heldRows.every((row) => row.status === TaskStatus.DONE)) return null;
   const completeLayer = layers
-    .filter((layer) => rows.some((row) => executionLayer(row) === layer)
-      && rows.filter((row) => executionLayer(row) === layer).every((row) => row.status === TaskStatus.DONE))
+    .filter((layer) => rows.some((row) => chainLayerOf(row) === layer)
+      && rows.filter((row) => chainLayerOf(row) === layer).every((row) => row.status === TaskStatus.DONE))
     .sort((left, right) => right - left)[0];
   if (completeLayer === undefined) return null;
   return rows
-    .filter((row) => executionLayer(row) === completeLayer)
-    .sort((left, right) => (
-      (left.chainIndex ?? Number.MAX_SAFE_INTEGER) - (right.chainIndex ?? Number.MAX_SAFE_INTEGER)
-        || left.id.localeCompare(right.id)
-    ))[0] ?? null;
+    .filter((row) => chainLayerOf(row) === completeLayer)
+    .sort(chainOrder)[0] ?? null;
 };
 
 export const resumeActivationNeedsSourceRun = (
   rows: readonly ChainResumeRow[],
   anchor: ChainResumeRow,
 ): boolean => {
-  const anchorLayer = executionLayer(anchor);
+  const anchorLayer = chainLayerOf(anchor);
   if (anchorLayer === null) return false;
-  const nextLayer = [...new Set(rows.map(executionLayer).filter((layer): layer is number => layer !== null))]
+  const nextLayer = [...new Set(rows.map(chainLayerOf).filter((layer): layer is number => layer !== null))]
     .filter((layer) => layer > anchorLayer
-      && rows.some((row) => executionLayer(row) === layer && row.status !== TaskStatus.DONE))
+      && rows.some((row) => chainLayerOf(row) === layer && row.status !== TaskStatus.DONE))
     .sort((left, right) => left - right)[0];
   if (nextLayer === undefined) return false;
   return rows
     // Activation handles an operator-parked successor before assignee shape.
-    .filter((row) => executionLayer(row) === nextLayer
+    .filter((row) => chainLayerOf(row) === nextLayer
       && row.status !== TaskStatus.DONE
       && row.status !== TaskStatus.BACKLOG)
     .some((row) => row.assigneeType !== AssigneeType.AGENT
@@ -290,7 +293,7 @@ export const holdChain = async (
 
   const heldLayer = chainRows
     .filter((row) => row.status !== TaskStatus.DONE)
-    .map(executionLayer)
+    .map(chainLayerOf)
     .filter((layer): layer is number => layer !== null)
     .sort((left, right) => left - right)[0];
   if (heldLayer === undefined) {
@@ -397,12 +400,12 @@ export const resumeChain = async (
   if (existing.heldLayer === null) throw new Error("Held Chain control is missing its held layer");
 
   const anchor = resumeActivationAnchor(chainRows, existing.heldLayer);
-  const anchorLayer = anchor === null ? null : executionLayer(anchor);
+  const anchorLayer = anchor === null ? null : chainLayerOf(anchor);
   const sourceRun = anchorLayer === null
     ? null
     : await tx.run.findFirst({
       where: {
-        taskId: { in: chainRows.filter((row) => executionLayer(row) === anchorLayer).map((row) => row.id) },
+        taskId: { in: chainRows.filter((row) => chainLayerOf(row) === anchorLayer).map((row) => row.id) },
         status: RunStatus.SUCCEEDED,
         session: { isNot: null },
       },

--- a/packages/db/src/chain-order.test.ts
+++ b/packages/db/src/chain-order.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { compare, denseOrdinals, layerOf, type ChainOrderRow } from "./chain-order.js";
+
+const row = (
+  id: string,
+  layer: number | null,
+  index: number | null,
+): ChainOrderRow => ({ id, layer, index });
+
+test("the browser-safe ordering module imports nothing", () => {
+  const source = readFileSync(new URL("./chain-order.ts", import.meta.url), "utf8");
+  assert.doesNotMatch(source, /^\s*import\s/mu);
+});
+
+test("the package publishes chain-order as an isolated subpath", () => {
+  const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+    exports: Record<string, unknown>;
+  };
+  assert.deepEqual(packageJson.exports["./chain-order"], {
+    types: "./src/chain-order.ts",
+    import: "./dist/chain-order.js",
+  });
+});
+
+test("layerOf prefers stored layer, falls back to index, and preserves an unknown layer", () => {
+  assert.equal(layerOf(row("stored", 4, 1)), 4);
+  assert.equal(layerOf(row("null-layer", null, 3)), 3);
+  assert.equal(layerOf(row("null-index", 7, null)), 7);
+  assert.equal(layerOf(row("both-null", null, null)), null);
+});
+
+test("the named last sentinel puts missing execution metadata after persisted layers", () => {
+  const missing = layerOf(row("missing", null, null), { missing: "last" });
+  assert.equal(missing, Number.MAX_SAFE_INTEGER);
+  assert.ok(missing > layerOf(row("known", 9, null), { missing: "last" }));
+});
+
+test("compare is total across layer ties, null indexes, and ids", () => {
+  const rows = [
+    row("missing", null, null),
+    row("layer-two-null-index", 2, null),
+    row("layer-one-b", 1, 4),
+    row("layer-one-a", 1, 4),
+    row("legacy", null, 3),
+  ];
+
+  assert.deepEqual([...rows].sort(compare).map(({ id }) => id), [
+    "layer-one-a",
+    "layer-one-b",
+    "layer-two-null-index",
+    "legacy",
+    "missing",
+  ]);
+  assert.equal(compare(row("same", 1, 2), row("same", 1, 2)), 0);
+});
+
+test("denseOrdinals is one-based across sparse layers and the named sentinel", () => {
+  const ordinals = denseOrdinals([
+    row("parallel-a", 40, 2),
+    row("unknown", null, null),
+    row("first", 10, 1),
+    row("parallel-b", 40, 3),
+    row("legacy", null, 90),
+  ]);
+
+  assert.deepEqual([...ordinals], [
+    [10, 1],
+    [40, 2],
+    [90, 3],
+    [Number.MAX_SAFE_INTEGER, 4],
+  ]);
+});

--- a/packages/db/src/chain-order.ts
+++ b/packages/db/src/chain-order.ts
@@ -1,0 +1,51 @@
+/**
+ * Browser-safe Chain execution ordering.
+ *
+ * Callers adapt their persisted or wire field names to this small structural
+ * interface. A stored layer is authoritative, with the Chain index retained
+ * only as the legacy compatibility fallback.
+ */
+
+export type ChainLayerRow = {
+  layer: number | null;
+  index: number | null;
+};
+
+export type ChainOrderRow = ChainLayerRow & {
+  id: string;
+};
+
+export type MissingLayerOptions = {
+  /** Unknown execution metadata sorts after every persisted layer. */
+  missing: "last";
+};
+
+const MISSING_LAYER_LAST = Number.MAX_SAFE_INTEGER;
+
+export function layerOf(row: ChainLayerRow): number | null;
+export function layerOf(row: ChainLayerRow, options: MissingLayerOptions): number;
+export function layerOf(row: ChainLayerRow, options?: MissingLayerOptions): number | null {
+  return row.layer ?? row.index ?? (options?.missing === "last" ? MISSING_LAYER_LAST : null);
+}
+
+const numberOrder = (left: number, right: number): number => (
+  left < right ? -1 : left > right ? 1 : 0
+);
+
+const textOrder = (left: string, right: string): number => (
+  left < right ? -1 : left > right ? 1 : 0
+);
+
+/** Total execution order: effective layer, legacy index, then stable row id. */
+export const compare = (left: ChainOrderRow, right: ChainOrderRow): number => (
+  numberOrder(layerOf(left, { missing: "last" }), layerOf(right, { missing: "last" }))
+    || numberOrder(left.index ?? MISSING_LAYER_LAST, right.index ?? MISSING_LAYER_LAST)
+    || textOrder(left.id, right.id)
+);
+
+/** Dense one-based ordinals keyed by effective layer in execution order. */
+export const denseOrdinals = (rows: readonly ChainLayerRow[]): ReadonlyMap<number, number> => {
+  const layers = [...new Set(rows.map((row) => layerOf(row, { missing: "last" })))]
+    .sort(numberOrder);
+  return new Map(layers.map((layer, index) => [layer, index + 1]));
+};

--- a/packages/db/src/run-open.ts
+++ b/packages/db/src/run-open.ts
@@ -13,6 +13,7 @@ import { catalogRunnerForModel, DIRECT_TEMPLATE_NAME } from "./agent-contract.js
 import { canonicalTemplateIdentity } from "./canonical-template-transition.js";
 import { sharedChainBranch } from "./chain-branch.js";
 import { readChainControl } from "./chain-control.js";
+import { layerOf } from "./chain-order.js";
 import { lockAgentRow } from "./locks.js";
 import { INTEGRATOR_TEMPLATE_NAME } from "./merge-integrator.js";
 import {
@@ -734,7 +735,7 @@ export const openRun = async (
   // transaction and before any Run-birth work so a held successor produces no
   // Run or queue activity. The database prevents a HELD control without a
   // layer; malformed legacy Task rows still fail closed at this seam.
-  const taskLayer = task.chainLayer ?? task.chainIndex;
+  const taskLayer = layerOf({ layer: task.chainLayer, index: task.chainIndex });
   if (task.chainId) {
     const control = await readChainControl(tx, { projectId: task.projectId, chainId: task.chainId });
     if (control.held && (control.heldLayer === null || taskLayer === null || taskLayer > control.heldLayer)) {


### PR DESCRIPTION
## What changed

- Added the zero-import, browser-safe `@anneal/db/chain-order` Module. Its Interface owns `layerOf`, one total `compare`, and `denseOrdinals`, with a stable id tie-break and one named `missing: "last"` sentinel.
- Migrated the database, API, and browser callers to that Module. Chain detail now consumes the same execution order as the board aggregate instead of rebuilding layer groups and dense ordinals from display position.
- Added table coverage for null layer, null index, both null, ties, the named sentinel, zero imports, and the package subpath. Added one cross-surface assertion proving board aggregate and Chain detail select the same first unfinished layer.
- Left the Chain-hold predicates in `run-claim.ts`, including the raw SQL form, semantically unchanged; only the TypeScript layer expression moved behind the Module.

Tail rulings:

- `?? null` is required: control, admission, revalidation, and template checks need an explicit unknown-layer result. Default `layerOf` preserves `null`.
- `?? index` using arrival order was accidental: arrival order is not execution metadata. `denseOrdinals` now treats rows missing both stored fields as one final unknown layer.
- `?? Number.MAX_SAFE_INTEGER` is required for a total order that keeps malformed or detached rows last. The Module owns it through the named `missing: "last"` option; callers no longer choose the sentinel.
- `?? step.position` was accidental: `position` is a display ordinal, not an execution layer. Browser grouping now consumes the Module and uses the server-provided layer with the legacy chain index fallback.

## Evidence

- `npm run lint` — PASS; Biome checked 592 files and ESLint completed with no findings.
- `npm run typecheck` — PASS across all workspaces.
- `npm test --workspace @anneal/db` — PASS; 271 tests, 0 failures.
- `npm test --workspace @anneal/api` — PASS; 662 tests, 0 failures, 1 existing opt-in skip.
- `npm run build --workspace @anneal/web` — PASS; generated the ignored assets required by bundle and CSS tests.
- `npm test --workspace @anneal/web` — PASS; 542 tests, 0 failures, 1 existing browser opt-in skip.
- Initial ad hoc direct-Node API preflight failed before test loading with `ERR_MODULE_NOT_FOUND` for `@anneal/db/dist/index.js` because it skipped the workspace pretest; the required workspace command built the dependency and passed as recorded above.
- Initial patterned web preflight loaded asset tests before a web build and reported `Build apps/web before running`; after the explicit web build, the exact required command passed as recorded above.

## Reported but unfixed

- The verified fail-open/fail-closed divergence between the Chain-hold TypeScript predicates and the raw SQL predicate remains unchanged. It is explicitly outside D5 ownership and belongs to the follow-on lane.