### PR TITLE
fix(delivery): gate merge train prefixes from exact checkouts

### DIFF
--- a/scripts/merge-train.mjs
+++ b/scripts/merge-train.mjs
@@ -87,9 +87,9 @@ const defaultFetchCandidate = async (repoRoot, candidate) => {
   }
 };
 
-const defaultGate = async (repoRoot, prefix) => {
-  const script = path.join(repoRoot, "scripts", "gate-worker", "gate-dispatch.sh");
-  const result = await runProcess("bash", [script, prefix.oid, "--master", prefix.predecessor], { cwd: repoRoot });
+const defaultGate = async (_repoRoot, prefix, checkout) => {
+  const script = path.join(checkout, "scripts", "gate-worker", "gate-dispatch.sh");
+  const result = await runProcess("bash", [script, prefix.oid, "--master", prefix.predecessor], { cwd: checkout });
   const output = `${result.stdout}${result.stderr}`;
   const exactPass = new RegExp(`(?:^|\\n)MERGE GATE: PASS ${prefix.oid}(?:\\r?$|\\n)`, "u").test(
     output.replaceAll("\u001b[32m", "").replaceAll("\u001b[0m", ""),
@@ -279,16 +279,25 @@ export const coordinateMergeTrain = async ({ repoRoot, task, candidates, adapter
     return { status: "all-already-delivered", baseSha, alreadyDelivered, prefixes: [], gateResults: [], published: [] };
   }
   const temporaryRoot = await mkdtemp(path.join(tmpdir(), "agentos-merge-train-"));
-  const checkout = path.join(temporaryRoot, "checkout");
-  let worktreeAdded = false;
+  const buildCheckout = path.join(temporaryRoot, "build");
+  const gateCheckouts = [];
+  let buildWorktreeAdded = false;
   let leaseHeld = false;
   let safeToRelease = false;
   let primaryError = null;
   try {
-    worktreeAdded = true;
-    const built = await buildPrefixes(repoRoot, checkout, baseSha, pending);
+    buildWorktreeAdded = true;
+    const built = await buildPrefixes(repoRoot, buildCheckout, baseSha, pending);
+    for (const prefix of built.prefixes) {
+      const gateCheckout = path.join(temporaryRoot, `prefix-${prefix.index}`);
+      await git(repoRoot, ["worktree", "add", "--detach", gateCheckout, prefix.oid]);
+      gateCheckouts.push(gateCheckout);
+    }
     const gateResults = await Promise.all(
-      built.prefixes.map(async (prefix) => ({ prefix, ...(await adapters.gate(repoRoot, prefix)) })),
+      built.prefixes.map(async (prefix, index) => ({
+        prefix,
+        ...(await adapters.gate(repoRoot, prefix, gateCheckouts[index])),
+      })),
     );
     const passingCount = contiguousPassingCount(gateResults);
     if (passingCount === 0) {
@@ -370,10 +379,16 @@ export const coordinateMergeTrain = async ({ repoRoot, task, candidates, adapter
       }
       else process.stderr.write(`merge-train: publication read-back is unknown; lease for task ${task} was retained\n`);
     }
-    if (worktreeAdded) {
-      const removed = await gitResult(repoRoot, ["worktree", "remove", "--force", checkout]);
+    for (const gateCheckout of gateCheckouts) {
+      const removed = await gitResult(repoRoot, ["worktree", "remove", "--force", gateCheckout]);
       if (removed.code !== 0 && !cleanupError) {
-        cleanupError = new CommandError(`git worktree remove --force ${checkout}`, removed);
+        cleanupError = new CommandError(`git worktree remove --force ${gateCheckout}`, removed);
+      }
+    }
+    if (buildWorktreeAdded) {
+      const removed = await gitResult(repoRoot, ["worktree", "remove", "--force", buildCheckout]);
+      if (removed.code !== 0 && !cleanupError) {
+        cleanupError = new CommandError(`git worktree remove --force ${buildCheckout}`, removed);
       }
     }
     try {

--- a/scripts/merge-train.test.mjs
+++ b/scripts/merge-train.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -80,6 +80,62 @@ const passGate = async (_repoRoot, prefix) => ({
 const noLease = (events = []) => ({
   acquireLease: async () => events.push("lease-acquire"),
   releaseLease: async () => events.push("lease-release"),
+});
+
+test("the default adapter locally dispatches from a clean exact-prefix checkout", async () => {
+  const fixture = await makeFixture();
+  try {
+    const dispatcher = await readFile(new URL("./gate-worker/gate-dispatch.sh", import.meta.url), "utf8");
+    const gateLibrary = await readFile(new URL("./gate-worker/lib.sh", import.meta.url), "utf8");
+    const wrapper = `#!/usr/bin/env bash
+set -eu
+unset AGENTOS_GATE_SERVER AGENTOS_GATE_PRIMARY_SERVER AGENTOS_GATE_FALLBACK_SERVER
+export AGENTOS_GATE_ALLOW_LOCAL=1
+export XDG_CACHE_HOME=${JSON.stringify(path.join(fixture.root, "gate-cache"))}
+exec bash "$(dirname "$0")/gate-dispatch-real.sh" "$@"
+`;
+    const mergeGate = `#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "--expect-head" ]
+expected="$2"
+[ "$3" = "--master" ]
+head="$(git rev-parse HEAD)"
+status="$(git status --porcelain)"
+[ "$head" = "$expected" ]
+[ -z "$status" ]
+printf 'FIXTURE GATE: cwd=%s head=%s clean=yes\\n' "$PWD" "$head"
+printf 'MERGE GATE: PASS %s\\n' "$head"
+`;
+    const candidate = await fixture.candidate(300, {
+      "scripts/gate-worker/gate-dispatch.sh": wrapper,
+      "scripts/gate-worker/gate-dispatch-real.sh": dispatcher,
+      "scripts/gate-worker/lib.sh": gateLibrary,
+      "scripts/merge-gate.sh": mergeGate,
+    });
+    const result = await coordinateMergeTrain({
+      repoRoot: fixture.repo,
+      task: "local-dispatch",
+      candidates: [candidate],
+      adapters: {
+        ...noLease(),
+        readPullRequest: fixture.readPullRequest([candidate]),
+        sleep: async () => {},
+      },
+    });
+
+    assert.equal(result.status, "published-all");
+    assert.equal(result.gateResults[0].status, "pass");
+    const evidence = /FIXTURE GATE: cwd=(.+) head=([0-9a-f]{40}) clean=yes/u.exec(
+      result.gateResults[0].output,
+    );
+    assert.ok(evidence, result.gateResults[0].output);
+    assert.notEqual(path.resolve(evidence[1]), path.resolve(fixture.repo));
+    assert.equal(evidence[2], result.prefixes[0].oid);
+    const worktrees = await git(fixture.repo, "worktree", "list", "--porcelain");
+    assert.equal(worktrees.match(/^worktree /gmu)?.length, 1);
+  } finally {
+    await fixture.cleanup();
+  }
 });
 
 test("three cumulative prefixes gate concurrently and publish in FIFO order", async () => {


### PR DESCRIPTION
## What changed

- Create one detached temporary worktree for each cumulative merge-train prefix.
- Invoke the prefix commit own gate dispatcher with that worktree as cwd, so local eligibility sees a clean exact HEAD and remote dispatch still transports the same frozen candidate and baseline.
- Add a single-candidate local-dispatch regression test that executes the candidate-shipped dispatcher and proves the gate cwd HEAD equals the prefix OID, the tree is clean, and temporary worktrees are cleaned up.

## Evidence

- npm run lint
- npm run typecheck
- npm run test:merge-train (6 passed)
- npm run test:gate-worker (75 passed)
- node --test scripts/merge-lease.test.mjs scripts/merge-gate-profile.test.mjs scripts/merge-gate-parallel.test.mjs (44 passed)
- Regression proof: the new focused test fails against the old repoRoot adapter with nothing-publishable.
- Merge gate, merge Lease, and merge were intentionally not run; delivery machinery must use the old single-candidate exact-head publication path.

## Reported but unfixed

None.