### PR TITLE
refactor(api): centralize task move authority

### DIFF
--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -271,7 +271,7 @@ test("task status patch does not apply create defaults to other fields", async (
     const tx = {
       $queryRaw: async (_strings: unknown, taskId: string) => [{ id: taskId, status: "REVIEW", archivedAt: null }],
       task: {
-        findUniqueOrThrow: async () => ({ id: "task-1", projectId: "project-1", status: "REVIEW", archivedAt: null, assigneeType: "HUMAN", chainId: null }),
+        findUniqueOrThrow: async () => ({ id: "task-1", projectId: "project-1", status: "REVIEW", archivedAt: null, assigneeType: "HUMAN", chainId: null, dispatchAfterTaskId: null, dispatchAfter: null }),
         // §D-P7's stop-state guard loads the task with its template step before
         // any status write. An ordinary task has no step, and the guard is then
         // a no-op — but it still asks.
@@ -403,7 +403,7 @@ test("operator DONE on an AGENT chain task is refused without closing its gate",
       assigneeAgent: { id: "agent-1", model: "claude", runnerPreference: "CLAUDE", foundationalPrompt: "f", rolePrompt: "r" },
       repo: { id: "repo-1", defaultBranch: "main" }, templateStep: null, archivedAt: null,
     };
-    const before = { id: "task-1", projectId: "project-1", name: "Gate", status: "REVIEW", templateId: null, approvalGate: true, chainId: "chain-1", chainIndex: 0, assigneeType: "AGENT", assigneeAgentId: "agent-1", repoId: "repo-1", archivedAt: null };
+    const before = { id: "task-1", projectId: "project-1", name: "Gate", status: "REVIEW", templateId: null, approvalGate: true, chainId: "chain-1", chainIndex: 0, assigneeType: "AGENT", assigneeAgentId: "agent-1", repoId: "repo-1", archivedAt: null, dispatchAfterTaskId: null, dispatchAfter: null };
     const tx = {
       // The status write takes the Task-row mutex before advancing the chain.
       $queryRaw: async (_strings: unknown, taskId: string) => [{ id: taskId }],
@@ -453,6 +453,7 @@ test("a template HUMAN final step closes its exact OPEN gate even when approvalG
       id: "task-1", projectId: "project-1", name: "Human final", status: "REVIEW", templateId: "template-1",
       approvalGate: false, chainId: "chain-1", chainIndex: 2,
       assigneeType: "HUMAN", assigneeAgentId: null, repoId: null, archivedAt: null,
+      dispatchAfterTaskId: null, dispatchAfter: null,
     };
     const tx = {
       $queryRaw: async () => [{ id: before.id }],

--- a/packages/api/src/board.test.ts
+++ b/packages/api/src/board.test.ts
@@ -198,6 +198,35 @@ test("the board projection carries the operator transition matrix", () => {
   assert.equal(agentTargets.some(({ status, via }) => via === "patch" && ["DOING", "REVIEW", "DONE"].includes(status)), false);
 });
 
+test("a standalone Agent task with an active Run does not offer Backlog", () => {
+  const card = boardCard(row({
+    status: "TODO",
+    assigneeAgentId: "a1",
+    repoId: "r1",
+    assigneeAgent: {
+      id: "a1", name: "developer", title: "Developer", model: "gpt-5.6-sol", archivedAt: null,
+    },
+    runs: [{
+      id: "run-1", runNumber: 1, status: "RUNNING", model: "gpt-5.6-sol", budgetGrants: 0, session: null,
+    }],
+  }), null, { hasRepoGrant: true, chainPredecessorsDone: true });
+
+  assert.equal(card.moveTargets.some(({ status }) => status === "BACKLOG"), false);
+});
+
+test("a Backlog task with an archived assignee does not offer Todo", () => {
+  const card = boardCard(row({
+    status: "BACKLOG",
+    assigneeAgentId: "a1",
+    repoId: "r1",
+    assigneeAgent: {
+      id: "a1", name: "retired", title: "Retired", model: "gpt-5.6-sol", archivedAt: new Date(),
+    },
+  }), null, { hasRepoGrant: true, chainPredecessorsDone: true });
+
+  assert.equal(card.moveTargets.some(({ status }) => status === "TODO"), false);
+});
+
 test("a repair task is bound to the chain of the regression task its marker names", () => {
   const chain = (): { chainId: string; chainName: string | null } => ({ chainId: "c1", chainName: "Release" });
   assert.deepEqual(

--- a/packages/api/src/board.ts
+++ b/packages/api/src/board.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 import {
   ACTIVE_RUN_STATUSES,
+  isIntegratorStep,
   markerFromMetadata,
   MERGE_TAIL_KIND,
   projectMergeOutcome,
@@ -45,7 +46,7 @@ import {
   taskStartability,
   type ChainProgress,
 } from "./chain.js";
-import { operatorStatusTransitionRefusal } from "./task-patch.js";
+import { taskMoveAuthority } from "./task-move-authority.js";
 
 /**
  * The Tasks board's own wire shape.
@@ -115,8 +116,13 @@ export type BoardRow = {
   dispatchAfterTaskId: string | null;
   createdAt: Date;
   updatedAt: Date;
-  assigneeAgent: { id: string; title: string; model: string; archivedAt: Date | null } | null;
-  templateStep: { name: string } | null;
+  assigneeAgent: { id: string; name?: string; title: string; model: string; archivedAt: Date | null } | null;
+  templateStep: {
+    name: string;
+    stepIndex?: number;
+    outputKind?: string;
+    taskTemplate?: { name: string };
+  } | null;
   runs: Array<{
     id: string;
     runNumber: number;
@@ -154,31 +160,73 @@ export type SerializedUsageCost = BoardUsageCost;
 export const serializeUsageCost = (cost: UsageCost | null): SerializedUsageCost | null =>
   cost === null ? null : { ...cost, costUsd: decimal(cost.costUsd) };
 
-const TASK_STATUSES: TaskStatusType[] = [
-  TaskStatus.BACKLOG,
-  TaskStatus.TODO,
-  TaskStatus.DOING,
-  TaskStatus.REVIEW,
-  TaskStatus.DONE,
-];
+type MoveProjectionFacts = {
+  dispatchAfter?: BoardBlockedOnTask | null;
+  chainPredecessor?: { name: string } | null;
+  stopStateRefusal?: string | null;
+};
 
-/** Project operator destinations from the same ownership refusal used by
+/** Project operator destinations from the move authority shared with
  * `PATCH /tasks/:id`. A startable standalone Agent queue task may additionally
  * reach Doing through the start action; it is never represented as a PATCH. */
 export const operatorMoveTargets = (
-  task: Pick<BoardRow, "assigneeType" | "chainId" | "status">,
-  startability: { startable: boolean; checklist: { predecessorsDone: boolean } },
+  task: Pick<BoardRow,
+    | "name" | "status" | "assigneeType" | "chainId" | "archivedAt"
+    | "dispatchAfterTaskId" | "assigneeAgentId" | "assigneeAgent" | "templateStep"
+  >,
+  startability: { startable: boolean; checklist: { predecessorsDone: boolean; noActiveRun: boolean } },
+  projected: MoveProjectionFacts = {},
 ): BoardMoveTarget[] => {
-  const targets = TASK_STATUSES.flatMap((status): BoardMoveTarget[] => {
-    if (status === task.status) return [];
-    const refusal = operatorStatusTransitionRefusal(task, status);
-    if (refusal === null) return [{ status, via: "patch" }];
-    const startsStandaloneAgent = status === TaskStatus.DOING
-      && task.chainId === null
-      && task.assigneeType === "AGENT"
-      && (task.status === TaskStatus.BACKLOG || task.status === TaskStatus.TODO);
-    return startsStandaloneAgent && startability.startable ? [{ status, via: "start" }] : [];
+  const dispatchAfter = projected.dispatchAfter !== undefined
+    ? projected.dispatchAfter
+    : task.dispatchAfterTaskId === null || startability.checklist.predecessorsDone
+      ? null
+      : { id: task.dispatchAfterTaskId, name: task.dispatchAfterTaskId, status: TaskStatus.TODO };
+  const assigneeName = task.assigneeAgent?.name ?? task.assigneeAgent?.title ?? task.assigneeAgentId;
+  const reactivationRefusal = task.assigneeAgentId === null
+    ? null
+    : task.assigneeAgent === null
+      ? "Assignee does not belong to this project"
+      : task.assigneeAgent.archivedAt === null
+        ? null
+        : `Assignee ${assigneeName} is archived; unarchive the agent or reassign this task first`;
+  const templateStep = task.templateStep?.stepIndex === undefined
+    || task.templateStep.outputKind === undefined
+    || task.templateStep.taskTemplate === undefined
+    ? null
+    : {
+        stepIndex: task.templateStep.stepIndex,
+        outputKind: task.templateStep.outputKind,
+        taskTemplate: task.templateStep.taskTemplate,
+      };
+  const stopStateRefusal = projected.stopStateRefusal !== undefined
+    ? projected.stopStateRefusal
+    : isIntegratorStep(templateStep) ? undefined : null;
+  const chainPredecessor = projected.chainPredecessor !== undefined
+    ? projected.chainPredecessor
+    : task.chainId !== null && !startability.checklist.predecessorsDone
+      ? { name: "an earlier Chain task" }
+      : null;
+  const authority = taskMoveAuthority({
+    name: task.name,
+    status: task.status,
+    assigneeType: task.assigneeType,
+    chainId: task.chainId,
+    archivedAt: task.archivedAt,
+    dispatchAfterTaskId: task.dispatchAfterTaskId,
+    dispatchAfter,
+    reactivationRefusal,
+    activeRun: !startability.checklist.noActiveRun,
+    stopStateRefusal,
+    chainPredecessor,
   });
+  const targets = authority.targets.map((status): BoardMoveTarget => ({ status, via: "patch" }));
+  const startsStandaloneAgent = task.chainId === null
+    && task.assigneeType === "AGENT"
+    && (task.status === TaskStatus.BACKLOG || task.status === TaskStatus.TODO);
+  if (startsStandaloneAgent && startability.startable) {
+    targets.push({ status: TaskStatus.DOING, via: "start" });
+  }
   return startability.checklist.predecessorsDone ? targets : [];
 };
 
@@ -410,7 +458,11 @@ export const chainDisplayByTask = (rows: readonly Pick<BoardRow, "id" | "project
 export const boardCard = (
   row: BoardRow,
   chainProgress: (ChainProgress & { position: number | null }) | null,
-  moveContext: { hasRepoGrant: boolean; chainPredecessorsDone: boolean },
+  moveContext: {
+    hasRepoGrant: boolean;
+    chainPredecessorsDone: boolean;
+    chainPredecessor?: { name: string } | null;
+  },
   display: ChainDisplay = { chainName: taskChainName(row), displayName: row.name },
   predecessor: BoardBlockedOnTask | null = null,
   repairOf: RepairBinding | null = null,
@@ -462,7 +514,10 @@ export const boardCard = (
       ? null
       : { id: row.assigneeAgent.id, title: row.assigneeAgent.title, model: row.assigneeAgent.model },
     chainProgress,
-    moveTargets: operatorMoveTargets(row, startability),
+    moveTargets: operatorMoveTargets(row, startability, {
+      dispatchAfter: predecessor,
+      chainPredecessor: moveContext.chainPredecessor ?? null,
+    }),
     latestRun: latestRunProjection(row.runs),
     taskCost: serializeUsageCost(taskCost),
     // Bound to the run the card actually shows: a stop recorded by run 1 is not
@@ -751,8 +806,15 @@ export const readBoard = async (db: PrismaClient, scope: TaskReadScope): Promise
       scheduleKind: true, runAt: true, cron: true, timezone: true, approvalGate: true,
       templateId: true, source: true, chainId: true, chainIndex: true, chainLayer: true, createdAt: true, updatedAt: true,
       dispatchAfterTaskId: true,
-      assigneeAgent: { select: { id: true, title: true, model: true, archivedAt: true } },
-      templateStep: { select: { name: true } },
+      assigneeAgent: { select: { id: true, name: true, title: true, model: true, archivedAt: true } },
+      templateStep: {
+        select: {
+          name: true,
+          stepIndex: true,
+          outputKind: true,
+          taskTemplate: { select: { name: true } },
+        },
+      },
       runs: {
         orderBy: { runNumber: "desc" },
         select: {
@@ -904,13 +966,13 @@ export const readBoard = async (db: PrismaClient, scope: TaskReadScope): Promise
     const key = row.chainId === null
       ? repairKey
       : chainKey({ projectId: row.projectId, chainId: row.chainId });
-    let chainPredecessorsDone = true;
+    let chainPredecessor: { name: string } | null = null;
     if (row.chainId !== null) {
       const chainGroup = membersByChain.get(chainKey({ projectId: row.projectId, chainId: row.chainId }));
       if (chainGroup === undefined) {
         throw new Error(`Board move target projection is missing Chain ${row.chainId}`);
       }
-      chainPredecessorsDone = blockingPredecessor(chainGroup.primary, row.id) === null;
+      chainPredecessor = blockingPredecessor(chainGroup.primary, row.id);
     }
     const card = boardCard(
       row,
@@ -921,7 +983,8 @@ export const readBoard = async (db: PrismaClient, scope: TaskReadScope): Promise
           agentId: row.assigneeAgentId,
           repoId: row.repoId,
         })),
-        chainPredecessorsDone,
+        chainPredecessorsDone: chainPredecessor === null,
+        chainPredecessor,
       },
       displayByTask.get(row.id),
       row.dispatchAfterTaskId === null ? null : predecessorById.get(row.dispatchAfterTaskId) ?? null,

--- a/packages/api/src/task-move-authority.test.ts
+++ b/packages/api/src/task-move-authority.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AssigneeType, TaskStatus } from "@anneal/db";
+
+import { taskMoveAuthority, type TaskMoveFacts } from "./task-move-authority.js";
+
+const facts = (overrides: Partial<TaskMoveFacts> = {}): TaskMoveFacts => ({
+  name: "Ship the thing",
+  status: TaskStatus.TODO,
+  assigneeType: AssigneeType.AGENT,
+  chainId: null,
+  archivedAt: null,
+  dispatchAfterTaskId: null,
+  dispatchAfter: null,
+  reactivationRefusal: null,
+  activeRun: false,
+  stopStateRefusal: null,
+  chainPredecessor: null,
+  ...overrides,
+});
+
+const refusal = (subject: TaskMoveFacts, status: TaskStatus): string | null => (
+  taskMoveAuthority(subject).refusals.find((candidate) => candidate.status === status)?.message ?? null
+);
+
+test("the authority owns Agent, Human, and Chain transition targets", () => {
+  assert.deepEqual(taskMoveAuthority(facts()).targets, [TaskStatus.BACKLOG]);
+  assert.deepEqual(taskMoveAuthority(facts({ status: TaskStatus.BACKLOG })).targets, [TaskStatus.TODO]);
+  assert.deepEqual(taskMoveAuthority(facts({ assigneeType: AssigneeType.HUMAN })).targets, [
+    TaskStatus.BACKLOG,
+    TaskStatus.DONE,
+  ]);
+  assert.deepEqual(taskMoveAuthority(facts({
+    status: TaskStatus.REVIEW,
+    assigneeType: AssigneeType.HUMAN,
+    chainId: "chain-1",
+  })).targets, [TaskStatus.DONE]);
+  assert.match(refusal(facts({ chainId: "chain-1" }), TaskStatus.BACKLOG) ?? "", /controlled by chain execution/u);
+});
+
+test("archived and predecessor-bound tasks refuse status movement", () => {
+  assert.match(refusal(facts({ archivedAt: new Date() }), TaskStatus.BACKLOG) ?? "", /archived task/u);
+  assert.match(refusal(facts({
+    dispatchAfterTaskId: "predecessor-1",
+    dispatchAfter: { name: "Build", status: TaskStatus.DOING },
+  }), TaskStatus.BACKLOG) ?? "", /predecessor Build is done/u);
+});
+
+test("reactivation refuses an archived stored assignee", () => {
+  const subject = facts({
+    status: TaskStatus.BACKLOG,
+    reactivationRefusal: "Assignee Retired is archived; unarchive the agent or reassign this task first",
+  });
+  assert.equal(refusal(subject, TaskStatus.TODO), subject.reactivationRefusal);
+  assert.deepEqual(taskMoveAuthority(subject).targets, []);
+});
+
+test("an active Run refuses both parking and Human completion", () => {
+  assert.match(refusal(facts({ activeRun: true }), TaskStatus.BACKLOG) ?? "", /active run to Backlog/u);
+  assert.match(refusal(facts({
+    assigneeType: AssigneeType.HUMAN,
+    activeRun: true,
+  }), TaskStatus.DONE) ?? "", /done while it has an active run/u);
+});
+
+test("stop state and an unfinished Chain predecessor keep their refusal priority", () => {
+  const stopped = "Merge integrator stopped on head-drift; answer the stop question before changing this task";
+  assert.equal(refusal(facts({ stopStateRefusal: stopped }), TaskStatus.BACKLOG), stopped);
+  assert.equal(refusal(facts({
+    status: TaskStatus.REVIEW,
+    assigneeType: AssigneeType.HUMAN,
+    chainId: "chain-1",
+    chainPredecessor: { name: "Regression" },
+  }), TaskStatus.DONE), "Cannot complete Ship the thing; predecessor Regression is not done");
+});
+
+test("dynamic facts remain named deferred residue until read under the mutex", () => {
+  assert.deepEqual(taskMoveAuthority(facts({ activeRun: undefined })).deferred, [
+    { status: TaskStatus.BACKLOG, residue: "active-run" },
+    { status: TaskStatus.DONE, residue: "active-run" },
+  ]);
+  assert.deepEqual(taskMoveAuthority(facts({ stopStateRefusal: undefined })).deferred, [
+    { status: TaskStatus.BACKLOG, residue: "stop-state" },
+    { status: TaskStatus.DOING, residue: "stop-state" },
+    { status: TaskStatus.REVIEW, residue: "stop-state" },
+    { status: TaskStatus.DONE, residue: "stop-state" },
+  ]);
+});

--- a/packages/api/src/task-move-authority.ts
+++ b/packages/api/src/task-move-authority.ts
@@ -1,0 +1,123 @@
+import { AssigneeType, TaskStatus, type TaskStatus as TaskStatusType } from "@anneal/db";
+
+export type TaskMoveDeferred = "active-run" | "stop-state";
+
+export type TaskMoveFacts = {
+  name: string;
+  status: TaskStatusType;
+  assigneeType: AssigneeType;
+  chainId: string | null;
+  archivedAt: Date | null;
+  dispatchAfterTaskId: string | null;
+  dispatchAfter: { name: string; status: TaskStatusType } | null;
+  reactivationRefusal: string | null;
+  activeRun: boolean | undefined;
+  stopStateRefusal: string | null | undefined;
+  chainPredecessor: { name: string } | null;
+};
+
+export type TaskMoveAuthority = {
+  targets: TaskStatusType[];
+  refusals: Array<{ status: TaskStatusType; message: string }>;
+  deferred: Array<{ status: TaskStatusType; residue: TaskMoveDeferred }>;
+};
+
+const TASK_STATUSES: TaskStatusType[] = [
+  TaskStatus.BACKLOG,
+  TaskStatus.TODO,
+  TaskStatus.DOING,
+  TaskStatus.REVIEW,
+  TaskStatus.DONE,
+];
+
+const liveStatus = (status: TaskStatusType): boolean => (
+  status === TaskStatus.TODO || status === TaskStatus.DOING || status === TaskStatus.REVIEW
+);
+
+const ownershipRefusal = (task: TaskMoveFacts, next: TaskStatusType): string | null => {
+  if (next === task.status) return null;
+  if (task.assigneeType === AssigneeType.HUMAN && next === TaskStatus.DONE) return null;
+  if (task.chainId !== null) return "Chain task statuses are controlled by chain execution";
+  const queueTransition = (
+    (task.status === TaskStatus.BACKLOG && next === TaskStatus.TODO)
+    || (task.status === TaskStatus.TODO && next === TaskStatus.BACKLOG)
+  );
+  if (queueTransition) return null;
+  return task.assigneeType === AssigneeType.AGENT
+    ? "Doing, Review, and Done for agent tasks are controlled by execution"
+    : "Human tasks may move between Backlog and Todo or be marked Done";
+};
+
+type MoveDecision =
+  | { kind: "accepted" }
+  | { kind: "refused"; message: string }
+  | { kind: "deferred"; residue: TaskMoveDeferred };
+
+/**
+ * Decide every operator PATCH destination from one set of already-read facts.
+ *
+ * `undefined` on `activeRun` or `stopStateRefusal` means that fact still needs
+ * an authoritative read under the Task mutex. The named residue is part of the
+ * result instead of an implicit rule that board projection could overlook.
+ */
+const decisionFor = (task: TaskMoveFacts, next: TaskStatusType): MoveDecision => {
+  if (task.archivedAt !== null) {
+    return { kind: "refused", message: "Cannot change the status of an archived task; unarchive it first" };
+  }
+  if (task.dispatchAfterTaskId !== null
+    && task.dispatchAfter?.status !== TaskStatus.DONE
+    && next !== task.status) {
+    return {
+      kind: "refused",
+      message: `Cannot change bound task status before predecessor ${task.dispatchAfter?.name ?? task.dispatchAfterTaskId} is done`,
+    };
+  }
+  if (!liveStatus(task.status) && liveStatus(next) && task.reactivationRefusal !== null) {
+    return { kind: "refused", message: task.reactivationRefusal };
+  }
+  if (next === TaskStatus.BACKLOG && task.status !== TaskStatus.BACKLOG) {
+    if (task.activeRun === undefined) return { kind: "deferred", residue: "active-run" };
+    if (task.activeRun) {
+      return { kind: "refused", message: "Cannot move a task with an active run to Backlog" };
+    }
+  }
+  if (next !== task.status) {
+    if (task.stopStateRefusal === undefined) return { kind: "deferred", residue: "stop-state" };
+    if (task.stopStateRefusal !== null) {
+      return { kind: "refused", message: task.stopStateRefusal };
+    }
+  }
+  const operatorRefusal = ownershipRefusal(task, next);
+  if (next !== TaskStatus.DONE && operatorRefusal !== null) {
+    return { kind: "refused", message: operatorRefusal };
+  }
+  if (next === TaskStatus.DONE) {
+    if (task.activeRun === undefined) return { kind: "deferred", residue: "active-run" };
+    if (task.activeRun) {
+      return { kind: "refused", message: "Cannot mark a task done while it has an active run" };
+    }
+    if (task.chainPredecessor !== null) {
+      return {
+        kind: "refused",
+        message: `Cannot complete ${task.name}; predecessor ${task.chainPredecessor.name} is not done`,
+      };
+    }
+    if (operatorRefusal !== null) return { kind: "refused", message: operatorRefusal };
+  }
+  return { kind: "accepted" };
+};
+
+export const taskMoveAuthority = (task: TaskMoveFacts): TaskMoveAuthority => {
+  const authority: TaskMoveAuthority = { targets: [], refusals: [], deferred: [] };
+  for (const status of TASK_STATUSES) {
+    const decision = decisionFor(task, status);
+    if (decision.kind === "accepted") {
+      if (status !== task.status) authority.targets.push(status);
+    } else if (decision.kind === "refused") {
+      authority.refusals.push({ status, message: decision.message });
+    } else {
+      authority.deferred.push({ status, residue: decision.residue });
+    }
+  }
+  return authority;
+};

--- a/packages/api/src/task-patch.dbtest.ts
+++ b/packages/api/src/task-patch.dbtest.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { after, before, beforeEach, test } from "node:test";
 
-import { PrismaClient, TaskStatus } from "@anneal/db";
+import { PrismaClient, RunStatus, TaskStatus } from "@anneal/db";
 
 import { patchTask } from "./task-patch.js";
 import { resetTestDb, setupTestDb } from "./testdb.js";
@@ -65,6 +65,42 @@ test("an archived task refuses a status write from inside the transaction", asyn
   assert.deepEqual(result, {
     reason: "conflict",
     message: "Cannot change the status of an archived task; unarchive it first",
+  });
+});
+
+test("an active Run refuses a move to Backlog from inside the transaction", async () => {
+  const { project, agent, task } = await seed();
+  await db.run.create({ data: {
+    projectId: project.id,
+    taskId: task.id,
+    agentId: agent.id,
+    runNumber: 1,
+    dedupeKey: `task:${task.id}:run:1`,
+    status: RunStatus.QUEUED,
+    runner: "CODEX",
+    model: agent.model,
+    promptHash: "hash",
+    branch: `codex/${task.id}`,
+    workspacePath: `/scratch/${task.id}`,
+  } });
+
+  const result = await patchTask(db, task.id, { status: TaskStatus.BACKLOG });
+
+  assert.deepEqual(result, {
+    reason: "conflict",
+    message: "Cannot move a task with an active run to Backlog",
+  });
+});
+
+test("an archived stored assignee refuses Backlog reactivation", async () => {
+  const { agent, task } = await seed({ status: TaskStatus.BACKLOG });
+  await db.agent.update({ where: { id: agent.id }, data: { archivedAt: new Date() } });
+
+  const result = await patchTask(db, task.id, { status: TaskStatus.TODO });
+
+  assert.deepEqual(result, {
+    reason: "conflict",
+    message: `Assignee ${agent.name} is archived; unarchive the agent or reassign this task first`,
   });
 });
 

--- a/packages/api/src/task-patch.test.ts
+++ b/packages/api/src/task-patch.test.ts
@@ -4,53 +4,7 @@ import test from "node:test";
 import { AssigneeType, type PrismaClient, TaskStatus } from "@anneal/db";
 
 import { composeBrief, readBrief } from "./task-brief.js";
-import { operatorStatusTransitionRefusal, patchTask } from "./task-patch.js";
-
-const statusSubject = (
-  status: TaskStatus,
-  assigneeType: AssigneeType,
-  chainId: string | null = null,
-) => ({ status, assigneeType, chainId });
-
-test("operator status ownership excludes agent execution and chain-derived states", () => {
-  assert.equal(operatorStatusTransitionRefusal(
-    statusSubject(TaskStatus.TODO, AssigneeType.AGENT),
-    TaskStatus.BACKLOG,
-  ), null);
-  assert.equal(operatorStatusTransitionRefusal(
-    statusSubject(TaskStatus.BACKLOG, AssigneeType.AGENT),
-    TaskStatus.TODO,
-  ), null);
-  for (const target of [TaskStatus.DOING, TaskStatus.REVIEW, TaskStatus.DONE]) {
-    assert.match(operatorStatusTransitionRefusal(
-      statusSubject(TaskStatus.TODO, AssigneeType.AGENT),
-      target,
-    ) ?? "", /controlled by execution/u);
-  }
-  assert.match(operatorStatusTransitionRefusal(
-    statusSubject(TaskStatus.TODO, AssigneeType.AGENT, "chain-1"),
-    TaskStatus.BACKLOG,
-  ) ?? "", /controlled by chain execution/u);
-});
-
-test("a Human owns queue movement and the Done decision", () => {
-  assert.equal(operatorStatusTransitionRefusal(
-    statusSubject(TaskStatus.BACKLOG, AssigneeType.HUMAN),
-    TaskStatus.TODO,
-  ), null);
-  assert.equal(operatorStatusTransitionRefusal(
-    statusSubject(TaskStatus.TODO, AssigneeType.HUMAN),
-    TaskStatus.BACKLOG,
-  ), null);
-  assert.equal(operatorStatusTransitionRefusal(
-    statusSubject(TaskStatus.REVIEW, AssigneeType.HUMAN, "chain-1"),
-    TaskStatus.DONE,
-  ), null);
-  assert.match(operatorStatusTransitionRefusal(
-    statusSubject(TaskStatus.TODO, AssigneeType.HUMAN),
-    TaskStatus.REVIEW,
-  ) ?? "", /may move between Backlog and Todo or be marked Done/u);
-});
+import { patchTask } from "./task-patch.js";
 
 const patchFixture = (description: string, outputKind = "implementation") => {
   let update: Record<string, unknown> | null = null;

--- a/packages/api/src/task-patch.ts
+++ b/packages/api/src/task-patch.ts
@@ -21,6 +21,7 @@ import { FAILURE_REASON_LIMIT, failureReasonText } from "./failure-reason.js";
 import { type Refusal, refusalFor } from "./refusal.js";
 import { validateSchedule } from "./scheduler.js";
 import { rewriteBrief, stepHasTaskBrief } from "./task-brief.js";
+import { taskMoveAuthority } from "./task-move-authority.js";
 import {
   hasActiveRun,
   isLiveStatus,
@@ -117,33 +118,6 @@ type GateWinner = {
   card: { id: string; body: string; gateTaskId: string | null; sessionId: string | null };
   runId: string;
 } | null;
-
-/**
- * The status transitions owned by the board operator.
- *
- * Execution code does not call this action: runners and the chain control
- * plane write their machine-owned states through their own fenced paths.  A
- * board PATCH may therefore only move standalone work between its two queue
- * states, or record the one terminal decision a Human owns.  Chain state is a
- * projection of chain execution, with that Human completion as its sole
- * operator-owned exception.
- */
-export const operatorStatusTransitionRefusal = (
-  task: Pick<Task, "assigneeType" | "chainId" | "status">,
-  next: TaskStatus,
-): string | null => {
-  if (next === task.status) return null;
-  if (task.assigneeType === "HUMAN" && next === TaskStatus.DONE) return null;
-  if (task.chainId !== null) return "Chain task statuses are controlled by chain execution";
-  const queueTransition = (
-    (task.status === TaskStatus.BACKLOG && next === TaskStatus.TODO)
-    || (task.status === TaskStatus.TODO && next === TaskStatus.BACKLOG)
-  );
-  if (queueTransition) return null;
-  return task.assigneeType === "AGENT"
-    ? "Doing, Review, and Done for agent tasks are controlled by execution"
-    : "Human tasks may move between Backlog and Todo or be marked Done";
-};
 
 /** A refusal from `writeTask` in this action's terms: the task is gone, or the
  *  assignee the request named may not be written onto it. */
@@ -302,6 +276,7 @@ export const patchTask = async (
   // on a row another writer has since parked or archived — and outside the
   // transaction it wrote that TODO back with no lock and no guard at all.
   if (body.status !== undefined) {
+    const nextStatus = body.status;
     const written = await db.$transaction(async (tx) => {
       const result = await writeTask<StatusWritePlan>(tx, taskId, async (locked) => {
         const refuse = (message: string) => ({
@@ -309,75 +284,54 @@ export const patchTask = async (
           activity: null,
           value: { reason: "conflict" as const, message },
         });
-        if (locked.archivedAt !== null) {
-          return refuse("Cannot change the status of an archived task; unarchive it first");
-        }
-        if (typeof locked.dispatchAfterTaskId === "string"
-          && locked.dispatchAfter?.status !== TaskStatus.DONE
-          && body.status !== locked.status) {
-          const predecessorName = locked.dispatchAfter?.name ?? locked.dispatchAfterTaskId;
-          return refuse(`Cannot change bound task status before predecessor ${predecessorName} is done`);
-        }
-        // Promoting BACKLOG or DONE history into TODO|DOING|REVIEW gives the
-        // task back to whoever it is *already* assigned to, and that assignee is
-        // in no request field for the module's assignment guard to have checked.
-        // So the stored one joins the same protocol here, read under the
-        // Agent-row mutex the locked Task row already ordered us into. `locked`
-        // is the authority on it, not the pre-transaction `before` read.
-        //
-        // 409, not the 400 the module answers with: nothing in the request is
-        // malformed — the conflict is in the state of the assignee, which the
-        // operator can fix and retry, exactly like Retry's archived-assignee
-        // refusal.
-        if (body.assigneeAgentId === undefined
+        // These reads stay inside the Task/Chain mutex. Board projection can
+        // answer from its snapshot, but PATCH revalidates the two dynamic
+        // residues (`active-run`, `stop-state`) at the write's serialization
+        // point before the shared move authority accepts a target.
+        const statusChanged = nextStatus !== locked.status;
+        const reactivationRefusal = body.assigneeAgentId === undefined
           && !isLiveStatus(locked.status)
-          && body.status !== undefined
-          && isLiveStatus(body.status)) {
-          const blockedReactivation = await reactivationBlocked(tx, locked);
-          if (blockedReactivation) return refuse(blockedReactivation);
+          && isLiveStatus(nextStatus)
+          ? await reactivationBlocked(tx, locked)
+          : null;
+        const activeRun = (nextStatus === TaskStatus.BACKLOG && statusChanged)
+          || nextStatus === TaskStatus.DONE
+          ? await hasActiveRun(tx, taskId)
+          : false;
+        const stopped = statusChanged ? await stopStateFor(tx, taskId) : null;
+        let chainPredecessor: { name: string } | null = null;
+        if (nextStatus === TaskStatus.DONE && locked.chainId) {
+          const chainRows = await tx.task.findMany({
+            where: {
+              projectId: locked.projectId,
+              chainId: locked.chainId,
+            },
+            orderBy: [{ chainLayer: "asc" }, { chainIndex: "asc" }, { id: "asc" }],
+            select: { id: true, name: true, status: true, chainIndex: true, chainLayer: true },
+          });
+          chainPredecessor = blockingPredecessor(chainRows, taskId);
         }
-        // Against `locked`, not `before`: a park is a park whenever the row this
-        // transaction holds is not already in Backlog.
-        if (body.status === TaskStatus.BACKLOG
-          && locked.status !== TaskStatus.BACKLOG
-          && await hasActiveRun(tx, taskId)) {
-          return refuse("Cannot move a task with an active run to Backlog");
+        const authority = taskMoveAuthority({
+          name: before.name,
+          status: locked.status,
+          assigneeType: locked.assigneeType,
+          chainId: locked.chainId,
+          archivedAt: locked.archivedAt,
+          dispatchAfterTaskId: locked.dispatchAfterTaskId,
+          dispatchAfter: locked.dispatchAfter,
+          reactivationRefusal,
+          activeRun,
+          stopStateRefusal: stopped === null ? null : stopStateRefusal(stopped),
+          chainPredecessor,
+        });
+        const moveRefusal = authority.refusals.find(({ status }) => status === nextStatus);
+        if (moveRefusal) return refuse(moveRefusal.message);
+        const unresolved = authority.deferred.find(({ status }) => status === nextStatus);
+        if (unresolved) {
+          throw new Error(`PATCH move authority left ${unresolved.residue} unresolved under the Task mutex`);
         }
-        // §D-P7 / Step 5. The exclusivity guard, composed rather than
-        // duplicated: while a recorded stop has no terminal-disposition answer,
-        // this task does not move. Keyed on the disposition, not on an answer
-        // existing, because `flag-incident` writes an answer and must still
-        // hold the chain.
-        const stopped = await stopStateFor(tx, taskId);
-        if (stopped && body.status !== undefined && body.status !== locked.status) {
-          return refuse(stopStateRefusal(stopped));
-        }
-        // Ownership is the generic boundary. A forbidden board move must not
-        // hide the more actionable reason that this same write is impossible
-        // anyway. The shared guards are above; DONE's active-run and chain-
-        // predecessor guards run below before its ownership refusal.
-        const operatorRefusal = operatorStatusTransitionRefusal(locked, body.status!);
-        if (body.status !== TaskStatus.DONE && operatorRefusal !== null) return refuse(operatorRefusal);
         let gate: GateWinner = null;
-        if (body.status === TaskStatus.DONE) {
-          if (await hasActiveRun(tx, taskId)) {
-            return refuse("Cannot mark a task done while it has an active run");
-          }
-          if (locked.chainId) {
-            const chainRows = await tx.task.findMany({
-              where: {
-                projectId: locked.projectId,
-                chainId: locked.chainId,
-              },
-              orderBy: [{ chainLayer: "asc" }, { chainIndex: "asc" }, { id: "asc" }],
-              select: { id: true, name: true, status: true, chainIndex: true, chainLayer: true },
-            });
-            const blocker = blockingPredecessor(chainRows, taskId);
-            if (blocker) {
-              return refuse(`Cannot complete ${before.name}; predecessor ${blocker.name} is not done`);
-            }
-          }
-          if (operatorRefusal !== null) return refuse(operatorRefusal);
+        if (nextStatus === TaskStatus.DONE) {
           // A Human approval has one durable decision identity on both API
           // channels. The earliest OPEN card is the deterministic winner; the
           // gate Task lock the module took makes this selection and the Inbox
@@ -417,11 +371,10 @@ export const patchTask = async (
             }
           }
         }
-        const statusChanged = body.status !== undefined && body.status !== locked.status;
         return {
           update: updateData,
           activity: statusChanged
-            ? taskStatusChangedActivity(locked.status, body.status!)
+            ? taskStatusChangedActivity(locked.status, nextStatus)
             : null,
           value: { gate, previousStatus: locked.status },
         };
@@ -436,7 +389,7 @@ export const patchTask = async (
       // This OPEN row is the gate-decision CAS. It deliberately depends on
       // neither templateId nor approvalGate: gate creation records the
       // relationship in gateTaskId, and that is the only authority here.
-      if (body.status === TaskStatus.DONE) {
+      if (nextStatus === TaskStatus.DONE) {
         if (plan.gate) {
           await tx.inboxMessage.update({
             where: { id: plan.gate.card.id },
@@ -464,7 +417,7 @@ export const patchTask = async (
         }, new Date());
       }
       if (plan.previousStatus !== TaskStatus.DONE
-        && body.status === TaskStatus.DONE
+        && nextStatus === TaskStatus.DONE
         && Boolean(updated.chainId)
         && authorization?.purpose !== "confirmation") {
         await activateChainSuccessor(tx, updated, { sourceRunId: null }, new Date());


### PR DESCRIPTION
## What changed

- Added one deep `taskMoveAuthority` module whose interface returns accepted targets, refusals, and named `active-run` / `stop-state` deferred residue.
- Routed both board projection and PATCH status decisions through the same static rules for archived tasks, dispatch bindings, archived assignees, active Runs, stop state, operator ownership, and Chain predecessor completion.
- Kept the HTTP and board wire contracts unchanged while ensuring projected PATCH targets are a subset of targets the authority accepts from the same facts.
- Added regressions for the active-Run Backlog divergence and archived-assignee reactivation divergence.

## Evidence

Exact head: `e059021f5380129f3b1994e407b378e46eb83ab1`

- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `RUNNER_WORKSPACE_ROOT="$(mktemp -d)" node --import tsx --test packages/api/src/task-move-authority.test.ts packages/api/src/board.test.ts packages/api/src/task-patch.test.ts` — PASS (45 tests)
- Against a disposable PostgreSQL 16 database with a unique `e3_move_authority` schema, `AGENTOS_ALLOW_SCRATCH_DATABASES=1 npm run test:db -w @anneal/api -- src/task-patch.dbtest.ts src/board-blocked-on.dbtest.ts` — PASS (7 tests)

## Reported but unfixed

- None.