### PR TITLE
refactor(chain): centralize hold decisions

### DIFF
--- a/packages/api/src/chain-activation-barrier.dbtest.ts
+++ b/packages/api/src/chain-activation-barrier.dbtest.ts
@@ -194,6 +194,55 @@ test("completion under a held Chain persists output and withholds successor acti
   assert.ok(activity, "completion records why the successor was withheld");
 });
 
+test("completion under a held Chain records fail-closed activity for a successor with no execution layer", async () => {
+  const chain = await seedRunningHeldChain();
+  await db.$executeRawUnsafe('ALTER TABLE "Task" DROP CONSTRAINT "Task_chain_identity_all_or_none_check"');
+  try {
+    await db.task.update({
+      where: { id: chain.successor.id },
+      data: { chainLayer: null, chainIndex: null },
+    });
+    const response = await createApp(db).request(`/runner/runs/${chain.run.id}/complete`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${RUNNER_TOKEN}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        runnerId: "activation-runner",
+        fencingToken: "activation-fence",
+        exitCode: 0,
+        terminalEventSeen: true,
+        terminalSuccess: true,
+        cleanupStatus: "SUCCEEDED",
+        output: "completed before malformed successor",
+      }),
+    });
+
+    assert.equal(response.status, 200, await response.text());
+    assert.equal(await db.run.count({ where: { taskId: chain.successor.id } }), 0);
+    const activity = await db.taskActivity.findFirstOrThrow({
+      where: { taskId: chain.predecessor.id, metadata: { path: ["kind"], equals: "chainControl.activationWithheld" } },
+      orderBy: { createdAt: "desc" },
+    });
+    assert.match(activity.body, /activation withheld because Chain is held after layer 1/u);
+    assert.deepEqual(activity.metadata, {
+      kind: "chainControl.activationWithheld",
+      schemaVersion: 1,
+      heldLayer: 1,
+      nextLayer: null,
+    });
+  } finally {
+    await db.task.update({
+      where: { id: chain.successor.id },
+      data: { chainLayer: 2, chainIndex: 1 },
+    });
+    await db.$executeRawUnsafe(`ALTER TABLE "Task"
+      ADD CONSTRAINT "Task_chain_identity_all_or_none_check" CHECK (
+        ("chainId" IS NULL AND "chainIndex" IS NULL AND "chainLayer" IS NULL)
+        OR
+        ("chainId" IS NOT NULL AND "chainIndex" IS NOT NULL AND "chainLayer" IS NOT NULL)
+      )`);
+  }
+});
+
 test("a held fan-out layer completes every sibling while its join remains unactivated", async () => {
   const chain = await seedBasicChain(db, {
     statuses: [TaskStatus.DOING, TaskStatus.DOING, TaskStatus.TODO],

--- a/packages/api/src/chain-enqueue-barrier.dbtest.ts
+++ b/packages/api/src/chain-enqueue-barrier.dbtest.ts
@@ -145,3 +145,27 @@ test("a direct producer cannot bypass the held-layer gate", async () => {
   assert.equal(await db.run.count({ where: { taskId: task.id } }), 0);
   assert.equal(await db.taskActivity.count({ where: { taskId: task.id } }), 0);
 });
+
+test("a direct producer fails closed when both Chain execution fields are null", async () => {
+  const seed = await seedExecutor();
+  await db.$executeRawUnsafe('ALTER TABLE "Task" DROP CONSTRAINT "Task_chain_identity_all_or_none_check"');
+  try {
+    const task = await scheduledTask(seed, { chainId: "held-chain", chainIndex: null, chainLayer: null });
+    await hold(seed.project.id, task.chainId!, 1);
+
+    await assert.rejects(
+      () => db.$transaction((tx) => enqueueTaskRun(tx, task.id, due)),
+      /Chain .* is held; Task .* cannot queue a Run/u,
+    );
+    assert.equal(await db.run.count({ where: { taskId: task.id } }), 0);
+    assert.equal(await db.taskActivity.count({ where: { taskId: task.id } }), 0);
+  } finally {
+    await resetTestDb(db);
+    await db.$executeRawUnsafe(`ALTER TABLE "Task"
+      ADD CONSTRAINT "Task_chain_identity_all_or_none_check" CHECK (
+        ("chainId" IS NULL AND "chainIndex" IS NULL AND "chainLayer" IS NULL)
+        OR
+        ("chainId" IS NOT NULL AND "chainIndex" IS NOT NULL AND "chainLayer" IS NOT NULL)
+      )`);
+  }
+});

--- a/packages/api/src/chain.test.ts
+++ b/packages/api/src/chain.test.ts
@@ -161,7 +161,7 @@ test("a resolved dispatch binding restores the ordinary first-step decision", ()
   assert.equal(taskStartability(resolved, { total: 0, active: false }, 3, true).startable, true);
 });
 
-const heldControl = (heldLayer: number): ChainControlSnapshot => ({
+const heldControl = (heldLayer: number | null): ChainControlSnapshot => ({
   projectId: "project-1",
   chainId: "chain-1",
   state: ChainControlState.HELD,
@@ -205,6 +205,18 @@ test("held-layer admission prefers chainLayer and falls back to chainIndex", () 
   assert.match(refusalForHeldChainStep({
     projectId: "project-1", chainId: "chain-1", chainIndex: 3, chainLayer: null, name: "Legacy later",
   }, control)?.message ?? "", /held after layer 2/u);
+  assert.deepEqual(refusalForHeldChainStep({
+    projectId: "project-1", chainId: "chain-1", chainIndex: null, chainLayer: null, name: "Missing layer",
+  }, control), {
+    reason: "conflict",
+    message: "Cannot start Missing layer; Chain is held",
+  });
+  assert.deepEqual(refusalForHeldChainStep({
+    projectId: "project-1", chainId: "chain-1", chainIndex: 1, chainLayer: 1, name: "Invalid control",
+  }, heldControl(null)), {
+    reason: "conflict",
+    message: "Cannot start Invalid control; Chain is held",
+  });
 });
 
 test("released, absent, and chainless control states do not refuse admission", () => {

--- a/packages/api/src/chain.ts
+++ b/packages/api/src/chain.ts
@@ -13,6 +13,7 @@ import {
   type PrismaClient,
   TaskStatus,
 } from "@anneal/db";
+import { heldPredicate } from "@anneal/db/chain-hold";
 import { compare, denseOrdinals, layerOf } from "@anneal/db/chain-order";
 
 export { resumeActivationAnchor, resumeActivationNeedsSourceRun };
@@ -337,8 +338,12 @@ export const refusalForHeldChainStep = (
   task: Pick<StepAdmissionTask, "projectId" | "chainId" | "chainIndex" | "chainLayer" | "name">,
   control: ChainControlSnapshot | null | undefined,
 ): Refusal | null => {
-  if (!control?.held || task.chainId === null
-    || control.projectId !== task.projectId || control.chainId !== task.chainId) return null;
+  if (!control || !heldPredicate({
+    projectId: task.projectId,
+    chainId: task.chainId,
+    layer: task.chainLayer,
+    index: task.chainIndex,
+  }, control)) return null;
   const taskLayer = chainLayerOf(task);
   // A held control is only valid with a persisted layer, but fail closed if a
   // malformed legacy row reaches admission: an unknown layer must not bypass
@@ -346,7 +351,6 @@ export const refusalForHeldChainStep = (
   if (taskLayer === null || control.heldLayer === null) {
     return { reason: "conflict", message: `Cannot start ${task.name}; Chain is held` };
   }
-  if (taskLayer <= control.heldLayer) return null;
   return {
     reason: "conflict",
     message: `Cannot start ${task.name}; Chain is held after layer ${control.heldLayer}`,

--- a/packages/api/src/claim-exclusion.dbtest.ts
+++ b/packages/api/src/claim-exclusion.dbtest.ts
@@ -12,6 +12,7 @@ import {
   RunStatus,
   TaskStatus,
 } from "@anneal/db";
+import { heldPredicate } from "@anneal/db/chain-hold";
 
 import { seedIntegratorChain } from "./merge-integrator-fixture.js";
 import { createApp } from "./test-app.js";
@@ -23,6 +24,14 @@ const EXECUTOR_RUNNER = "claim-exclusion-merge-executor";
 const RUNNER_ID = "claim-exclusion-runner";
 const EARLIER = new Date("2026-08-01T00:00:00.000Z");
 const LATER = new Date("2026-08-02T00:00:00.000Z");
+
+const HOLD_FIXTURES = [
+  { name: "stored layer below hold", chainLayer: 1, chainIndex: 99, heldLayer: 2, held: false },
+  { name: "stored layer above hold", chainLayer: 3, chainIndex: 0, heldLayer: 2, held: true },
+  { name: "legacy index below hold", chainLayer: null, chainIndex: 1, heldLayer: 2, held: false },
+  { name: "legacy index above hold", chainLayer: null, chainIndex: 3, heldLayer: 2, held: true },
+  { name: "missing layer and index", chainLayer: null, chainIndex: null, heldLayer: 2, held: true },
+] as const;
 
 let db: PrismaClient;
 const previousEnvironment = {
@@ -281,6 +290,72 @@ test("merge-executor claims apply the same held-layer exclusion and see release 
   assert.equal((await db.run.findUniqueOrThrow({ where: { id: run.id } })).status, RunStatus.CLAIMED);
 });
 
+test("shared fixtures agree across the TypeScript, Prisma, and raw SQL hold expressions", async () => {
+  await db.$executeRawUnsafe('ALTER TABLE "Task" DROP CONSTRAINT "Task_chain_identity_all_or_none_check"');
+  try {
+    for (const fixture of HOLD_FIXTURES) {
+      await resetTestDb(db);
+      const ordinaryOwner = await seedRunner();
+      const ordinaryChain = await seedChain(ordinaryOwner, [1]);
+      const ordinaryTask = ordinaryChain.tasks[0]!;
+      const ordinaryRun = await queue(ordinaryTask.id);
+      await db.task.update({
+        where: { id: ordinaryTask.id },
+        data: { chainLayer: fixture.chainLayer, chainIndex: fixture.chainIndex },
+      });
+      await hold(ordinaryOwner.project.id, ordinaryChain.chainId, fixture.heldLayer);
+
+      assert.equal(heldPredicate({
+        projectId: ordinaryOwner.project.id,
+        chainId: ordinaryChain.chainId,
+        layer: fixture.chainLayer,
+        index: fixture.chainIndex,
+      }, {
+        projectId: ordinaryOwner.project.id,
+        chainId: ordinaryChain.chainId,
+        state: ChainControlState.HELD,
+        heldLayer: fixture.heldLayer,
+      }), fixture.held, `${fixture.name}: TypeScript`);
+
+      const ordinaryClaim = await claim(`raw-${fixture.name.replaceAll(" ", "-")}`);
+      assert.equal(ordinaryClaim.status, fixture.held ? 204 : 200, `${fixture.name}: raw SQL`);
+      if (!fixture.held) assert.equal(ordinaryClaim.body.run.id, ordinaryRun.id, `${fixture.name}: raw SQL run`);
+      assert.equal(
+        (await db.run.findUniqueOrThrow({ where: { id: ordinaryRun.id } })).status,
+        fixture.held ? RunStatus.QUEUED : RunStatus.CLAIMED,
+        `${fixture.name}: raw SQL state`,
+      );
+
+      await resetTestDb(db);
+      const executorChain = await seedIntegratorChain(db, { label: `fixture-${fixture.name.replaceAll(" ", "-")}` });
+      assert.ok(executorChain.integratorTask);
+      const executorRun = await queue(executorChain.integratorTask.id);
+      await db.task.update({
+        where: { id: executorChain.integratorTask.id },
+        data: { chainLayer: fixture.chainLayer, chainIndex: fixture.chainIndex },
+      });
+      await hold(executorChain.project.id, executorChain.chainId, fixture.heldLayer);
+
+      const executorClaim = await claim(EXECUTOR_RUNNER, EXECUTOR_TOKEN);
+      assert.equal(executorClaim.status, fixture.held ? 204 : 200, `${fixture.name}: Prisma`);
+      if (!fixture.held) assert.equal(executorClaim.body.run.id, executorRun.id, `${fixture.name}: Prisma run`);
+      assert.equal(
+        (await db.run.findUniqueOrThrow({ where: { id: executorRun.id } })).status,
+        fixture.held ? RunStatus.QUEUED : RunStatus.CLAIMED,
+        `${fixture.name}: Prisma state`,
+      );
+    }
+  } finally {
+    await resetTestDb(db);
+    await db.$executeRawUnsafe(`ALTER TABLE "Task"
+      ADD CONSTRAINT "Task_chain_identity_all_or_none_check" CHECK (
+        ("chainId" IS NULL AND "chainIndex" IS NULL AND "chainLayer" IS NULL)
+        OR
+        ("chainId" IS NOT NULL AND "chainIndex" IS NOT NULL AND "chainLayer" IS NOT NULL)
+      )`);
+  }
+});
+
 test("a Hold that wins the Chain mutex bars an ordinary claim selected from a stale candidate scan", async () => {
   const owner = await seedRunner();
   const chain = await seedChain(owner, [1, 2]);
@@ -293,6 +368,38 @@ test("a Hold that wins the Chain mutex bars an ordinary claim selected from a st
     runnerId: "claim-race-ordinary",
     token: RUNNER_TOKEN,
   });
+});
+
+test("the live claim loop fails closed when a racing Hold finds null Chain execution fields", async () => {
+  const owner = await seedRunner();
+  const chain = await seedChain(owner, [1]);
+  const run = await queue(chain.tasks[0]!.id);
+  await db.$executeRawUnsafe('ALTER TABLE "Task" DROP CONSTRAINT "Task_chain_identity_all_or_none_check"');
+  try {
+    await db.task.update({
+      where: { id: chain.tasks[0]!.id },
+      data: { chainLayer: null, chainIndex: null },
+    });
+    await holdWinsClaimRace({
+      projectId: owner.project.id,
+      chainId: chain.chainId,
+      heldLayer: 1,
+      runId: run.id,
+      runnerId: "claim-race-null-layer",
+      token: RUNNER_TOKEN,
+    });
+  } finally {
+    await db.task.update({
+      where: { id: chain.tasks[0]!.id },
+      data: { chainLayer: 1, chainIndex: 0 },
+    });
+    await db.$executeRawUnsafe(`ALTER TABLE "Task"
+      ADD CONSTRAINT "Task_chain_identity_all_or_none_check" CHECK (
+        ("chainId" IS NULL AND "chainIndex" IS NULL AND "chainLayer" IS NULL)
+        OR
+        ("chainId" IS NOT NULL AND "chainIndex" IS NOT NULL AND "chainLayer" IS NOT NULL)
+      )`);
+  }
 });
 
 test("a Hold that wins the Chain mutex bars a merge-executor claim selected from a stale candidate scan", async () => {

--- a/packages/api/src/run-claim.ts
+++ b/packages/api/src/run-claim.ts
@@ -23,7 +23,7 @@ import {
   taskIsIntegratorStep,
   TaskStatus,
 } from "@anneal/db";
-import { layerOf } from "@anneal/db/chain-order";
+import { heldPredicate, heldSql, heldWhere } from "@anneal/db/chain-hold";
 import { z } from "zod";
 
 import { issueSessionToken } from "./auth.js";
@@ -115,18 +115,11 @@ const SPECIFICATION_READ_DEFERRAL_DELAYS_MS = [15_000, 30_000, 60_000] as const;
 const heldChainTaskIdsForClaim = async (tx: Prisma.TransactionClient): Promise<string[]> => {
   const controls = await tx.chainControl.findMany({
     where: { state: ChainControlState.HELD },
-    select: { projectId: true, chainId: true, heldLayer: true },
+    select: { projectId: true, chainId: true, state: true, heldLayer: true },
   });
-  const heldChains = controls.flatMap(({ projectId, chainId, heldLayer }) => {
-    if (heldLayer === null) return [{ projectId, chainId }];
-    return [{
-      projectId,
-      chainId,
-      OR: [
-        { chainLayer: { gt: heldLayer } },
-        { chainLayer: null, chainIndex: { gt: heldLayer } },
-      ],
-    }];
+  const heldChains = controls.flatMap((control) => {
+    const where = heldWhere(control);
+    return where === null ? [] : [where];
   });
   if (heldChains.length === 0) return [];
   const tasks = await tx.task.findMany({ where: { OR: heldChains }, select: { id: true } });
@@ -281,14 +274,7 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
             AND NOT EXISTS (
               SELECT 1
               FROM "ChainControl" AS chain_control
-              WHERE chain_control."projectId" = task."projectId"
-                AND chain_control."chainId" = task."chainId"
-                AND chain_control."state" = lower(${ChainControlState.HELD})::"ChainControlState"
-                AND (
-                  chain_control."heldLayer" IS NULL
-                  OR COALESCE(task."chainLayer", task."chainIndex") IS NULL
-                  OR COALESCE(task."chainLayer", task."chainIndex") > chain_control."heldLayer"
-                )
+              WHERE ${heldSql(Prisma.sql`task`, Prisma.sql`chain_control`)}
             )
           ORDER BY COALESCE(chain_priority."unfinished", 1) ASC,
             candidate."readyAt" ASC,
@@ -762,11 +748,14 @@ export const claimRun = async (db: PrismaClient, input: ClaimRunInput) => {
             projectId: candidate.task.projectId,
             chainId: candidate.task.chainId,
           } },
-          select: { state: true, heldLayer: true },
+          select: { projectId: true, chainId: true, state: true, heldLayer: true },
         });
-        const taskLayer = layerOf({ layer: candidate.task.chainLayer, index: candidate.task.chainIndex });
-        if (control?.state === ChainControlState.HELD
-          && (control.heldLayer === null || taskLayer === null || taskLayer > control.heldLayer)) {
+        if (heldPredicate({
+          projectId: candidate.task.projectId,
+          chainId: candidate.task.chainId,
+          layer: candidate.task.chainLayer,
+          index: candidate.task.chainIndex,
+        }, control)) {
           // The Chain mutex was acquired after the candidate scan. Hold may
           // have won that race, so the live authority under this lock decides.
           // End the scan while retaining lock order; the Run stays QUEUED.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -26,6 +26,10 @@
       "types": "./src/chain-order.ts",
       "import": "./dist/chain-order.js"
     },
+    "./chain-hold": {
+      "types": "./src/chain-hold.ts",
+      "import": "./dist/chain-hold.js"
+    },
     "./wire-contract": {
       "types": "./src/wire-contract.ts",
       "import": "./dist/wire-contract.js"

--- a/packages/db/src/chain-activation.ts
+++ b/packages/db/src/chain-activation.ts
@@ -8,6 +8,7 @@ import {
 } from "@prisma/client";
 
 import { readChainControl } from "./chain-control.js";
+import { heldPredicate } from "./chain-hold.js";
 import { compare, layerOf } from "./chain-order.js";
 import { lockAgentRepoGrant, lockAgentRow, lockChainRows } from "./locks.js";
 import { parseAuthorizationMetadata } from "./merge-integrator.js";
@@ -651,6 +652,35 @@ const activateChainSuccessorInternal = async (
     .filter((value) => value > currentLayer)
     .sort((left, right) => left - right)
     .find((value) => chainRows.some((row) => chainLayerOf(row) === value && row.status !== TaskStatus.DONE));
+  const missingSuccessorLayer = nextLayer === undefined
+    && chainRows.some((row) => chainLayerOf(row) === null && row.status !== TaskStatus.DONE);
+  const withholdSuccessorActivation = async (withheldLayer: number | null) => {
+    await tx.taskActivity.create({ data: {
+      taskId: current.id,
+      actorType: "control-plane",
+      body: chainControl.heldLayer === null
+        ? "Predecessor layer completed; successor activation withheld because Chain is held"
+        : `Predecessor layer completed; successor activation withheld because Chain is held after layer ${String(chainControl.heldLayer)}`,
+      metadata: {
+        kind: "chainControl.activationWithheld",
+        schemaVersion: 1,
+        heldLayer: chainControl.heldLayer,
+        nextLayer: withheldLayer,
+      },
+    } });
+    return { nextTaskId: null, gated: false };
+  };
+  if (missingSuccessorLayer && heldPredicate({
+    projectId: task.projectId,
+    chainId: task.chainId,
+    layer: null,
+    index: null,
+  }, chainControl)) {
+    if (boundSuccessor && current.archivedAt === null) {
+      await dispatchBoundSuccessor(tx, current, boundSuccessor.id, now, false);
+    }
+    return withholdSuccessorActivation(null);
+  }
   if (nextLayer === undefined) {
     const predecessorComplete = chainRows.every((row) => row.status === TaskStatus.DONE);
     if (!boundSuccessor || predecessorComplete) {
@@ -674,21 +704,13 @@ const activateChainSuccessorInternal = async (
     await dispatchBoundSuccessor(tx, current, boundSuccessor.id, now, false);
   }
 
-  if (chainControl.held && (chainControl.heldLayer === null || nextLayer > chainControl.heldLayer)) {
-    await tx.taskActivity.create({ data: {
-      taskId: current.id,
-      actorType: "control-plane",
-      body: chainControl.heldLayer === null
-        ? "Predecessor layer completed; successor activation withheld because Chain is held"
-        : `Predecessor layer completed; successor activation withheld because Chain is held after layer ${String(chainControl.heldLayer)}`,
-      metadata: {
-        kind: "chainControl.activationWithheld",
-        schemaVersion: 1,
-        heldLayer: chainControl.heldLayer,
-        nextLayer,
-      },
-    } });
-    return { nextTaskId: null, gated: false };
+  if (heldPredicate({
+    projectId: task.projectId,
+    chainId: task.chainId,
+    layer: nextLayer,
+    index: null,
+  }, chainControl)) {
+    return withholdSuccessorActivation(nextLayer);
   }
 
   const nextRows = chainRows.filter((row) => chainLayerOf(row) === nextLayer).sort(layerOrder);

--- a/packages/db/src/chain-hold.test.ts
+++ b/packages/db/src/chain-hold.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { ChainControlState, Prisma } from "@prisma/client";
+
+import {
+  type ChainHoldControl,
+  type ChainHoldSubject,
+  heldPredicate,
+  heldSql,
+  heldWhere,
+} from "./chain-hold.js";
+
+const control = (overrides: Partial<ChainHoldControl> = {}): ChainHoldControl => ({
+  projectId: "project-1",
+  chainId: "chain-1",
+  state: ChainControlState.HELD,
+  heldLayer: 2,
+  ...overrides,
+});
+
+const subject = (overrides: Partial<ChainHoldSubject> = {}): ChainHoldSubject => ({
+  projectId: "project-1",
+  chainId: "chain-1",
+  layer: 3,
+  index: 3,
+  ...overrides,
+});
+
+test("the package publishes the Chain hold decider as an isolated subpath", () => {
+  const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+    exports: Record<string, unknown>;
+  };
+  assert.deepEqual(packageJson.exports["./chain-hold"], {
+    types: "./src/chain-hold.ts",
+    import: "./dist/chain-hold.js",
+  });
+});
+
+test("heldPredicate uses stored layer, legacy index, and fail-closed missing metadata", () => {
+  const fixtures: Array<{ name: string; subject: ChainHoldSubject; expected: boolean }> = [
+    { name: "above", subject: subject({ layer: 3, index: 0 }), expected: true },
+    { name: "at", subject: subject({ layer: 2, index: 99 }), expected: false },
+    { name: "below", subject: subject({ layer: 1, index: 99 }), expected: false },
+    { name: "legacy above", subject: subject({ layer: null, index: 3 }), expected: true },
+    { name: "legacy below", subject: subject({ layer: null, index: 1 }), expected: false },
+    { name: "missing", subject: subject({ layer: null, index: null }), expected: true },
+  ];
+  for (const fixture of fixtures) {
+    assert.equal(heldPredicate(fixture.subject, control()), fixture.expected, fixture.name);
+  }
+  assert.equal(heldPredicate(subject(), control({ heldLayer: null })), true);
+});
+
+test("heldPredicate treats absent, released, chainless, and foreign controls as unheld", () => {
+  assert.equal(heldPredicate(subject(), null), false);
+  assert.equal(heldPredicate(subject(), control({ state: ChainControlState.RELEASED })), false);
+  assert.equal(heldPredicate(subject({ chainId: null }), control()), false);
+  assert.equal(heldPredicate(subject({ projectId: "project-2" }), control()), false);
+  assert.equal(heldPredicate(subject({ chainId: "chain-2" }), control()), false);
+});
+
+test("heldWhere encodes the same authoritative layer fallback and missing-layer refusal", () => {
+  assert.deepEqual(heldWhere(control()), {
+    projectId: "project-1",
+    chainId: "chain-1",
+    OR: [
+      { chainLayer: { gt: 2 } },
+      {
+        chainLayer: null,
+        OR: [
+          { chainIndex: { gt: 2 } },
+          { chainIndex: null },
+        ],
+      },
+    ],
+  });
+  assert.deepEqual(heldWhere(control({ heldLayer: null })), {
+    projectId: "project-1",
+    chainId: "chain-1",
+  });
+  assert.equal(heldWhere(control({ state: ChainControlState.RELEASED })), null);
+});
+
+test("heldSql owns identity, state, effective layer, and fail-closed null SQL", () => {
+  const statement = heldSql(Prisma.sql`task`, Prisma.sql`chain_control`);
+  const sql = statement.text.replace(/\s+/gu, " ").trim();
+  assert.equal(statement.values.length, 1);
+  assert.equal(statement.values[0], ChainControlState.HELD);
+  assert.match(sql, /chain_control\."projectId" = task\."projectId"/u);
+  assert.match(sql, /chain_control\."chainId" = task\."chainId"/u);
+  assert.match(sql, /chain_control\."state" = lower\(\$1\)::"ChainControlState"/u);
+  assert.match(sql, /COALESCE\(task\."chainLayer", task\."chainIndex"\) IS NULL/u);
+  assert.match(sql, /COALESCE\(task\."chainLayer", task\."chainIndex"\) > chain_control\."heldLayer"/u);
+});

--- a/packages/db/src/chain-hold.ts
+++ b/packages/db/src/chain-hold.ts
@@ -1,0 +1,67 @@
+import { ChainControlState, Prisma } from "@prisma/client";
+
+import { layerOf, type ChainLayerRow } from "./chain-order.js";
+
+export type ChainHoldSubject = ChainLayerRow & {
+  projectId: string;
+  chainId: string | null;
+};
+
+export type ChainHoldControl = {
+  projectId: string;
+  chainId: string;
+  state: ChainControlState;
+  heldLayer: number | null;
+};
+
+/**
+ * Answers whether one Step is beyond its persisted Chain hold. Unknown Step
+ * execution metadata and an invalid HELD control without a layer both fail
+ * closed. An absent, released, or differently addressed control is unheld.
+ */
+export const heldPredicate = (
+  subject: ChainHoldSubject,
+  control: ChainHoldControl | null | undefined,
+): boolean => {
+  if (control?.state !== ChainControlState.HELD
+    || subject.chainId === null
+    || control.projectId !== subject.projectId
+    || control.chainId !== subject.chainId) return false;
+  const subjectLayer = layerOf(subject);
+  return control.heldLayer === null || subjectLayer === null || subjectLayer > control.heldLayer;
+};
+
+/** Prisma expression for every Task refused by one persisted control row. */
+export const heldWhere = (control: ChainHoldControl): Prisma.TaskWhereInput | null => {
+  if (control.state !== ChainControlState.HELD) return null;
+  const address = { projectId: control.projectId, chainId: control.chainId };
+  if (control.heldLayer === null) return address;
+  return {
+    ...address,
+    OR: [
+      { chainLayer: { gt: control.heldLayer } },
+      {
+        chainLayer: null,
+        OR: [
+          { chainIndex: { gt: control.heldLayer } },
+          { chainIndex: null },
+        ],
+      },
+    ],
+  };
+};
+
+/**
+ * Raw SQL expression equivalent to heldPredicate. The arguments are trusted
+ * SQL fragments naming the Task and ChainControl aliases in the caller query.
+ */
+export const heldSql = (task: Prisma.Sql, control: Prisma.Sql): Prisma.Sql => Prisma.sql`
+  ${control}."projectId" = ${task}."projectId"
+  AND ${control}."chainId" = ${task}."chainId"
+  AND ${control}."state" = lower(${ChainControlState.HELD})::"ChainControlState"
+  AND (
+    ${control}."heldLayer" IS NULL
+    OR COALESCE(${task}."chainLayer", ${task}."chainIndex") IS NULL
+    OR COALESCE(${task}."chainLayer", ${task}."chainIndex") > ${control}."heldLayer"
+  )
+`;

--- a/packages/db/src/run-open.ts
+++ b/packages/db/src/run-open.ts
@@ -13,6 +13,7 @@ import { catalogRunnerForModel, DIRECT_TEMPLATE_NAME } from "./agent-contract.js
 import { canonicalTemplateIdentity } from "./canonical-template-transition.js";
 import { sharedChainBranch } from "./chain-branch.js";
 import { readChainControl } from "./chain-control.js";
+import { heldPredicate } from "./chain-hold.js";
 import { layerOf } from "./chain-order.js";
 import { lockAgentRow } from "./locks.js";
 import { INTEGRATOR_TEMPLATE_NAME } from "./merge-integrator.js";
@@ -738,7 +739,12 @@ export const openRun = async (
   const taskLayer = layerOf({ layer: task.chainLayer, index: task.chainIndex });
   if (task.chainId) {
     const control = await readChainControl(tx, { projectId: task.projectId, chainId: task.chainId });
-    if (control.held && (control.heldLayer === null || taskLayer === null || taskLayer > control.heldLayer)) {
+    if (heldPredicate({
+      projectId: task.projectId,
+      chainId: task.chainId,
+      layer: task.chainLayer,
+      index: task.chainIndex,
+    }, control)) {
       const error = new ChainHeldError(task.id, task.chainId, taskLayer, control.heldLayer);
       return openRunRefusal(
         "chain-held",
@@ -852,11 +858,19 @@ export const errorForOpenRunRefusal = (refusal: OpenRunRefusal): Error => {
     );
   }
   if (refusal.reason === "chain-held") {
+    const nullableLayer = (field: "taskLayer" | "heldLayer"): number | null => {
+      const value = refusal.context?.[field];
+      if (value === null) return null;
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        throw new Error(`Chain hold refusal is missing numeric ${field}`);
+      }
+      return value;
+    };
     return new ChainHeldError(
       String(refusal.context?.taskId ?? "unknown"),
       String(refusal.context?.chainId ?? "unknown"),
-      Number(refusal.context?.taskLayer ?? 0),
-      Number(refusal.context?.heldLayer ?? 0),
+      nullableLayer("taskLayer"),
+      nullableLayer("heldLayer"),
     );
   }
   if (refusal.reason === "compound-implementation-assignee") {


### PR DESCRIPTION
## What changed

- Added a deep Chain hold module with a small interface: `heldPredicate`, `heldWhere`, and `heldSql`. All three use the D5 execution-layer semantics and fail closed for unknown Step layers.
- Replaced inline hold comparisons in Step admission, Run opening, successor activation, both claim scans, and the post-lock claim loop. Caller-specific refusal wording, wire context, activity metadata, and `HALT` behavior remain in their adapters.
- Corrected the Prisma scan so `chainLayer = null` and `chainIndex = null` is held, matching raw SQL. Preserved nullable layer values when adapting `OpenRunRefusal` back to `ChainHeldError`.
- Added shared TS/Prisma/raw SQL fixtures for stored, legacy, held, unheld, and missing layers, plus defensive legacy-row coverage for Run birth, activation activity, and the live claim race.

## Evidence

- `npm install` — PASS
- `npm run db:generate` — PASS after merging current `origin/main`
- `RUNNER_WORKSPACE_ROOT="$(mktemp -d)" node --import tsx --test packages/db/src/chain-hold.test.ts packages/api/src/chain.test.ts` — PASS, 34/34
- With a disposable PostgreSQL container, a dedicated non-public schema, `AGENTOS_ALLOW_SCRATCH_DATABASES=1`, and a fresh `RUNNER_WORKSPACE_ROOT`: `npm run test:db -w @anneal/api -- src/chain-enqueue-barrier.dbtest.ts src/chain-activation-barrier.dbtest.ts src/claim-exclusion.dbtest.ts src/admission-refusal.dbtest.ts src/chain-read-control.dbtest.ts` — PASS, 29/29
- `npm run lint` — PASS
- `npm run typecheck` — PASS
- Merge gate not run, as required for this lane.

## Reported but unfixed

None.