### PR TITLE
refactor(merge): share lease script adapter

### DIFF
--- a/packages/api/src/merge-lease-adapter-script.d.ts
+++ b/packages/api/src/merge-lease-adapter-script.d.ts
@@ -1,0 +1,68 @@
+declare module "*merge-lease-adapter.mjs" {
+  export type LeaseProcessResult = {
+    code: number | null;
+    stdout?: string;
+    stderr?: string;
+    error?: unknown;
+  };
+
+  export type LeaseRunner = (
+    command: string,
+    argv: string[],
+    options: {
+      cwd?: string;
+      environment: NodeJS.ProcessEnv;
+      processTimeoutMs?: number;
+    },
+  ) => Promise<LeaseProcessResult>;
+
+  export type MergeLeaseRelease =
+    | { outcome: "released"; ref: string; sha: string; acquiredAt: string; detail?: string }
+    | { outcome: "not-held"; detail?: string }
+    | { outcome: "skipped"; heldFor: string; detail?: string }
+    | { outcome: "refused"; heldBy: string; detail?: string }
+    | { outcome: "unreachable"; detail: string };
+
+  export type MergeLeaseAcquisition =
+    | { outcome: "acquired"; detail?: string }
+    | { outcome: "contended"; detail?: string }
+    | { outcome: "unreachable"; detail: string };
+
+  export function resolveMergeLeaseScriptPath(options?: {
+    environment?: NodeJS.ProcessEnv;
+    repoRoot?: string;
+  }): string;
+
+  export function buildMergeLeaseArgv(options:
+    | { operation: "release"; scriptPath: string; task: string }
+    | { operation: "acquire"; scriptPath: string; task: string; reason: string; timeoutMinutes: number }
+  ): string[];
+
+  export function parseMergeLeaseRelease(output: string):
+    | { outcome: "released"; ref: string; sha: string; acquiredAt: string }
+    | { outcome: "not-held" }
+    | { outcome: "skipped"; heldFor: string }
+    | { outcome: "refused"; heldBy: string }
+    | null;
+
+  export function classifyMergeLeaseExecution(input: LeaseProcessResult & {
+    operation: "acquire" | "release";
+  }): MergeLeaseAcquisition | MergeLeaseRelease;
+
+  export function isMergeLeaseReleaseAnomaly(release: MergeLeaseRelease): boolean;
+
+  type InvocationOptions = {
+    repoRoot?: string;
+    environment?: NodeJS.ProcessEnv;
+    processTimeoutMs?: number;
+    task: string;
+    runner?: LeaseRunner;
+  };
+
+  export function acquireMergeLease(options: InvocationOptions & {
+    reason: string;
+    timeoutMinutes: number;
+  }): Promise<MergeLeaseAcquisition>;
+
+  export function releaseMergeLease(options: InvocationOptions): Promise<MergeLeaseRelease>;
+}

--- a/packages/api/src/merge-lease.test.ts
+++ b/packages/api/src/merge-lease.test.ts
@@ -4,12 +4,12 @@ import test from "node:test";
 import { type Prisma, type PrismaClient } from "@anneal/db";
 
 import {
+  acquireMergeLeaseAdapter,
   commitWithLeaseOutcome,
   commitWithLeaseOutcomes,
   LeaseReleaseDeferralRecordError,
   leaseHolderFor,
-  mergeLeaseScriptPath,
-  readMergeLeaseRelease,
+  releaseMergeLeaseAdapter,
   withMergeLease,
   type MergeLeaseAcquirer,
   type MergeLeaseReleaser,
@@ -112,18 +112,38 @@ const holderTx = (input: {
   },
 } as unknown as Prisma.TransactionClient);
 
-test("release runtime executes the current release's helper while keeping the Git checkout separate", () => {
-  assert.equal(
-    mergeLeaseScriptPath({
-      AGENTOS_RELEASE_ROOT: "/srv/agentos/current",
-      AGENTOS_REPOSITORY_ROOT: "/srv/agentos/source",
-    }),
-    "/srv/agentos/current/scripts/merge-lease.sh",
-  );
-  assert.match(
-    mergeLeaseScriptPath({ AGENTOS_REPOSITORY_ROOT: "/srv/agentos/source" }),
-    /\/scripts\/merge-lease\.sh$/u,
-  );
+test("API lease caller keeps zero-wait acquisition and bounded process timeouts", async (t) => {
+  t.mock.method(console, "log", () => {});
+  const environment = { AGENTOS_RELEASE_ROOT: "/srv/agentos/current" };
+  const calls: unknown[][] = [];
+  const runner = async (...args: Parameters<import("../../../scripts/merge-lease-adapter.mjs").LeaseRunner>) => {
+    calls.push(args);
+    return calls.length === 1
+      ? { code: 75, stderr: "merge-lease: timed out\n" }
+      : { code: 0, stdout: "MERGE LEASE: not-held\n" };
+  };
+
+  assert.equal((await acquireMergeLeaseAdapter("chain-42", { environment, runner })).outcome, "contended");
+  assert.equal((await releaseMergeLeaseAdapter("chain-42", { environment, runner })).outcome, "not-held");
+  assert.deepEqual(calls[0], [
+    "bash",
+    [
+      "/srv/agentos/current/scripts/merge-lease.sh",
+      "acquire",
+      "--task",
+      "chain-42",
+      "--reason",
+      "chain merge tail chain-42",
+      "--timeout-minutes",
+      "0",
+    ],
+    { cwd: undefined, environment, processTimeoutMs: 30_000 },
+  ]);
+  assert.deepEqual(calls[1], [
+    "bash",
+    ["/srv/agentos/current/scripts/merge-lease.sh", "release", "--task", "chain-42"],
+    { cwd: undefined, environment, processTimeoutMs: 90_000 },
+  ]);
 });
 
 test("leaseHolderFor owns every merge-tail Task shape, including a failed auxiliary", async () => {
@@ -157,28 +177,6 @@ test("leaseHolderFor owns every merge-tail Task shape, including a failed auxili
   for (const entry of cases) {
     assert.deepEqual(await leaseHolderFor(entry.tx, "task-1"), entry.expected, entry.name);
   }
-});
-
-test("release parsing requires the timestamp while leaving duration validation to the calculator", () => {
-  assert.deepEqual(
-    readMergeLeaseRelease("MERGE LEASE: released refs/merge-lease/holder lease-sha 2026-08-27T12:00:00.000Z"),
-    {
-      outcome: "released",
-      ref: "refs/merge-lease/holder",
-      sha: "lease-sha",
-      acquiredAt: "2026-08-27T12:00:00.000Z",
-    },
-  );
-  assert.deepEqual(
-    readMergeLeaseRelease("MERGE LEASE: released refs/merge-lease/holder lease-sha malformed-timestamp"),
-    {
-      outcome: "released",
-      ref: "refs/merge-lease/holder",
-      sha: "lease-sha",
-      acquiredAt: "malformed-timestamp",
-    },
-  );
-  assert.equal(readMergeLeaseRelease("MERGE LEASE: released refs/merge-lease/holder lease-sha"), null);
 });
 
 test("mergeLeaseHold calculates whole elapsed seconds and clamps invalid or skewed timestamps", () => {

--- a/packages/api/src/merge-lease.ts
+++ b/packages/api/src/merge-lease.ts
@@ -1,8 +1,3 @@
-import { execFile } from "node:child_process";
-import { join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
-
 import {
   executionModeFor,
   isRegressionVerificationOutputKind,
@@ -16,19 +11,17 @@ import {
   type PrismaClient,
 } from "@anneal/db";
 import {
+  acquireMergeLease as invokeMergeLeaseAcquisition,
+  isMergeLeaseReleaseAnomaly,
+  releaseMergeLease as invokeMergeLeaseRelease,
+  type LeaseRunner,
+  type MergeLeaseAcquisition as LeaseScriptAcquisition,
+} from "../../../scripts/merge-lease-adapter.mjs";
+import {
   recordMergeLeaseHold,
   type MergeLeaseRelease,
   type MergeLeaseTarget,
 } from "./merge-lease-hold.js";
-
-const execFileAsync = promisify(execFile);
-
-export const mergeLeaseScriptPath = (environment: NodeJS.ProcessEnv = process.env): string =>
-  environment.AGENTOS_RELEASE_ROOT
-    ? join(resolve(environment.AGENTOS_RELEASE_ROOT), "scripts/merge-lease.sh")
-    : fileURLToPath(new URL("../../../scripts/merge-lease.sh", import.meta.url));
-
-const mergeLeaseScript = mergeLeaseScriptPath();
 
 /**
  * What one `merge-lease.sh release` did. The script has four outcomes and three
@@ -39,51 +32,21 @@ const mergeLeaseScript = mergeLeaseScriptPath();
  */
 export type MergeLeaseReleaser = (chainId: string) => Promise<MergeLeaseRelease>;
 
-// The line scripts/merge-lease.sh prints beside its prose for the operator.
-const MACHINE_LINE = /^MERGE LEASE: (.+)$/mu;
-
-/** Parse the machine-readable result emitted after a release attempt. */
-export const readMergeLeaseRelease = (output: string): MergeLeaseRelease | null => {
-  const spoken = MACHINE_LINE.exec(output)?.[1]?.trim();
-  if (!spoken) return null;
-  const [outcome, ...tokens] = spoken.split(" ");
-  switch (outcome) {
-    case "released": {
-      const [ref, sha, acquiredAt, ...extra] = tokens;
-      if (ref === undefined || sha === undefined || acquiredAt === undefined || extra.length > 0) return null;
-      return { outcome: "released", ref, sha, acquiredAt };
-    }
-    case "not-held":
-      return tokens.length === 0 ? { outcome: "not-held" } : null;
-    case "skipped":
-      return tokens.length === 1 && tokens[0] !== undefined ? { outcome: "skipped", heldFor: tokens[0] } : null;
-    case "refused":
-      return tokens.length === 1 && tokens[0] !== undefined ? { outcome: "refused", heldBy: tokens[0] } : null;
-    default:
-      return null;
+export const releaseMergeLeaseAdapter = async (
+  chainId: string,
+  options: { environment?: NodeJS.ProcessEnv; runner?: LeaseRunner } = {},
+): Promise<MergeLeaseRelease> => {
+  const release = await invokeMergeLeaseRelease({
+    environment: options.environment ?? process.env,
+    ...(options.runner ? { runner: options.runner } : {}),
+    task: chainId,
+    processTimeoutMs: 90_000,
+  });
+  if (release.detail) {
+    if (release.outcome === "unreachable") console.error(`Merge lease release failed for chain ${chainId}: ${release.detail}`);
+    else console.log(release.detail);
   }
-};
-
-const releaseMergeLeaseAdapter: MergeLeaseReleaser = async (chainId) => {
-  try {
-    const { stdout, stderr } = await execFileAsync("bash", [mergeLeaseScript, "release", "--task", chainId], {
-      timeout: 90_000,
-      encoding: "utf8",
-    });
-    const detail = `${stdout}${stderr}`.trim();
-    if (detail) console.log(detail);
-    return readMergeLeaseRelease(detail) ?? { outcome: "unreachable", detail: detail || "the release printed nothing" };
-  } catch (error: unknown) {
-    const failure = error as { stdout?: string; stderr?: string };
-    const detail = `${failure.stdout ?? ""}${failure.stderr ?? ""}`.trim();
-    console.error(`Merge lease release failed for chain ${chainId}${detail ? `: ${detail}` : ""}`);
-    // A refusal is the one non-zero exit the script means: it read the lease and
-    // declined to break it. Anything else never got that far, so the state of
-    // the lock on main is unknown rather than decided.
-    const spoken = readMergeLeaseRelease(detail);
-    if (spoken?.outcome === "refused") return spoken;
-    return { outcome: "unreachable", detail: detail || String(error) };
-  }
+  return release;
 };
 
 const releaseMergeLeaseWith = async (
@@ -117,6 +80,7 @@ export const releaseMergeLease: ReleaseMergeLease = async (target, db) => {
  * obligation: every release adapter result is consumed inside this module.
  */
 const reportMergeLeaseAnomaly = (chainId: string, release: MergeLeaseRelease): void => {
+  if (!isMergeLeaseReleaseAnomaly(release)) return;
   switch (release.outcome) {
     case "released":
     case "not-held":
@@ -483,14 +447,9 @@ export const commitWithLeaseOutcomes = async <T>(
  * same task id, which is what its own regression run leaves behind -- and 75
  * means somebody else holds it. Anything else never got far enough to say.
  */
-export type MergeLeaseAcquisition =
-  | { outcome: "acquired" }
-  | { outcome: "contended" }
-  | { outcome: "unreachable"; detail: string };
+export type MergeLeaseAcquisition = LeaseScriptAcquisition;
 
 export type MergeLeaseAcquirer = (chainId: string) => Promise<MergeLeaseAcquisition>;
-
-const CONTENDED_EXIT = 75;
 
 /**
  * One attempt, never a poll. The caller is the readiness tick, which cannot
@@ -499,28 +458,23 @@ const CONTENDED_EXIT = 75;
  * string matches the one the chain's own regression run writes, so an operator
  * reading `merge-lease.sh status` sees the same lease either way.
  */
-const acquireMergeLease: MergeLeaseAcquirer = async (chainId) => {
-  try {
-    const { stdout, stderr } = await execFileAsync("bash", [
-      mergeLeaseScript,
-      "acquire",
-      "--task",
-      chainId,
-      "--reason",
-      `chain merge tail ${chainId}`,
-      "--timeout-minutes",
-      "0",
-    ], { timeout: 30_000, encoding: "utf8" });
-    const detail = `${stdout}${stderr}`.trim();
-    if (detail) console.log(detail);
-    return { outcome: "acquired" };
-  } catch (error: unknown) {
-    const failure = error as { code?: number; stdout?: string; stderr?: string };
-    if (failure.code === CONTENDED_EXIT) return { outcome: "contended" };
-    const detail = `${failure.stdout ?? ""}${failure.stderr ?? ""}`.trim();
-    console.error(`Merge lease acquire failed for chain ${chainId}${detail ? `: ${detail}` : ""}`);
-    return { outcome: "unreachable", detail: detail || String(error) };
+export const acquireMergeLeaseAdapter = async (
+  chainId: string,
+  options: { environment?: NodeJS.ProcessEnv; runner?: LeaseRunner } = {},
+): Promise<MergeLeaseAcquisition> => {
+  const acquisition = await invokeMergeLeaseAcquisition({
+    environment: options.environment ?? process.env,
+    ...(options.runner ? { runner: options.runner } : {}),
+    task: chainId,
+    reason: `chain merge tail ${chainId}`,
+    timeoutMinutes: 0,
+    processTimeoutMs: 30_000,
+  });
+  if (acquisition.detail) {
+    if (acquisition.outcome === "unreachable") console.error(`Merge lease acquire failed for chain ${chainId}: ${acquisition.detail}`);
+    else if (acquisition.outcome === "acquired") console.log(acquisition.detail);
   }
+  return acquisition;
 };
 
 export type HeldLeaseOutcome =
@@ -557,7 +511,7 @@ export const withMergeLease = async <T>(
   fn: () => Promise<{ leaseOutcome: HeldLeaseOutcome; value: T }>,
   db: PrismaClient,
   dependencies: MergeLeaseDependencies = {
-    acquire: acquireMergeLease,
+    acquire: acquireMergeLeaseAdapter,
     release: releaseMergeLeaseAdapter,
   },
 ): Promise<

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -139,6 +139,8 @@
     { "glob": "scripts/merge-gate-profile.mjs", "purpose": "fail-closed exact-diff classifier for the merge gate's docs-only profile" },
     { "glob": "scripts/merge-gate-profile.test.mjs", "purpose": "merge-gate profile classifier fixtures" },
     { "glob": "scripts/merge-gate-parallel.test.mjs", "purpose": "merge-gate concurrent-group failure reporting fixtures" },
+    { "glob": "scripts/merge-lease-adapter.mjs", "purpose": "shared merge lease script path, argv, exit, machine-line and anomaly adapter" },
+    { "glob": "scripts/merge-lease-adapter.test.mjs", "purpose": "merge lease adapter recorded-output, path, argv and classification fixtures" },
     { "glob": "scripts/merge-lease.sh", "purpose": "global exact-head merge delivery lease backed by an atomic origin ref" },
     { "glob": "scripts/merge-lease.test.mjs", "purpose": "merge lease: mutual exclusion, release outcomes, status and the machine and human steal boundaries against a real origin ref" },
     { "glob": "scripts/merge-train.mjs", "purpose": "fixed-width cumulative-prefix coordinator for concurrent host delivery" },

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -220,19 +220,52 @@ test("production host requires every deploy phase", () => {
   }
 });
 
-test("release artifact inventory includes deploy runtime and workspace dependencies", () => {
+test("release artifact inventory copies and verifies deploy runtime and workspace dependencies", () => {
   const root = mkdtempSync(join(tmpdir(), "anneal-artifact-inventory-"));
+  const deployRoot = mkdtempSync(join(tmpdir(), "anneal-artifact-inventory-release-"));
   writeFileSync(join(root, "package.json"), JSON.stringify({ workspaces: ["apps/*", "packages/*"] }));
   for (const workspace of ["apps/web", "packages/api"]) {
     mkdirSync(join(root, workspace), { recursive: true });
     writeFileSync(join(root, workspace, "package.json"), "{}\n");
   }
-  assert.deepEqual(workspaceDependencyPaths(root), ["apps/web/node_modules", "packages/api/node_modules"]);
-  const paths = deployReleaseArtifactPaths(root);
-  assert.ok(paths.includes("scripts/deploy"));
-  assert.ok(paths.includes("packages/db/src"));
-  for (const path of DEPLOY_REQUIRED_ARTIFACT_PATHS) assert.ok(paths.includes(path), path);
-  rmSync(root, { recursive: true, force: true });
+  const adapterPath = "scripts/merge-lease-adapter.mjs";
+  const adapterContents = "export const fixture = true;\n";
+  minimalBuildTree(root, revisions.to);
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, adapterPath), adapterContents);
+  try {
+    assert.deepEqual(workspaceDependencyPaths(root), ["apps/web/node_modules", "packages/api/node_modules"]);
+    const paths = deployReleaseArtifactPaths(root);
+    assert.ok(paths.includes("scripts/deploy"));
+    assert.ok(paths.includes(adapterPath));
+    assert.ok(paths.includes("packages/db/src"));
+    for (const path of DEPLOY_REQUIRED_ARTIFACT_PATHS) assert.ok(paths.includes(path), path);
+    const assembled = assembleReleaseDirectory({
+      stageRoot: root,
+      deployRoot,
+      revision: revisions.to,
+      artifactPaths: paths.filter((path) => [
+        "packages/api/dist",
+        "packages/db/prisma",
+        "packages/db/src",
+        adapterPath,
+      ].includes(path)),
+      optionalArtifactPaths: [],
+    });
+    const verified = verifyReleaseArtifact({
+      deployRoot,
+      revision: revisions.to,
+      releaseName: assembled.releaseName,
+    });
+    assert.equal(readFileSync(join(verified.releaseDirectory, adapterPath), "utf8"), adapterContents);
+    const adapterEvidence = verified.files.find(({ path }) => path === adapterPath);
+    assert.equal(adapterEvidence?.type, "file");
+    assert.equal(adapterEvidence?.size, Buffer.byteLength(adapterContents));
+    assert.match(adapterEvidence?.sha256 ?? "", /^[0-9a-f]{64}$/u);
+  } finally {
+    removeTree(root);
+    removeTree(deployRoot);
+  }
 });
 
 test("fixture executes the whole deploy sequence with explicit attempt facts", async () => {

--- a/scripts/deploy/release-artifacts.mjs
+++ b/scripts/deploy/release-artifacts.mjs
@@ -84,6 +84,7 @@ export const DEPLOY_RELEASE_EXTRA_ARTIFACT_PATHS = Object.freeze([
   "agents/roles",
   "agents/templates",
   "scripts/deploy",
+  "scripts/merge-lease-adapter.mjs",
   "scripts/merge-lease.sh",
 ]);
 

--- a/scripts/merge-lease-adapter.mjs
+++ b/scripts/merge-lease-adapter.mjs
@@ -1,0 +1,118 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const CONTENDED_EXIT = 75;
+const MACHINE_LINE = /^MERGE LEASE: (.+)$/gmu;
+
+export const resolveMergeLeaseScriptPath = ({ environment = process.env, repoRoot } = {}) => {
+  if (environment.AGENTOS_RELEASE_ROOT) {
+    return path.join(path.resolve(environment.AGENTOS_RELEASE_ROOT), "scripts/merge-lease.sh");
+  }
+  return repoRoot
+    ? path.join(path.resolve(repoRoot), "scripts/merge-lease.sh")
+    : fileURLToPath(new URL("./merge-lease.sh", import.meta.url));
+};
+
+export const buildMergeLeaseArgv = ({ operation, scriptPath, task, reason, timeoutMinutes }) => {
+  if (operation === "release") return [scriptPath, "release", "--task", task];
+  if (operation === "acquire") {
+    return [
+      scriptPath,
+      "acquire",
+      "--task",
+      task,
+      "--reason",
+      reason,
+      "--timeout-minutes",
+      String(timeoutMinutes),
+    ];
+  }
+  throw new Error(`Unsupported merge lease operation: ${operation}`);
+};
+
+export const parseMergeLeaseRelease = (output) => {
+  const lines = [...output.matchAll(MACHINE_LINE)];
+  if (lines.length !== 1) return null;
+  const spoken = lines[0][1]?.trim();
+  if (!spoken) return null;
+  const [outcome, ...tokens] = spoken.split(" ");
+  switch (outcome) {
+    case "released": {
+      const [ref, sha, acquiredAt, ...extra] = tokens;
+      if (ref === undefined || sha === undefined || acquiredAt === undefined || extra.length > 0) return null;
+      return { outcome: "released", ref, sha, acquiredAt };
+    }
+    case "not-held":
+      return tokens.length === 0 ? { outcome: "not-held" } : null;
+    case "skipped":
+      return tokens.length === 1 && tokens[0] ? { outcome: "skipped", heldFor: tokens[0] } : null;
+    case "refused":
+      return tokens.length === 1 && tokens[0] ? { outcome: "refused", heldBy: tokens[0] } : null;
+    default:
+      return null;
+  }
+};
+
+const outputDetail = ({ stdout = "", stderr = "" }) => `${stdout}${stderr}`.trim();
+
+export const classifyMergeLeaseExecution = ({ operation, code, stdout = "", stderr = "", error }) => {
+  const detail = outputDetail({ stdout, stderr });
+  if (operation === "acquire") {
+    if (code === 0) return { outcome: "acquired", detail };
+    if (code === CONTENDED_EXIT) return { outcome: "contended", detail };
+    return {
+      outcome: "unreachable",
+      detail: detail || (error instanceof Error ? error.message : `merge-lease.sh acquire exited ${String(code)}`),
+    };
+  }
+
+  if (operation !== "release") throw new Error(`Unsupported merge lease operation: ${operation}`);
+  const parsed = parseMergeLeaseRelease(detail);
+  if (code === 0 && parsed && parsed.outcome !== "refused") return { ...parsed, detail };
+  if (code === 1 && parsed?.outcome === "refused") return { ...parsed, detail };
+  return {
+    outcome: "unreachable",
+    detail: detail || (error instanceof Error ? error.message : `merge-lease.sh release exited ${String(code)}`),
+  };
+};
+
+export const isMergeLeaseReleaseAnomaly = (release) =>
+  release.outcome === "skipped" || release.outcome === "refused" || release.outcome === "unreachable";
+
+const defaultRunner = async (command, args, options) => {
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, {
+      cwd: options.cwd,
+      env: options.environment,
+      timeout: options.processTimeoutMs,
+      encoding: "utf8",
+    });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    return {
+      code: typeof error?.code === "number" ? error.code : null,
+      stdout: error?.stdout ?? "",
+      stderr: error?.stderr ?? "",
+      error,
+    };
+  }
+};
+
+const execute = async ({ operation, repoRoot, environment, processTimeoutMs, task, reason, timeoutMinutes, runner }) => {
+  const effectiveEnvironment = environment ?? process.env;
+  const scriptPath = resolveMergeLeaseScriptPath({ environment: effectiveEnvironment, repoRoot });
+  const argv = buildMergeLeaseArgv({ operation, scriptPath, task, reason, timeoutMinutes });
+  const execution = await (runner ?? defaultRunner)("bash", argv, {
+    cwd: repoRoot,
+    environment: effectiveEnvironment,
+    processTimeoutMs,
+  });
+  return classifyMergeLeaseExecution({ operation, ...execution });
+};
+
+export const acquireMergeLease = (options) => execute({ operation: "acquire", ...options });
+
+export const releaseMergeLease = (options) => execute({ operation: "release", ...options });

--- a/scripts/merge-lease-adapter.test.mjs
+++ b/scripts/merge-lease-adapter.test.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  acquireMergeLease,
+  buildMergeLeaseArgv,
+  classifyMergeLeaseExecution,
+  isMergeLeaseReleaseAnomaly,
+  parseMergeLeaseRelease,
+  releaseMergeLease,
+  resolveMergeLeaseScriptPath,
+} from "./merge-lease-adapter.mjs";
+
+const releasedLine = "MERGE LEASE: released refs/merge-lease/holder lease-sha 2026-08-29T12:00:00.000Z";
+
+test("recorded release output maps every machine line to one structured result", () => {
+  const cases = [
+    {
+      name: "released",
+      execution: { code: 0, stdout: `merge-lease: released refs/merge-lease/holder (lease-sha)\n${releasedLine}\n` },
+      expected: {
+        outcome: "released",
+        ref: "refs/merge-lease/holder",
+        sha: "lease-sha",
+        acquiredAt: "2026-08-29T12:00:00.000Z",
+      },
+    },
+    {
+      name: "not-held",
+      execution: { code: 0, stdout: "merge-lease: no lease held\nMERGE LEASE: not-held\n" },
+      expected: { outcome: "not-held" },
+    },
+    {
+      name: "skipped",
+      execution: { code: 0, stdout: "merge-lease: release skipped\nMERGE LEASE: skipped chain-42\n" },
+      expected: { outcome: "skipped", heldFor: "chain-42" },
+    },
+    {
+      name: "refused",
+      execution: { code: 1, stderr: "MERGE LEASE: refused holder@host\nmerge-lease: release refused\n" },
+      expected: { outcome: "refused", heldBy: "holder@host" },
+    },
+  ];
+
+  for (const entry of cases) {
+    const result = classifyMergeLeaseExecution({ operation: "release", ...entry.execution });
+    const { detail: _detail, ...structured } = result;
+    assert.deepEqual(structured, entry.expected, entry.name);
+  }
+});
+
+test("release parsing rejects malformed, missing, duplicate, and exit-inconsistent output", () => {
+  assert.deepEqual(
+    parseMergeLeaseRelease("MERGE LEASE: released refs/merge-lease/holder lease-sha malformed-timestamp"),
+    {
+      outcome: "released",
+      ref: "refs/merge-lease/holder",
+      sha: "lease-sha",
+      acquiredAt: "malformed-timestamp",
+    },
+  );
+  assert.equal(parseMergeLeaseRelease("MERGE LEASE: released refs/merge-lease/holder lease-sha"), null);
+  assert.equal(parseMergeLeaseRelease("no machine output"), null);
+  assert.equal(parseMergeLeaseRelease(`${releasedLine}\nMERGE LEASE: not-held\n`), null);
+
+  const cases = [
+    { code: 0, stdout: "" },
+    { code: 0, stdout: "MERGE LEASE: released refs/merge-lease/holder lease-sha\n" },
+    { code: 1, stdout: `${releasedLine}\n` },
+    { code: 0, stderr: "MERGE LEASE: refused holder@host\n" },
+    { code: 75, stderr: "MERGE LEASE: refused holder@host\n" },
+    { code: 75, stderr: "merge-lease: unexpected release failure\n" },
+  ];
+  for (const execution of cases) {
+    assert.equal(classifyMergeLeaseExecution({ operation: "release", ...execution }).outcome, "unreachable");
+  }
+});
+
+test("release classification identifies ordinary results and anomalies", () => {
+  assert.equal(isMergeLeaseReleaseAnomaly({ outcome: "released" }), false);
+  assert.equal(isMergeLeaseReleaseAnomaly({ outcome: "not-held" }), false);
+  assert.equal(isMergeLeaseReleaseAnomaly({ outcome: "skipped", heldFor: "chain-42" }), true);
+  assert.equal(isMergeLeaseReleaseAnomaly({ outcome: "refused", heldBy: "holder@host" }), true);
+  assert.equal(isMergeLeaseReleaseAnomaly({ outcome: "unreachable", detail: "transport failed" }), true);
+});
+
+test("acquisition exit table distinguishes acquired, contended, and unreachable", () => {
+  assert.equal(classifyMergeLeaseExecution({ operation: "acquire", code: 0 }).outcome, "acquired");
+  assert.equal(classifyMergeLeaseExecution({ operation: "acquire", code: 75 }).outcome, "contended");
+  assert.deepEqual(
+    classifyMergeLeaseExecution({ operation: "acquire", code: 1, stderr: "transport failed" }),
+    { outcome: "unreachable", detail: "transport failed" },
+  );
+  assert.deepEqual(
+    classifyMergeLeaseExecution({ operation: "acquire", code: null, error: new Error("spawn bash ENOENT") }),
+    { outcome: "unreachable", detail: "spawn bash ENOENT" },
+  );
+});
+
+test("path resolution and argv honor the release root and caller policy", async () => {
+  const releaseRoot = path.resolve("/srv/agentos/current");
+  const scriptPath = path.join(releaseRoot, "scripts/merge-lease.sh");
+  assert.equal(
+    resolveMergeLeaseScriptPath({
+      environment: { AGENTOS_RELEASE_ROOT: releaseRoot, AGENTOS_REPOSITORY_ROOT: "/srv/agentos/source" },
+      repoRoot: "/checkout",
+    }),
+    scriptPath,
+  );
+  assert.equal(
+    resolveMergeLeaseScriptPath({ environment: {}, repoRoot: "/checkout" }),
+    path.resolve("/checkout/scripts/merge-lease.sh"),
+  );
+  assert.equal(
+    resolveMergeLeaseScriptPath({ environment: {} }),
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "merge-lease.sh"),
+  );
+  assert.deepEqual(buildMergeLeaseArgv({
+    operation: "acquire",
+    scriptPath,
+    task: "chain-42",
+    reason: "chain merge tail chain-42",
+    timeoutMinutes: 0,
+  }), [
+    scriptPath,
+    "acquire",
+    "--task",
+    "chain-42",
+    "--reason",
+    "chain merge tail chain-42",
+    "--timeout-minutes",
+    "0",
+  ]);
+  assert.deepEqual(buildMergeLeaseArgv({ operation: "release", scriptPath, task: "chain-42" }), [
+    scriptPath,
+    "release",
+    "--task",
+    "chain-42",
+  ]);
+
+  const calls = [];
+  const runner = async (...args) => {
+    calls.push(args);
+    return calls.length === 1
+      ? { code: 75, stderr: "merge-lease: timed out\n" }
+      : { code: 0, stdout: "MERGE LEASE: not-held\n" };
+  };
+  assert.equal((await acquireMergeLease({
+    repoRoot: "/checkout",
+    environment: { AGENTOS_RELEASE_ROOT: releaseRoot },
+    runner,
+    task: "chain-42",
+    reason: "zero wait",
+    timeoutMinutes: 0,
+    processTimeoutMs: 30_000,
+  })).outcome, "contended");
+  assert.equal((await releaseMergeLease({
+    repoRoot: "/checkout",
+    environment: { AGENTOS_RELEASE_ROOT: releaseRoot },
+    runner,
+    task: "chain-42",
+    processTimeoutMs: 90_000,
+  })).outcome, "not-held");
+  assert.deepEqual(calls[0], [
+    "bash",
+    [scriptPath, "acquire", "--task", "chain-42", "--reason", "zero wait", "--timeout-minutes", "0"],
+    { cwd: "/checkout", environment: { AGENTOS_RELEASE_ROOT: releaseRoot }, processTimeoutMs: 30_000 },
+  ]);
+  assert.deepEqual(calls[1], [
+    "bash",
+    [scriptPath, "release", "--task", "chain-42"],
+    { cwd: "/checkout", environment: { AGENTOS_RELEASE_ROOT: releaseRoot }, processTimeoutMs: 90_000 },
+  ]);
+});

--- a/scripts/merge-train.mjs
+++ b/scripts/merge-train.mjs
@@ -6,6 +6,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  acquireMergeLease,
+  isMergeLeaseReleaseAnomaly,
+  releaseMergeLease,
+} from "./merge-lease-adapter.mjs";
+
 const SHA_PATTERN = /^[0-9a-f]{40}$/u;
 const MAX_CANDIDATES = 3;
 
@@ -98,17 +104,18 @@ const defaultGate = async (_repoRoot, prefix, checkout) => {
   return { status, code: result.code, output };
 };
 
-const defaultAcquireLease = (repoRoot, task, count) =>
-  checkedProcess(
-    "bash",
-    [path.join(repoRoot, "scripts", "merge-lease.sh"), "acquire", "--reason", `Publish ${count}-entry merge train`, "--task", task],
-    { cwd: repoRoot },
-  );
-
-const defaultReleaseLease = (repoRoot, task) =>
-  checkedProcess("bash", [path.join(repoRoot, "scripts", "merge-lease.sh"), "release", "--task", task], {
-    cwd: repoRoot,
+export const acquireMergeTrainLease = (repoRoot, task, count, { environment = process.env, runner } = {}) =>
+  acquireMergeLease({
+    repoRoot,
+    environment,
+    runner,
+    task,
+    reason: `Publish ${count}-entry merge train`,
+    timeoutMinutes: 0,
   });
+
+export const releaseMergeTrainLease = (repoRoot, task, { environment = process.env, runner } = {}) =>
+  releaseMergeLease({ repoRoot, environment, runner, task });
 
 const defaultPush = async (repoRoot, prefix) => {
   const result = await gitResult(repoRoot, ["push", "--porcelain", "origin", `${prefix.oid}:refs/heads/main`]);
@@ -126,13 +133,13 @@ const defaultPush = async (repoRoot, prefix) => {
 };
 
 const realAdapters = {
-  acquireLease: defaultAcquireLease,
+  acquireLease: acquireMergeTrainLease,
   fetchCandidate: defaultFetchCandidate,
   gate: defaultGate,
   push: defaultPush,
   readMain,
   readPullRequest: defaultReadPullRequest,
-  releaseLease: defaultReleaseLease,
+  releaseLease: releaseMergeTrainLease,
   sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
 };
 
@@ -312,7 +319,21 @@ export const coordinateMergeTrain = async ({ repoRoot, task, candidates, adapter
       };
     }
 
-    await adapters.acquireLease(repoRoot, task, passingCount);
+    const acquisition = await adapters.acquireLease(repoRoot, task, passingCount);
+    if (acquisition.outcome === "contended") {
+      return {
+        status: "lease-contended",
+        baseSha,
+        alreadyDelivered,
+        prefixes: built.prefixes,
+        blocked: built.blocked,
+        gateResults,
+        published: [],
+      };
+    }
+    if (acquisition.outcome === "unreachable") {
+      throw new Error(`merge Lease acquisition was unreachable: ${acquisition.detail}`);
+    }
     leaseHeld = true;
     safeToRelease = true;
     let liveMain = await adapters.readMain(repoRoot);
@@ -372,7 +393,11 @@ export const coordinateMergeTrain = async ({ repoRoot, task, candidates, adapter
     if (leaseHeld) {
       if (safeToRelease) {
         try {
-          await adapters.releaseLease(repoRoot, task);
+          const release = await adapters.releaseLease(repoRoot, task);
+          if (isMergeLeaseReleaseAnomaly(release)) {
+            const detail = release.detail ?? release.heldFor ?? release.heldBy ?? "no detail";
+            cleanupError = new Error(`merge Lease release ${release.outcome}: ${detail}`);
+          }
         } catch (error) {
           cleanupError = error;
         }

--- a/scripts/merge-train.test.mjs
+++ b/scripts/merge-train.test.mjs
@@ -6,7 +6,13 @@ import path from "node:path";
 import { promisify } from "node:util";
 import test from "node:test";
 
-import { coordinateMergeTrain } from "./merge-train.mjs";
+import "./merge-lease-adapter.test.mjs";
+
+import {
+  acquireMergeTrainLease,
+  coordinateMergeTrain,
+  releaseMergeTrainLease,
+} from "./merge-train.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -78,8 +84,143 @@ const passGate = async (_repoRoot, prefix) => ({
 });
 
 const noLease = (events = []) => ({
-  acquireLease: async () => events.push("lease-acquire"),
-  releaseLease: async () => events.push("lease-release"),
+  acquireLease: async () => {
+    events.push("lease-acquire");
+    return { outcome: "acquired" };
+  },
+  releaseLease: async () => {
+    events.push("lease-release");
+    return { outcome: "not-held" };
+  },
+});
+
+test("merge train lease caller uses the release root and zero-wait acquisition policy", async () => {
+  const calls = [];
+  const environment = { AGENTOS_RELEASE_ROOT: "/srv/agentos/current" };
+  const runner = async (...args) => {
+    calls.push(args);
+    return calls.length === 1
+      ? { code: 75, stderr: "merge-lease: timed out\n" }
+      : { code: 0, stdout: "MERGE LEASE: not-held\n" };
+  };
+
+  assert.equal((await acquireMergeTrainLease("/checkout", "train-42", 2, { environment, runner })).outcome, "contended");
+  assert.equal((await releaseMergeTrainLease("/checkout", "train-42", { environment, runner })).outcome, "not-held");
+  assert.deepEqual(calls[0], [
+    "bash",
+    [
+      "/srv/agentos/current/scripts/merge-lease.sh",
+      "acquire",
+      "--task",
+      "train-42",
+      "--reason",
+      "Publish 2-entry merge train",
+      "--timeout-minutes",
+      "0",
+    ],
+    { cwd: "/checkout", environment, processTimeoutMs: undefined },
+  ]);
+  assert.deepEqual(calls[1], [
+    "bash",
+    ["/srv/agentos/current/scripts/merge-lease.sh", "release", "--task", "train-42"],
+    { cwd: "/checkout", environment, processTimeoutMs: undefined },
+  ]);
+});
+
+test("lease contention is a structured no-publication result", async () => {
+  const fixture = await makeFixture();
+  try {
+    const candidate = await fixture.candidate(290, { "candidate.txt": "candidate\n" });
+    let releaseCalled = false;
+    const result = await coordinateMergeTrain({
+      repoRoot: fixture.repo,
+      task: "contended-train",
+      candidates: [candidate],
+      adapters: {
+        acquireLease: async () => ({ outcome: "contended" }),
+        releaseLease: async () => {
+          releaseCalled = true;
+          return { outcome: "not-held" };
+        },
+        gate: passGate,
+        readPullRequest: fixture.readPullRequest([candidate]),
+        sleep: async () => {},
+      },
+    });
+
+    assert.equal(result.status, "lease-contended");
+    assert.deepEqual(result.published, []);
+    assert.equal(releaseCalled, false);
+    assert.equal(await fixture.remoteMain(), fixture.baseSha);
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("release anomalies prevent a clean merge train finish after safe read-back", async () => {
+  const anomalies = [
+    { outcome: "skipped", heldFor: "another-task" },
+    { outcome: "refused", heldBy: "another@host" },
+    { outcome: "unreachable", detail: "release transport failed" },
+  ];
+
+  for (const [index, release] of anomalies.entries()) {
+    const fixture = await makeFixture();
+    try {
+      const candidate = await fixture.candidate(291 + index, { [`candidate-${index}.txt`]: "candidate\n" });
+      await assert.rejects(coordinateMergeTrain({
+        repoRoot: fixture.repo,
+        task: `release-${release.outcome}`,
+        candidates: [candidate],
+        adapters: {
+          acquireLease: async () => ({ outcome: "acquired" }),
+          releaseLease: async () => release,
+          gate: passGate,
+          readPullRequest: fixture.readPullRequest([candidate]),
+          sleep: async () => {},
+        },
+      }), new RegExp(`merge Lease release ${release.outcome}`, "u"));
+      assert.equal(await fixture.remoteContains(candidate.headSha), true);
+    } finally {
+      await fixture.cleanup();
+    }
+  }
+});
+
+test("an unknown publication read-back retains the lease", async (t) => {
+  const fixture = await makeFixture();
+  const stderr = [];
+  t.mock.method(process.stderr, "write", (chunk) => {
+    stderr.push(String(chunk));
+    return true;
+  });
+  try {
+    const candidate = await fixture.candidate(294, { "candidate.txt": "candidate\n" });
+    let releaseCalled = false;
+    await assert.rejects(coordinateMergeTrain({
+      repoRoot: fixture.repo,
+      task: "unknown-read-back",
+      candidates: [candidate],
+      adapters: {
+        acquireLease: async () => ({ outcome: "acquired" }),
+        releaseLease: async () => {
+          releaseCalled = true;
+          return { outcome: "released" };
+        },
+        gate: passGate,
+        push: async () => {
+          throw new Error("main read-back unavailable");
+        },
+        readPullRequest: fixture.readPullRequest([candidate]),
+        sleep: async () => {},
+      },
+    }), /main read-back unavailable/u);
+    assert.equal(releaseCalled, false);
+    assert.match(stderr.join(""), /lease for task unknown-read-back was retained/u);
+    assert.equal(await fixture.remoteMain(), fixture.baseSha);
+  } finally {
+    await fixture.cleanup();
+  }
 });
 
 test("the default adapter locally dispatches from a clean exact-prefix checkout", async () => {


### PR DESCRIPTION
## What changed

- Added one shared merge-lease script adapter for path resolution, argv construction, exit classification, machine-line parsing, and release anomaly classification.
- Routed the API merge tail and host merge train through that adapter while preserving caller-owned timeout and polling policy.
- Made merge-train acquisition zero-wait and contention-aware, and made release anomalies prevent a clean finish without weakening publication read-back retention.
- Added the adapter to the immutable release inventory and verified its copied bytes and manifest digest evidence in the existing deploy inventory test.
- Classified the adapter and its recorded-output test by exact path in the closed public snapshot authority.

## Evidence

- Gate-derived snapshot tests for the two failing contracts — 2/2 PASS
- `npm run test:snapshot-scan` — 20/20 PASS
- `npm run snapshot:scan` — PASS with `unclassifiedFiles: 0`, `overlappingFiles: 0`, and `blocker: 0`
- `npm run lint` — PASS
- `npm run typecheck` — PASS
- `npm run build -w @anneal/api` — PASS
- Immutable artifact-layout import of `packages/api/dist/merge-lease.js` with the inventoried adapter — PASS
- `npm run test:auto-deploy` — 48/48 PASS
- `npm run test:merge-train` — 15/15 PASS
- `node --import tsx --test packages/api/src/merge-lease.test.ts` — 21/21 PASS

## Reported but unfixed

None.
