### PR TITLE
Deepen the frontier wire contract

### DIFF
--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -3,9 +3,6 @@
 
 import type {
   AssigneeType,
-  BoardCard as BoardContractCard,
-  BoardChainAggregate as BoardContractChainAggregate,
-  BoardChainFrontier as BoardContractChainFrontier,
   ChainControl,
   ChainProgress,
   ChainStep,
@@ -35,11 +32,15 @@ import type {
 
 export type {
   AssigneeType,
+  BoardCard,
   BoardChainActivationState,
   BoardLatestRun,
   BoardMoveTarget,
+  BoardTask,
+  ChainAggregate,
   ChainAggregateState,
   ChainControl,
+  ChainFrontier,
   ChainProgress,
   ChainStep,
   ExecutionOwner,
@@ -74,19 +75,6 @@ export type {
   SessionExecutionStatus,
   Skill,
 } from "@anneal/db/wire-contract";
-
-export type ChainFrontier<DateTime = string> = BoardContractChainFrontier<DateTime> & {
-  mergeOutcome: MergeOutcome | null;
-};
-export type BoardChainFrontier<DateTime = string> = ChainFrontier<DateTime>;
-export type ChainAggregate<DateTime = string> = Omit<BoardContractChainAggregate<DateTime>, "frontier"> & {
-  frontier: ChainFrontier<DateTime>;
-};
-export type BoardChainAggregate<DateTime = string> = ChainAggregate<DateTime>;
-export type BoardCard<DateTime = string> = Omit<BoardContractCard<DateTime>, "chainAggregate"> & {
-  chainAggregate: ChainAggregate<DateTime> | null;
-};
-export type BoardTask = BoardCard<string>;
 
 export type Session = {
   id: string;

--- a/apps/web/src/tests/startup-board.browser.test.ts
+++ b/apps/web/src/tests/startup-board.browser.test.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 
 import { REQUEST_TIMEOUT_MS } from "../lib/api";
 import { CARD_PAGE_SIZE } from "../lib/board";
+import type { BoardTask } from "../lib/types";
 
 const chromePath = [
   process.env.CHROME_BIN,
@@ -99,13 +100,14 @@ const waitFor = async (cdp: Cdp, expression: string, timeoutMs = 10_000): Promis
   throw new Error(`Browser condition timed out: ${expression}`);
 };
 
-const taskRow = (index: number) => ({
+const taskRow = (index: number): BoardTask => ({
   id: `done-${index}`, name: `Completed task ${index}`, displayName: `Completed task ${index}`,
   assigneeType: "HUMAN", createdAt: "2026-08-27T00:00:00.000Z",
   status: "DONE", failureReason: null, scheduleKind: "NOW", runAt: null, cron: null, timezone: null,
   approvalGate: false, templateId: null, source: "MANUAL", chainId: null, chainIndex: null,
   chainName: null, updatedAt: "2026-08-28T00:00:00.000Z", assigneeAgent: null,
-  chainProgress: null, blockedOn: null, latestRun: null, taskCost: null, repairOf: null,
+  moveTargets: [], chainProgress: null, blockedOn: null, latestRun: null, taskCost: null,
+  mergeOutcome: null, repairOf: null, chainAggregate: null,
 });
 
 test("Chrome recovers from a bounded stalled startup and keeps large Tasks DOM work fixed", {

--- a/packages/api/src/board.test.ts
+++ b/packages/api/src/board.test.ts
@@ -291,6 +291,18 @@ test("chainAggregate derives primary progress and every board column from the fr
   assert.equal(done.frontier.taskId, "step-2");
 });
 
+test("chainAggregate returns the exact board contract keys", () => {
+  const aggregate = chainAggregate("c1", "Release", [member()], []);
+
+  assert.deepEqual(Object.keys(aggregate).sort(), [
+    "activation", "chainId", "chainName", "createdAt", "detailTaskId", "frontier",
+    "status", "statusCounts", "stepCount", "totalCost", "updatedAt",
+  ]);
+  assert.deepEqual(Object.keys(aggregate.frontier).sort(), [
+    "failureReason", "latestRun", "mergeOutcome", "position", "status", "taskId", "title",
+  ]);
+});
+
 test("board aggregate and Chain detail choose the same first unfinished execution layer", () => {
   const shared = [
     { id: "done", name: "Completed layer", chainIndex: 1, chainLayer: 10, status: "DONE" as const },

--- a/packages/api/src/board.ts
+++ b/packages/api/src/board.ts
@@ -27,10 +27,10 @@ import {
 import type {
   BoardCard as BoardContractCard,
   BoardChainActivationState as BoardContractChainActivationState,
-  BoardChainAggregate as BoardContractChainAggregate,
-  BoardChainFrontier as BoardContractChainFrontier,
   BoardLatestRun as BoardContractLatestRun,
   BoardMoveTarget as BoardContractMoveTarget,
+  ChainAggregate as BoardContractChainAggregate,
+  ChainFrontier as BoardContractChainFrontier,
   RepairBinding as BoardContractRepairBinding,
   RunStatus as BoardRunStatus,
   UsageCost as BoardUsageCost,
@@ -65,15 +65,7 @@ import { taskMoveAuthority } from "./task-move-authority.js";
  * point of the shape is that its cost is legible.
  */
 export type BoardMoveTarget = BoardContractMoveTarget;
-export type BoardChainFrontier = BoardContractChainFrontier<Date> & {
-  mergeOutcome: BoardContractCard<Date>["mergeOutcome"];
-};
-export type BoardChainAggregate = Omit<BoardContractChainAggregate<Date>, "frontier"> & {
-  frontier: BoardChainFrontier;
-};
-export type BoardCard = Omit<BoardContractCard<Date>, "chainAggregate"> & {
-  chainAggregate: BoardChainAggregate | null;
-};
+export type BoardCard = BoardContractCard<Date>;
 export type BoardLatestRun = BoardContractLatestRun<Date>;
 export type BoardChainActivationState = BoardContractChainActivationState;
 export type RepairBinding = BoardContractRepairBinding;
@@ -85,10 +77,28 @@ type JsonSerialized<T> = T extends Date
     : T extends object
       ? { [Key in keyof T]: JsonSerialized<T[Key]> }
       : T;
-type ContractCheck<T extends BoardContractCard> = T;
+type ExactKeys<Left, Right> = [
+  Exclude<keyof Left, keyof Right>,
+  Exclude<keyof Right, keyof Left>,
+] extends [never, never] ? true : false;
+type ContractCheck<
+  Projection extends BoardContractCard,
+  Proof extends [true, true, true, false, false],
+> = Proof extends [true, true, true, false, false] ? Projection : never;
 /** Compile-time proof that JSON serialization turns the native projection into
- * the shared browser contract, including every required field. */
-export type SerializedBoardCardProjection = ContractCheck<JsonSerialized<BoardCard>>;
+ * the exact shared browser contract, including every nested aggregate and
+ * frontier key. The final two checks prove missing and surplus adapter keys
+ * both fail the bidirectional key comparison. */
+export type SerializedBoardCardProjection = ContractCheck<
+  JsonSerialized<BoardCard>,
+  [
+    ExactKeys<JsonSerialized<BoardCard>, BoardContractCard>,
+    ExactKeys<NonNullable<JsonSerialized<BoardCard>["chainAggregate"]>, BoardContractChainAggregate>,
+    ExactKeys<NonNullable<JsonSerialized<BoardCard>["chainAggregate"]>["frontier"], BoardContractChainFrontier>,
+    ExactKeys<Omit<JsonSerialized<BoardCard>, "id">, BoardContractCard>,
+    ExactKeys<JsonSerialized<BoardCard> & { surplus: never }, BoardContractCard>,
+  ]
+>;
 
 /** The Prisma row shape `boardCard` needs — declared structurally so `readBoard`
  *  can select exactly these columns and nothing else. */
@@ -313,7 +323,7 @@ export const chainAggregate = (
   primaryMembers: readonly BoardChainMember[],
   repairMembers: readonly BoardChainMember[],
   predecessorById: ReadonlyMap<string, BoardBlockedOnTask> = new Map(),
-): BoardChainAggregate => {
+): BoardContractChainAggregate<Date> => {
   const primary = [...primaryMembers].sort(chainMemberOrder);
   const repairs = [...repairMembers].sort(chainMemberOrder);
   const members = [...primary, ...repairs];
@@ -403,7 +413,7 @@ export const chainAggregate = (
     totalCost: serializeUsageCost(totalCost),
     createdAt,
     updatedAt,
-  } satisfies BoardChainAggregate;
+  } satisfies BoardContractChainAggregate<Date>;
 };
 
 /** The instantiated chain name is persisted as the prefix of every task name.
@@ -945,7 +955,7 @@ export const readBoard = async (db: PrismaClient, scope: TaskReadScope): Promise
     const group = addChain(key, repairByTask.get(row.id)?.chainName ?? null);
     group.repairs.push(memberWithDisplay(row));
   }
-  const aggregateByChain = new Map<string, BoardChainAggregate>();
+  const aggregateByChain = new Map<string, BoardContractChainAggregate<Date>>();
   for (const [key, group] of membersByChain) {
     const chainId = group.primary[0]?.chainId
       ?? (group.repairs[0] === undefined

--- a/packages/db/src/board-contract.ts
+++ b/packages/db/src/board-contract.ts
@@ -94,6 +94,7 @@ export type ChainFrontier<DateTime = string> = {
   title: string;
   status: TaskStatus;
   latestRun: BoardLatestRun<DateTime> | null;
+  mergeOutcome: MergeOutcome | null;
   failureReason: string | null;
   /** Dense one-based position among primary Steps; omitted for a repair. */
   position?: number | null;


### PR DESCRIPTION
## What changed

- Completed the browser-safe board contract interface with `frontier.mergeOutcome`, so the API board adapter and web adapter consume one wire shape directly.
- Removed the mirrored `Omit`, intersection, and synonym aliases that repaired the missing field in both adapters.
- Added a bidirectional exact-key proof for the card, Chain aggregate, and Frontier; compile-time fixtures prove both missing and surplus adapter keys are rejected.
- Added exact aggregate/Frontier key assertions and made the startup browser fixture typecheck through the shared `BoardTask` interface.

This deepens the board contract module at its existing two-adapter seam: callers gain leverage from one complete interface, while maintainers gain locality for future wire-shape changes.

## Evidence

- `npm run lint` — PASS (Biome checked 599 files; ESLint exit 0).
- `npm run typecheck` — PASS across all workspaces.
- `npm test --workspace @anneal/db` — PASS, 276/276.
- Targeted `packages/api/src/board.test.ts` — PASS, 37/37, including exact aggregate/Frontier keys and Run ownership for projected merge outcomes.
- `npm test --workspace @anneal/api` — two full attempts each reached 691 pass, 1 fail, 1 opt-in skip. Attempt 1 timed out after 10 seconds in `RP-OWN-RECOVERY-CLEANUP`; its isolated retry passed. Attempt 2 passed that case but timed out after 10 seconds in `RP-OWN-FILES-ALIAS`; its isolated retry passed. The frontier contract tests passed in both full attempts.
- `npm run build -w @anneal/web` — PASS.
- `npm test --workspace @anneal/web` after the required web build — PASS, 541 pass, 0 fail, 1 opt-in browser skip.
- Targeted `apps/web/src/tests/startup-board.browser.test.ts` — fixture loaded and the opt-in Chrome case skipped because `RUN_BROWSER_REGRESSION` was not set.

## Reported but unfixed

- `packages/api/src/control-plane-ownership.test.ts` has load-sensitive 10-second subprocess waits: two full-suite attempts timed out in different cases, while each failed case passed in isolation. This file is outside Lane E4 ownership and was not changed.
