### PR TITLE
fix(api): prevent overlapping base-drift recovery ticks

### DIFF
--- a/packages/api/src/merge-base-drift-worker.test.ts
+++ b/packages/api/src/merge-base-drift-worker.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { PrismaClient } from "@anneal/db";
+
+import { startBaseDriftRecoveryWorker } from "./merge-base-drift-worker.js";
+
+const wait = (milliseconds: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const waitUntil = async (predicate: () => boolean, timeoutMs = 10_000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`condition was not met within ${timeoutMs}ms`);
+    await wait(25);
+  }
+};
+
+test("the base-drift recovery worker never overlaps ticks in one process", async () => {
+  const previousInterval = process.env.MERGE_BASE_DRIFT_RECOVERY_POLL_INTERVAL_MS;
+  process.env.MERGE_BASE_DRIFT_RECOVERY_POLL_INTERVAL_MS = "250";
+  let active = 0;
+  let maximumActive = 0;
+  let calls = 0;
+  const db = {
+    task: {
+      findMany: async () => {
+        calls += 1;
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        await wait(350);
+        active -= 1;
+        return [];
+      },
+    },
+  } as unknown as PrismaClient;
+  const timer = startBaseDriftRecoveryWorker(db, null);
+  try {
+    await waitUntil(() => calls >= 2);
+  } finally {
+    clearInterval(timer);
+    if (previousInterval === undefined) delete process.env.MERGE_BASE_DRIFT_RECOVERY_POLL_INTERVAL_MS;
+    else process.env.MERGE_BASE_DRIFT_RECOVERY_POLL_INTERVAL_MS = previousInterval;
+  }
+  await waitUntil(() => active === 0);
+  assert.equal(maximumActive, 1);
+});

--- a/packages/api/src/merge-base-drift-worker.ts
+++ b/packages/api/src/merge-base-drift-worker.ts
@@ -604,8 +604,13 @@ export const startBaseDriftRecoveryWorker = (
   db: PrismaClient,
   reader: PullRequestReader | null = createGitHubReader(),
 ): ReturnType<typeof setInterval> => {
+  let inFlight = false;
   const run = (): void => {
-    void baseDriftRecoveryTick(db, reader).catch((error: unknown) => console.error("Base-drift recovery tick failed", error));
+    if (inFlight) return;
+    inFlight = true;
+    void baseDriftRecoveryTick(db, reader)
+      .catch((error: unknown) => console.error("Base-drift recovery tick failed", error))
+      .finally(() => { inFlight = false; });
   };
   run();
   const timer = setInterval(run, baseDriftRecoveryPollIntervalMs());


### PR DESCRIPTION
## Summary

- prevent concurrent base-drift recovery ticks in one API process
- add a regression test that makes each tick outlive the polling interval

## Verification

- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) node --import tsx --test src/merge-base-drift-worker.test.ts`
- `npm run typecheck -w @anneal/api`
- `npm run lint`