### PR TITLE
refactor(api): deepen run lifecycle transitions

### DIFF
--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -1740,6 +1740,7 @@ test("successful completion commits output and parks an archived chain successor
         updatedAt: new Date(),
         runs: [],
         assigneeAgent: { id: "agent-2", name: "Archived Successor", archivedAt: new Date() },
+        repo: { id: "repo-1", name: "Repo", defaultBranch: "main" },
       };
       const predecessor = {
         id: "task-1",
@@ -1802,6 +1803,7 @@ test("successful completion commits output and parks an archived chain successor
             return {};
           },
         },
+        agent: { findUnique: async () => successor.assigneeAgent },
         chainControl: { findMany: async () => [] },
         runnerBackendState: { upsert: async () => ({ consecutiveAuthFailures: 0 }) },
       };
@@ -1828,9 +1830,14 @@ test("successful completion commits output and parks an archived chain successor
       assert.equal(closed, true);
       assert.equal(outputCreated, true);
       assert.equal(runCreates, 0);
-      assert.equal(successorUpdate?.status, "REVIEW");
-      assert.match(String(successorUpdate?.failureReason), /Archived Successor/);
-      assert.match(String(successorActivity?.body), /Archived Successor.*not queued/);
+      const refusalMessage = "Task Archived Successor assignee Archived Successor is archived; unarchive the agent to queue this step";
+      assert.deepEqual(successorUpdate, { status: "REVIEW", failureReason: refusalMessage });
+      assert.deepEqual(successorActivity, {
+        taskId: successor.id,
+        actorType: "control-plane",
+        body: `Predecessor layer completed but Run birth was refused: ${refusalMessage}`,
+        metadata: { refusal: "assignee-archived" },
+      });
     } finally {
       if (previousRoot === undefined) delete process.env.RUNNER_WORKSPACE_ROOT;
       else process.env.RUNNER_WORKSPACE_ROOT = previousRoot;

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -1833,6 +1833,8 @@ test("successful completion commits output and parks an archived chain successor
       assert.equal(successorUpdate?.status, "REVIEW");
       assert.match(String(successorUpdate?.failureReason), /Archived Successor/);
       assert.match(String(successorUpdate?.failureReason), /archived/i);
+      assert.equal(successorActivity?.taskId, successor.id);
+      assert.equal(successorActivity?.actorType, "control-plane");
       assert.match(String(successorActivity?.body), /predecessor.*complet/i);
       assert.match(String(successorActivity?.body), /Archived Successor/);
       assert.match(String(successorActivity?.body), /archived/i);

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -644,15 +644,11 @@ test("starting a run without an exact dispatched prompt hash is refused before d
 
 test("merge-executor start maps an omitted promptHash to null and dispatches", async () => {
   await withTokens(async () => {
-    let fencedRead = 0;
     let promptHash: unknown = "not-written";
     const tx = {
       $queryRaw: async () => [{ id: "run-1" }],
       run: {
-        findFirst: async () => {
-          fencedRead += 1;
-          return fencedRead === 1 ? { taskId: null } : { startedAt: null };
-        },
+        findFirst: async () => ({ startedAt: null }),
         updateMany: async ({ data }: { data: Record<string, unknown> }) => {
           promptHash = data.promptHash;
           return { count: 1 };

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -642,6 +642,46 @@ test("starting a run without an exact dispatched prompt hash is refused before d
   });
 });
 
+test("merge-executor start maps an omitted promptHash to null and dispatches", async () => {
+  await withTokens(async () => {
+    let fencedRead = 0;
+    let promptHash: unknown = "not-written";
+    const tx = {
+      $queryRaw: async () => [{ id: "run-1" }],
+      run: {
+        findFirst: async () => {
+          fencedRead += 1;
+          return fencedRead === 1 ? { taskId: null } : { startedAt: null };
+        },
+        updateMany: async ({ data }: { data: Record<string, unknown> }) => {
+          promptHash = data.promptHash;
+          return { count: 1 };
+        },
+      },
+      session: { updateMany: async () => ({ count: 1 }) },
+    };
+    const database = {
+      $transaction: async (operation: (client: unknown) => Promise<unknown>) => operation(tx),
+    } as unknown as PrismaClient;
+    const response = await createApp(database).request("/runner/runs/run-1/start", {
+      method: "POST",
+      headers: { Authorization: "Bearer merge-executor-unit-token", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        runnerId: "merge-executor-1",
+        fencingToken: "1:run-1:current",
+        adapterVersion: "executor-1",
+        cliVersion: "executor-1",
+        manifest: { executionMode: "mechanical" },
+        workspacePath: null,
+      }),
+    });
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+    assert.equal(promptHash, null);
+  });
+});
+
 test("completion requires both exit zero and a successful terminal event", () => {
   assert.equal(completionSucceeded({
     exitCode: 0,
@@ -1987,209 +2027,6 @@ test("GET /runs/:runId/events pages by seq and reports hasMore without a second 
     const clamped = findManyArgs.at(-1) as { take: number; where: Record<string, unknown> };
     assert.equal(clamped.take, 2001);
     assert.equal(clamped.where.seq, undefined);
-  });
-});
-
-/* --------------------------------- the usage recompute's ingest wiring */
-
-/** A CLAUDE terminal `result` line, trimmed to the fields `extractUsage` reads.
- *  Values are the captured shape from `spikes/cli-capabilities/samples/`.
- *
- *  It stays trimmed ON PURPOSE, and specifically it carries no `modelUsage`:
- *  these three tests are what keep `extractUsage`'s top-level snake_case
- *  fallback branch covered — the branch CODEX and PI always take. The complete
- *  captures, `modelUsage` included, live in `usage.test.ts`. */
-const finalOutputPayload = {
-  type: "result",
-  total_cost_usd: 0.049117,
-  usage: { input_tokens: 4, output_tokens: 77, cache_read_input_tokens: 8_700, cache_creation_input_tokens: 120 },
-};
-
-/** The stub the three wiring tests share: one live run with a session, a
- *  `createMany` that accepts anything, and a recording `session.update`.
- *  `onUpdate` lets a test make the derived-cache write fail. */
-const ingestDatabase = (
-  updates: Array<Record<string, unknown>>,
-  finalOutputRows: Array<{ payload: unknown }>,
-  onUpdate?: () => never,
-): PrismaClient => {
-  const database: Record<string, unknown> = {
-    // `recomputeSessionUsage` now opens one interactive transaction and takes an
-    // advisory lock inside it. These three answer that scaffolding inertly; the
-    // lock itself is proven against a real PostgreSQL in `usage.dbtest.ts`.
-    $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation(database),
-    $executeRawUnsafe: async () => 0,
-    $queryRaw: async () => [],
-    run: {
-      findFirst: async () => ({ id: "run-1", session: { id: "ses-1", providerConversationId: "conv-1" } }),
-    },
-    sessionEvent: {
-      createMany: async ({ data }: { data: unknown[] }) => ({ count: data.length }),
-      findMany: async () => finalOutputRows,
-    },
-    session: {
-      findUnique: async () => ({ inputTokens: null, outputTokens: null, cachedInputTokens: null, totalTokens: null, costUsd: null }),
-      update: async (args: Record<string, unknown>) => { onUpdate?.(); updates.push(args); return {}; },
-    },
-  };
-  return database as unknown as PrismaClient;
-};
-
-const postEvents = async (database: PrismaClient, types: string[]): Promise<Response> =>
-  createApp(database).request("/runner/runs/run-1/events", {
-    method: "POST",
-    headers: { Authorization: "Bearer runner-unit-token", "Content-Type": "application/json" },
-    body: JSON.stringify({
-      runnerId: "runner-1",
-      fencingToken: "1:run-1:current",
-      events: types.map((type, index) => ({
-        seq: index + 1,
-        source: "CLAUDE",
-        type,
-        payload: type === "FINAL_OUTPUT" ? finalOutputPayload : { text: "hello" },
-      })),
-    }),
-  });
-
-test("ingesting a FINAL_OUTPUT writes the derived usage columns", async () => {
-  await withTokens(async () => {
-    const updates: Array<Record<string, unknown>> = [];
-    const response = await postEvents(ingestDatabase(updates, [{ payload: finalOutputPayload }]), ["MODEL_COMPLETED", "FINAL_OUTPUT"]);
-
-    assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), { accepted: 2 });
-    assert.equal(updates.length, 1);
-    const write = updates[0] as { where: { id: string }; data: Record<string, unknown> };
-    assert.equal(write.where.id, "ses-1");
-    assert.equal(write.data.inputTokens, 8_824);
-    assert.equal(write.data.outputTokens, 77);
-    assert.equal(write.data.cachedInputTokens, 8_820);
-    // inputTokens includes cached input; totalTokens is input + output by
-    // definition, so the cache is not added a second time.
-    assert.equal(write.data.totalTokens, 8_901);
-    assert.equal(String(write.data.costUsd), "0.0491");
-  });
-});
-
-test("a batch with no FINAL_OUTPUT does not touch the usage columns", async () => {
-  await withTokens(async () => {
-    const updates: Array<Record<string, unknown>> = [];
-    const response = await postEvents(ingestDatabase(updates, [{ payload: finalOutputPayload }]), ["MODEL_COMPLETED", "TOOL_STARTED"]);
-
-    assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), { accepted: 2 });
-    assert.equal(updates.length, 0);
-  });
-});
-
-test("an observed native child is persisted independently of the launch grant", async () => {
-  await withTokens(async () => {
-    const updates: Array<Record<string, unknown>> = [];
-    const response = await postEvents(ingestDatabase(updates, []), ["NATIVE_CHILD_STARTED"]);
-
-    assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), { accepted: 1 });
-    assert.deepEqual(updates, [{ where: { id: "ses-1" }, data: { nativeChildUsed: true } }]);
-  });
-});
-
-test("a failing usage recompute does not fail the ingest", async () => {
-  await withTokens(async () => {
-    // The derived cache must never be fatal to the write path it decorates:
-    // `appendEvents` has no retry, so a 500 here would reject the runner's
-    // terminal flush, skip deliverWorkspace/completeRun, record a successful
-    // run as failed and delete its workspace unpushed.
-    const updates: Array<Record<string, unknown>> = [];
-    const database = ingestDatabase(updates, [{ payload: finalOutputPayload }], () => {
-      throw new Error("value out of range for type integer");
-    });
-    const errors: unknown[] = [];
-    const consoleError = console.error;
-    console.error = (...args: unknown[]) => { errors.push(args); };
-    try {
-      const response = await postEvents(database, ["FINAL_OUTPUT"]);
-      assert.equal(response.status, 200);
-      assert.deepEqual(await response.json(), { accepted: 1 });
-    } finally {
-      console.error = consoleError;
-    }
-    assert.equal(updates.length, 0);
-    assert.equal(errors.length, 1);
-  });
-});
-
-test("event ingestion makes literal NULs visible without changing seq order", async () => {
-  await withTokens(async () => {
-    const nul = "\u0000";
-    const visibleNul = "\\u0000";
-    const stored: Array<Record<string, unknown>> = [];
-    const database = {
-      $queryRaw: async () => [{ id: "run-1" }],
-      run: {
-        findFirst: async () => ({ session: { id: "ses-1", providerConversationId: null } }),
-      },
-      sessionEvent: {
-        createMany: async ({ data }: { data: Array<Record<string, unknown>> }) => {
-          stored.push(...data);
-          return { count: data.length };
-        },
-        findMany: async (): Promise<Array<Record<string, unknown>>> => {
-          const rows = stored.map((event, index) => ({ id: `event-${index}`, ...event })) as Array<Record<string, unknown>>;
-          rows.sort((left, right) => Number(left.seq) - Number(right.seq));
-          return rows;
-        },
-        count: async () => stored.length,
-      },
-    } as Record<string, unknown>;
-    database.$transaction = async (operation: (tx: unknown) => Promise<unknown>) => operation(database);
-    const app = createApp(database as unknown as PrismaClient);
-    const response = await app.request("/runner/runs/run-1/events", {
-      method: "POST",
-      headers: { Authorization: "Bearer runner-unit-token", "Content-Type": "application/json" },
-      body: JSON.stringify({
-        runnerId: "runner-1",
-        fencingToken: "1:run-1:current",
-        events: [
-          {
-            seq: 4,
-            source: "CLAUDE",
-            type: `EVENT${nul}TYPE`,
-            providerEventId: `provider${nul}id`,
-            toolCallId: `tool${nul}id`,
-            payload: {
-              unchanged: "plain text",
-              nested: { message: `left${nul}right`, list: [`a${nul}b`, { deep: "value" }] },
-              [`field${visibleNul}`]: "literal key value",
-              [`field${nul}`]: "NUL key value",
-              [`key${nul}`]: "key value",
-            },
-          },
-          { seq: 9, source: "CLAUDE", type: "VALID", payload: { unchanged: "still exact" } },
-        ],
-      }),
-    });
-    assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), { accepted: 2 });
-
-    const read = await app.request("/runs/run-1/events", {
-      headers: { Authorization: "Bearer operator-unit-token" },
-    });
-    assert.equal(read.status, 200);
-    const body = await read.json() as { events: Array<Record<string, any>>; total: number };
-    assert.deepEqual(body.events.map((event) => event.seq), [4, 9]);
-    assert.equal(body.total, 2);
-    assert.equal(body.events[0]?.type, `EVENT${visibleNul}TYPE`);
-    assert.equal(body.events[0]?.providerEventId, `provider${visibleNul}id`);
-    assert.equal(body.events[0]?.toolCallId, `tool${visibleNul}id`);
-    assert.deepEqual(body.events[0]?.payload, {
-      unchanged: "plain text",
-      nested: { message: `left${visibleNul}right`, list: [`a${visibleNul}b`, { deep: "value" }] },
-      [`field${visibleNul}`]: "literal key value",
-      [`field${visibleNul}${visibleNul}`]: "NUL key value",
-      [`key${visibleNul}`]: "key value",
-    });
-    assert.deepEqual(body.events[1]?.payload, { unchanged: "still exact" });
-    assert.equal(JSON.stringify(body).includes(nul), false);
   });
 });
 

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -1830,14 +1830,12 @@ test("successful completion commits output and parks an archived chain successor
       assert.equal(closed, true);
       assert.equal(outputCreated, true);
       assert.equal(runCreates, 0);
-      const refusalMessage = "Task Archived Successor assignee Archived Successor is archived; unarchive the agent to queue this step";
-      assert.deepEqual(successorUpdate, { status: "REVIEW", failureReason: refusalMessage });
-      assert.deepEqual(successorActivity, {
-        taskId: successor.id,
-        actorType: "control-plane",
-        body: `Predecessor layer completed but Run birth was refused: ${refusalMessage}`,
-        metadata: { refusal: "assignee-archived" },
-      });
+      assert.equal(successorUpdate?.status, "REVIEW");
+      assert.match(String(successorUpdate?.failureReason), /Archived Successor/);
+      assert.match(String(successorUpdate?.failureReason), /archived/i);
+      assert.match(String(successorActivity?.body), /predecessor.*complet/i);
+      assert.match(String(successorActivity?.body), /Archived Successor/);
+      assert.match(String(successorActivity?.body), /archived/i);
     } finally {
       if (previousRoot === undefined) delete process.env.RUNNER_WORKSPACE_ROOT;
       else process.env.RUNNER_WORKSPACE_ROOT = previousRoot;

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -575,38 +575,6 @@ test("AT create waits for the scheduler and merged-view patch cannot remove its 
   });
 });
 
-test("fencing rejects an expired generation token", async () => {
-  await withTokens(async () => {
-    const currentToken = "2:run-1:current";
-    const database = {
-      run: {
-        updateMany: async ({ where }: { where: { fencingToken: string } }) => ({ count: where.fencingToken === currentToken ? 1 : 0 }),
-        findFirst: async () => null,
-        // The refusal is explained from the row, not guessed from the miss.
-        findUnique: async () => ({
-          runnerId: "runner-1",
-          fencingToken: currentToken,
-          cancelRequestedAt: null,
-          leaseExpiresAt: new Date(Date.now() + 60_000),
-          status: RunStatus.RUNNING,
-        }),
-      },
-    } as unknown as PrismaClient;
-    const response = await createApp(database).request("/runner/runs/run-1/heartbeat", {
-      method: "POST",
-      headers: { Authorization: "Bearer runner-unit-token", "Content-Type": "application/json" },
-      body: JSON.stringify({
-        runnerId: "runner-1",
-        fencingToken: "1:run-1:expired",
-        leaseSeconds: 60,
-        processAlive: true,
-      }),
-    });
-    assert.equal(response.status, 409);
-    assert.deepEqual(await response.json(), { error: "Stale fencing token", reason: "stale-fence" });
-  });
-});
-
 test("session output authorization cannot introduce a second fence instant", async () => {
   const fencedPredicates: Prisma.RunWhereInput[] = [];
   const task = {
@@ -656,97 +624,6 @@ test("session output authorization cannot introduce a second fence instant", asy
   ).in === activeRunStatuses));
 });
 
-test("resuming a run preserves its original Run and Session start timestamps", async () => {
-  await withTokens(async () => {
-    const originalStartedAt = new Date("2026-08-21T00:00:00.000Z");
-    const resumedPromptHash = createHash("sha256").update("exact continuation input").digest("hex");
-    const runWrites: Array<Record<string, unknown>> = [];
-    const sessionWrites: Array<Record<string, unknown>> = [];
-    const tx = {
-      $queryRaw: async () => [{ id: "run-1" }],
-      run: {
-        findUnique: async () => ({ startedAt: originalStartedAt, session: { startedAt: originalStartedAt } }),
-        updateMany: async ({ data }: { data: Record<string, unknown> }) => {
-          runWrites.push(data);
-          return { count: 1 };
-        },
-      },
-      session: {
-        updateMany: async ({ data }: { data: Record<string, unknown> }) => {
-          sessionWrites.push(data);
-          return { count: 1 };
-        },
-      },
-    };
-    const database = {
-      $transaction: async (operation: (client: typeof tx) => Promise<unknown>) => operation(tx),
-    } as unknown as PrismaClient;
-    const response = await createApp(database).request("/runner/runs/run-1/start", {
-      method: "POST",
-      headers: { Authorization: "Bearer runner-unit-token", "Content-Type": "application/json" },
-      body: JSON.stringify({
-        runnerId: "runner-1",
-        fencingToken: "1:run-1:current",
-        adapterVersion: "test",
-        cliVersion: "test",
-        promptHash: resumedPromptHash,
-        manifest: {},
-        workspacePath: "/scratch/resumed",
-      }),
-    });
-    assert.equal(response.status, 200);
-    assert.equal(runWrites[0]?.startedAt, originalStartedAt);
-    assert.equal(runWrites[0]?.promptHash, resumedPromptHash);
-    assert.equal(sessionWrites[0]?.startedAt, originalStartedAt);
-  });
-});
-
-test("starting a fresh run stamps the same new timestamp on its Run and Session", async () => {
-  await withTokens(async () => {
-    const runWrites: Array<Record<string, unknown>> = [];
-    const sessionWrites: Array<Record<string, unknown>> = [];
-    const dispatchedPromptHash = createHash("sha256").update("the exact dispatched prompt").digest("hex");
-    const tx = {
-      $queryRaw: async () => [{ id: "run-1" }],
-      run: {
-        findUnique: async () => ({ startedAt: null, session: { startedAt: null } }),
-        updateMany: async ({ data }: { data: Record<string, unknown> }) => {
-          runWrites.push(data);
-          return { count: 1 };
-        },
-      },
-      session: {
-        updateMany: async ({ data }: { data: Record<string, unknown> }) => {
-          sessionWrites.push(data);
-          return { count: 1 };
-        },
-      },
-    };
-    const database = {
-      $transaction: async (operation: (client: typeof tx) => Promise<unknown>) => operation(tx),
-    } as unknown as PrismaClient;
-    const before = Date.now();
-    const response = await createApp(database).request("/runner/runs/run-1/start", {
-      method: "POST",
-      headers: { Authorization: "Bearer runner-unit-token", "Content-Type": "application/json" },
-      body: JSON.stringify({
-        runnerId: "runner-1",
-        fencingToken: "1:run-1:current",
-        adapterVersion: "test",
-        cliVersion: "test",
-        promptHash: dispatchedPromptHash,
-        manifest: {},
-        workspacePath: "/scratch/fresh",
-      }),
-    });
-    assert.equal(response.status, 200);
-    assert.ok(runWrites[0]?.startedAt instanceof Date);
-    assert.equal(sessionWrites[0]?.startedAt, runWrites[0]?.startedAt);
-    assert.ok((runWrites[0]?.startedAt as Date).getTime() >= before);
-    assert.equal(runWrites[0]?.promptHash, dispatchedPromptHash);
-  });
-});
-
 test("starting a run without an exact dispatched prompt hash is refused before database access", async () => {
   await withTokens(async () => {
     const response = await createApp({} as PrismaClient).request("/runner/runs/run-1/start", {
@@ -762,40 +639,6 @@ test("starting a run without an exact dispatched prompt hash is refused before d
       }),
     });
     assert.equal(response.status, 400);
-  });
-});
-
-test("the mechanical merge-executor start body is accepted without a prompt hash", async () => {
-  await withTokens(async () => {
-    const runWrites: Array<Record<string, unknown>> = [];
-    const tx = {
-      $queryRaw: async () => [{ id: "mechanical-run" }],
-      run: {
-        findUnique: async () => ({ startedAt: null }),
-        updateMany: async ({ data }: { data: Record<string, unknown> }) => {
-          runWrites.push(data);
-          return { count: 1 };
-        },
-      },
-      session: { updateMany: async () => ({ count: 1 }) },
-    };
-    const database = {
-      $transaction: async (operation: (client: typeof tx) => Promise<unknown>) => operation(tx),
-    } as unknown as PrismaClient;
-    const response = await createApp(database).request("/runner/runs/mechanical-run/start", {
-      method: "POST",
-      headers: { Authorization: "Bearer merge-executor-unit-token", "Content-Type": "application/json" },
-      body: JSON.stringify({
-        runnerId: "merge-executor-1",
-        fencingToken: "1:mechanical-run:current",
-        adapterVersion: "merge-executor-v1",
-        cliVersion: "merge-executor-v1",
-        workspacePath: null,
-        manifest: { executionMode: "mechanical", childProcessCount: 0 },
-      }),
-    });
-    assert.equal(response.status, 200);
-    assert.equal(runWrites[0]?.promptHash, null);
   });
 });
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -6,7 +6,6 @@ import {
   agentArchiveBlocker,
   applyInboxDecision,
   catalogRunnerForModel,
-  CleanupStatus,
   CodexServiceTier,
   GoalStatus,
   enqueueTaskRun,
@@ -18,23 +17,18 @@ import {
   lockAgentRow,
   lockChainRows,
   lockChainStructure,
-  lockRunRow,
   NetworkingMode,
   Prisma,
   type PrismaClient,
   RepoPermission,
-  RunStatus,
   ScheduleKind,
   RunnerKind,
   RunnerPreference,
-  recomputeSessionUsage,
   runnerFor,
   runSessionUsageCost,
   sumUsageCosts,
   SecretPurpose,
   SkillKind,
-  SessionEventSource,
-  SessionExecutionStatus,
   TaskSource,
   TaskStatus,
   TriggerFireSource,
@@ -135,7 +129,6 @@ import {
 } from "./chain.js";
 import {
   jsonValue,
-  normalizeSessionEventValue,
 } from "./execution.js";
 import {
   createArchivedRunNoticeScheduler,
@@ -150,17 +143,13 @@ import {
   refusalFor,
   refusalResponse,
 } from "./refusal.js";
-import {
-  acknowledgeReclaimSalvage, publishReclaimIntents, recordReclaimOutcomes, repairReplacementAfterSalvage,
-} from "./workspace-reclaim.js";
+import { acknowledgeReclaimSalvage, publishReclaimIntents, recordReclaimOutcomes } from "./workspace-reclaim.js";
 import { encryptSecret } from "./secrets.js";
 import {
   activeRunStatuses,
-  explainFenceRefusal,
   fenceRefusalResponse,
-  fencedRunWhere,
   isFenceRefusalResponse,
-  type FenceRefusalResponse,
+  runFenceRefusal as fenceRefusal,
   type RunFence,
   withFencedRun,
 } from "./run-fence.js";
@@ -194,9 +183,25 @@ import {
   revalidationCancelRequestId,
   SPEC_REVALIDATOR_AGENT_NAME,
 } from "./revalidation.js";
-import { claimInput, claimRun, OPERATOR_NOTE_METADATA_FIELD, runnerTelemetryFields } from "./run-claim.js";
+import { claimInput, claimRun, OPERATOR_NOTE_METADATA_FIELD } from "./run-claim.js";
 import { completeRun, completionInput, worktreeContainmentViolationsInput } from "./run-completion.js";
 import { acknowledgeCancellation, cancelRun } from "./run-cancel.js";
+import {
+  activityInput,
+  appendRunActivity,
+  appendRunEvents,
+  eventsInput,
+  fencedActivityInput,
+  heartbeatInput,
+  heartbeatRun,
+  leaseIndependentCleanupInput,
+  mechanicalStartInput,
+  publicationInput,
+  publishRun,
+  recordRunCleanup,
+  startInput,
+  startRun,
+} from "./run-lifecycle.js";
 import { withoutUndefined } from "./without-undefined.js";
 import { versionPayload } from "./version.js";
 
@@ -210,10 +215,6 @@ const refusalJson = (context: Context, refused: Refusal): Response => {
   const response = refusalResponse(refused);
   return context.json(response.body, response.status);
 };
-
-const runFenceRefusal = (refused: FenceRefusalResponse): Refusal => (
-  refusal("conflict", refused.error, { reason: refused.reason })
-);
 
 type TaskChainResolution = {
   task: { id: string; projectId: string };
@@ -526,13 +527,6 @@ const progressInput = z.object({
   sessionId: id.nullable().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
-const activityInput = z.object({
-  actorType: z.string().trim().min(1).max(40).default("operator"),
-  actorId: z.string().trim().min(1).nullable().optional(),
-  body: z.string().min(1),
-  metadata: z.record(z.string(), z.unknown()).optional(),
-});
-const fencedActivityInput = activityInput.extend({ fencingToken: fence });
 /** Revalidation is intentionally narrower than the operator task PATCH: the
  * session names only the replacement brief and the server derives the one
  * same-chain implementation task from the fenced Run. */
@@ -567,15 +561,6 @@ const reclaimSalvageInput = z.object({
   runId: id,
   pushedBranch: z.string().trim().min(1).max(255),
 });
-const heartbeatInput = z.object({
-  runnerId: z.string().trim().min(1).max(120),
-  fencingToken: fence,
-  leaseSeconds: z.number().int().min(15).max(3600).default(60),
-  processAlive: z.boolean(),
-  lastProgressEventAt: z.coerce.date().nullable().optional(),
-  inFlightTool: z.record(z.string(), z.unknown()).nullable().optional(),
-  ...runnerTelemetryFields,
-});
 const cancelRunInput = z.object({
   requestId: z.string().trim().min(1).max(160),
   reason: z.string().trim().min(1).pipe(failureReasonText(FAILURE_REASON_LIMIT)),
@@ -589,53 +574,6 @@ const cancelAcknowledgeInput = z.object({
   branch: z.string().min(1).optional(),
   baseSha: z.string().min(1).optional(),
   worktreeContainmentViolations: worktreeContainmentViolationsInput.optional(),
-});
-const publicationInput = z.object({
-  runnerId: z.string().trim().min(1).max(120),
-  fencingToken: fence,
-  pushedBranch: z.string().trim().min(1).max(255),
-});
-const leaseIndependentCleanupInput = z.object({
-  runnerId: z.string().trim().min(1).max(120),
-  fencingToken: fence,
-  cleanupStatus: z.nativeEnum(CleanupStatus),
-  cleanupFailureReason: z.string().max(4000).optional(),
-  workspaceRetained: z.boolean(),
-});
-const mechanicalStartInput = z.object({
-  runnerId: z.string().trim().min(1).max(120),
-  fencingToken: fence,
-  adapterVersion: z.string().min(1),
-  cliVersion: z.string().min(1),
-  authMode: z.string().nullable().optional(),
-  manifest: z.record(z.string(), z.unknown()),
-  // Nullable for the mechanical executor only, which provisions no workspace at
-  // all — the column is already `String?`. An ordinary runner still sends a
-  // path; nothing downstream reads this field as a guarantee that one exists.
-  workspacePath: z.string().min(1).nullable(),
-  branch: z.string().nullable().optional(),
-  baseSha: z.string().nullable().optional(),
-  runtimeHandle: z.string().nullable().optional(),
-});
-const startInput = mechanicalStartInput.extend({
-  // The runner computes this from the exact bytes handed to the provider.
-  // Requiring it prevents a start write from leaving a queued or prior hash.
-  promptHash: z.string().regex(/^[0-9a-f]{64}$/u),
-});
-const eventInput = z.object({
-  seq: z.number().int().nonnegative(),
-  at: z.coerce.date().optional(),
-  source: z.nativeEnum(SessionEventSource),
-  type: z.string().min(1).max(100),
-  providerEventId: z.string().nullable().optional(),
-  toolCallId: z.string().nullable().optional(),
-  payload: z.record(z.string(), z.unknown()),
-});
-const eventsInput = z.object({
-  runnerId: z.string().trim().min(1).max(120),
-  fencingToken: fence,
-  providerConversationId: z.string().nullable().optional(),
-  events: z.array(eventInput).min(1).max(250),
 });
 const preflightInput = z.object({
   runner: z.nativeEnum(RunnerKind),
@@ -2886,114 +2824,18 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
   app.post("/runner/runs/:runId/start", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const principal = context.get("principal");
-    // A mechanical run hands no bytes to a provider, so it has no dispatched
-    // prompt to hash. The independently authenticated executor alone receives
-    // that exemption; ordinary runner starts still require an exact hash.
     const body = principal.kind === "merge-executor"
       ? { ...await readJson(context.req.raw, mechanicalStartInput), promptHash: null }
       : await readJson(context.req.raw, startInput);
-    const now = new Date();
-    // A run that has already started is not startable again, so this fence is
-    // narrower than the live-lease set every other route uses.
-    const fence: RunFence = {
-      runId,
-      runnerId: body.runnerId,
-      fencingToken: body.fencingToken,
-      at: now,
-      statuses: [RunStatus.CLAIMED, RunStatus.PROVISIONING],
-    };
-    const started = await db.$transaction(async (tx) => {
-      const locked = await lockRunRow(tx, runId);
-      // Inbox resume reuses the same Run and Session. Keep the original
-      // lifecycle anchor when the resumed provider calls /start again; only a
-      // run that has never started gets this request's timestamp.
-      const existing = locked === null ? null : await tx.run.findUnique({
-        where: { id: runId },
-        select: { startedAt: true },
-      });
-      const startedAt = existing?.startedAt ?? now;
-      const updated = await tx.run.updateMany({
-        where: fencedRunWhere(fence),
-        data: {
-          status: RunStatus.RUNNING,
-          startedAt,
-          adapterVersion: body.adapterVersion,
-          cliVersion: body.cliVersion,
-          authMode: body.authMode ?? null,
-          promptHash: body.promptHash,
-          manifest: jsonValue(body.manifest),
-          workspacePath: body.workspacePath,
-          branch: body.branch ?? null,
-          baseSha: body.baseSha ?? null,
-        },
-      });
-      if (updated.count !== 1) return explainFenceRefusal(tx, fence);
-      const session = await tx.session.updateMany({
-        where: { runId, executionStatus: SessionExecutionStatus.PROVISIONING },
-        data: {
-          executionStatus: SessionExecutionStatus.RUNNING,
-          runtimeHandle: body.runtimeHandle ?? null,
-          resumeInput: null,
-          provisionedAt: now,
-          startedAt,
-        },
-      });
-      if (session.count !== 1) throw new Error(`Run ${runId} has no startable Session`);
-      return null;
-    });
-    return started === null
-      ? context.json({ ok: true })
-      : refusalJson(context, runFenceRefusal(fenceRefusalResponse(started)));
+    const result = await startRun(db, { runId, body });
+    return "message" in result ? refusalJson(context, result) : context.json(result);
   });
 
   app.post("/runner/runs/:runId/heartbeat", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, heartbeatInput);
-    const now = new Date();
-    runners.note(body.runnerId, body, now);
-    const fence: RunFence = { runId, runnerId: body.runnerId, fencingToken: body.fencingToken, at: now };
-    const updated = await db.run.updateMany({
-      where: fencedRunWhere(fence),
-      data: {
-        heartbeatAt: now,
-        ...(body.processAlive ? {
-          lastProcessAliveAt: now,
-          leaseExpiresAt: new Date(now.getTime() + body.leaseSeconds * 1000),
-        } : {}),
-        ...(body.lastProgressEventAt !== undefined ? { lastProgressEventAt: body.lastProgressEventAt } : {}),
-        ...(body.inFlightTool !== undefined ? { inFlightTool: body.inFlightTool ? jsonValue(body.inFlightTool) : Prisma.JsonNull } : {}),
-      },
-    });
-    if (updated.count === 1) return context.json({
-      ok: true,
-      cancellation: null,
-      mechanicalCancellationPolicy: "refused",
-    });
-    const cancelling = await db.run.findFirst({
-      where: {
-        id: runId,
-        runnerId: body.runnerId,
-        fencingToken: body.fencingToken,
-        status: { in: activeRunStatuses },
-        cancelRequestedAt: { not: null },
-      },
-      select: { cancelRequestId: true, cancelReason: true, cancelRequestedAt: true },
-    });
-    if (cancelling?.cancelRequestId && cancelling.cancelReason && cancelling.cancelRequestedAt) {
-      return context.json({
-        ok: false,
-        mechanicalCancellationPolicy: "refused",
-        cancellation: {
-          requestId: cancelling.cancelRequestId,
-          reason: cancelling.cancelReason,
-          requestedAt: cancelling.cancelRequestedAt,
-        },
-      });
-    }
-    const waiting = await db.run.findFirst({ where: { id: runId, status: RunStatus.WAITING_INBOX }, select: { id: true } });
-    return waiting
-      ? refusalJson(context, refusal("conflict", "Run suspended for Inbox", { code: "WAITING_INBOX" }))
-      : refusalJson(context, runFenceRefusal(fenceRefusalResponse(await explainFenceRefusal(db, fence))));
+    const result = await heartbeatRun(db, { runId, body, noteRunner: runners.note });
+    return "message" in result ? refusalJson(context, result) : context.json(result);
   });
 
   app.post("/runner/runs/:runId/cancel/acknowledge", async (context) => {
@@ -3004,207 +2846,33 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     return context.json(result);
   });
 
-  // Publication is a separate durable fact from terminal completion. Persist
-  // it immediately after git push, before GitHub work and cleanup, so a lost
-  // runner does not make the reconciler forget a branch that already exists.
   app.post("/runner/runs/:runId/publication", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, publicationInput);
-    const now = new Date();
-    const fence: RunFence = { runId, runnerId: body.runnerId, fencingToken: body.fencingToken, at: now };
-    const run = await db.run.findUnique({
-      where: { id: runId },
-      select: {
-        runnerId: true, fencingToken: true, leaseExpiresAt: true, status: true,
-        taskId: true, repoId: true, runNumber: true, pushedBranch: true, branch: true,
-        cancelRequestedAt: true,
-      },
-    });
-    const owned = run?.runnerId === body.runnerId && run.fencingToken === body.fencingToken;
-    const live = owned && run.cancelRequestedAt === null && run.leaseExpiresAt !== null && run.leaseExpiresAt > now
-      && activeRunStatuses.includes(run.status);
-    // Salvage is the one publication allowed after lease loss. It is confined
-    // to this run's deterministic per-run ref, requires the same runner and
-    // fencing token that owned the workspace, and cannot replace a different
-    // publication already acknowledged for the run. Git durability does not
-    // depend on a live platform lease; making its ACK depend on one used to
-    // leave a pushed recovery ref invisible to the resolver.
-    const salvageBranch = run?.taskId
-      ? `agentos/${run.taskId}/run-${run.runNumber}`
-      : null;
-    const salvage = owned && run?.repoId !== null
-      && body.pushedBranch === salvageBranch
-      && (run?.pushedBranch === null || run?.pushedBranch === body.pushedBranch);
-    if (!live && !salvage) {
-      return refusalJson(context, runFenceRefusal(fenceRefusalResponse(await explainFenceRefusal(db, fence))));
-    }
-    const updated = await db.$transaction(async (tx) => {
-      const ack = await tx.run.updateMany({
-        where: live
-          ? fencedRunWhere(fence)
-          : {
-              id: runId,
-              runnerId: body.runnerId,
-              fencingToken: body.fencingToken,
-              OR: [{ pushedBranch: null }, { pushedBranch: body.pushedBranch }],
-            },
-        data: { pushedBranch: body.pushedBranch },
-      });
-      if (ack.count !== 1 || !salvage || !run?.taskId) return { count: ack.count, repair: "none" as const };
-      const repair = await repairReplacementAfterSalvage(tx, {
-        taskId: run.taskId,
-        runNumber: run.runNumber,
-        branch: run.branch,
-      });
-      return { count: ack.count, repair };
-    });
-    return updated.count === 1 && updated.repair !== "already-started"
-      ? context.json({ ok: true, replacementRepair: updated.repair })
-      : updated.count === 1
-        ? refusalJson(context, refusal("conflict", "Salvage is durable, but the replacement already started from its prior base"))
-        : refusalJson(context, runFenceRefusal(fenceRefusalResponse(await explainFenceRefusal(db, fence))));
+    const result = await publishRun(db, { runId, body });
+    return "message" in result ? refusalJson(context, result) : context.json(result);
   });
 
-  // Cleanup is still runner-owned after the live lease is gone. This endpoint
-  // can update only cleanup bookkeeping for the exact runner/fence that owned
-  // an expired or terminal run; it cannot change the run outcome or publish a
-  // branch.
   app.post("/runner/runs/:runId/cleanup", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, leaseIndependentCleanupInput);
-    const now = new Date();
-    const run = await db.run.findUnique({
-      where: { id: runId },
-      select: { runnerId: true, fencingToken: true, leaseExpiresAt: true, status: true },
-    });
-    const expiredOrTerminal = run && (
-      run.leaseExpiresAt === null || run.leaseExpiresAt <= now
-      || !activeRunStatuses.includes(run.status)
-    );
-    if (!run || run.runnerId !== body.runnerId || run.fencingToken !== body.fencingToken || !expiredOrTerminal) {
-      return context.json({ error: "Cleanup outcome is not authorized for a live or foreign run" }, 409);
-    }
-    await db.$transaction(async (tx) => {
-      await tx.run.update({
-        where: { id: runId },
-        data: { workspaceRetained: body.workspaceRetained },
-      });
-      await tx.session.updateMany({
-        where: { runId },
-        data: {
-          cleanupStatus: body.cleanupStatus,
-          cleanupEndedAt: now,
-          cleanupFailureReason: body.cleanupFailureReason ?? null,
-        },
-      });
-    });
-    return context.json({ ok: true });
+    const result = await recordRunCleanup(db, { runId, body });
+    return "message" in result ? refusalJson(context, result) : context.json(result);
   });
 
   app.post("/runner/runs/:runId/events", async (context) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, eventsInput);
-    const fence: RunFence = { runId, runnerId: body.runnerId, fencingToken: body.fencingToken, at: new Date() };
-    const result = await db.$transaction((tx) => withFencedRun(tx, fence, {
-      session: { select: { id: true, providerConversationId: true } },
-    }, async (run) => {
-      if (!run.session) return fenceRefusalResponse("stale-fence");
-      await tx.sessionEvent.createMany({
-        data: body.events.map((event) => ({
-          sessionId: run.session!.id,
-          runId,
-          seq: event.seq,
-          at: event.at ?? new Date(),
-          source: event.source,
-          type: normalizeSessionEventValue(event.type) as string,
-          providerEventId: event.providerEventId === undefined || event.providerEventId === null
-            ? null
-            : normalizeSessionEventValue(event.providerEventId) as string,
-          toolCallId: event.toolCallId === undefined || event.toolCallId === null
-            ? null
-            : normalizeSessionEventValue(event.toolCallId) as string,
-          payload: jsonValue(normalizeSessionEventValue(event.payload)),
-        })),
-        skipDuplicates: true,
-      });
-      if (body.events.some((event) => event.type === "NATIVE_CHILD_STARTED")) {
-        await tx.session.update({ where: { id: run.session.id }, data: { nativeChildUsed: true } });
-      }
-      if (body.providerConversationId && !run.session.providerConversationId) {
-        await tx.session.update({ where: { id: run.session.id }, data: { providerConversationId: body.providerConversationId } });
-      }
-      return { sessionId: run.session.id };
-    }));
-    if (isFenceRefusalResponse(result)) {
-      const waiting = await db.run.findFirst({ where: { id: runId, status: RunStatus.WAITING_INBOX }, select: { id: true } });
-      return waiting
-        ? refusalJson(context, refusal("conflict", "Run suspended for Inbox", { code: "WAITING_INBOX" }))
-        : refusalJson(context, runFenceRefusal(result));
-    }
-    // Recompute on "a FINAL_OUTPUT arrived", not "this payload had usage": a batch
-    // whose event was already stored still recomputes, which is what self-heals a
-    // write lost between createMany and here. The guard reads the request body
-    // already in memory, so a batch without one costs zero extra queries.
-    // Never fatal to the ingest. A throw here would 500 the route, and
-    // `appendEvents` has no retry (runner/src/api.ts:79), so the terminal flush
-    // would reject, `deliverWorkspace`/`completeRun` would be skipped, and the
-    // runner's outer catch would record a successful run as failed and delete
-    // its workspace unpushed. These columns are a derived cache that the next
-    // FINAL_OUTPUT or `db:backfill-session-usage` repairs (db/src/usage.ts).
-    // `recomputeSessionUsage` now waits on a per-session advisory lock, so a
-    // lock-wait timeout is one more throw this catch absorbs — same repair path.
-    if (body.events.some((event) => event.type === "FINAL_OUTPUT")) {
-      try {
-        await recomputeSessionUsage(db, result.sessionId);
-      } catch (error) {
-        console.error(`Session usage recompute failed for ${result.sessionId}`, error);
-      }
-    }
-    return context.json({ accepted: body.events.length });
+    const result = await appendRunEvents(db, { runId, body });
+    return "message" in result ? refusalJson(context, result) : context.json(result);
   });
 
   const appendFencedActivity = async (context: Context<AppEnvironment, string>) => {
     const runId = id.parse(context.req.param("runId"));
     const body = await readJson(context.req.raw, fencedActivityInput);
     const principal = context.get("principal");
-    const fence: RunFence = { runId, fencingToken: body.fencingToken, at: new Date() };
-    const result = await db.$transaction((tx) => withFencedRun(tx, fence, {
-      taskId: true,
-      leaseGeneration: true,
-      task: { select: { templateStep: { select: {
-        stepIndex: true,
-        outputKind: true,
-        taskTemplate: { select: { name: true } },
-      } } } },
-    }, async (run) => {
-      // A session principal carries its own generation of the same fence.
-      const leaseGeneration = principal.kind === "session" ? principal.leaseGeneration : null;
-      if (!run.taskId || leaseGeneration !== null && run.leaseGeneration !== leaseGeneration) {
-        return fenceRefusalResponse("stale-fence");
-      }
-      const metadata = body.metadata
-        ? {
-            ...body.metadata,
-            ...(((body.metadata.kind === MERGE_INTEGRATOR_KIND.intent
-              || body.metadata.kind === MERGE_INTEGRATOR_KIND.result)
-              && executionModeFor(run.task?.templateStep ?? null) === "mechanical")
-              ? { sourceRunId: runId }
-              : {}),
-          }
-        : undefined;
-      return tx.taskActivity.create({
-        data: {
-          taskId: run.taskId,
-          actorType: principal.kind,
-          actorId: body.actorId ?? null,
-          body: body.body,
-          ...(metadata ? { metadata: jsonValue(metadata) } : {}),
-        },
-      });
-    }));
-    return isFenceRefusalResponse(result)
-      ? refusalJson(context, runFenceRefusal(result))
-      : context.json(result, 201);
+    const result = await appendRunActivity(db, { runId, body, principal });
+    return "message" in result ? refusalJson(context, result) : context.json(result, 201);
   };
   app.post("/runner/runs/:runId/activity", appendFencedActivity);
   app.post("/session/runs/:runId/activity", appendFencedActivity);
@@ -3371,7 +3039,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const body = await readJson(context.req.raw, revalidationPatchInput);
     const fence: RunFence = { runId, fencingToken: body.fencingToken, at: new Date() };
     const result = await patchBoundImplementationDescription(db, fence, body.description, principal.leaseGeneration);
-    if (isFenceRefusalResponse(result)) return refusalJson(context, runFenceRefusal(result));
+    if (isFenceRefusalResponse(result)) return refusalJson(context, fenceRefusal(result.reason));
     if ("message" in result) return refusalJson(context, result);
     return context.json(result.task);
   });
@@ -3384,7 +3052,7 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
     const body = await readJson(context.req.raw, revalidationCancelInput);
     const fence: RunFence = { runId, fencingToken: body.fencingToken, at: new Date() };
     const result = await cancelBoundRevalidationRun(db, fence, new Date(), principal.leaseGeneration);
-    if (isFenceRefusalResponse(result)) return refusalJson(context, runFenceRefusal(result));
+    if (isFenceRefusalResponse(result)) return refusalJson(context, fenceRefusal(result.reason));
     if ("message" in result) return refusalJson(context, result);
     return context.json(result);
   });
@@ -3437,10 +3105,10 @@ export const createApp = (db: PrismaClient, options: LiveAppOptions): Hono<AppEn
         ...(body.metadata ? { metadata: jsonValue(body.metadata) } : {}),
       }) };
     }));
-    if (isFenceRefusalResponse(result)) return refusalJson(context, runFenceRefusal(result));
+    if (isFenceRefusalResponse(result)) return refusalJson(context, fenceRefusal(result.reason));
     if ("requestError" in result) return context.json({ error: result.requestError }, result.status);
     const { persisted } = result;
-    if (isFenceRefusalResponse(persisted)) return refusalJson(context, runFenceRefusal(persisted));
+    if (isFenceRefusalResponse(persisted)) return refusalJson(context, fenceRefusal(persisted.reason));
     if (!persisted.ok) return refusalJson(context, refusal("conflict", persisted.reason));
     return context.json({ ...persisted.output, predecessorOutputs: persisted.predecessorOutputs });
   });

--- a/packages/api/src/run-fence.dbtest.ts
+++ b/packages/api/src/run-fence.dbtest.ts
@@ -4,7 +4,8 @@ import { after, before, beforeEach, test } from "node:test";
 import { PrismaClient, RunStatus, SessionExecutionStatus, TaskStatus } from "@anneal/db";
 
 import { createApp } from "./test-app.js";
-import { resetTestDb, setupTestDb } from "./testdb.js";
+import { publishRun, startRun } from "./run-lifecycle.js";
+import { resetTestDb, setupTestDb, testDatabaseUrl } from "./testdb.js";
 
 let db: PrismaClient;
 before(() => { db = setupTestDb(); });
@@ -152,6 +153,149 @@ test("a run that has already started refuses a second start as not-active", asyn
   assert.equal(refused.status, 409);
   assert.equal(refused.body?.error, "Stale fencing token");
   assert.equal(refused.body?.reason, "not-active");
+});
+
+test("replacement start and late salvage publication complete without a Run-Task deadlock", { timeout: 20_000 }, async () => {
+  const seeded = await seed({ status: RunStatus.LOST, leaseExpiresAt: null });
+  const replacementRunner = "replacement-runner";
+  const replacementFence = `replacement-${seeded.run.id}`;
+  const originalBase = "main";
+  const replacement = await db.run.create({ data: {
+    projectId: seeded.project.id,
+    taskId: seeded.task.id,
+    agentId: seeded.task.assigneeAgentId!,
+    repoId: seeded.task.repoId,
+    runNumber: 2,
+    dedupeKey: `task:${seeded.task.id}:run:2`,
+    status: RunStatus.CLAIMED,
+    runner: "CODEX",
+    model: "gpt-5.6-sol:high",
+    promptHash: "b".repeat(64),
+    targetBranch: originalBase,
+    runnerId: replacementRunner,
+    fencingToken: replacementFence,
+    leaseGeneration: 2,
+    leaseExpiresAt: new Date(Date.now() + 600_000),
+    claimedAt: new Date(),
+  } });
+  await db.session.create({ data: {
+    runId: replacement.id,
+    projectId: seeded.project.id,
+    taskId: seeded.task.id,
+    agentId: seeded.task.assigneeAgentId!,
+    runner: "CODEX",
+    executionStatus: SessionExecutionStatus.PROVISIONING,
+  } });
+
+  const startClient = new PrismaClient({ datasources: { db: { url: testDatabaseUrl } } });
+  const publishClient = new PrismaClient({ datasources: { db: { url: testDatabaseUrl } } });
+  let reportStartLocked!: () => void;
+  let releaseStart!: () => void;
+  let reportTaskLocked!: () => void;
+  let reportRepairUpdate!: () => void;
+  const startLocked = new Promise<void>((resolve) => { reportStartLocked = resolve; });
+  const startGate = new Promise<void>((resolve) => { releaseStart = resolve; });
+  const taskLocked = new Promise<void>((resolve) => { reportTaskLocked = resolve; });
+  const repairUpdate = new Promise<void>((resolve) => { reportRepairUpdate = resolve; });
+
+  const startDb = {
+    $transaction: (operation: (tx: unknown) => Promise<unknown>) => startClient.$transaction(async (tx) => {
+      const instrumented = new Proxy(tx, {
+        get(target, property, receiver) {
+          if (property !== "$queryRaw") return Reflect.get(target, property, receiver);
+          return async (...args: unknown[]) => {
+            const result = await Reflect.apply(target.$queryRaw, target, args);
+            const query = args[0] as string[] | { strings?: string[] } | undefined;
+            const sql = Array.isArray(query) ? query.join(" ") : query?.strings?.join(" ") ?? "";
+            if (sql.includes('FROM "Run"') && args[1] === replacement.id) {
+              reportStartLocked();
+              await startGate;
+            }
+            return result;
+          };
+        },
+      });
+      return operation(instrumented);
+    }),
+  } as unknown as PrismaClient;
+  const publishDb = {
+    $transaction: (operation: (tx: unknown) => Promise<unknown>) => publishClient.$transaction(async (tx) => {
+      const instrumented = new Proxy(tx, {
+        get(target, property, receiver) {
+          if (property === "$queryRaw") {
+            return async (...args: unknown[]) => {
+              const result = await Reflect.apply(target.$queryRaw, target, args);
+              const query = args[0] as string[] | { strings?: string[] } | undefined;
+              const sql = Array.isArray(query) ? query.join(" ") : query?.strings?.join(" ") ?? "";
+              if (sql.includes('FROM "Task"') && args[1] === seeded.task.id) reportTaskLocked();
+              return result;
+            };
+          }
+          if (property === "run") {
+            return new Proxy(target.run, {
+              get(runTarget, runProperty, runReceiver) {
+                if (runProperty !== "updateMany") return Reflect.get(runTarget, runProperty, runReceiver);
+                return (...args: unknown[]) => {
+                  const update = args[0] as { where?: { id?: string } } | undefined;
+                  if (update?.where?.id === replacement.id) reportRepairUpdate();
+                  return Reflect.apply(runTarget.updateMany, runTarget, args);
+                };
+              },
+            });
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+      return operation(instrumented);
+    }),
+  } as unknown as PrismaClient;
+
+  const startedBranch = "replacement/original-base";
+  const salvage = `agentos/${seeded.task.id}/run-1`;
+  let starting: Promise<unknown> | undefined;
+  let publishing: Promise<unknown> | undefined;
+  try {
+    starting = startRun(startDb, {
+      runId: replacement.id,
+      body: {
+        runnerId: replacementRunner,
+        fencingToken: replacementFence,
+        adapterVersion: "test-adapter",
+        cliVersion: "test-cli",
+        promptHash: "b".repeat(64),
+        manifest: {},
+        workspacePath: `/scratch/${replacement.id}`,
+        branch: startedBranch,
+      },
+    });
+    await startLocked;
+    publishing = publishRun(publishDb, {
+      runId: seeded.run.id,
+      body: { runnerId: RUNNER_ID, fencingToken: seeded.run.fencingToken!, pushedBranch: salvage },
+    });
+    await taskLocked;
+    await repairUpdate;
+    releaseStart();
+
+    const [startResult, publishResult] = await Promise.all([starting, publishing]);
+    assert.deepEqual(startResult, { ok: true });
+    assert.deepEqual(publishResult, {
+      reason: "conflict",
+      message: "Salvage is durable, but the replacement already started from its prior base",
+    });
+  } finally {
+    releaseStart();
+    await Promise.allSettled([starting, publishing].filter((pending): pending is Promise<unknown> => pending !== undefined));
+    await Promise.all([startClient.$disconnect(), publishClient.$disconnect()]);
+  }
+
+  const published = await db.run.findUniqueOrThrow({ where: { id: seeded.run.id } });
+  const started = await db.run.findUniqueOrThrow({ where: { id: replacement.id } });
+  assert.equal(published.pushedBranch, salvage);
+  assert.equal(started.status, RunStatus.RUNNING);
+  assert.equal(started.targetBranch, originalBase);
+  assert.equal(started.branch, startedBranch);
+  assert.equal(await db.run.count({ where: { taskId: seeded.task.id } }), 2);
 });
 
 test("every fenced route on one expired run names the same cause", async () => {

--- a/packages/api/src/run-fence.test.ts
+++ b/packages/api/src/run-fence.test.ts
@@ -3,7 +3,18 @@ import { test } from "node:test";
 
 import { type Prisma, RunStatus } from "@anneal/db";
 
-import { explainFenceRefusal, fencedRunWhere, type RunFence, withFencedRun } from "./run-fence.js";
+import {
+  cleanupAuthorityRefusal,
+  explainFenceRefusal,
+  fencedRunWhere,
+  liveAuthorityRefusal,
+  lockAuthorityRun,
+  runFenceRefusal,
+  type LockedAuthorityRun,
+  type RunFence,
+  salvageAuthorityRefusal,
+  withFencedRun,
+} from "./run-fence.js";
 
 const fence: RunFence = {
   runId: "run-1",
@@ -106,4 +117,72 @@ test("an unowned run is wrong-runner before it is stale-fence", async () => {
     await explain({ ...live, runnerId: "runner-2", fencingToken: "2:run-1:superseded" }),
     "wrong-runner",
   );
+});
+
+const authorityRun: LockedAuthorityRun = {
+  id: "run-1",
+  runnerId: "runner-1",
+  fencingToken: "3:run-1:current",
+  cancelRequestId: null,
+  cancelReason: null,
+  cancelRequestedAt: null,
+  leaseExpiresAt: new Date("2026-08-25T12:05:00.000Z"),
+  status: RunStatus.RUNNING,
+  taskId: "task-1",
+  repoId: "repo-1",
+  runNumber: 4,
+  pushedBranch: null,
+  branch: "feature/task-1",
+};
+
+test("authority modes stay distinct while sharing one refusal vocabulary", () => {
+  assert.equal(liveAuthorityRefusal(authorityRun, fence), null);
+  assert.equal(salvageAuthorityRefusal(authorityRun, {
+    runnerId: "runner-1",
+    fencingToken: "3:run-1:current",
+    pushedBranch: "agentos/task-1/run-4",
+  }), null);
+  assert.equal(salvageAuthorityRefusal(authorityRun, {
+    runnerId: "runner-1",
+    fencingToken: "3:run-1:current",
+    pushedBranch: "feature/task-1",
+  }), "not-active");
+  assert.equal(cleanupAuthorityRefusal(authorityRun, {
+    runnerId: "runner-1",
+    fencingToken: "3:run-1:current",
+    at: fence.at,
+  }), "cleanup-not-authorized");
+  assert.equal(cleanupAuthorityRefusal({ ...authorityRun, status: RunStatus.SUCCEEDED }, {
+    runnerId: "runner-1",
+    fencingToken: "3:run-1:current",
+    at: fence.at,
+  }), null);
+});
+
+test("authority refusals preserve their transport behavior from one vocabulary", () => {
+  assert.deepEqual(runFenceRefusal("stale-fence"), {
+    reason: "conflict",
+    message: "Stale fencing token",
+    detail: { reason: "stale-fence" },
+  });
+  assert.deepEqual(runFenceRefusal("waiting-inbox"), {
+    reason: "conflict",
+    message: "Run suspended for Inbox",
+    detail: { code: "WAITING_INBOX" },
+  });
+  assert.deepEqual(runFenceRefusal("cleanup-not-authorized"), {
+    reason: "conflict",
+    message: "Cleanup outcome is not authorized for a live or foreign run",
+  });
+});
+
+test("authority inspection locks the Run before reading it", async () => {
+  const calls: string[] = [];
+  const tx = {
+    $queryRaw: async () => { calls.push("lock.run"); return [{ id: "run-1" }]; },
+    run: { findFirst: async () => { calls.push("read.run"); return authorityRun; } },
+  } as unknown as Prisma.TransactionClient;
+
+  assert.equal(await lockAuthorityRun(tx, "run-1"), authorityRun);
+  assert.deepEqual(calls, ["lock.run", "read.run"]);
 });

--- a/packages/api/src/run-fence.test.ts
+++ b/packages/api/src/run-fence.test.ts
@@ -14,6 +14,7 @@ import {
   type RunFence,
   salvageAuthorityRefusal,
   withFencedRun,
+  withRunOnlyFencedRun,
 } from "./run-fence.js";
 
 const fence: RunFence = {
@@ -76,6 +77,28 @@ test("one fenced read owns its clock and Run -> Task lock order", async () => {
   assert.equal(predicates.length, 2);
   assert.equal((predicates[0]?.leaseExpiresAt as { gt: Date }).gt, fence.at);
   assert.equal((predicates[1]?.leaseExpiresAt as { gt: Date }).gt, fence.at);
+});
+
+test("a Run-only fenced read preserves the complete predicate without taking the Task lock", async () => {
+  const calls: string[] = [];
+  let predicate: Prisma.RunWhereInput | undefined;
+  const tx = {
+    $queryRaw: async () => { calls.push("lock.run"); return [{ id: "run-1" }]; },
+    run: { findFirst: async ({ where }: { where: Prisma.RunWhereInput }) => {
+      calls.push("read.run");
+      predicate = where;
+      return { id: "run-1" };
+    } },
+  } as unknown as Prisma.TransactionClient;
+
+  const result = await withRunOnlyFencedRun(tx, fence, { id: true }, (run) => {
+    calls.push("body");
+    return run.id;
+  });
+
+  assert.equal(result, "run-1");
+  assert.deepEqual(calls, ["lock.run", "read.run", "body"]);
+  assert.deepEqual(predicate, fencedRunWhere(fence));
 });
 
 test("the predicate carries the six clauses that make a run this request's to write", () => {

--- a/packages/api/src/run-fence.ts
+++ b/packages/api/src/run-fence.ts
@@ -1,5 +1,7 @@
 import { lockRunRow, lockTaskRow, Prisma, RunStatus } from "@anneal/db";
 
+import type { Refusal } from "./refusal.js";
+
 /**
  * The statuses a lease can still be live under. Distinct from the database
  * package's `ACTIVE_RUN_STATUSES`, which answers "does this task already have a
@@ -41,7 +43,7 @@ export type RunFence = {
 
 /** Why a fenced query matched nothing. Ordered from the most specific cause to
  *  the least: a run that does not exist is `unknown-run`, never `stale-fence`. */
-export type FenceRefusal =
+export type LeaseFenceRefusal =
   | "unknown-run"
   | "wrong-runner"
   | "stale-fence"
@@ -49,15 +51,42 @@ export type FenceRefusal =
   | "lease-expired"
   | "not-active";
 
+export type FenceRefusal =
+  | LeaseFenceRefusal
+  | "waiting-inbox"
+  | "cleanup-not-authorized";
+
 export type FenceRefusalResponse = {
   error: "Stale fencing token";
-  reason: FenceRefusal;
+  reason: LeaseFenceRefusal;
 };
 
-export const fenceRefusalResponse = (reason: FenceRefusal): FenceRefusalResponse => ({
+export const fenceRefusalResponse = (reason: LeaseFenceRefusal): FenceRefusalResponse => ({
   error: "Stale fencing token",
   reason,
 });
+
+/** The one transport-neutral refusal vocabulary for every Run authority mode. */
+export const runFenceRefusal = (reason: FenceRefusal): Refusal => {
+  if (reason === "waiting-inbox") {
+    return {
+      reason: "conflict",
+      message: "Run suspended for Inbox",
+      detail: { code: "WAITING_INBOX" },
+    };
+  }
+  if (reason === "cleanup-not-authorized") {
+    return {
+      reason: "conflict",
+      message: "Cleanup outcome is not authorized for a live or foreign run",
+    };
+  }
+  return {
+    reason: "conflict",
+    message: "Stale fencing token",
+    detail: { reason },
+  };
+};
 
 export const isFenceRefusalResponse = (value: unknown): value is FenceRefusalResponse => (
   typeof value === "object"
@@ -92,7 +121,7 @@ export const fencedRunWhere = (fence: RunFence): Prisma.RunWhereInput => ({
 export const explainFenceRefusal = async (
   tx: Prisma.TransactionClient,
   fence: RunFence,
-): Promise<FenceRefusal> => {
+): Promise<LeaseFenceRefusal> => {
   const run = await tx.run.findUnique({
     where: { id: fence.runId },
     select: { runnerId: true, fencingToken: true, cancelRequestedAt: true, leaseExpiresAt: true, status: true },
@@ -104,6 +133,113 @@ export const explainFenceRefusal = async (
   if (run.leaseExpiresAt === null || run.leaseExpiresAt <= fence.at) return "lease-expired";
   if (!(fence.statuses ?? activeRunStatuses).includes(run.status)) return "not-active";
   return "stale-fence";
+};
+
+export type LockedAuthorityRun = {
+  id: string;
+  runnerId: string | null;
+  fencingToken: string | null;
+  cancelRequestId: string | null;
+  cancelReason: string | null;
+  cancelRequestedAt: Date | null;
+  leaseExpiresAt: Date | null;
+  status: RunStatus;
+  taskId: string | null;
+  repoId: string | null;
+  runNumber: number;
+  pushedBranch: string | null;
+  branch: string | null;
+};
+
+/**
+ * Locks the Run mutex before reading any authority mode. Callers that also
+ * mutate Task state acquire that lock only after this function returns.
+ */
+export const lockAuthorityRun = async (
+  tx: Prisma.TransactionClient,
+  runId: string,
+): Promise<LockedAuthorityRun | null> => {
+  await tx.$queryRaw<Array<{ id: string }>>`
+    SELECT candidate."id" FROM "Run" AS candidate WHERE candidate."id" = ${runId} FOR UPDATE
+  `;
+  return tx.run.findFirst({
+    where: { id: runId },
+    select: {
+      id: true,
+      runnerId: true,
+      fencingToken: true,
+      cancelRequestId: true,
+      cancelReason: true,
+      cancelRequestedAt: true,
+      leaseExpiresAt: true,
+      status: true,
+      taskId: true,
+      repoId: true,
+      runNumber: true,
+      pushedBranch: true,
+      branch: true,
+    },
+  });
+};
+
+/** Live authority is the full six-clause lease fence. */
+export const liveAuthorityRefusal = (
+  run: LockedAuthorityRun | null,
+  fence: RunFence,
+): LeaseFenceRefusal | null => {
+  if (!run) return "unknown-run";
+  if (fence.runnerId !== undefined && run.runnerId !== fence.runnerId) return "wrong-runner";
+  if (run.fencingToken !== fence.fencingToken) return "stale-fence";
+  if (run.cancelRequestedAt !== null) return "cancel-requested";
+  if (run.leaseExpiresAt === null || run.leaseExpiresAt <= fence.at) return "lease-expired";
+  if (!(fence.statuses ?? activeRunStatuses).includes(run.status)) return "not-active";
+  return null;
+};
+
+export type SalvageAuthority = {
+  runnerId: string;
+  fencingToken: string;
+  pushedBranch: string;
+};
+
+/**
+ * Salvage authority is deliberately narrower than live authority: it admits
+ * only the recorded owner publishing this Run's deterministic per-run ref.
+ */
+export const salvageAuthorityRefusal = (
+  run: LockedAuthorityRun | null,
+  authority: SalvageAuthority,
+): LeaseFenceRefusal | null => {
+  if (!run) return "unknown-run";
+  if (run.runnerId !== authority.runnerId) return "wrong-runner";
+  if (run.fencingToken !== authority.fencingToken) return "stale-fence";
+  const expectedBranch = run.taskId ? `agentos/${run.taskId}/run-${run.runNumber}` : null;
+  if (
+    run.repoId === null
+    || authority.pushedBranch !== expectedBranch
+    || run.pushedBranch !== null && run.pushedBranch !== authority.pushedBranch
+  ) return "not-active";
+  return null;
+};
+
+export type CleanupAuthority = {
+  runnerId: string;
+  fencingToken: string;
+  at: Date;
+};
+
+/** Cleanup authority admits only the recorded owner after lease loss or terminalization. */
+export const cleanupAuthorityRefusal = (
+  run: LockedAuthorityRun | null,
+  authority: CleanupAuthority,
+): FenceRefusal | null => {
+  if (
+    !run
+    || run.runnerId !== authority.runnerId
+    || run.fencingToken !== authority.fencingToken
+    || run.leaseExpiresAt !== null && run.leaseExpiresAt > authority.at && activeRunStatuses.includes(run.status)
+  ) return "cleanup-not-authorized";
+  return null;
 };
 
 /**

--- a/packages/api/src/run-fence.ts
+++ b/packages/api/src/run-fence.ts
@@ -243,6 +243,27 @@ export const cleanupAuthorityRefusal = (
 };
 
 /**
+ * Runs one write-authorizing read behind the complete fence while holding only
+ * the Run mutex. Callers use this when every mutation is owned by the Run and
+ * its Session, so taking the Task mutex would add a lock-order dependency that
+ * the transition does not need.
+ */
+export const withRunOnlyFencedRun = async <Select extends Prisma.RunSelect, Result>(
+  tx: Prisma.TransactionClient,
+  fence: RunFence,
+  select: Select,
+  body: (run: Prisma.RunGetPayload<{ select: Select }>) => Promise<Result> | Result,
+): Promise<Result | FenceRefusalResponse> => {
+  await lockRunRow(tx, fence.runId);
+  const run = await tx.run.findFirst({
+    where: fencedRunWhere(fence),
+    select,
+  });
+  if (!run) return fenceRefusalResponse(await explainFenceRefusal(tx, fence));
+  return body(run);
+};
+
+/**
  * Runs one write-authorizing read behind the complete fence.
  *
  * Run owns fencing and cancellation, while Task owns the lifecycle mutations

--- a/packages/api/src/run-lifecycle.test.ts
+++ b/packages/api/src/run-lifecycle.test.ts
@@ -108,19 +108,12 @@ test("start owns the transaction and preserves one Run and Session lifecycle tim
   const calls: string[] = [];
   const runWrites: Array<Record<string, unknown>> = [];
   const sessionWrites: Array<Record<string, unknown>> = [];
-  let fencedRead = 0;
   const tx = {
-    $queryRaw: async (query: TemplateStringsArray) => {
-      calls.push(query.join("?").includes('FROM "Run"') ? "lock.run" : "lock.task");
-      return query.join("?").includes('FROM "Run"')
-        ? [{ id: "run-1" }]
-        : [{ id: "task-1", archivedAt: null }];
-    },
+    $queryRaw: async () => { calls.push("lock.run"); return [{ id: "run-1" }]; },
     run: {
       findFirst: async () => {
         calls.push("read.run");
-        fencedRead += 1;
-        return fencedRead === 1 ? { taskId: "task-1" } : { startedAt: null };
+        return { startedAt: null };
       },
       updateMany: async ({ data }: { data: Record<string, unknown> }) => {
         calls.push("write.run");
@@ -156,8 +149,6 @@ test("start owns the transaction and preserves one Run and Session lifecycle tim
     "transaction",
     "lock.run",
     "read.run",
-    "lock.task",
-    "read.run",
     "write.run",
     "write.session",
   ]);
@@ -167,16 +158,10 @@ test("start preserves a resumed lifecycle anchor and admits the mechanical null 
   const originalStartedAt = new Date("2026-08-29T10:00:00.000Z");
   const runWrites: Array<Record<string, unknown>> = [];
   const sessionWrites: Array<Record<string, unknown>> = [];
-  let fencedRead = 0;
   const tx = {
-    $queryRaw: async (query: TemplateStringsArray) => query.join("?").includes('FROM "Run"')
-      ? [{ id: "run-1" }]
-      : [{ id: "task-1", archivedAt: null }],
+    $queryRaw: async () => [{ id: "run-1" }],
     run: {
-      findFirst: async () => {
-        fencedRead += 1;
-        return fencedRead === 1 ? { taskId: "task-1" } : { startedAt: originalStartedAt };
-      },
+      findFirst: async () => ({ startedAt: originalStartedAt }),
       updateMany: async ({ data }: { data: Record<string, unknown> }) => {
         runWrites.push(data);
         return { count: 1 };

--- a/packages/api/src/run-lifecycle.test.ts
+++ b/packages/api/src/run-lifecycle.test.ts
@@ -1,0 +1,354 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { type PrismaClient, RunStatus } from "@anneal/db";
+
+import {
+  appendRunActivity,
+  appendRunEvents,
+  eventsInput,
+  heartbeatInput,
+  heartbeatRun,
+  publishRun,
+  recordRunCleanup,
+  startRun,
+} from "./run-lifecycle.js";
+import type { LockedAuthorityRun } from "./run-fence.js";
+
+const now = new Date("2026-08-30T12:00:00.000Z");
+
+const databaseFor = (tx: Record<string, unknown>, calls: string[] = []): PrismaClient => ({
+  $transaction: async (operation: (client: unknown) => Promise<unknown>) => {
+    calls.push("transaction");
+    return operation(tx);
+  },
+} as unknown as PrismaClient);
+
+const authorityRun = (overrides: Partial<LockedAuthorityRun> = {}): LockedAuthorityRun => ({
+  id: "run-1",
+  runnerId: "runner-1",
+  fencingToken: "fence-1",
+  cancelRequestId: null,
+  cancelReason: null,
+  cancelRequestedAt: null,
+  leaseExpiresAt: new Date(now.getTime() + 60_000),
+  status: RunStatus.RUNNING,
+  taskId: "task-1",
+  repoId: "repo-1",
+  runNumber: 1,
+  pushedBranch: null,
+  branch: "feature/task-1",
+  ...overrides,
+});
+
+test("start owns the transaction and preserves one Run and Session lifecycle timestamp", async () => {
+  const calls: string[] = [];
+  const runWrites: Array<Record<string, unknown>> = [];
+  const sessionWrites: Array<Record<string, unknown>> = [];
+  let fencedRead = 0;
+  const tx = {
+    $queryRaw: async (query: TemplateStringsArray) => {
+      calls.push(query.join("?").includes('FROM "Run"') ? "lock.run" : "lock.task");
+      return query.join("?").includes('FROM "Run"')
+        ? [{ id: "run-1" }]
+        : [{ id: "task-1", archivedAt: null }];
+    },
+    run: {
+      findFirst: async () => {
+        calls.push("read.run");
+        fencedRead += 1;
+        return fencedRead === 1 ? { taskId: "task-1" } : { startedAt: null };
+      },
+      updateMany: async ({ data }: { data: Record<string, unknown> }) => {
+        calls.push("write.run");
+        runWrites.push(data);
+        return { count: 1 };
+      },
+    },
+    session: { updateMany: async ({ data }: { data: Record<string, unknown> }) => {
+      calls.push("write.session");
+      sessionWrites.push(data);
+      return { count: 1 };
+    } },
+  };
+
+  const result = await startRun(databaseFor(tx, calls), {
+    runId: "run-1",
+    now,
+    body: {
+      runnerId: "runner-1",
+      fencingToken: "fence-1",
+      adapterVersion: "adapter-1",
+      cliVersion: "cli-1",
+      manifest: {},
+      workspacePath: "/scratch/run-1",
+      promptHash: "a".repeat(64),
+    },
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(runWrites[0]?.startedAt, now);
+  assert.equal(sessionWrites[0]?.startedAt, now);
+  assert.deepEqual(calls, [
+    "transaction",
+    "lock.run",
+    "read.run",
+    "lock.task",
+    "read.run",
+    "write.run",
+    "write.session",
+  ]);
+});
+
+test("start preserves a resumed lifecycle anchor and admits the mechanical null prompt", async () => {
+  const originalStartedAt = new Date("2026-08-29T10:00:00.000Z");
+  const runWrites: Array<Record<string, unknown>> = [];
+  const sessionWrites: Array<Record<string, unknown>> = [];
+  let fencedRead = 0;
+  const tx = {
+    $queryRaw: async (query: TemplateStringsArray) => query.join("?").includes('FROM "Run"')
+      ? [{ id: "run-1" }]
+      : [{ id: "task-1", archivedAt: null }],
+    run: {
+      findFirst: async () => {
+        fencedRead += 1;
+        return fencedRead === 1 ? { taskId: "task-1" } : { startedAt: originalStartedAt };
+      },
+      updateMany: async ({ data }: { data: Record<string, unknown> }) => {
+        runWrites.push(data);
+        return { count: 1 };
+      },
+    },
+    session: { updateMany: async ({ data }: { data: Record<string, unknown> }) => {
+      sessionWrites.push(data);
+      return { count: 1 };
+    } },
+  };
+
+  const result = await startRun(databaseFor(tx), {
+    runId: "run-1",
+    now,
+    body: {
+      runnerId: "merge-executor-1",
+      fencingToken: "fence-1",
+      adapterVersion: "executor-1",
+      cliVersion: "executor-1",
+      manifest: { executionMode: "mechanical" },
+      workspacePath: null,
+      promptHash: null,
+    },
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(runWrites[0]?.startedAt, originalStartedAt);
+  assert.equal(sessionWrites[0]?.startedAt, originalStartedAt);
+  assert.equal(runWrites[0]?.promptHash, null);
+});
+
+test("heartbeat observes the runner before refusing stale and WAITING_INBOX Runs", async () => {
+  const body = heartbeatInput.parse({
+    runnerId: "runner-1",
+    fencingToken: "stale-fence",
+    leaseSeconds: 60,
+    processAlive: true,
+  });
+  const calls: string[] = [];
+  const makeDb = (run: LockedAuthorityRun) => databaseFor({
+    $queryRaw: async () => { calls.push("lock.run"); return [{ id: "run-1" }]; },
+    run: { findFirst: async () => run },
+  }, calls);
+  const noteRunner = () => { calls.push("note.runner"); };
+
+  const stale = await heartbeatRun(makeDb(authorityRun()), { runId: "run-1", body, noteRunner, now });
+  assert.deepEqual(stale, {
+    reason: "conflict",
+    message: "Stale fencing token",
+    detail: { reason: "stale-fence" },
+  });
+  assert.equal(calls[0], "note.runner");
+
+  calls.length = 0;
+  const waiting = await heartbeatRun(makeDb(authorityRun({
+    status: RunStatus.WAITING_INBOX,
+    leaseExpiresAt: null,
+  })), { runId: "run-1", body: { ...body, fencingToken: "fence-1" }, noteRunner, now });
+  assert.deepEqual(waiting, {
+    reason: "conflict",
+    message: "Run suspended for Inbox",
+    detail: { code: "WAITING_INBOX" },
+  });
+});
+
+test("heartbeat writes through live authority and returns cancellation through the same interface", async () => {
+  const writes: Array<Record<string, unknown>> = [];
+  const makeDb = (run: LockedAuthorityRun) => databaseFor({
+    $queryRaw: async () => [{ id: "run-1" }],
+    run: {
+      findFirst: async () => run,
+      updateMany: async ({ data }: { data: Record<string, unknown> }) => {
+        writes.push(data);
+        return { count: 1 };
+      },
+    },
+  });
+  const body = heartbeatInput.parse({
+    runnerId: "runner-1",
+    fencingToken: "fence-1",
+    leaseSeconds: 60,
+    processAlive: true,
+  });
+  const live = await heartbeatRun(makeDb(authorityRun()), {
+    runId: "run-1", body, noteRunner: () => {}, now,
+  });
+  assert.deepEqual(live, { ok: true, cancellation: null, mechanicalCancellationPolicy: "refused" });
+  assert.equal(writes[0]?.heartbeatAt, now);
+
+  const requestedAt = new Date(now.getTime() - 1_000);
+  const cancellation = await heartbeatRun(makeDb(authorityRun({
+    cancelRequestId: "cancel-1",
+    cancelReason: "stop",
+    cancelRequestedAt: requestedAt,
+  })), { runId: "run-1", body, noteRunner: () => {}, now });
+  assert.deepEqual(cancellation, {
+    ok: false,
+    mechanicalCancellationPolicy: "refused",
+    cancellation: { requestId: "cancel-1", reason: "stop", requestedAt },
+  });
+});
+
+test("publication admits deterministic salvage after lease loss and keeps Run before Task lock order", async () => {
+  const calls: string[] = [];
+  const run = authorityRun({
+    leaseExpiresAt: new Date(now.getTime() - 1_000),
+    status: RunStatus.LOST,
+  });
+  const tx = {
+    $queryRaw: async (query: TemplateStringsArray) => {
+      const target = query.join("?").includes('FROM "Run"') ? "run" : "task";
+      calls.push(`lock.${target}`);
+      return [{ id: `${target}-1`, archivedAt: null }];
+    },
+    run: {
+      findFirst: async ({ select }: { select: Record<string, unknown> }) => {
+        if (select.runnerId) { calls.push("read.run"); return run; }
+        calls.push("read.replacement");
+        return null;
+      },
+      updateMany: async () => { calls.push("write.run"); return { count: 1 }; },
+    },
+    task: {
+      findUnique: async () => { calls.push("read.task-identity"); return { projectId: "project-1", chainId: null }; },
+      findUniqueOrThrow: async () => { calls.push("read.task"); return { id: "task-1" }; },
+    },
+  };
+
+  const result = await publishRun(databaseFor(tx, calls), {
+    runId: "run-1",
+    now,
+    body: {
+      runnerId: "runner-1",
+      fencingToken: "fence-1",
+      pushedBranch: "agentos/task-1/run-1",
+    },
+  });
+
+  assert.deepEqual(result, { ok: true, replacementRepair: "none" });
+  assert.ok(calls.indexOf("lock.run") < calls.indexOf("lock.task"));
+});
+
+test("cleanup admits only the owning fence after live authority has ended", async () => {
+  const writes: string[] = [];
+  const makeDb = (run: LockedAuthorityRun) => databaseFor({
+    $queryRaw: async () => [{ id: "run-1" }],
+    run: {
+      findFirst: async () => run,
+      update: async () => { writes.push("run"); return {}; },
+    },
+    session: { updateMany: async () => { writes.push("session"); return { count: 1 }; } },
+  });
+  const body = {
+    runnerId: "runner-1",
+    fencingToken: "fence-1",
+    cleanupStatus: "FAILED" as const,
+    cleanupFailureReason: "retained",
+    workspaceRetained: true,
+  };
+
+  const refused = await recordRunCleanup(makeDb(authorityRun()), { runId: "run-1", body, now });
+  assert.deepEqual(refused, {
+    reason: "conflict",
+    message: "Cleanup outcome is not authorized for a live or foreign run",
+  });
+  assert.deepEqual(writes, []);
+
+  const accepted = await recordRunCleanup(makeDb(authorityRun({ status: RunStatus.LOST })), {
+    runId: "run-1", body, now,
+  });
+  assert.deepEqual(accepted, { ok: true });
+  assert.deepEqual(writes, ["run", "session"]);
+});
+
+test("events normalize and persist through the lifecycle interface", async () => {
+  const stored: Array<Record<string, unknown>> = [];
+  let fencedRead = 0;
+  const tx = {
+    $queryRaw: async (query: TemplateStringsArray) => query.join("?").includes('FROM "Run"')
+      ? [{ id: "run-1" }]
+      : [{ id: "task-1", archivedAt: null }],
+    run: { findFirst: async () => {
+      fencedRead += 1;
+      return fencedRead === 1
+        ? { taskId: "task-1" }
+        : { session: { id: "session-1", providerConversationId: null } };
+    } },
+    sessionEvent: { createMany: async ({ data }: { data: Array<Record<string, unknown>> }) => {
+      stored.push(...data);
+      return { count: data.length };
+    } },
+    session: { update: async () => ({}) },
+  };
+  const body = eventsInput.parse({
+    runnerId: "runner-1",
+    fencingToken: "fence-1",
+    events: [{ seq: 1, source: "CLAUDE", type: "NUL\u0000EVENT", payload: { text: "a\u0000b" } }],
+  });
+
+  const result = await appendRunEvents(databaseFor(tx), { runId: "run-1", body, now });
+  assert.deepEqual(result, { accepted: 1 });
+  assert.equal(stored[0]?.type, "NUL\\u0000EVENT");
+  assert.deepEqual(stored[0]?.payload, { text: "a\\u0000b" });
+});
+
+test("activity persists the authenticated principal through the lifecycle interface", async () => {
+  let fencedRead = 0;
+  const writes: Array<Record<string, unknown>> = [];
+  const tx = {
+    $queryRaw: async (query: TemplateStringsArray) => query.join("?").includes('FROM "Run"')
+      ? [{ id: "run-1" }]
+      : [{ id: "task-1", archivedAt: null }],
+    run: { findFirst: async () => {
+      fencedRead += 1;
+      return fencedRead === 1
+        ? { taskId: "task-1" }
+        : { taskId: "task-1", leaseGeneration: 1, task: { templateStep: null } };
+    } },
+    taskActivity: { create: async ({ data }: { data: Record<string, unknown> }) => {
+      writes.push(data);
+      return { id: "activity-1", ...data };
+    } },
+  };
+
+  const result = await appendRunActivity(databaseFor(tx), {
+    runId: "run-1",
+    now,
+    principal: { kind: "session", runId: "run-1", leaseGeneration: 1 },
+    body: { actorType: "operator", fencingToken: "fence-1", body: "progress" },
+  });
+  assert.equal("message" in result, false);
+  assert.deepEqual(writes[0], {
+    taskId: "task-1",
+    actorType: "session",
+    actorId: null,
+    body: "progress",
+  });
+});

--- a/packages/api/src/run-lifecycle.test.ts
+++ b/packages/api/src/run-lifecycle.test.ts
@@ -41,6 +41,69 @@ const authorityRun = (overrides: Partial<LockedAuthorityRun> = {}): LockedAuthor
   ...overrides,
 });
 
+const finalOutputPayload = {
+  type: "result",
+  total_cost_usd: 0.049117,
+  usage: { input_tokens: 4, output_tokens: 77, cache_read_input_tokens: 8_700, cache_creation_input_tokens: 120 },
+};
+
+const eventDatabase = (options: {
+  finalOutputRows?: Array<{ payload: unknown }>;
+  onUsageUpdate?: () => void;
+  stored?: Array<Record<string, unknown>>;
+  sessionWrites?: Array<Record<string, unknown>>;
+} = {}): PrismaClient => {
+  let fencedRead = 0;
+  const stored = options.stored ?? [];
+  const sessionWrites = options.sessionWrites ?? [];
+  const tx = {
+    $queryRaw: async (query: TemplateStringsArray) => query.join("?").includes('FROM "Run"')
+      ? [{ id: "run-1" }]
+      : [{ id: "task-1", archivedAt: null }],
+    $executeRawUnsafe: async () => 0,
+    run: { findFirst: async () => {
+      fencedRead += 1;
+      return fencedRead === 1
+        ? { taskId: "task-1" }
+        : { session: { id: "session-1", providerConversationId: null } };
+    } },
+    sessionEvent: {
+      createMany: async ({ data }: { data: Array<Record<string, unknown>> }) => {
+        stored.push(...data);
+        return { count: data.length };
+      },
+      findMany: async () => options.finalOutputRows ?? [],
+    },
+    session: {
+      findUnique: async () => ({
+        inputTokens: null,
+        outputTokens: null,
+        cachedInputTokens: null,
+        totalTokens: null,
+        costUsd: null,
+      }),
+      update: async (args: Record<string, unknown>) => {
+        const data = args.data as Record<string, unknown>;
+        if ("inputTokens" in data) options.onUsageUpdate?.();
+        sessionWrites.push(args);
+        return {};
+      },
+    },
+  };
+  return databaseFor(tx);
+};
+
+const eventBody = (types: string[]) => eventsInput.parse({
+  runnerId: "runner-1",
+  fencingToken: "fence-1",
+  events: types.map((type, index) => ({
+    seq: index + 1,
+    source: "CLAUDE",
+    type,
+    payload: type === "FINAL_OUTPUT" ? finalOutputPayload : { text: "hello" },
+  })),
+});
+
 test("start owns the transaction and preserves one Run and Session lifecycle timestamp", async () => {
   const calls: string[] = [];
   const runWrites: Array<Record<string, unknown>> = [];
@@ -288,35 +351,168 @@ test("cleanup admits only the owning fence after live authority has ended", asyn
   assert.deepEqual(writes, ["run", "session"]);
 });
 
-test("events normalize and persist through the lifecycle interface", async () => {
+test("events normalize and persist through the lifecycle interface without changing seq order", async () => {
+  const nul = "\u0000";
+  const visibleNul = "\\u0000";
   const stored: Array<Record<string, unknown>> = [];
-  let fencedRead = 0;
-  const tx = {
-    $queryRaw: async (query: TemplateStringsArray) => query.join("?").includes('FROM "Run"')
-      ? [{ id: "run-1" }]
-      : [{ id: "task-1", archivedAt: null }],
-    run: { findFirst: async () => {
-      fencedRead += 1;
-      return fencedRead === 1
-        ? { taskId: "task-1" }
-        : { session: { id: "session-1", providerConversationId: null } };
-    } },
-    sessionEvent: { createMany: async ({ data }: { data: Array<Record<string, unknown>> }) => {
-      stored.push(...data);
-      return { count: data.length };
-    } },
-    session: { update: async () => ({}) },
-  };
   const body = eventsInput.parse({
     runnerId: "runner-1",
     fencingToken: "fence-1",
-    events: [{ seq: 1, source: "CLAUDE", type: "NUL\u0000EVENT", payload: { text: "a\u0000b" } }],
+    events: [
+      {
+        seq: 4,
+        source: "CLAUDE",
+        type: `EVENT${nul}TYPE`,
+        providerEventId: `provider${nul}id`,
+        toolCallId: `tool${nul}id`,
+        payload: {
+          unchanged: "plain text",
+          nested: { message: `left${nul}right`, list: [`a${nul}b`, { deep: "value" }] },
+          [`field${visibleNul}`]: "literal key value",
+          [`field${nul}`]: "NUL key value",
+          [`key${nul}`]: "key value",
+        },
+      },
+      { seq: 9, source: "CLAUDE", type: "VALID", payload: { unchanged: "still exact" } },
+    ],
   });
 
-  const result = await appendRunEvents(databaseFor(tx), { runId: "run-1", body, now });
+  const result = await appendRunEvents(eventDatabase({ stored }), { runId: "run-1", body, now });
+  assert.deepEqual(result, { accepted: 2 });
+  assert.deepEqual(stored.map((event) => event.seq), [4, 9]);
+  assert.equal(stored[0]?.type, `EVENT${visibleNul}TYPE`);
+  assert.equal(stored[0]?.providerEventId, `provider${visibleNul}id`);
+  assert.equal(stored[0]?.toolCallId, `tool${visibleNul}id`);
+  assert.deepEqual(stored[0]?.payload, {
+    unchanged: "plain text",
+    nested: { message: `left${visibleNul}right`, list: [`a${visibleNul}b`, { deep: "value" }] },
+    [`field${visibleNul}`]: "literal key value",
+    [`field${visibleNul}${visibleNul}`]: "NUL key value",
+    [`key${visibleNul}`]: "key value",
+  });
+  assert.deepEqual(stored[1]?.payload, { unchanged: "still exact" });
+});
+
+test("FINAL_OUTPUT recomputes derived usage through the lifecycle interface", async () => {
+  const sessionWrites: Array<Record<string, unknown>> = [];
+  const result = await appendRunEvents(eventDatabase({
+    finalOutputRows: [{ payload: finalOutputPayload }],
+    sessionWrites,
+  }), { runId: "run-1", body: eventBody(["MODEL_COMPLETED", "FINAL_OUTPUT"]), now });
+
+  assert.deepEqual(result, { accepted: 2 });
+  assert.equal(sessionWrites.length, 1);
+  const write = sessionWrites[0] as { where: { id: string }; data: Record<string, unknown> };
+  assert.equal(write.where.id, "session-1");
+  assert.equal(write.data.inputTokens, 8_824);
+  assert.equal(write.data.outputTokens, 77);
+  assert.equal(write.data.cachedInputTokens, 8_820);
+  assert.equal(write.data.totalTokens, 8_901);
+  assert.equal(String(write.data.costUsd), "0.0491");
+});
+
+test("events without FINAL_OUTPUT do not touch derived usage", async () => {
+  const sessionWrites: Array<Record<string, unknown>> = [];
+  const result = await appendRunEvents(eventDatabase({
+    finalOutputRows: [{ payload: finalOutputPayload }],
+    sessionWrites,
+  }), { runId: "run-1", body: eventBody(["MODEL_COMPLETED", "TOOL_STARTED"]), now });
+
+  assert.deepEqual(result, { accepted: 2 });
+  assert.deepEqual(sessionWrites, []);
+});
+
+test("an observed native child is persisted independently of the launch grant", async () => {
+  const sessionWrites: Array<Record<string, unknown>> = [];
+  const result = await appendRunEvents(eventDatabase({ sessionWrites }), {
+    runId: "run-1",
+    body: eventBody(["NATIVE_CHILD_STARTED"]),
+    now,
+  });
+
   assert.deepEqual(result, { accepted: 1 });
-  assert.equal(stored[0]?.type, "NUL\\u0000EVENT");
-  assert.deepEqual(stored[0]?.payload, { text: "a\\u0000b" });
+  assert.deepEqual(sessionWrites, [{
+    where: { id: "session-1" },
+    data: { nativeChildUsed: true },
+  }]);
+});
+
+test("a failing derived usage write does not fail event ingestion", async () => {
+  const errors: unknown[] = [];
+  const consoleError = console.error;
+  console.error = (...args: unknown[]) => { errors.push(args); };
+  try {
+    const result = await appendRunEvents(eventDatabase({
+      finalOutputRows: [{ payload: finalOutputPayload }],
+      onUsageUpdate: () => { throw new Error("value out of range for type integer"); },
+    }), { runId: "run-1", body: eventBody(["FINAL_OUTPUT"]), now });
+    assert.deepEqual(result, { accepted: 1 });
+  } finally {
+    console.error = consoleError;
+  }
+  assert.equal(errors.length, 1);
+});
+
+test("events decide WAITING_INBOX refusal before the locked transaction releases", async () => {
+  let transactionOpen = false;
+  let signalWaitingRead: (() => void) | undefined;
+  let continueWaitingRead: (() => void) | undefined;
+  const waitingReadStarted = new Promise<void>((resolve) => { signalWaitingRead = resolve; });
+  const waitingReadAllowed = new Promise<void>((resolve) => { continueWaitingRead = resolve; });
+  const calls: string[] = [];
+  let findFirstCalls = 0;
+  const tx = {
+    $queryRaw: async () => { calls.push("lock.run"); return [{ id: "run-1" }]; },
+    run: {
+      findFirst: async ({ where }: { where: Record<string, unknown> }) => {
+        findFirstCalls += 1;
+        if (findFirstCalls === 1) return null;
+        assert.deepEqual(where, { id: "run-1", status: RunStatus.WAITING_INBOX });
+        calls.push("read.waiting");
+        signalWaitingRead?.();
+        await waitingReadAllowed;
+        assert.equal(transactionOpen, true);
+        return { id: "run-1" };
+      },
+      findUnique: async () => ({
+        runnerId: "runner-1",
+        fencingToken: "fence-1",
+        cancelRequestedAt: null,
+        leaseExpiresAt: null,
+        status: RunStatus.WAITING_INBOX,
+      }),
+    },
+  };
+  const database = {
+    $transaction: async (operation: (client: unknown) => Promise<unknown>) => {
+      transactionOpen = true;
+      try {
+        return await operation(tx);
+      } finally {
+        calls.push("transaction.release");
+        transactionOpen = false;
+      }
+    },
+    run: { findFirst: async () => { calls.push("outside.read"); return null; } },
+  } as unknown as PrismaClient;
+
+  const pending = appendRunEvents(database, {
+    runId: "run-1",
+    body: eventBody(["MODEL_COMPLETED"]),
+    now,
+  });
+  await waitingReadStarted;
+  assert.equal(transactionOpen, true);
+  assert.equal(calls.includes("transaction.release"), false);
+  continueWaitingRead?.();
+
+  assert.deepEqual(await pending, {
+    reason: "conflict",
+    message: "Run suspended for Inbox",
+    detail: { code: "WAITING_INBOX" },
+  });
+  assert.ok(calls.indexOf("read.waiting") < calls.indexOf("transaction.release"));
+  assert.equal(calls.includes("outside.read"), false);
 });
 
 test("activity persists the authenticated principal through the lifecycle interface", async () => {

--- a/packages/api/src/run-lifecycle.ts
+++ b/packages/api/src/run-lifecycle.ts
@@ -310,46 +310,48 @@ export const appendRunEvents = async (
     fencingToken: input.body.fencingToken,
     at: now,
   };
-  const result = await db.$transaction((tx) => withFencedRun(tx, fence, {
-    session: { select: { id: true, providerConversationId: true } },
-  }, async (run) => {
-    if (!run.session) return fenceRefusalResponse("stale-fence");
-    await tx.sessionEvent.createMany({
-      data: input.body.events.map((event) => ({
-        sessionId: run.session!.id,
-        runId: input.runId,
-        seq: event.seq,
-        at: event.at ?? new Date(),
-        source: event.source,
-        type: normalizeSessionEventValue(event.type) as string,
-        providerEventId: event.providerEventId === undefined || event.providerEventId === null
-          ? null
-          : normalizeSessionEventValue(event.providerEventId) as string,
-        toolCallId: event.toolCallId === undefined || event.toolCallId === null
-          ? null
-          : normalizeSessionEventValue(event.toolCallId) as string,
-        payload: jsonValue(normalizeSessionEventValue(event.payload)),
-      })),
-      skipDuplicates: true,
-    });
-    if (input.body.events.some((event) => event.type === "NATIVE_CHILD_STARTED")) {
-      await tx.session.update({ where: { id: run.session.id }, data: { nativeChildUsed: true } });
-    }
-    if (input.body.providerConversationId && !run.session.providerConversationId) {
-      await tx.session.update({
-        where: { id: run.session.id },
-        data: { providerConversationId: input.body.providerConversationId },
+  const result = await db.$transaction(async (tx) => {
+    const appended = await withFencedRun(tx, fence, {
+      session: { select: { id: true, providerConversationId: true } },
+    }, async (run) => {
+      if (!run.session) return fenceRefusalResponse("stale-fence");
+      await tx.sessionEvent.createMany({
+        data: input.body.events.map((event) => ({
+          sessionId: run.session!.id,
+          runId: input.runId,
+          seq: event.seq,
+          at: event.at ?? new Date(),
+          source: event.source,
+          type: normalizeSessionEventValue(event.type) as string,
+          providerEventId: event.providerEventId === undefined || event.providerEventId === null
+            ? null
+            : normalizeSessionEventValue(event.providerEventId) as string,
+          toolCallId: event.toolCallId === undefined || event.toolCallId === null
+            ? null
+            : normalizeSessionEventValue(event.toolCallId) as string,
+          payload: jsonValue(normalizeSessionEventValue(event.payload)),
+        })),
+        skipDuplicates: true,
       });
-    }
-    return { sessionId: run.session.id };
-  }));
-  if (isFenceRefusalResponse(result)) {
-    const waiting = await db.run.findFirst({
+      if (input.body.events.some((event) => event.type === "NATIVE_CHILD_STARTED")) {
+        await tx.session.update({ where: { id: run.session.id }, data: { nativeChildUsed: true } });
+      }
+      if (input.body.providerConversationId && !run.session.providerConversationId) {
+        await tx.session.update({
+          where: { id: run.session.id },
+          data: { providerConversationId: input.body.providerConversationId },
+        });
+      }
+      return { sessionId: run.session.id };
+    });
+    if (!isFenceRefusalResponse(appended)) return appended;
+    const waiting = await tx.run.findFirst({
       where: { id: input.runId, status: RunStatus.WAITING_INBOX },
       select: { id: true },
     });
-    return waiting ? runFenceRefusal("waiting-inbox") : runFenceRefusal(result.reason);
-  }
+    return waiting ? runFenceRefusal("waiting-inbox") : runFenceRefusal(appended.reason);
+  });
+  if ("message" in result) return result;
 
   if (input.body.events.some((event) => event.type === "FINAL_OUTPUT")) {
     try {

--- a/packages/api/src/run-lifecycle.ts
+++ b/packages/api/src/run-lifecycle.ts
@@ -27,6 +27,7 @@ import {
   salvageAuthorityRefusal,
   type RunFence,
   withFencedRun,
+  withRunOnlyFencedRun,
 } from "./run-fence.js";
 import { repairReplacementAfterSalvage } from "./workspace-reclaim.js";
 
@@ -120,7 +121,7 @@ export const startRun = async (
     at: now,
     statuses: [RunStatus.CLAIMED, RunStatus.PROVISIONING],
   };
-  const result = await db.$transaction((tx) => withFencedRun(tx, fence, {
+  const result = await db.$transaction((tx) => withRunOnlyFencedRun(tx, fence, {
     startedAt: true,
   }, async (run) => {
     const startedAt = run.startedAt ?? now;

--- a/packages/api/src/run-lifecycle.ts
+++ b/packages/api/src/run-lifecycle.ts
@@ -1,0 +1,407 @@
+import {
+  CleanupStatus,
+  executionModeFor,
+  MERGE_INTEGRATOR_KIND,
+  Prisma,
+  type PrismaClient,
+  recomputeSessionUsage,
+  RunStatus,
+  SessionEventSource,
+  SessionExecutionStatus,
+} from "@anneal/db";
+import { z } from "zod";
+
+import type { Principal } from "./auth.js";
+import { jsonValue, normalizeSessionEventValue } from "./execution.js";
+import type { Refusal } from "./refusal.js";
+import { runnerTelemetryFields } from "./run-claim.js";
+import {
+  activeRunStatuses,
+  cleanupAuthorityRefusal,
+  fenceRefusalResponse,
+  fencedRunWhere,
+  isFenceRefusalResponse,
+  liveAuthorityRefusal,
+  lockAuthorityRun,
+  runFenceRefusal,
+  salvageAuthorityRefusal,
+  type RunFence,
+  withFencedRun,
+} from "./run-fence.js";
+import { repairReplacementAfterSalvage } from "./workspace-reclaim.js";
+
+const fence = z.string().min(1);
+
+export const activityInput = z.object({
+  actorType: z.string().trim().min(1).max(40).default("operator"),
+  actorId: z.string().trim().min(1).nullable().optional(),
+  body: z.string().min(1),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const fencedActivityInput = activityInput.extend({ fencingToken: fence });
+
+export const heartbeatInput = z.object({
+  runnerId: z.string().trim().min(1).max(120),
+  fencingToken: fence,
+  leaseSeconds: z.number().int().min(15).max(3600).default(60),
+  processAlive: z.boolean(),
+  lastProgressEventAt: z.coerce.date().nullable().optional(),
+  inFlightTool: z.record(z.string(), z.unknown()).nullable().optional(),
+  ...runnerTelemetryFields,
+});
+
+export const publicationInput = z.object({
+  runnerId: z.string().trim().min(1).max(120),
+  fencingToken: fence,
+  pushedBranch: z.string().trim().min(1).max(255),
+});
+
+export const leaseIndependentCleanupInput = z.object({
+  runnerId: z.string().trim().min(1).max(120),
+  fencingToken: fence,
+  cleanupStatus: z.nativeEnum(CleanupStatus),
+  cleanupFailureReason: z.string().max(4000).optional(),
+  workspaceRetained: z.boolean(),
+});
+
+export const mechanicalStartInput = z.object({
+  runnerId: z.string().trim().min(1).max(120),
+  fencingToken: fence,
+  adapterVersion: z.string().min(1),
+  cliVersion: z.string().min(1),
+  authMode: z.string().nullable().optional(),
+  manifest: z.record(z.string(), z.unknown()),
+  workspacePath: z.string().min(1).nullable(),
+  branch: z.string().nullable().optional(),
+  baseSha: z.string().nullable().optional(),
+  runtimeHandle: z.string().nullable().optional(),
+});
+
+export const startInput = mechanicalStartInput.extend({
+  promptHash: z.string().regex(/^[0-9a-f]{64}$/u),
+});
+
+const eventInput = z.object({
+  seq: z.number().int().nonnegative(),
+  at: z.coerce.date().optional(),
+  source: z.nativeEnum(SessionEventSource),
+  type: z.string().min(1).max(100),
+  providerEventId: z.string().nullable().optional(),
+  toolCallId: z.string().nullable().optional(),
+  payload: z.record(z.string(), z.unknown()),
+});
+
+export const eventsInput = z.object({
+  runnerId: z.string().trim().min(1).max(120),
+  fencingToken: fence,
+  providerConversationId: z.string().nullable().optional(),
+  events: z.array(eventInput).min(1).max(250),
+});
+
+export type StartRunBody = z.infer<typeof mechanicalStartInput> & { promptHash: string | null };
+export type HeartbeatRunBody = z.infer<typeof heartbeatInput>;
+export type PublicationBody = z.infer<typeof publicationInput>;
+export type CleanupBody = z.infer<typeof leaseIndependentCleanupInput>;
+export type EventsBody = z.infer<typeof eventsInput>;
+export type ActivityBody = z.infer<typeof fencedActivityInput>;
+
+const refused = (message: string): Refusal => ({ reason: "conflict", message });
+
+export const startRun = async (
+  db: PrismaClient,
+  input: { runId: string; body: StartRunBody; now?: Date },
+): Promise<{ ok: true } | Refusal> => {
+  const now = input.now ?? new Date();
+  const fence: RunFence = {
+    runId: input.runId,
+    runnerId: input.body.runnerId,
+    fencingToken: input.body.fencingToken,
+    at: now,
+    statuses: [RunStatus.CLAIMED, RunStatus.PROVISIONING],
+  };
+  const result = await db.$transaction((tx) => withFencedRun(tx, fence, {
+    startedAt: true,
+  }, async (run) => {
+    const startedAt = run.startedAt ?? now;
+    const updated = await tx.run.updateMany({
+      where: fencedRunWhere(fence),
+      data: {
+        status: RunStatus.RUNNING,
+        startedAt,
+        adapterVersion: input.body.adapterVersion,
+        cliVersion: input.body.cliVersion,
+        authMode: input.body.authMode ?? null,
+        promptHash: input.body.promptHash,
+        manifest: jsonValue(input.body.manifest),
+        workspacePath: input.body.workspacePath,
+        branch: input.body.branch ?? null,
+        baseSha: input.body.baseSha ?? null,
+      },
+    });
+    if (updated.count !== 1) throw new Error(`Run ${input.runId} changed while its start transition held the lock`);
+    const session = await tx.session.updateMany({
+      where: { runId: input.runId, executionStatus: SessionExecutionStatus.PROVISIONING },
+      data: {
+        executionStatus: SessionExecutionStatus.RUNNING,
+        runtimeHandle: input.body.runtimeHandle ?? null,
+        resumeInput: null,
+        provisionedAt: now,
+        startedAt,
+      },
+    });
+    if (session.count !== 1) throw new Error(`Run ${input.runId} has no startable Session`);
+    return { ok: true } as const;
+  }));
+  return isFenceRefusalResponse(result) ? runFenceRefusal(result.reason) : result;
+};
+
+type RunnerObservation = (runnerId: string, body: HeartbeatRunBody, now: Date) => void;
+
+export const heartbeatRun = async (
+  db: PrismaClient,
+  input: { runId: string; body: HeartbeatRunBody; noteRunner: RunnerObservation; now?: Date },
+): Promise<
+  | { ok: true; cancellation: null; mechanicalCancellationPolicy: "refused" }
+  | {
+    ok: false;
+    mechanicalCancellationPolicy: "refused";
+    cancellation: { requestId: string; reason: string; requestedAt: Date };
+  }
+  | Refusal
+> => {
+  const now = input.now ?? new Date();
+  input.noteRunner(input.body.runnerId, input.body, now);
+  return db.$transaction(async (tx) => {
+    const run = await lockAuthorityRun(tx, input.runId);
+    const fence: RunFence = {
+      runId: input.runId,
+      runnerId: input.body.runnerId,
+      fencingToken: input.body.fencingToken,
+      at: now,
+    };
+    const authorityRefusal = liveAuthorityRefusal(run, fence);
+    if (authorityRefusal === null) {
+      const updated = await tx.run.updateMany({
+        where: fencedRunWhere(fence),
+        data: {
+          heartbeatAt: now,
+          ...(input.body.processAlive ? {
+            lastProcessAliveAt: now,
+            leaseExpiresAt: new Date(now.getTime() + input.body.leaseSeconds * 1000),
+          } : {}),
+          ...(input.body.lastProgressEventAt !== undefined
+            ? { lastProgressEventAt: input.body.lastProgressEventAt }
+            : {}),
+          ...(input.body.inFlightTool !== undefined
+            ? { inFlightTool: input.body.inFlightTool ? jsonValue(input.body.inFlightTool) : Prisma.JsonNull }
+            : {}),
+        },
+      });
+      if (updated.count !== 1) throw new Error(`Run ${input.runId} changed while its heartbeat transition held the lock`);
+      return { ok: true, cancellation: null, mechanicalCancellationPolicy: "refused" } as const;
+    }
+    if (
+      run
+      && run.runnerId === input.body.runnerId
+      && run.fencingToken === input.body.fencingToken
+      && run.cancelRequestId
+      && run.cancelReason
+      && run.cancelRequestedAt
+      && activeRunStatuses.includes(run.status)
+    ) {
+      return {
+        ok: false,
+        mechanicalCancellationPolicy: "refused",
+        cancellation: {
+          requestId: run.cancelRequestId,
+          reason: run.cancelReason,
+          requestedAt: run.cancelRequestedAt,
+        },
+      } as const;
+    }
+    return run?.status === RunStatus.WAITING_INBOX
+      ? runFenceRefusal("waiting-inbox")
+      : runFenceRefusal(authorityRefusal);
+  });
+};
+
+export const publishRun = async (
+  db: PrismaClient,
+  input: { runId: string; body: PublicationBody; now?: Date },
+): Promise<{ ok: true; replacementRepair: "none" | "repaired" | "requeued" } | Refusal> => {
+  const now = input.now ?? new Date();
+  return db.$transaction(async (tx) => {
+    const run = await lockAuthorityRun(tx, input.runId);
+    const fence: RunFence = {
+      runId: input.runId,
+      runnerId: input.body.runnerId,
+      fencingToken: input.body.fencingToken,
+      at: now,
+    };
+    const liveRefusal = liveAuthorityRefusal(run, fence);
+    const salvageRefusal = salvageAuthorityRefusal(run, input.body);
+    if (liveRefusal !== null && salvageRefusal !== null) return runFenceRefusal(liveRefusal);
+    if (!run) return runFenceRefusal("unknown-run");
+
+    const updated = await tx.run.updateMany({
+      where: liveRefusal === null
+        ? fencedRunWhere(fence)
+        : {
+            id: input.runId,
+            runnerId: input.body.runnerId,
+            fencingToken: input.body.fencingToken,
+            OR: [{ pushedBranch: null }, { pushedBranch: input.body.pushedBranch }],
+          },
+      data: { pushedBranch: input.body.pushedBranch },
+    });
+    if (updated.count !== 1) throw new Error(`Run ${input.runId} changed while its publication transition held the lock`);
+
+    const repair = salvageRefusal === null && run.taskId
+      ? await repairReplacementAfterSalvage(tx, {
+          taskId: run.taskId,
+          runNumber: run.runNumber,
+          branch: run.branch,
+        })
+      : "none";
+    return repair === "already-started"
+      ? refused("Salvage is durable, but the replacement already started from its prior base")
+      : { ok: true, replacementRepair: repair };
+  });
+};
+
+export const recordRunCleanup = async (
+  db: PrismaClient,
+  input: { runId: string; body: CleanupBody; now?: Date },
+): Promise<{ ok: true } | Refusal> => {
+  const now = input.now ?? new Date();
+  return db.$transaction(async (tx) => {
+    const run = await lockAuthorityRun(tx, input.runId);
+    const authorityRefusal = cleanupAuthorityRefusal(run, {
+      runnerId: input.body.runnerId,
+      fencingToken: input.body.fencingToken,
+      at: now,
+    });
+    if (authorityRefusal !== null) return runFenceRefusal(authorityRefusal);
+    await tx.run.update({
+      where: { id: input.runId },
+      data: { workspaceRetained: input.body.workspaceRetained },
+    });
+    await tx.session.updateMany({
+      where: { runId: input.runId },
+      data: {
+        cleanupStatus: input.body.cleanupStatus,
+        cleanupEndedAt: now,
+        cleanupFailureReason: input.body.cleanupFailureReason ?? null,
+      },
+    });
+    return { ok: true };
+  });
+};
+
+export const appendRunEvents = async (
+  db: PrismaClient,
+  input: { runId: string; body: EventsBody; now?: Date },
+): Promise<{ accepted: number } | Refusal> => {
+  const now = input.now ?? new Date();
+  const fence: RunFence = {
+    runId: input.runId,
+    runnerId: input.body.runnerId,
+    fencingToken: input.body.fencingToken,
+    at: now,
+  };
+  const result = await db.$transaction((tx) => withFencedRun(tx, fence, {
+    session: { select: { id: true, providerConversationId: true } },
+  }, async (run) => {
+    if (!run.session) return fenceRefusalResponse("stale-fence");
+    await tx.sessionEvent.createMany({
+      data: input.body.events.map((event) => ({
+        sessionId: run.session!.id,
+        runId: input.runId,
+        seq: event.seq,
+        at: event.at ?? new Date(),
+        source: event.source,
+        type: normalizeSessionEventValue(event.type) as string,
+        providerEventId: event.providerEventId === undefined || event.providerEventId === null
+          ? null
+          : normalizeSessionEventValue(event.providerEventId) as string,
+        toolCallId: event.toolCallId === undefined || event.toolCallId === null
+          ? null
+          : normalizeSessionEventValue(event.toolCallId) as string,
+        payload: jsonValue(normalizeSessionEventValue(event.payload)),
+      })),
+      skipDuplicates: true,
+    });
+    if (input.body.events.some((event) => event.type === "NATIVE_CHILD_STARTED")) {
+      await tx.session.update({ where: { id: run.session.id }, data: { nativeChildUsed: true } });
+    }
+    if (input.body.providerConversationId && !run.session.providerConversationId) {
+      await tx.session.update({
+        where: { id: run.session.id },
+        data: { providerConversationId: input.body.providerConversationId },
+      });
+    }
+    return { sessionId: run.session.id };
+  }));
+  if (isFenceRefusalResponse(result)) {
+    const waiting = await db.run.findFirst({
+      where: { id: input.runId, status: RunStatus.WAITING_INBOX },
+      select: { id: true },
+    });
+    return waiting ? runFenceRefusal("waiting-inbox") : runFenceRefusal(result.reason);
+  }
+
+  if (input.body.events.some((event) => event.type === "FINAL_OUTPUT")) {
+    try {
+      await recomputeSessionUsage(db, result.sessionId);
+    } catch (error) {
+      console.error(`Session usage recompute failed for ${result.sessionId}`, error);
+    }
+  }
+  return { accepted: input.body.events.length };
+};
+
+export const appendRunActivity = async (
+  db: PrismaClient,
+  input: { runId: string; body: ActivityBody; principal: Principal; now?: Date },
+) => {
+  const fence: RunFence = {
+    runId: input.runId,
+    fencingToken: input.body.fencingToken,
+    at: input.now ?? new Date(),
+  };
+  const result = await db.$transaction((tx) => withFencedRun(tx, fence, {
+    taskId: true,
+    leaseGeneration: true,
+    task: { select: { templateStep: { select: {
+      stepIndex: true,
+      outputKind: true,
+      taskTemplate: { select: { name: true } },
+    } } } },
+  }, async (run) => {
+    const leaseGeneration = input.principal.kind === "session" ? input.principal.leaseGeneration : null;
+    if (!run.taskId || leaseGeneration !== null && run.leaseGeneration !== leaseGeneration) {
+      return fenceRefusalResponse("stale-fence");
+    }
+    const metadata = input.body.metadata
+      ? {
+          ...input.body.metadata,
+          ...(((input.body.metadata.kind === MERGE_INTEGRATOR_KIND.intent
+            || input.body.metadata.kind === MERGE_INTEGRATOR_KIND.result)
+            && executionModeFor(run.task?.templateStep ?? null) === "mechanical")
+            ? { sourceRunId: input.runId }
+            : {}),
+        }
+      : undefined;
+    return tx.taskActivity.create({
+      data: {
+        taskId: run.taskId,
+        actorType: input.principal.kind,
+        actorId: input.body.actorId ?? null,
+        body: input.body.body,
+        ...(metadata ? { metadata: jsonValue(metadata) } : {}),
+      },
+    });
+  }));
+  return isFenceRefusalResponse(result) ? runFenceRefusal(result.reason) : result;
+};


### PR DESCRIPTION
## What changed

- Added a deep Run lifecycle module whose interface owns start, heartbeat, publication, cleanup, events, and activity schemas and transitions.
- Deepened the run-fence module so live, salvage, and cleanup authority modes share one FenceRefusal vocabulary while retaining distinct predicates and deliberate lock order.
- Kept the appendRunEvents WAITING_INBOX versus LeaseFenceRefusal decision inside the transaction that holds the Run lock, with a controlled interleaving regression test.
- Added a Run-only fenced seam for startRun, preserving all six fence/refusal semantics without taking the Task lock that caused the replacement-start versus late-salvage 40P01 cycle.
- Moved observable appendRunEvents implementation tests to the Run lifecycle interface and kept app.test.ts focused on HTTP adapter behavior, including merge-executor omitted promptHash mapping to null.
- HTTP routes and response shapes are unchanged.

## Evidence

- Focused interface tests with a fresh `RUNNER_WORKSPACE_ROOT` — PASS: 102 tests, 0 failed.
- `npm run lint` — PASS, including after the docs-only append-only merge.
- `npm run typecheck` — PASS, including after the docs-only append-only merge.
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm test --workspace @anneal/api` — PASS: 701 tests, 700 passed, 1 existing opt-in skip, 0 failed.
- Real PostgreSQL concurrency dbtest `src/run-fence.dbtest.ts` — PASS: 9 tests, 0 failed; the forced replacement Run / Task / repair interleaving completed without deadlock and preserved the prior-base refusal outcome.
- Relevant targeted dbtests (`run-fence`, `active-run-cancellation`, `event-ingestion`, `workspace-reclaim`, `chain-branch`, `run-output`) — PASS: 98 tests, 0 failed.
- The first concurrency dbtest invocation stopped in `pretest:db` TypeScript compilation before any database test ran because the new fixture passed a nullable seeded agent id into required fields. The fixture was narrowed and the unchanged concurrency test then passed.
- An earlier targeted invocation during the prior review stopped in harness preflight before any test file ran because its isolated server did not yet contain the target scratch database; after creating that disposable database, the unchanged command passed.
- Verification used isolated temporary PostgreSQL containers with no volumes; each was stopped, removed, and read back as absent.

## Reported but unfixed

- `packages/api/src/run-completion.ts` still carries its own WAITING_INBOX refusal prose. That existing completion module is outside Lane E5 owned paths, so this PR centralizes the vocabulary for the six owned middle transitions without crossing the fence.
- No operator handbook drift was observed; route shapes are unchanged.