### PR TITLE
perf(db): let the retention interval be shortened for tests that spawn a service

### DIFF
--- a/packages/api/src/service-maintenance-lock.dbtest.ts
+++ b/packages/api/src/service-maintenance-lock.dbtest.ts
@@ -130,6 +130,11 @@ test("api shared maintenance lock real-process acceptance", {
     ...process.env,
     ...spawnedStartupEnvironment({ DATABASE_URL: source.url }),
     SCHEDULER_POLL_INTERVAL_MS: "0",
+    // Two of the cases below wait for a retention tick to fire. At the shipped
+    // ten seconds that wait is the entire cost of this file; the protocol being
+    // proved is what the check does, not how long the service sat between two
+    // of them.
+    SERVICE_LOCK_RETENTION_INTERVAL_MS: "250",
     RUNNER_WORKSPACE_ROOT: workspace,
     FILES_ROOT: files,
     CONTROL_PLANE_STATE_DIR: state,

--- a/packages/db/src/service-maintenance-lock.dbtest.ts
+++ b/packages/db/src/service-maintenance-lock.dbtest.ts
@@ -119,6 +119,10 @@ const spawnRunner = async (databaseUrl: string): Promise<{ child: ChildProcess; 
       RUNNER_API_URL: `http://127.0.0.1:${controlPlane.port}`,
       RUNNER_WORKSPACE_ROOT: workspace,
       RUNNER_POLL_INTERVAL_MS: "200",
+      // Same reason as the poll interval above: the cases that lose a backend
+      // wait for the next retention check, and ten real seconds of sleeping
+      // proves nothing the check itself does not.
+      SERVICE_LOCK_RETENTION_INTERVAL_MS: "250",
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/packages/db/src/service-maintenance-lock.test.ts
+++ b/packages/db/src/service-maintenance-lock.test.ts
@@ -14,8 +14,10 @@ import { describe, it } from "node:test";
 import type { HeldMaintenanceLock, MaintenanceLockAcquisition, MaintenanceLockRole } from "./maintenance-lock.js";
 import {
   holdSharedServiceMaintenanceLock,
+  resolveServiceLockRetentionIntervalMs,
   resolveServiceLockTarget,
   ServiceMaintenanceLockError,
+  SERVICE_LOCK_RETENTION_INTERVAL_ENV,
   SERVICE_LOCK_CONFIGURATION_EXIT_CODE,
   SERVICE_LOCK_CONTENTION_EXIT_CODE,
   SERVICE_LOCK_LOST_REASON,
@@ -124,6 +126,50 @@ describe("resolveServiceLockTarget", () => {
       ok: false,
       reason: "database-url-schema-unnamed",
     });
+  });
+});
+
+describe("resolveServiceLockRetentionIntervalMs", () => {
+  it("leaves the shipped interval alone when nothing is set", () => {
+    assert.equal(resolveServiceLockRetentionIntervalMs(undefined), SERVICE_LOCK_RETENTION_INTERVAL_MS);
+    // Unset and set-to-nothing are the same intent, and a shell that exports an
+    // empty value is the ordinary way to reach the second one.
+    assert.equal(resolveServiceLockRetentionIntervalMs(""), SERVICE_LOCK_RETENTION_INTERVAL_MS);
+  });
+
+  it("accepts a shorter interval, which is the only direction a test needs", () => {
+    assert.equal(resolveServiceLockRetentionIntervalMs("250"), 250);
+    assert.equal(
+      resolveServiceLockRetentionIntervalMs(String(SERVICE_LOCK_RETENTION_INTERVAL_MS)),
+      SERVICE_LOCK_RETENTION_INTERVAL_MS,
+    );
+  });
+
+  it("refuses a longer interval instead of clamping it", () => {
+    // Clamping would honour the variable's presence while ignoring its value,
+    // and the operator would never learn the window they asked for was denied.
+    assert.throws(
+      () => resolveServiceLockRetentionIntervalMs(String(SERVICE_LOCK_RETENTION_INTERVAL_MS + 1)),
+      /may only shorten the retention check/u,
+    );
+  });
+
+  it("refuses anything that is not a positive integer, rather than scheduling NaN", () => {
+    for (const raw of ["0", "-1", "1.5", "10s", "abc", " 250"]) {
+      assert.throws(
+        () => resolveServiceLockRetentionIntervalMs(raw),
+        /must be a positive integer of milliseconds/u,
+        `'${raw}' must be refused`,
+      );
+    }
+  });
+
+  it("names itself, so a refusal tells the operator which variable to fix", () => {
+    assert.equal(SERVICE_LOCK_RETENTION_INTERVAL_ENV, "SERVICE_LOCK_RETENTION_INTERVAL_MS");
+    assert.throws(
+      () => resolveServiceLockRetentionIntervalMs("nope"),
+      new RegExp(SERVICE_LOCK_RETENTION_INTERVAL_ENV, "u"),
+    );
   });
 });
 

--- a/packages/db/src/service-maintenance-lock.ts
+++ b/packages/db/src/service-maintenance-lock.ts
@@ -59,6 +59,44 @@ import {
 export const SERVICE_LOCK_RETENTION_INTERVAL_MS = 10_000;
 
 /**
+ * The one environment variable that moves the interval, and it may only move it
+ * *down*.
+ *
+ * Tests that prove this protocol have to start the shipped entrypoint — that is
+ * the whole point of them, a fixture holding its own shared lock would prove
+ * PostgreSQL's compatibility matrix instead of the service's participation — and
+ * a started process takes no options. Without an override those tests can only
+ * wait out a real ten-second tick, which is four intervals of pure sleep across
+ * the two suites and, measured on the gate, the two longest files in the
+ * database wave.
+ *
+ * Lengthening is refused rather than clamped. A shorter interval only makes a
+ * service more eager to discover it has lost the key; a longer one widens
+ * exactly the window this module exists to close, and an operator who set it by
+ * accident would get a quieter service that is wrong for longer. Refusing is
+ * also why this is parsed rather than `parseInt`-with-a-default: a typo that
+ * silently became `NaN` would schedule the check at an interval nobody chose.
+ */
+export const SERVICE_LOCK_RETENTION_INTERVAL_ENV = "SERVICE_LOCK_RETENTION_INTERVAL_MS";
+
+export const resolveServiceLockRetentionIntervalMs = (raw: string | undefined): number => {
+  if (raw === undefined || raw === "") return SERVICE_LOCK_RETENTION_INTERVAL_MS;
+  if (!/^[1-9][0-9]*$/u.test(raw)) {
+    throw new Error(
+      `${SERVICE_LOCK_RETENTION_INTERVAL_ENV} must be a positive integer of milliseconds, got '${raw}'`,
+    );
+  }
+  const requested = Number(raw);
+  if (requested > SERVICE_LOCK_RETENTION_INTERVAL_MS) {
+    throw new Error(
+      `${SERVICE_LOCK_RETENTION_INTERVAL_ENV} may only shorten the retention check: `
+        + `${requested} exceeds the ${SERVICE_LOCK_RETENTION_INTERVAL_MS}ms default`,
+    );
+  }
+  return requested;
+};
+
+/**
  * A reconnect can fail while PostgreSQL or the local network is recovering.
  * Retrying only the stable "connection unavailable" refusal gives that event
  * more than one chance without ever retrying past an observed lock conflict.
@@ -298,7 +336,8 @@ export const holdSharedServiceMaintenanceLock = async (
 
   state.cancel = (options.schedule ?? defaultSchedule)(
     () => { void verifyRetention(); },
-    options.retentionIntervalMs ?? SERVICE_LOCK_RETENTION_INTERVAL_MS,
+    options.retentionIntervalMs
+      ?? resolveServiceLockRetentionIntervalMs(process.env[SERVICE_LOCK_RETENTION_INTERVAL_ENV]),
   );
 
   return {


### PR DESCRIPTION
First of the two work-reduction changes for the merge gate. It removes sleeping, not checking: no case is dropped and no assertion is weakened.

## Why these two files could only sleep

`service-maintenance-lock.dbtest.ts` in `packages/api` and `packages/db` prove that a *shipped* entrypoint participates in the maintenance lock. They have to start the real process — a fixture that took its own shared lock would prove PostgreSQL's compatibility matrix, which `maintenance-lock.dbtest.ts` already proves — and a started process takes no options. The cases that terminate a lock backend and wait for the service to notice therefore waited out a real ten-second `SERVICE_LOCK_RETENTION_INTERVAL_MS` tick.

## Measured, against a scratch PostgreSQL on one machine

| file | 10s interval | 250ms interval |
| --- | --- | --- |
| `packages/api/.../service-maintenance-lock.dbtest` | 25.8s | **11.2s** |
| `packages/db/.../service-maintenance-lock.dbtest` | 23.3s | **5.6s** |
| total | 49.1s | **16.8s** |

32 core-seconds, and these were the two longest poles in the database wave, so it lands on the tail rather than in the middle of it. `node:test` only parallelises across files, so a file's own length is the wave's lower bound.

## The override only shortens

`SERVICE_LOCK_RETENTION_INTERVAL_MS` is validated, not `parseInt`-with-a-default:

- A **longer** interval is refused, not clamped. Shortening only makes a service more eager to discover it lost the key; lengthening widens exactly the window the module exists to close. Clamping would honour the variable's presence while ignoring its value, and the operator would never learn the window they asked for was denied.
- A **non-integer** is refused rather than scheduling `NaN`.
- Unset and empty are the same intent and both keep the shipped 10s.

Five unit cases pin those rules.

## Verification

- `packages/db` unit suite: 22 pass, 0 fail (17 before, 5 new).
- Both dbtest files against a scratch PostgreSQL: 6 pass and 5 pass, 0 fail, at both interval settings — the before/after numbers above come from those runs.
- `npm run lint` clean.

Merge gate to be dispatched against the final integrated head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fbhp8jZP5bLJcJja7dGsCQ