### PR TITLE
perf(api): run migration-fixture setup in process instead of spawning prisma

### DIFF
--- a/packages/api/src/chain-layer-migration-fixture.ts
+++ b/packages/api/src/chain-layer-migration-fixture.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from "node:url";
 
 import { PrismaClient } from "@anneal/db";
 
+import { splitSqlStatements } from "./sql-statements.js";
 import { testDatabaseUrl } from "./testdb.js";
 
 export const chainLayerExpandMigration = "20260823100000_chain_layer_expand";
@@ -27,10 +28,10 @@ export interface ChainLayerMigrationFixture {
   schema: string;
   url: string;
   quotedSchema: string;
-  execute(sql: string): void;
+  execute(sql: string): Promise<void>;
   applyExpandMigration(): void;
   applyContractMigration(): void;
-  cleanup(): void;
+  cleanup(): Promise<void>;
 }
 
 /**
@@ -40,7 +41,7 @@ export interface ChainLayerMigrationFixture {
  * only when the test is ready to exercise it. A unique schema derived from
  * the explicitly opted-in test URL keeps the fixture away from live data.
  */
-export const stageBeforeChainLayerExpand = (): ChainLayerMigrationFixture => {
+export const stageBeforeChainLayerExpand = async (): Promise<ChainLayerMigrationFixture> => {
   const base = new URL(testDatabaseUrl);
   const sourceSchema = base.searchParams.get("schema");
   if (!sourceSchema || sourceSchema === "public") throw new Error("chain-layer migration fixture refuses public schema");
@@ -48,15 +49,18 @@ export const stageBeforeChainLayerExpand = (): ChainLayerMigrationFixture => {
   base.searchParams.set("schema", schema);
   const url = base.toString();
   const quotedSchema = `"${schema.replaceAll('"', '""')}"`;
-  const execute = (sql: string): void => {
-    execFileSync("npx", ["prisma", "db", "execute", "--url", url, "--stdin"], {
-      cwd: dbDirectory,
-      input: sql,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+
+  // One connection for the fixture's lifetime rather than a `prisma db execute`
+  // per call. The spawned form accepts a multi-statement block, which is why it
+  // was used; it also costs about two seconds of npx and engine startup every
+  // time, and this fixture is called once per case across five files. The
+  // statements are cut here instead — see `splitSqlStatements`.
+  const client = new PrismaClient({ datasources: { db: { url } } });
+  const execute = async (sql: string): Promise<void> => {
+    for (const statement of splitSqlStatements(sql)) await client.$executeRawUnsafe(statement);
   };
 
-  execute(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE; CREATE SCHEMA ${quotedSchema};`);
+  await execute(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE; CREATE SCHEMA ${quotedSchema};`);
   const staging = mkdtempSync(join(tmpdir(), "chain-layer-expand-fixture."));
   cpSync(join(dbDirectory, "prisma"), join(staging, "prisma"), { recursive: true });
   for (const entry of readdirSync(join(staging, "prisma", "migrations"), { withFileTypes: true })) {
@@ -95,13 +99,15 @@ export const stageBeforeChainLayerExpand = (): ChainLayerMigrationFixture => {
       );
       deploy();
     },
-    cleanup: () => {
+    cleanup: async (): Promise<void> => {
       rmSync(staging, { recursive: true, force: true });
       try {
-        execute(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE;`);
+        await execute(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE;`);
       } catch {
         // A failed fixture must not leave its private schema behind if the
         // server has already terminated the connection.
+      } finally {
+        await client.$disconnect();
       }
     },
   };

--- a/packages/api/src/goal-execution-fixture.ts
+++ b/packages/api/src/goal-execution-fixture.ts
@@ -4,6 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { PrismaClient } from "@anneal/db";
+
+import { splitSqlStatements } from "./sql-statements.js";
 import { testDatabaseUrl } from "./testdb.js";
 
 /**
@@ -24,14 +27,14 @@ export interface PreKernelDatabase {
   url: string;
   schema: string;
   quoted: string;
-  /** Runs SQL against the staged schema. */
-  execute: (sql: string) => void;
+  /** Runs SQL against the staged schema, over the fixture's own connection. */
+  execute: (sql: string) => Promise<void>;
   /** Applies the kernel migration through the real `prisma migrate deploy`. */
   applyKernelMigration: () => void;
-  cleanup: () => void;
+  cleanup: () => Promise<void>;
 }
 
-export const stageAtPreviousMigration = (label: string): PreKernelDatabase => {
+export const stageAtPreviousMigration = async (label: string): Promise<PreKernelDatabase> => {
   const base = new URL(testDatabaseUrl);
   const schema = `${base.searchParams.get("schema") ?? "public"}_${label}`;
   if (schema.startsWith("public")) throw new Error("the pre-kernel fixture refuses to touch the public schema");
@@ -39,15 +42,16 @@ export const stageAtPreviousMigration = (label: string): PreKernelDatabase => {
   const url = base.toString();
   const quoted = `"${schema.replaceAll('"', '""')}"`;
 
-  const execute = (sql: string): void => {
-    execFileSync("npx", ["prisma", "db", "execute", "--url", url, "--stdin"], {
-      cwd: dbDirectory,
-      input: sql,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+  // One connection for the fixture's lifetime. `prisma db execute` accepts a
+  // multi-statement block, which is why it was used, but it also pays about two
+  // seconds of npx and engine startup per call and this fixture stages once per
+  // case. The block is cut here instead — see `splitSqlStatements`.
+  const client = new PrismaClient({ datasources: { db: { url } } });
+  const execute = async (sql: string): Promise<void> => {
+    for (const statement of splitSqlStatements(sql)) await client.$executeRawUnsafe(statement);
   };
 
-  execute(`DROP SCHEMA IF EXISTS ${quoted} CASCADE; CREATE SCHEMA ${quoted};`);
+  await execute(`DROP SCHEMA IF EXISTS ${quoted} CASCADE; CREATE SCHEMA ${quoted};`);
   const staging = mkdtempSync(join(tmpdir(), "goal5a0-fixture."));
   cpSync(join(dbDirectory, "prisma"), join(staging, "prisma"), { recursive: true });
   // This fixture is staged *before* the kernel. Remove the kernel and every
@@ -81,12 +85,14 @@ export const stageAtPreviousMigration = (label: string): PreKernelDatabase => {
       );
       deploy();
     },
-    cleanup: () => {
+    cleanup: async (): Promise<void> => {
       rmSync(staging, { recursive: true, force: true });
       try {
-        execute(`DROP SCHEMA IF EXISTS ${quoted} CASCADE;`);
+        await execute(`DROP SCHEMA IF EXISTS ${quoted} CASCADE;`);
       } catch {
         // A test schema that will not drop must not fail the suite.
+      } finally {
+        await client.$disconnect();
       }
     },
   };
@@ -122,16 +128,16 @@ export interface PreflightResult { code: number; stdout: string; stderr: string 
  * happen to share a database.
  */
 export const preflightHarness = (label: string): {
-  stage: (rows: string[]) => PreKernelDatabase;
+  stage: (rows: string[]) => Promise<PreKernelDatabase>;
   runPreflight: (environment?: Record<string, string | undefined>) => PreflightResult;
-  cleanup: () => void;
+  cleanup: () => Promise<void>;
 } => {
   let fixture: PreKernelDatabase | undefined;
   return {
-    stage: (rows: string[]): PreKernelDatabase => {
-      fixture?.cleanup();
-      fixture = stageAtPreviousMigration(label);
-      fixture.execute(preKernelSeed + rows.join("\n"));
+    stage: async (rows: string[]): Promise<PreKernelDatabase> => {
+      await fixture?.cleanup();
+      fixture = await stageAtPreviousMigration(label);
+      await fixture.execute(preKernelSeed + rows.join("\n"));
       return fixture;
     },
     runPreflight: (environment: Record<string, string | undefined> = {}): PreflightResult => {
@@ -158,7 +164,7 @@ export const preflightHarness = (label: string): {
         return { code: failure.status ?? -1, stdout: String(failure.stdout ?? ""), stderr: String(failure.stderr ?? "") };
       }
     },
-    cleanup: (): void => { fixture?.cleanup(); },
+    cleanup: async (): Promise<void> => { await fixture?.cleanup(); },
   };
 };
 

--- a/packages/api/src/goal-execution-upgrade.dbtest.ts
+++ b/packages/api/src/goal-execution-upgrade.dbtest.ts
@@ -21,7 +21,7 @@ import { preKernelRun, preKernelSeed, stageAtPreviousMigration } from "./goal-ex
 
 const sha256 = (value: string): string => createHash("sha256").update(value).digest("hex");
 
-let fixture: ReturnType<typeof stageAtPreviousMigration>;
+let fixture: Awaited<ReturnType<typeof stageAtPreviousMigration>>;
 const quotedSchema = (): string => fixture.quoted;
 
 const query = async <T>(fn: (client: PrismaClient) => Promise<T>): Promise<T> => {
@@ -33,15 +33,15 @@ const query = async <T>(fn: (client: PrismaClient) => Promise<T>): Promise<T> =>
   }
 };
 
-after(() => fixture?.cleanup());
+after(async () => { await fixture?.cleanup(); });
 
 test("the kernel migration upgrades a database that already holds Goal-linked Runs", async () => {
-  fixture = stageAtPreviousMigration("upgrade");
+  fixture = await stageAtPreviousMigration("upgrade");
   // Two closed Tasks on one Goal, each with a Goal-linked Run: the ordinary
   // pre-kernel shape. Before the ordering fix this alone failed the migration,
   // because Run_goal_lineage_all_or_none_check was validated while every
   // freshly added goalGeneration/goalIteration was still null.
-  fixture.execute(preKernelSeed + [
+  await fixture.execute(preKernelSeed + [
     preKernelRun("r-old", "t-old", "g-up", 1),
     preKernelRun("r-old-2", "t-old", "g-up", 2),
     preKernelRun("r-new", "t-new", "g-up", 1),
@@ -95,12 +95,12 @@ test("the kernel migration upgrades a database that already holds Goal-linked Ru
 });
 
 test("an ambiguous pre-kernel Run aborts the migration with schema and data unchanged", async () => {
-  fixture.cleanup();
-  fixture = stageAtPreviousMigration("upgrade");
+  await fixture.cleanup();
+  fixture = await stageAtPreviousMigration("upgrade");
   // One Task whose Runs disagree: one carries the Goal, one does not. The
   // backfill refuses to fill a null Run from its sibling, so the deferred
   // VALIDATE is what must reject this — and reject it atomically.
-  fixture.execute(preKernelSeed + [
+  await fixture.execute(preKernelSeed + [
     preKernelRun("r-mixed", "t-old", "g-up", 1),
     preKernelRun("r-null", "t-old", null, 2),
   ].join("\n"));

--- a/packages/api/src/migration-chain-layer-contract.dbtest.ts
+++ b/packages/api/src/migration-chain-layer-contract.dbtest.ts
@@ -24,9 +24,9 @@ import {
 test("contract migration preserves a consistent legacy chain and removes follow-ups", {
   skip: !migrationHarnessEnabled,
 }, async () => {
-  const fixture = stageBeforeChainLayerExpand();
+  const fixture = await stageBeforeChainLayerExpand();
   try {
-    fixture.execute(`
+    await fixture.execute(`
       INSERT INTO "Project" ("id", "name", "slug", "updatedAt")
       VALUES ('contract-project', 'contract-project', 'contract-project', NOW());
       INSERT INTO "TaskTemplate" ("id", "projectId", "name", "description", "variables", "updatedAt")
@@ -59,16 +59,16 @@ test("contract migration preserves a consistent legacy chain and removes follow-
       [],
     );
   } finally {
-    fixture.cleanup();
+    await fixture.cleanup();
   }
 });
 
 test("contract migration refuses an inconsistent follow-up before tightening or dropping", {
   skip: !migrationHarnessEnabled,
 }, async () => {
-  const fixture = stageBeforeChainLayerExpand();
+  const fixture = await stageBeforeChainLayerExpand();
   try {
-    fixture.execute(`
+    await fixture.execute(`
       INSERT INTO "Project" ("id", "name", "slug", "updatedAt")
       VALUES ('contract-fence-project', 'contract-fence-project', 'contract-fence-project', NOW());
       INSERT INTO "TaskTemplate" ("id", "projectId", "name", "description", "variables", "updatedAt")
@@ -82,7 +82,7 @@ test("contract migration refuses an inconsistent follow-up before tightening or 
     fixture.applyExpandMigration();
     // The expand fence has already run. Introduce a legacy inconsistency after
     // it so this test exercises the contract migration's second fence.
-    fixture.execute(`UPDATE "Task" SET "${retiredFollowUpColumn}" = 'contract-fence-source' WHERE "id" = 'contract-fence-target';`);
+    await fixture.execute(`UPDATE "Task" SET "${retiredFollowUpColumn}" = 'contract-fence-source' WHERE "id" = 'contract-fence-target';`);
     const before = await migrationSnapshot(fixture);
     let error: unknown;
     try {
@@ -105,6 +105,6 @@ test("contract migration refuses an inconsistent follow-up before tightening or 
       [{ column_name: retiredFollowUpColumn }],
     );
   } finally {
-    fixture.cleanup();
+    await fixture.cleanup();
   }
 });

--- a/packages/api/src/migration-chain-layer-expand.dbtest.ts
+++ b/packages/api/src/migration-chain-layer-expand.dbtest.ts
@@ -21,9 +21,9 @@ import {
 test("chain-layer expand migration dense-ranks legacy template steps and chain nodes", {
   skip: !migrationHarnessEnabled,
 }, async () => {
-  const fixture = stageBeforeChainLayerExpand();
+  const fixture = await stageBeforeChainLayerExpand();
   try {
-    fixture.execute(`
+    await fixture.execute(`
       INSERT INTO "Project" ("id", "name", "slug", "updatedAt")
       VALUES ('chain-layer-project', 'chain-layer-project', 'chain-layer-project', NOW());
       INSERT INTO "TaskTemplate" ("id", "projectId", "name", "description", "variables", "updatedAt")
@@ -61,16 +61,16 @@ test("chain-layer expand migration dense-ranks legacy template steps and chain n
       ],
     );
   } finally {
-    fixture.cleanup();
+    await fixture.cleanup();
   }
 });
 
 test("partial chain identity aborts expand before changing rows", {
   skip: !migrationHarnessEnabled,
 }, async () => {
-  const fixture = stageBeforeChainLayerExpand();
+  const fixture = await stageBeforeChainLayerExpand();
   try {
-    fixture.execute(`
+    await fixture.execute(`
       INSERT INTO "Project" ("id", "name", "slug", "updatedAt")
       VALUES ('partial-project', 'partial-project', 'partial-project', NOW());
       INSERT INTO "Task" ("id", "projectId", "name", "description", "chainId", "updatedAt")
@@ -88,16 +88,16 @@ test("partial chain identity aborts expand before changing rows", {
     assert.deepEqual(await migrationSnapshot(fixture), before);
     assert.deepEqual(await migrationColumns(fixture), []);
   } finally {
-    fixture.cleanup();
+    await fixture.cleanup();
   }
 });
 
 test("inconsistent follow-up relationship aborts expand before changing rows", {
   skip: !migrationHarnessEnabled,
 }, async () => {
-  const fixture = stageBeforeChainLayerExpand();
+  const fixture = await stageBeforeChainLayerExpand();
   try {
-    fixture.execute(`
+    await fixture.execute(`
       INSERT INTO "Project" ("id", "name", "slug", "updatedAt")
       VALUES ('follow-up-project', 'follow-up-project', 'follow-up-project', NOW());
       INSERT INTO "Task" ("id", "projectId", "name", "description", "chainId", "chainIndex", "updatedAt")
@@ -117,6 +117,6 @@ test("inconsistent follow-up relationship aborts expand before changing rows", {
     assert.deepEqual(await migrationSnapshot(fixture), before);
     assert.deepEqual(await migrationColumns(fixture), []);
   } finally {
-    fixture.cleanup();
+    await fixture.cleanup();
   }
 });

--- a/packages/api/src/migration.dbtest.ts
+++ b/packages/api/src/migration.dbtest.ts
@@ -20,6 +20,7 @@ import {
   retiredFollowUpIndex,
 } from "./chain-layer-migration-fixture.js";
 import { fireCronTask } from "./scheduler.js";
+import { splitSqlStatements } from "./sql-statements.js";
 import { resetTestDb, setupTestDb, testDatabaseSchema, testDatabaseUrl } from "./testdb.js";
 
 const taskDispatchBindingMigration = "20260825120000_task_dispatch_binding";
@@ -28,9 +29,9 @@ interface TaskDispatchBindingMigrationFixture {
   schema: string;
   url: string;
   quotedSchema: string;
-  execute(sql: string): void;
+  execute(sql: string): Promise<void>;
   applyMigration(): void;
-  cleanup(): void;
+  cleanup(): Promise<void>;
 }
 
 /**
@@ -38,7 +39,7 @@ interface TaskDispatchBindingMigrationFixture {
  * migration. The fixture deliberately creates a task before the migration so
  * the additive-only proof can compare its row content and count after deploy.
  */
-const stageBeforeTaskDispatchBinding = (): TaskDispatchBindingMigrationFixture => {
+const stageBeforeTaskDispatchBinding = async (): Promise<TaskDispatchBindingMigrationFixture> => {
   const base = new URL(testDatabaseUrl);
   const sourceSchema = base.searchParams.get("schema");
   if (!sourceSchema || sourceSchema === "public") throw new Error("dispatch-binding migration fixture refuses public schema");
@@ -46,15 +47,14 @@ const stageBeforeTaskDispatchBinding = (): TaskDispatchBindingMigrationFixture =
   base.searchParams.set("schema", schema);
   const url = base.toString();
   const quotedSchema = `"${schema.replaceAll('"', '""')}"`;
-  const execute = (sql: string): void => {
-    execFileSync("npx", ["prisma", "db", "execute", "--url", url, "--stdin"], {
-      cwd: dbDirectory,
-      input: sql,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+  // In-process, for the same reason as the two sibling fixtures: a spawned
+  // `prisma db execute` costs about two seconds of startup per call.
+  const client = new PrismaClient({ datasources: { db: { url } } });
+  const execute = async (sql: string): Promise<void> => {
+    for (const statement of splitSqlStatements(sql)) await client.$executeRawUnsafe(statement);
   };
 
-  execute(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE; CREATE SCHEMA ${quotedSchema};`);
+  await execute(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE; CREATE SCHEMA ${quotedSchema};`);
   const staging = mkdtempSync(join(tmpdir(), "task-dispatch-binding-fixture."));
   cpSync(join(dbDirectory, "prisma"), join(staging, "prisma"), { recursive: true });
   for (const entry of readdirSync(join(staging, "prisma", "migrations"), { withFileTypes: true })) {
@@ -85,13 +85,15 @@ const stageBeforeTaskDispatchBinding = (): TaskDispatchBindingMigrationFixture =
       );
       deploy();
     },
-    cleanup: () => {
+    cleanup: async (): Promise<void> => {
       rmSync(staging, { recursive: true, force: true });
       try {
-        execute(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE;`);
+        await execute(`DROP SCHEMA IF EXISTS ${quotedSchema} CASCADE;`);
       } catch {
         // A failed fixture must not leave its private schema behind if the
         // server has already terminated the connection.
+      } finally {
+        await client.$disconnect();
       }
     },
   };
@@ -483,9 +485,9 @@ test("final contract accepts standalone tasks and requires complete chain identi
 test("dispatch binding migration is additive and preserves existing task rows", {
   skip: !migrationHarnessEnabled,
 }, async () => {
-  const fixture = stageBeforeTaskDispatchBinding();
+  const fixture = await stageBeforeTaskDispatchBinding();
   try {
-    fixture.execute(`
+    await fixture.execute(`
       INSERT INTO "Project" ("id", "name", "slug", "updatedAt")
       VALUES ('dispatch-migration-project', 'dispatch-migration-project', 'dispatch-migration-project', NOW());
       INSERT INTO "Task" ("id", "projectId", "name", "description", "chainId", "chainIndex", "chainLayer", "updatedAt")
@@ -523,7 +525,7 @@ test("dispatch binding migration is additive and preserves existing task rows", 
     `);
     assert.deepEqual(columns, [{ column_name: "dispatchAfterTaskId", is_nullable: "YES", column_default: null }]);
   } finally {
-    fixture.cleanup();
+    await fixture.cleanup();
   }
 });
 

--- a/packages/api/src/preflight-goal-execution-abort.dbtest.ts
+++ b/packages/api/src/preflight-goal-execution-abort.dbtest.ts
@@ -15,27 +15,27 @@ import { preflightHarness, preKernelRun } from "./goal-execution-fixture.js";
  */
 
 const harness = preflightHarness("preflight_abort");
-after(() => {
-  harness.cleanup();
+after(async () => {
+  await harness.cleanup();
 });
 
-const abortsWith = (condition: string, rows: string[]): void => {
-  harness.stage(rows);
+const abortsWith = async (condition: string, rows: string[]): Promise<void> => {
+  await harness.stage(rows);
   const result = harness.runPreflight();
   assert.equal(result.code, 1, `must abort: ${result.stdout}${result.stderr}`);
   assert.match(result.stderr, new RegExp(`STOP preflight ${condition}`, "u"));
   assert.doesNotMatch(result.stdout, /preflight PASS/u);
 };
 
-test("a Task with both null and non-null Run.goalId aborts the preflight", () => {
-  abortsWith("mixed-lineage", [
+test("a Task with both null and non-null Run.goalId aborts the preflight", async () => {
+  await abortsWith("mixed-lineage", [
     preKernelRun("r-a", "t-old", "g-up", 1),
     preKernelRun("r-b", "t-old", null, 2),
   ]);
 });
 
-test("a Task whose Runs name different Goals aborts the preflight", () => {
-  abortsWith("ambiguous-goal", [
+test("a Task whose Runs name different Goals aborts the preflight", async () => {
+  await abortsWith("ambiguous-goal", [
     `INSERT INTO "Goal" ("id", "projectId", "title", "spec", "updatedAt")
      VALUES ('g-second', 'p-up', 'Second', 'spec', NOW());`,
     preKernelRun("r-a", "t-old", "g-up", 1),
@@ -43,10 +43,10 @@ test("a Task whose Runs name different Goals aborts the preflight", () => {
   ]);
 });
 
-test("a Goal-linked Run with no Task aborts the preflight", () => {
-  abortsWith("orphan-run", [preKernelRun("r-a", null, "g-up", 1)]);
+test("a Goal-linked Run with no Task aborts the preflight", async () => {
+  await abortsWith("orphan-run", [preKernelRun("r-a", null, "g-up", 1)]);
 });
 
-test("an active Goal-linked Run aborts the preflight", () => {
-  abortsWith("active-run", [preKernelRun("r-a", "t-old", "g-up", 1, "running")]);
+test("an active Goal-linked Run aborts the preflight", async () => {
+  await abortsWith("active-run", [preKernelRun("r-a", "t-old", "g-up", 1, "running")]);
 });

--- a/packages/api/src/preflight-goal-execution.dbtest.ts
+++ b/packages/api/src/preflight-goal-execution.dbtest.ts
@@ -18,12 +18,12 @@ import { preflightHarness, preKernelRun } from "./goal-execution-fixture.js";
  */
 
 const harness = preflightHarness("preflight");
-after(() => {
-  harness.cleanup();
+after(async () => {
+  await harness.cleanup();
 });
 
-test("a clean history passes and the report carries only IDs and counts", () => {
-  harness.stage([preKernelRun("r-1", "t-old", "g-up", 1)]);
+test("a clean history passes and the report carries only IDs and counts", async () => {
+  await harness.stage([preKernelRun("r-1", "t-old", "g-up", 1)]);
 
   const result = harness.runPreflight();
   assert.equal(result.code, 0, `${result.stdout}\n${result.stderr}`);
@@ -33,24 +33,24 @@ test("a clean history passes and the report carries only IDs and counts", () => 
   assert.doesNotMatch(result.stdout + result.stderr, /secret-looking/u, "no prompt or spec text reaches the report");
 });
 
-test("a Goal/Run project disagreement cannot even be created on the pre-kernel schema", () => {
-  const fixture = harness.stage([preKernelRun("r-1", "t-old", "g-up", 1)]);
+test("a Goal/Run project disagreement cannot even be created on the pre-kernel schema", async () => {
+  const fixture = await harness.stage([preKernelRun("r-1", "t-old", "g-up", 1)]);
   // The preflight checks this condition anyway, as defence in depth. The pre-kernel
   // composite foreign key Run(goalId, projectId) -> Goal already makes the corrupt
   // state unreachable, and that is worth pinning: if a future migration weakens the
   // key, this test fails and the preflight's query becomes the live guard rather
   // than a redundant one.
-  assert.throws(
-    () => fixture.execute(`
+  await assert.rejects(
+    async () => { await fixture.execute(`
       INSERT INTO "Project" ("id", "name", "slug", "updatedAt") VALUES ('p-other', 'other', 'other', NOW());
       INSERT INTO "Goal" ("id", "projectId", "title", "spec", "updatedAt") VALUES ('g-other', 'p-other', 'Other', 'spec', NOW());
-      ${preKernelRun("r-cross", "t-old", "g-other", 2)}`),
+      ${preKernelRun("r-cross", "t-old", "g-other", 2)}`); },
     /Run_goalId_projectId_fkey/u,
   );
 });
 
-test("an unnamed schema stops the preflight", () => {
-  const fixture = harness.stage([preKernelRun("r-1", "t-old", "g-up", 1)]);
+test("an unnamed schema stops the preflight", async () => {
+  const fixture = await harness.stage([preKernelRun("r-1", "t-old", "g-up", 1)]);
 
   const url = new URL(fixture.url);
   url.searchParams.delete("schema");

--- a/packages/api/src/sql-statements.test.ts
+++ b/packages/api/src/sql-statements.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The splitter's whole job is to not cut inside a literal, and to say so when
+ * it meets something it cannot reason about.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { splitSqlStatements } from "./sql-statements.js";
+
+describe("splitSqlStatements", () => {
+  it("splits ordinary setup and drops the empty tail", () => {
+    assert.deepEqual(
+      splitSqlStatements(`DROP SCHEMA IF EXISTS "x" CASCADE; CREATE SCHEMA "x";`),
+      ['DROP SCHEMA IF EXISTS "x" CASCADE', 'CREATE SCHEMA "x"'],
+    );
+    assert.deepEqual(splitSqlStatements("  \n  "), []);
+    assert.deepEqual(splitSqlStatements("SELECT 1"), ["SELECT 1"], "a statement without a terminator still counts");
+  });
+
+  it("does not cut on a semicolon inside a string literal", () => {
+    // The reason this module exists: a seed row carrying a semicolon used to be
+    // fine only because a separate process parsed the SQL.
+    assert.deepEqual(
+      splitSqlStatements(`INSERT INTO "T" ("d") VALUES ('a; not a boundary'); SELECT 1;`),
+      [`INSERT INTO "T" ("d") VALUES ('a; not a boundary')`, "SELECT 1"],
+    );
+  });
+
+  it("treats a doubled quote as an escape rather than a boundary", () => {
+    assert.deepEqual(
+      splitSqlStatements(`INSERT INTO "T" VALUES ('it''s; fine'); SELECT 2;`),
+      [`INSERT INTO "T" VALUES ('it''s; fine')`, "SELECT 2"],
+    );
+  });
+
+  it("does not cut on a semicolon inside a quoted identifier", () => {
+    assert.deepEqual(
+      splitSqlStatements(`SELECT "weird;column" FROM "T"; SELECT 3;`),
+      [`SELECT "weird;column" FROM "T"`, "SELECT 3"],
+    );
+  });
+
+  it("ignores comments, including a semicolon inside one", () => {
+    assert.deepEqual(
+      splitSqlStatements(`SELECT 1; -- trailing; comment\nSELECT 2; /* block; comment */ SELECT 3;`),
+      ["SELECT 1", "SELECT 2", "SELECT 3"],
+    );
+  });
+
+  it("refuses what it cannot reason about instead of guessing", () => {
+    assert.throws(() => splitSqlStatements("SELECT $$body$$"), /dollar quoting/u);
+    assert.throws(() => splitSqlStatements("SELECT $tag$body$tag$"), /dollar quoting/u);
+    assert.throws(() => splitSqlStatements("SELECT 'unterminated"), /unterminated string/u);
+    assert.throws(() => splitSqlStatements('SELECT "unterminated'), /unterminated identifier/u);
+    assert.throws(() => splitSqlStatements("SELECT 1 /* unterminated"), /unterminated block comment/u);
+  });
+});

--- a/packages/api/src/sql-statements.ts
+++ b/packages/api/src/sql-statements.ts
@@ -1,0 +1,77 @@
+/**
+ * Cuts a fixture's setup SQL into statements a driver will take one at a time.
+ *
+ * Prisma sends raw SQL as a prepared statement and PostgreSQL refuses more than
+ * one command in one of those — `cannot insert multiple commands into a
+ * prepared statement`. The migration fixtures write their setup as one readable
+ * block of DDL and inserts, and that block used to be handed to a spawned
+ * `prisma db execute`, which accepts many. Running it in-process instead is
+ * worth about two seconds of process startup per call, and this is the part
+ * that has to change to make that possible.
+ *
+ * Splitting on every `;` would also split inside a string literal, so this
+ * tracks quoting instead of scanning for the character. Constructs these
+ * fixtures do not use are refused rather than guessed at: a dollar-quoted body
+ * needs tag matching, and a mis-split there would corrupt setup silently rather
+ * than fail it. An unterminated literal is refused for the same reason — the
+ * remainder would otherwise be swallowed into a statement nobody wrote.
+ */
+export const splitSqlStatements = (sql: string): string[] => {
+  const statements: string[] = [];
+  let current = "";
+  let index = 0;
+
+  const push = (): void => {
+    const trimmed = current.trim();
+    if (trimmed !== "") statements.push(trimmed);
+    current = "";
+  };
+
+  while (index < sql.length) {
+    const character = sql[index] ?? "";
+    const next = sql[index + 1] ?? "";
+
+    if (character === "-" && next === "-") {
+      const end = sql.indexOf("\n", index);
+      index = end === -1 ? sql.length : end;
+      continue;
+    }
+
+    if (character === "/" && next === "*") {
+      const end = sql.indexOf("*/", index + 2);
+      if (end === -1) throw new Error("fixture SQL has an unterminated block comment");
+      index = end + 2;
+      continue;
+    }
+
+    if (character === "$") {
+      // `$$body$$` and `$tag$body$tag$` both need the closing tag matched, and
+      // no fixture here has one. Refusing keeps the cheap scanner honest.
+      if (/^\$[A-Za-z_]*\$/u.test(sql.slice(index))) {
+        throw new Error("fixture SQL uses dollar quoting, which this splitter deliberately does not handle");
+      }
+    }
+
+    if (character === "'" || character === '"') {
+      const closing = sql.indexOf(character, index + 1);
+      if (closing === -1) throw new Error(`fixture SQL has an unterminated ${character === "'" ? "string" : "identifier"}`);
+      // A doubled quote is the escape, and closing then reopening on the next
+      // character is exactly how it is consumed.
+      current += sql.slice(index, closing + 1);
+      index = closing + 1;
+      continue;
+    }
+
+    if (character === ";") {
+      push();
+      index += 1;
+      continue;
+    }
+
+    current += character;
+    index += 1;
+  }
+
+  push();
+  return statements;
+};


### PR DESCRIPTION
Second of the two work-reduction changes for the merge gate. Like the first, it removes overhead rather than checks: every test case survives and the `prisma migrate deploy` subprocesses that *are* the subject of these tests are untouched.

## The recorded reason these tests were slow was wrong

The standing note said the migration-replay family cost 8–16s per case because each case replays ~30 migrations. Measured:

| | |
| --- | --- |
| `npx prisma migrate deploy`, all 43 migrations | **2.40s** |
| `npx prisma` startup alone (a no-op `db execute`) | **2.07s** |
| ⇒ the SQL replay itself | **0.33s** |

The cost is process startup, not replay. The fix that follows from the old premise — prebuild a checkpoint template per staging point and `CREATE DATABASE ... TEMPLATE` per case — would have removed that 0.33s and left every spawn in place. It is not worth doing and this PR does not do it.

## What is actually being paid for

Counted with a shim on `npx` over the five files that use these fixtures:

| | before | after |
| --- | --- | --- |
| `prisma db execute` spawns | **44** | **0** |
| `prisma migrate deploy` spawns | 23 | 23 |

44 spawns × 2.07s ≈ **91 core-seconds**. That count is the honest headline here: wall-clock on this machine is too noisy to quote a single figure (the same unchanged file measured 15.4s and 19.6s on consecutive runs), though every paired before/after run favoured the change — 199.6s→101.9s, 154.4s→57.9s, 98.5s→81.3s for the five-file set.

The unchanged `migrate deploy` count is the check that matters for correctness: no proof moved off the real code path.

## How

The three staging fixtures (`chain-layer-migration-fixture`, `goal-execution-fixture`, and `stageBeforeTaskDispatchBinding` in `migration.dbtest.ts`) now hold one `PrismaClient` for their lifetime — 137ms to connect, 52ms for six statements — instead of spawning per call. `execute` and `cleanup` became async, which is why the call sites move.

Prisma sends raw SQL as a prepared statement and PostgreSQL refuses more than one command in one of those, while this setup is written as a readable block. `splitSqlStatements` cuts the block, tracking quoting rather than scanning for `;`, so a semicolon inside a literal is not a boundary. It **refuses** dollar quoting and unterminated literals rather than guessing — a mis-split would corrupt setup silently instead of failing it, and no fixture here uses the construct.

## Verification

- The five files plus `migration.dbtest.ts`: 2 / 2 / 3 / 4 / 3 / 16 pass, 0 fail — the same case counts as before.
- `splitSqlStatements`: 6 unit cases covering literals, doubled quotes, quoted identifiers, comments, and each refusal.
- `npm run lint` clean.

Merge gate to be dispatched against the final integrated head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fbhp8jZP5bLJcJja7dGsCQ