### PR TITLE
feat(api): report per-file wall clock for the database test wave

### DIFF
--- a/packages/api/scripts/dbtest-preamble.mjs
+++ b/packages/api/scripts/dbtest-preamble.mjs
@@ -11,10 +11,11 @@
 // here costs one obvious red; failing open costs an intermittent one, somewhere
 // else, on a day when the paths happen not to match.
 
-import { readFileSync, realpathSync } from "node:fs";
+import { appendFileSync, readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { assignmentFor, environmentForAssignment, planEnvironmentVariable } from "../src/dbtest-plan.ts";
+import { formatTimingLine, timingsEnvironmentVariable } from "../src/dbtest-timings.ts";
 
 const planPath = process.env[planEnvironmentVariable];
 
@@ -33,4 +34,27 @@ if (planPath) {
   const plan = JSON.parse(readFileSync(planPath, "utf8"));
   const assignment = assignmentFor(plan, canonical);
   Object.assign(process.env, environmentForAssignment(assignment));
+}
+
+// The other thing per-test-file granularity is good for. node:test runs the
+// tests inside one file in order, so this process's own lifetime is the file's
+// contribution to the wave, and the wave drains at the pace of its longest
+// file. Written on exit rather than reported through node:test, because the
+// reporter sees tests and this needs to see files.
+const timingsPath = process.env[timingsEnvironmentVariable];
+if (timingsPath) {
+  const startedAt = Date.now();
+  const entry = process.argv[1];
+  process.on("exit", () => {
+    try {
+      appendFileSync(
+        timingsPath,
+        // The whole path, not the basename: two packages contribute
+        // same-named files to one pool, and the report has to tell them apart.
+        formatTimingLine({ file: entry === undefined ? "unknown" : resolve(entry), ms: Date.now() - startedAt }),
+      );
+    } catch {
+      // A run that produced a verdict must not be failed by its own bookkeeping.
+    }
+  });
 }

--- a/packages/api/src/dbtest-runner.ts
+++ b/packages/api/src/dbtest-runner.ts
@@ -8,7 +8,7 @@
 // than when it is finished with, and the run's result is not green unless the
 // cleanup was.
 
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -23,6 +23,7 @@ import {
   type DbtestAssignment,
   type DbtestPlan,
 } from "./dbtest-plan.js";
+import { formatTimingReport, parseTimings, timingsEnvironmentVariable } from "./dbtest-timings.js";
 
 /** Just enough of ScratchDatabaseManager to run against, and to fake. */
 export interface ScratchManagerLike {
@@ -122,6 +123,7 @@ export const runDbtest = async ({
   for (const [signal, handler] of handlers) signals.on(signal, handler);
 
   const planDirectory = mkdtempSync(join(tmpdir(), "agentos-dbtest-plan-"));
+  const timingsPath = join(planDirectory, "timings.jsonl");
   const abandoned = (): number => signalExitCode(signalled ?? "SIGTERM");
 
   const provisionAndRun = async (): Promise<number> => {
@@ -166,10 +168,19 @@ export const runDbtest = async ({
     writeFileSync(planPath, JSON.stringify(plan));
     log(`template ${template.name} cloned ${files.length} times, ${limit} connections each of ${maxConnections}`);
 
+    // Created empty rather than left to the first writer: an appending process
+    // should not have to decide whether the file exists, and an empty file is
+    // also the honest report for a run that was signalled before a file ended.
+    writeFileSync(timingsPath, "");
+
     return await runTests({
       files,
       concurrency,
-      environment: { ...environment, [planEnvironmentVariable]: planPath },
+      environment: {
+        ...environment,
+        [planEnvironmentVariable]: planPath,
+        [timingsEnvironmentVariable]: timingsPath,
+      },
       signal: controller.signal,
     });
   };
@@ -183,6 +194,14 @@ export const runDbtest = async ({
   }
 
   for (const [signal, handler] of handlers) signals.off(signal, handler);
+  // Read before the directory holding it goes, and reported even when the run
+  // failed: a red wave is exactly when someone wants to know which file it was.
+  try {
+    const { timings, unreadable } = parseTimings(readFileSync(timingsPath, "utf8"));
+    for (const line of formatTimingReport(timings, { unreadable })) log(line);
+  } catch {
+    // No timings file means the run never got as far as starting the tests.
+  }
   rmSync(planDirectory, { recursive: true, force: true });
   const leaked = await manager.dropAll();
   for (const { name, error } of leaked) log(`could not drop ${name}: ${error.message}`);

--- a/packages/api/src/dbtest-timings.test.ts
+++ b/packages/api/src/dbtest-timings.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The report is bookkeeping about a run, so its rules are about not lying and
+ * not failing: drop what it cannot read, say how much it dropped, and never
+ * throw where a verdict has already been reached.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { formatTimingLine, formatTimingReport, parseTimings, timingDisplayName } from "./dbtest-timings.js";
+
+describe("formatTimingLine", () => {
+  it("writes one complete line per file, which is what keeps concurrent writers apart", () => {
+    const line = formatTimingLine({ file: "chain.dbtest.ts", ms: 1234 });
+    assert.equal(line, '{"file":"chain.dbtest.ts","ms":1234}\n');
+    assert.equal(parseTimings(line).timings.length, 1);
+  });
+});
+
+describe("parseTimings", () => {
+  it("reads the lines the test processes wrote, in any order", () => {
+    const contents = formatTimingLine({ file: "b.dbtest.ts", ms: 200 })
+      + formatTimingLine({ file: "a.dbtest.ts", ms: 100 });
+    assert.deepEqual(parseTimings(contents), {
+      timings: [{ file: "b.dbtest.ts", ms: 200 }, { file: "a.dbtest.ts", ms: 100 }],
+      unreadable: 0,
+    });
+  });
+
+  it("counts what it cannot read instead of throwing or silently shrinking", () => {
+    // A process killed mid-write is the ordinary way to get a partial line, and
+    // that is exactly a run someone is already investigating.
+    const contents = `{"file":"a.dbtest.ts","ms":10}\n{"file":"trunc\n{"file":"b.dbtest.ts"}\n[]\n`;
+    const result = parseTimings(contents);
+    assert.deepEqual(result.timings, [{ file: "a.dbtest.ts", ms: 10 }]);
+    assert.equal(result.unreadable, 3);
+  });
+
+  it("ignores blank lines, including the trailing newline every writer leaves", () => {
+    assert.deepEqual(parseTimings("\n\n").timings, []);
+    assert.equal(parseTimings("\n\n").unreadable, 0);
+  });
+});
+
+describe("timingDisplayName", () => {
+  it("keeps the package, so the same-named pairs in db and api stay two rows", () => {
+    // The pool contains both of these, and a report that merged them would be
+    // pointing at the wrong file half the time.
+    assert.equal(
+      timingDisplayName("/repo/packages/api/src/service-maintenance-lock.dbtest.ts"),
+      "api/service-maintenance-lock.dbtest.ts",
+    );
+    assert.equal(
+      timingDisplayName("/repo/packages/db/src/service-maintenance-lock.dbtest.ts"),
+      "db/service-maintenance-lock.dbtest.ts",
+    );
+    assert.notEqual(
+      timingDisplayName("/repo/packages/api/src/preflight-goal-execution.dbtest.ts"),
+      timingDisplayName("/repo/packages/db/src/preflight-goal-execution.dbtest.ts"),
+    );
+  });
+
+  it("returns a path it does not recognise unchanged rather than guessing", () => {
+    assert.equal(timingDisplayName("/elsewhere/x.dbtest.ts"), "/elsewhere/x.dbtest.ts");
+    assert.equal(timingDisplayName("unknown"), "unknown");
+  });
+});
+
+describe("formatTimingReport", () => {
+  const timings = Array.from({ length: 12 }, (_unused, index) => ({
+    file: `f${index}.dbtest.ts`,
+    ms: (index + 1) * 1000,
+  }));
+
+  it("puts the longest file first, because that is what the wave waits for", () => {
+    const lines = formatTimingReport(timings);
+    assert.match(lines[0] ?? "", /slowest 10 of 12 files/u);
+    assert.match(lines[0] ?? "", /longest file 12\.0s/u);
+    assert.match(lines[1] ?? "", /f11\.dbtest\.ts\s+12\.0s/u);
+    assert.match(lines[10] ?? "", /f2\.dbtest\.ts\s+3\.0s/u);
+    assert.equal(lines.length, 11, "a table nobody reads is worse than a short one");
+  });
+
+  it("reports total work as well as the tail, so packing efficiency is computable", () => {
+    // 78s of work over 12 files: the gate's own question is how much of that a
+    // lane count can actually absorb.
+    assert.match(formatTimingReport(timings)[0] ?? "", /78\.0s of work/u);
+  });
+
+  it("says so when there is nothing to report rather than printing an empty table", () => {
+    assert.deepEqual(formatTimingReport([]), ["no per-file timings were recorded"]);
+    assert.deepEqual(formatTimingReport([], { unreadable: 2 }), ["no per-file timings were recorded (2 unreadable)"]);
+  });
+
+  it("admits dropped lines in the report itself, not only in the count", () => {
+    const lines = formatTimingReport([{ file: "a.dbtest.ts", ms: 1000 }], { unreadable: 1 });
+    assert.match(lines.at(-1) ?? "", /1 timing line\(s\) were unreadable/u);
+  });
+});

--- a/packages/api/src/dbtest-timings.ts
+++ b/packages/api/src/dbtest-timings.ts
@@ -1,0 +1,101 @@
+/**
+ * Where the database wave's time actually went, per file.
+ *
+ * The wave is the largest single cost in the merge gate and the only number the
+ * gate reports about it is the total. Deciding what to make cheaper from that
+ * number means guessing, and the two rounds of tuning before this one both
+ * started by guessing at file size and both guessed wrong — the expensive files
+ * were expensive for reasons (a ten-second sleep, a process spawn per statement)
+ * that no amount of reading the file would have shown.
+ *
+ * `node:test` parallelises across files and runs the tests inside one file in
+ * order, so a file's own wall clock is the wave's lower bound and the only
+ * granularity worth recording. Each test process appends one line here as it
+ * exits; the runner reads them afterwards and reports the slowest first.
+ *
+ * A line is a complete JSON object written in one `appendFileSync` call, which
+ * is what keeps concurrent writers from interleaving: several files finish at
+ * once by design.
+ */
+
+/** Names the file every test process appends its own line to. */
+export const timingsEnvironmentVariable = "AGENTOS_DBTEST_TIMINGS";
+
+/**
+ * How a file is named in the report.
+ *
+ * The whole path is what gets recorded, because the gate runs `packages/db` and
+ * `packages/api` as one pool and those suites contain same-named pairs —
+ * `preflight-goal-execution.dbtest.ts` and `service-maintenance-lock.dbtest.ts`
+ * exist in both. A report keyed on the basename would silently merge each pair
+ * into one line, which is the same trap `fileDirectoryName` documents. The
+ * package is kept and the invariant `src/` dropped, so the two are told apart
+ * without printing an absolute path per row.
+ */
+export const timingDisplayName = (file: string): string => {
+  const marker = "/packages/";
+  const index = file.lastIndexOf(marker);
+  if (index === -1) return file;
+  return file.slice(index + marker.length).replace("/src/", "/");
+};
+
+export interface DbtestFileTiming {
+  file: string;
+  ms: number;
+}
+
+export const formatTimingLine = (timing: DbtestFileTiming): string => `${JSON.stringify(timing)}\n`;
+
+/**
+ * Reads what the test processes wrote.
+ *
+ * A malformed or truncated line is dropped rather than thrown on: this is a
+ * report about a run, and a run that already produced a verdict must not be
+ * turned red by its own bookkeeping. A dropped line is counted so the report
+ * cannot quietly describe fewer files than ran.
+ */
+export const parseTimings = (contents: string): { timings: DbtestFileTiming[]; unreadable: number } => {
+  const timings: DbtestFileTiming[] = [];
+  let unreadable = 0;
+  for (const line of contents.split("\n")) {
+    if (line.trim() === "") continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      const record = parsed as Partial<DbtestFileTiming>;
+      if (typeof record.file !== "string" || typeof record.ms !== "number" || !Number.isFinite(record.ms)) {
+        unreadable += 1;
+        continue;
+      }
+      timings.push({ file: record.file, ms: record.ms });
+    } catch {
+      unreadable += 1;
+    }
+  }
+  return { timings, unreadable };
+};
+
+/**
+ * The report: slowest first, and only as long as it is useful.
+ *
+ * The tail is what decides the wave — the pool drains at the pace of its
+ * longest file — so the head of this list is the whole reason it exists. The
+ * rest is summarised rather than printed, because a 78-line table in a gate log
+ * is a wall nobody reads.
+ */
+export const formatTimingReport = (
+  timings: DbtestFileTiming[],
+  { top = 10, unreadable = 0 }: { top?: number; unreadable?: number } = {},
+): string[] => {
+  if (timings.length === 0) {
+    return [`no per-file timings were recorded${unreadable > 0 ? ` (${unreadable} unreadable)` : ""}`];
+  }
+  const ordered = [...timings].sort((left, right) => right.ms - left.ms);
+  const totalMs = ordered.reduce((sum, entry) => sum + entry.ms, 0);
+  const shown = ordered.slice(0, top).map((entry) => ({ name: timingDisplayName(entry.file), ms: entry.ms }));
+  const width = Math.max(...shown.map((entry) => entry.name.length));
+  const lines = shown.map((entry) => `  ${entry.name.padEnd(width)}  ${(entry.ms / 1000).toFixed(1)}s`);
+  const head = `slowest ${shown.length} of ${ordered.length} files`
+    + ` (${(totalMs / 1000).toFixed(1)}s of work, longest file ${(ordered[0]!.ms / 1000).toFixed(1)}s)`;
+  const tail = unreadable > 0 ? [`  ${unreadable} timing line(s) were unreadable and are missing from this report`] : [];
+  return [head, ...lines, ...tail];
+};


### PR DESCRIPTION
Third of the gate work-reduction series, and the one that makes the next round decidable from data instead of from reading files.

## Why

The database wave is the largest single cost in the merge gate, and the only number the gate reported about it was the total. The last two rounds of tuning both picked targets by file size and both picked wrong: the expensive files were expensive because of a ten-second sleep (#315) and a process spawn per SQL statement (#316), neither of which is visible by reading the file.

## How

`node:test` parallelises across files and runs the tests inside one file in order, so a file's own wall clock is the wave's lower bound and the only granularity worth recording. The preamble is already `--import`ed into every test process and already knows which file it is running; it now records its own lifetime and appends one JSON line as it exits. The runner reads them and prints the slowest first, with total work so packing efficiency stays computable.

Sample, end to end:

```
dbtest: slowest 3 of 3 files (120.8s of work, longest file 45.4s)
dbtest:   api/migration-chain-layer-expand.dbtest.ts  45.4s
dbtest:   api/preflight-goal-execution.dbtest.ts      43.3s
dbtest:   api/goal-execution-upgrade.dbtest.ts        32.1s
```

## Whole paths, not basenames

The gate runs `packages/db` and `packages/api` as one pool, and those suites contain same-named pairs — `preflight-goal-execution.dbtest.ts` and `service-maintenance-lock.dbtest.ts` exist in both. A report keyed on the basename merges each pair into one row and points at the wrong file half the time. This is the same trap `fileDirectoryName` already documents, so the path is recorded whole and shortened to `<package>/<file>` only for display.

## Bookkeeping must not change a verdict

- An unreadable or truncated line is dropped **and counted**, not thrown on; the count appears in the report so it cannot quietly describe fewer files than ran.
- A failed append is swallowed in the test process.
- The report prints after a failed run too — a red wave is exactly when someone wants to know which file it was.
- The table is capped at the slowest 10; a 78-row table in a gate log is a wall nobody reads.

## Verification

- 10 unit cases over the line format, parsing, refusal counting, display naming, and report shape.
- Existing `dbtest-runner` unit suite: 10 pass, 0 fail.
- End-to-end through `npm run test:db` against a scratch PostgreSQL, output above.
- `npm run lint` clean.

Merge gate to be dispatched against the final integrated head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fbhp8jZP5bLJcJja7dGsCQ