### PR TITLE
fix(api): reclaim expired legacy readiness claims

### DIFF
--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -25,7 +25,6 @@ import {
   type WithMergeLease,
 } from "./merge-lease.js";
 import type { MergeLeaseTarget } from "./merge-lease-hold.js";
-import { claimReadinessStep } from "./readiness-claim.js";
 import { READINESS_CLAIM_LEASE_MS, readinessTick } from "./merge-readiness-worker.js";
 import { reconcileDatabaseRuns } from "./reconcile.js";
 import { createApp } from "./test-app.js";
@@ -533,7 +532,7 @@ test("an expired orphaned DOING readiness claim is reclaimed after restart", asy
   assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 1, requeued: 0, stopped: 0 });
 });
 
-test("an expired pre-migration readiness claim is adopted into the durable claim columns", async () => {
+test("a pre-migration readiness claim waits through its expiry and is then recovered", async () => {
   const seeded = await seedReadiness();
   const expiresAt = new Date("2026-08-29T12:01:00.000Z");
   await db.task.update({ where: { id: seeded.readiness.id }, data: {
@@ -543,21 +542,24 @@ test("an expired pre-migration readiness claim is adopted into the durable claim
     readinessClaimExpiresAt: null,
   } });
 
-  assert.equal(
-    await claimReadinessStep(db, seeded.readiness.id, new Date(expiresAt.getTime() - 1)),
-    null,
+  assert.deepEqual(
+    await readinessTick(db, reader(), new Date(expiresAt.getTime() - 1), 5, releaseChainLease, runWithMergeLease),
+    { claimed: 0, authorized: 0, requeued: 0, stopped: 0 },
   );
-  const reclaimedAt = new Date(expiresAt.getTime() + 1);
-  assert.ok(await claimReadinessStep(db, seeded.readiness.id, reclaimedAt));
+  const waiting = await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } });
+  assert.match(waiting.failureReason ?? "", /^merge-readiness-claim:/u);
+  assert.equal(waiting.readinessClaimToken, null);
+  assert.equal(waiting.readinessClaimExpiresAt, null);
 
-  const adopted = await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } });
-  assert.equal(adopted.status, TaskStatus.DOING);
-  assert.equal(adopted.failureReason, null);
-  assert.match(adopted.readinessClaimToken ?? "", /^merge-readiness-claim:/u);
-  assert.equal(
-    adopted.readinessClaimExpiresAt?.getTime(),
-    reclaimedAt.getTime() + READINESS_CLAIM_LEASE_MS,
+  assert.deepEqual(
+    await readinessTick(db, reader(), expiresAt, 5, releaseChainLease, runWithMergeLease),
+    { claimed: 1, authorized: 1, requeued: 0, stopped: 0 },
   );
+  const recovered = await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } });
+  assert.equal(recovered.status, TaskStatus.DONE);
+  assert.equal(recovered.failureReason, null);
+  assert.equal(recovered.readinessClaimToken, null);
+  assert.equal(recovered.readinessClaimExpiresAt, null);
 });
 
 test("an incomplete compare response and a behind head fail closed", async () => {

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -25,6 +25,7 @@ import {
   type WithMergeLease,
 } from "./merge-lease.js";
 import type { MergeLeaseTarget } from "./merge-lease-hold.js";
+import { claimReadinessStep } from "./readiness-claim.js";
 import { READINESS_CLAIM_LEASE_MS, readinessTick } from "./merge-readiness-worker.js";
 import { reconcileDatabaseRuns } from "./reconcile.js";
 import { createApp } from "./test-app.js";
@@ -530,6 +531,33 @@ test("an expired orphaned DOING readiness claim is reclaimed after restart", asy
     readinessClaimExpiresAt: new Date("2000-01-01T00:00:00.000Z"),
   } });
   assert.deepEqual(await readinessTick(db, reader(), new Date(), 5, releaseChainLease, runWithMergeLease), { claimed: 1, authorized: 1, requeued: 0, stopped: 0 });
+});
+
+test("an expired pre-migration readiness claim is adopted into the durable claim columns", async () => {
+  const seeded = await seedReadiness();
+  const expiresAt = new Date("2026-08-29T12:01:00.000Z");
+  await db.task.update({ where: { id: seeded.readiness.id }, data: {
+    status: TaskStatus.DOING,
+    failureReason: `merge-readiness-claim:legacy|${expiresAt.toISOString()}`,
+    readinessClaimToken: null,
+    readinessClaimExpiresAt: null,
+  } });
+
+  assert.equal(
+    await claimReadinessStep(db, seeded.readiness.id, new Date(expiresAt.getTime() - 1)),
+    null,
+  );
+  const reclaimedAt = new Date(expiresAt.getTime() + 1);
+  assert.ok(await claimReadinessStep(db, seeded.readiness.id, reclaimedAt));
+
+  const adopted = await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } });
+  assert.equal(adopted.status, TaskStatus.DOING);
+  assert.equal(adopted.failureReason, null);
+  assert.match(adopted.readinessClaimToken ?? "", /^merge-readiness-claim:/u);
+  assert.equal(
+    adopted.readinessClaimExpiresAt?.getTime(),
+    reclaimedAt.getTime() + READINESS_CLAIM_LEASE_MS,
+  );
 });
 
 test("an incomplete compare response and a behind head fail closed", async () => {

--- a/packages/api/src/readiness-claim.test.ts
+++ b/packages/api/src/readiness-claim.test.ts
@@ -160,6 +160,25 @@ test("only an expired readiness claim can be reclaimed", async () => {
   assert.equal(await successor.renew(), true);
 });
 
+test("an expired legacy readiness claim can be reclaimed after migration", async () => {
+  const expiresAt = new Date(NOW.getTime() + READINESS_CLAIM_LEASE_MS);
+  const fake = fakeDatabase({
+    status: TaskStatus.DOING,
+    failureReason: `merge-readiness-claim:legacy|${expiresAt.toISOString()}`,
+  });
+
+  assert.equal(await claimReadinessStep(fake.db, fake.task.id, NOW), null);
+  const successor = await claimReadinessStep(
+    fake.db,
+    fake.task.id,
+    new Date(expiresAt.getTime() + 1),
+  );
+
+  assert.ok(successor);
+  assert.equal(fake.task.failureReason, null);
+  assert.notEqual(fake.task.readinessClaimToken, null);
+});
+
 test("claim loss classifies a concrete active successor as retained ownership", async () => {
   const fake = fakeDatabase({ chainId: "chain-1" });
   const handle = await claimReadinessStep(fake.db, fake.task.id, NOW);

--- a/packages/api/src/readiness-claim.ts
+++ b/packages/api/src/readiness-claim.ts
@@ -60,6 +60,12 @@ const newClaimState = (now: Date): ClaimState => ({
   expiresAt: new Date(now.getTime() + READINESS_CLAIM_LEASE_MS),
 });
 
+const expiredLegacyClaim = (reason: string | null, now: Date): boolean => {
+  if (!reason?.startsWith(READINESS_CLAIM_PREFIX)) return false;
+  const expiry = Date.parse(reason.slice(reason.lastIndexOf("|") + 1));
+  return Number.isFinite(expiry) && expiry <= now.getTime();
+};
+
 const ownershipAfterLoss = async (
   client: PrismaClient | Prisma.TransactionClient,
   taskId: string,
@@ -172,15 +178,21 @@ export const claimReadinessStep = async (
       where: { id: taskId },
       select: {
         status: true,
+        failureReason: true,
         readinessClaimToken: true,
         readinessClaimExpiresAt: true,
       },
     });
+    const legacyClaimAvailable = current?.status === TaskStatus.DOING
+      && current.readinessClaimToken === null
+      && current.readinessClaimExpiresAt === null
+      && expiredLegacyClaim(current.failureReason, now);
     const available = current?.status === TaskStatus.TODO
       || (current?.status === TaskStatus.DOING
         && current.readinessClaimToken !== null
         && current.readinessClaimExpiresAt !== null
-        && current.readinessClaimExpiresAt.getTime() <= now.getTime());
+        && current.readinessClaimExpiresAt.getTime() <= now.getTime())
+      || legacyClaimAvailable;
     if (!available) return false;
 
     const acquired = await tx.task.updateMany({
@@ -191,6 +203,7 @@ export const claimReadinessStep = async (
           status: TaskStatus.DOING,
           readinessClaimToken: current.readinessClaimToken,
           readinessClaimExpiresAt: current.readinessClaimExpiresAt,
+          ...(legacyClaimAvailable ? { failureReason: current.failureReason } : {}),
         },
       data: {
         status: TaskStatus.DOING,

--- a/packages/api/src/readiness-claim.ts
+++ b/packages/api/src/readiness-claim.ts
@@ -61,6 +61,8 @@ const newClaimState = (now: Date): ClaimState => ({
 });
 
 const expiredLegacyClaim = (reason: string | null, now: Date): boolean => {
+  // Remove this bridge after every deployment has crossed the claim-handle
+  // migration and its orphaned pre-migration claims have been swept.
   if (!reason?.startsWith(READINESS_CLAIM_PREFIX)) return false;
   const expiry = Date.parse(reason.slice(reason.lastIndexOf("|") + 1));
   return Number.isFinite(expiry) && expiry <= now.getTime();


### PR DESCRIPTION
## Summary

- reclaim expired readiness claims left in the pre-migration failureReason format
- preserve the legacy expiry boundary and include failureReason in the acquisition CAS
- cover the migrated database state through the real readiness worker path

## Confirmed P0

Before migration 20260829150000, the readiness worker stored ownership as DOING plus failureReason=merge-readiness-claim:<uuid>|<expiry>. The migration added nullable readinessClaimToken and readinessClaimExpiresAt columns without backfilling those rows. The new claimant rejected DOING rows whose new fields were null, so a crashed legacy claim could never be reclaimed and its merge chain remained stuck.

## Verification

Exact integrated head: d27bef03ce7195430cb798121cc889bc3226ba7b

- readiness claim unit tests: PASS, 5/5
- PostgreSQL merge-tail readiness suite: PASS, 28/28 after all 43 migrations
- remote full merge gate: MERGE GATE: PASS d27bef03ce7195430cb798121cc889bc3226ba7b
- fresh final blind review: no P0/P1 findings
- delivered to main by exact-head fast-forward
