### PR TITLE
fix(api): ignore orphaned regression verdicts

### DIFF
--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -774,6 +774,56 @@ test("invalid Regression output opens a stop notice with no unusable operator ch
   assert.match(card.dedupeKey ?? "", /^merge-tail-stop:/u);
 });
 
+test("a fresh Regression retry ignores an unconsumed no-changes output", async () => {
+  const seeded = await seedRegression();
+  await db.taskStepOutput.create({ data: {
+    taskId: seeded.regression.id,
+    runId: seeded.run.id,
+    kind: "regression-verification",
+    body: verdict("refresh-conflict"),
+    commitSha: HEAD,
+  } });
+  await db.run.update({
+    where: { id: seeded.run.id },
+    data: {
+      status: "FAILED",
+      failureClass: "NO_CHANGES_PRODUCED",
+      failureReason: "delivery failed after the verdict was persisted",
+      endedAt: new Date(),
+    },
+  });
+  await db.task.update({
+    where: { id: seeded.regression.id },
+    data: { status: TaskStatus.REVIEW, failureReason: "delivery failed after the verdict was persisted" },
+  });
+
+  const priorOperator = process.env.OPERATOR_TOKEN;
+  process.env.OPERATOR_TOKEN = "merge-tail-operator-token";
+  try {
+    const retried = await createApp(db).request(`/tasks/${seeded.regression.id}/retry`, {
+      method: "POST",
+      headers: { Authorization: "Bearer merge-tail-operator-token" },
+    });
+    assert.equal(retried.status, 201, await retried.text());
+  } finally {
+    if (priorOperator === undefined) delete process.env.OPERATOR_TOKEN;
+    else process.env.OPERATOR_TOKEN = priorOperator;
+  }
+
+  const run2 = await db.run.findFirstOrThrow({ where: { taskId: seeded.regression.id, runNumber: 2 } });
+  const claimed = await claimNext();
+  assert.equal(claimed.status, 200);
+  const body = claimed.body as {
+    run: { id: string };
+    regressionRepairHandoff: unknown;
+    resume: unknown;
+  };
+  assert.equal(body.run.id, run2.id);
+  assert.equal(body.regressionRepairHandoff, null);
+  assert.equal(body.resume, null);
+  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 0);
+});
+
 test("a fresh Regression claim carries the prior verdict and exact published repair without resuming context", async () => {
   const seeded = await exercise("review-fail");
   const repair = await repairFor(seeded, "review-fix");
@@ -801,6 +851,37 @@ test("a fresh Regression claim carries the prior verdict and exact published rep
     kind: "review-fix", taskId: repair.id, startHeadSha: HEAD, targetHeadSha: BASE,
     resolvedHeadSha: RESOLVED, outputKind: "result", outputBody: repairOutput,
   });
+});
+
+test("a repaired Regression claim keeps the handoff from a failed durable source Run", async () => {
+  const seeded = await exercise("review-fail");
+  await db.run.update({
+    where: { id: seeded.run.id },
+    data: {
+      status: "FAILED",
+      failureClass: "PROTOCOL_ERROR",
+      failureReason: "provider stream ended after the verdict was persisted",
+      retryable: true,
+      endedAt: new Date(),
+    },
+  });
+  const repair = await repairFor(seeded, "review-fix");
+  await completeRepair(seeded, repair.id, "Closed MF-2 and reran its focused regression.");
+  const run2 = await db.run.findFirstOrThrow({ where: { taskId: seeded.regression.id, runNumber: 2 } });
+
+  const claimed = await claimNext();
+  assert.equal(claimed.status, 200);
+  const body = claimed.body as {
+    run: { id: string };
+    regressionRepairHandoff: {
+      trigger: { verdict: { outcome: string } };
+      repair: { taskId: string; resolvedHeadSha: string };
+    };
+  };
+  assert.equal(body.run.id, run2.id);
+  assert.equal(body.regressionRepairHandoff.trigger.verdict.outcome, "review-fail");
+  assert.equal(body.regressionRepairHandoff.repair.taskId, repair.id);
+  assert.equal(body.regressionRepairHandoff.repair.resolvedHeadSha, RESOLVED);
 });
 
 test("a repaired Regression retry pins a failed prior Run's published head without rewriting repair evidence", async () => {

--- a/packages/api/src/regression-repair-handoff.ts
+++ b/packages/api/src/regression-repair-handoff.ts
@@ -1,5 +1,6 @@
 import {
   asJsonObject,
+  FailureClass,
   isRegressionVerificationOutputKind,
   MERGE_TAIL_KIND,
   parseRegressionVerdict,
@@ -42,7 +43,13 @@ export const regressionRepairHandoffForClaim = async (
   if (!isRegressionVerificationOutputKind(input.outputKind)) return { status: "none" };
   const priorOutput = await tx.taskStepOutput.findUnique({
     where: { taskId: input.taskId },
-    select: { body: true, runId: true, updatedAt: true },
+    select: {
+      body: true,
+      commitSha: true,
+      runId: true,
+      updatedAt: true,
+      run: { select: { failureClass: true, headSha: true, status: true } },
+    },
   });
   if (!priorOutput?.runId || priorOutput.runId === input.runId) return { status: "none" };
   const parsed = parseRegressionVerdict(priorOutput.body, input.outputKind);
@@ -84,7 +91,34 @@ export const regressionRepairHandoffForClaim = async (
     && metadata.targetHeadSha === expectedBaseHeadSha
     && metadata.state === undefined
   ));
-  if (!result) return invalid(`no successful ${repairKind} result binds ${expectedHeadSha} to ${expectedBaseHeadSha}`);
+  if (!result) {
+    const orphanedNoChangesOutput = priorOutput.run?.status === RunStatus.FAILED
+      && priorOutput.run.failureClass === FailureClass.NO_CHANGES_PRODUCED
+      && priorOutput.run.headSha === expectedHeadSha
+      && priorOutput.commitSha === expectedHeadSha;
+    if (orphanedNoChangesOutput) {
+      const consumedAttempt = await tx.taskActivity.findFirst({
+        where: {
+          taskId: input.taskId,
+          actorType: "control-plane",
+          createdAt: { gte: evidenceAt },
+          AND: [
+            { metadata: { path: ["kind"], equals: MERGE_TAIL_KIND.repairAttempt } },
+            { metadata: { path: ["sourceRunId"], equals: priorOutput.runId } },
+            { metadata: { path: ["repairKind"], equals: repairKind } },
+            { metadata: { path: ["headSha"], equals: expectedHeadSha } },
+            { metadata: { path: ["baseHeadSha"], equals: expectedBaseHeadSha } },
+          ],
+        },
+        select: { id: true },
+      });
+      // The old delivery contract could reject an otherwise valid output-only
+      // Run after its verdict was persisted. With no exact repair attempt, that
+      // output is audit evidence only and a fresh verifier must run.
+      if (!consumedAttempt) return { status: "none" };
+    }
+    return invalid(`no successful ${repairKind} result binds ${expectedHeadSha} to ${expectedBaseHeadSha}`);
+  }
   const repairTaskId = typeof result.repairTaskId === "string" ? result.repairTaskId : null;
   const resolvedHeadSha = typeof result.resolvedHeadSha === "string" ? result.resolvedHeadSha : null;
   if (!repairTaskId || !resolvedHeadSha || !EXACT_SHA.test(resolvedHeadSha)) {


### PR DESCRIPTION
## Summary
- treat exact no-changes Regression output without a repair attempt as audit-only evidence
- preserve fail-closed handoff validation for consumed and repaired failed Runs
- cover the production-equivalent retry and durable failed-source handoff

## Verification
- npm run typecheck -w @anneal/api
- npm run lint
- npm run build -w @anneal/api
- exact-head merge gate pending