### PR TITLE
chore(release): prepare Anneal v0.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: Release tag or commit
       description: The exact tag you checked out, or the commit SHA.
-      placeholder: v0.5.0
+      placeholder: v0.6.0
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,11 +66,12 @@ previews other than a fresh install. This release adds four migrations.
   latched, and the Inbox record remains as historical evidence.
 - Artifact build, backup, migration, Prisma generation, prompt sync and service
   control have independent deadlines plus a deployment-barrier watchdog.
-  Ordinary timeouts follow the normal failure path and release the barrier; the
-  current release remains active or is restored after a post-activation
-  failure. A migration-deploy timeout instead prevents activation and restart
-  and keeps the PostgreSQL barrier blocking new Run claims until an operator
-  safely runs `--clear-escalation`.
+  Ordinary timeouts follow the normal failure path and release the barrier.
+  Before publication the current release remains active; afterwards recovery
+  attempts to restore the prior release and services. Database migrations are
+  not rolled back. A migration-deploy timeout instead prevents activation and
+  restart and keeps the PostgreSQL barrier blocking new Run claims until an
+  operator safely runs `--clear-escalation`.
 
 ### Gate and test structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,10 @@ previews other than a fresh install. This release adds four migrations.
   delivery failure and does not raise the retry budget.
 - Canonical output-only Direct and Full Assurance Steps now snapshot an
   explicit `requiresCommit=false` contract onto each Run. They may publish an
-  unchanged shared branch for the next Step; implementation and planning Steps,
-  and manual Tasks, still require a commit by default.
+  unchanged shared branch for the next Step. The primary plan and implementation
+  Steps require a commit. A manual Task that requests a pull request also
+  requires one, while branch-only manual work retains its optional-commit
+  behaviour.
 - A negative Regression verdict from an older output-only Run rejected under
   the former commit requirement is audit-only evidence unless an exact repair
   attempt consumed it. Valid repair handoffs remain fail-closed.
@@ -64,9 +66,11 @@ previews other than a fresh install. This release adds four migrations.
   latched, and the Inbox record remains as historical evidence.
 - Artifact build, backup, migration, Prisma generation, prompt sync and service
   control have independent deadlines plus a deployment-barrier watchdog.
-  Ordinary timeouts roll back and release normally; a migration-deploy timeout
-  deliberately keeps services stopped and the PostgreSQL barrier held until an
-  operator safely runs `--clear-escalation`.
+  Ordinary timeouts follow the normal failure path and release the barrier; the
+  current release remains active or is restored after a post-activation
+  failure. A migration-deploy timeout instead prevents activation and restart
+  and keeps the PostgreSQL barrier blocking new Run claims until an operator
+  safely runs `--clear-escalation`.
 
 ### Gate and test structure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,88 @@ written.
 
 ## Unreleased
 
+## v0.6.0 — Developer Preview 6
+
+The sixth preview adds wave activation and live repair visibility to the chain
+board, makes zero-commit delivery outcomes explicit, and bounds the maintainer
+appliance's deployment steps. As with every 0.x minor, behaviour changes below
+are breaking-eligible. There is still no supported upgrade path between
+previews other than a fresh install. This release adds four migrations.
+
+### Board and chain operations
+
+- The Todo column can activate every parked chain aggregate on its current
+  visible page after one confirmation. Each chain retains its own startability
+  check; starts run concurrently, and a named refusal for one chain does not
+  stop the others.
+- Aggregate chain cards show an active detached merge-tail repair, including
+  its repair kind, latest Run, model and reasoning effort, Codex `FAST` tier and
+  elapsed time. The additive Board wire fields are
+  `chainAggregate.activeRepair` and `latestRun.codexServiceTier`.
+- Fully archived chains no longer reappear on the active Board through a
+  detached repair binding. Archived siblings still contribute to an aggregate
+  when a live member owns the card.
+
+### Runner delivery and chain evidence
+
+- A successful provider session whose Run requires a commit but leaves `HEAD`
+  at its base now fails before push or pull-request creation as
+  `NO_CHANGES_PRODUCED`, rather than surfacing GitHub's misleading
+  `No commits between` response. This outcome is not classified as an external
+  delivery failure and does not raise the retry budget.
+- Canonical output-only Direct and Full Assurance Steps now snapshot an
+  explicit `requiresCommit=false` contract onto each Run. They may publish an
+  unchanged shared branch for the next Step; implementation and planning Steps,
+  and manual Tasks, still require a commit by default.
+- A negative Regression verdict from an older output-only Run rejected under
+  the former commit requirement is audit-only evidence unless an exact repair
+  attempt consumed it. Valid repair handoffs remain fail-closed.
+
+### Merge-tail reliability
+
+- Historical pre-intent and target-branch-mismatch recovery refusals now use
+  typed `MergeRecoveryRefusalCode` values. Two migrations add the codes and
+  backfill exact legacy messages, so recovery decisions no longer parse
+  operator-facing prose.
+- Runner backend claim health, dependency-cache collaborators and the shared
+  Session, Run, Task, Chain, Trigger, Costs and Board wire contracts each have
+  one owning module instead of competing projections.
+
+### Maintainer deployment
+
+- A transient `remote-main-unreadable` result is retried within a bounded
+  budget. Only that transport escalation may self-clear after a later successful
+  read; persistent, authorization and malformed-response failures remain
+  latched, and the Inbox record remains as historical evidence.
+- Artifact build, backup, migration, Prisma generation, prompt sync and service
+  control have independent deadlines plus a deployment-barrier watchdog.
+  Ordinary timeouts roll back and release normally; a migration-deploy timeout
+  deliberately keeps services stopped and the PostgreSQL barrier held until an
+  operator safely runs `--clear-escalation`.
+
+### Gate and test structure
+
+- The longest parallel-review database test is split by subject so the merge
+  gate can schedule its cases in parallel without changing runtime behaviour.
+- No command, HTTP route or configuration key is intentionally removed in this
+  release. Observable contract additions are the `NO_CHANGES_PRODUCED` failure
+  class, the Step and Run `requiresCommit` policy, and the additive Board fields
+  above.
+
+### Known limitations
+
+- There is no supported in-place upgrade from v0.5.0. Install v0.6.0 against an
+  empty schema with `npm run db:migrate:release -- --fresh`.
+- The delivery symptom in [Issue #305](https://github.com/mosonlab/anneal/issues/305)
+  is now classified accurately, but the provider-side cause is not eliminated:
+  a code-producing provider can still end a successful session without writing
+  or committing its announced work. A manual Task's final prose remains in its
+  Session events and is not promoted to retry handoff output.
+- macOS on Apple Silicon remains the only target platform. Linux remains
+  unverified and Windows unsupported.
+- Anneal still launches coding CLIs with the operator account's authority and
+  is not a sandbox.
+
 ## v0.5.0 — Developer Preview 5
 
 The fifth preview makes the board read at chain level, makes completed work

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for reading this before opening something.
 
 ## The current state of contributions
 
-Anneal v0.5.0 is a Developer Preview published so that people can evaluate it,
+Anneal v0.6.0 is a Developer Preview published so that people can evaluate it,
 read it, and tell us where it is wrong. **We are not yet accepting outside pull
 requests.** The review and merge process this repository uses is built around a
 single gate run by maintainers, and we would rather say that plainly than leave

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You need:
 ```sh
 git clone https://github.com/mosonlab/anneal.git
 cd anneal
-git checkout v0.5.0
+git checkout v0.6.0
 npm ci
 npm run setup:local
 npm run build
@@ -151,7 +151,7 @@ The full sequence with its preflights is in
 
 ## Status
 
-Developer Preview 5 (v0.5.0): interfaces and stored data shapes may
+Developer Preview 6 (v0.6.0): interfaces and stored data shapes may
 change between previews, and the only upgrade path is a fresh install.
 macOS on Apple Silicon only.
 
@@ -171,7 +171,7 @@ you and the provider; the authoritative support statement is
 [Install](docs/install.md) ·
 [Security](docs/release/security.md) ·
 [Migration and recovery](docs/release/migration-and-recovery.md) ·
-[Release notes](docs/release/v0.5.0-release-notes.md) ·
+[Release notes](docs/release/v0.6.0-release-notes.md) ·
 [Contributing](CONTRIBUTING.md) ·
 [Support](SECURITY.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -118,7 +118,7 @@ merge-tail 修复。</sub>
 ```sh
 git clone https://github.com/mosonlab/anneal.git
 cd anneal
-git checkout v0.5.0
+git checkout v0.6.0
 npm ci
 npm run setup:local
 npm run build
@@ -132,7 +132,7 @@ npm run db:migrate:release -- --fresh
 
 ## 当前状态
 
-Developer Preview 5（v0.5.0）：接口与存储数据形态在 preview 之间可能
+Developer Preview 6（v0.6.0）：接口与存储数据形态在 preview 之间可能
 变化，唯一升级路径是全新安装。仅支持 Apple Silicon 上的 macOS。
 
 **把它指向任何你在乎的东西之前先读这段：** Anneal 以非交互的权限旁路
@@ -150,7 +150,7 @@ Provider CLI、它们的认证与套餐条款始终在你和 provider 之间；�
 [安装](docs/install.md) ·
 [安全](docs/release/security.md) ·
 [迁移与恢复](docs/release/migration-and-recovery.md) ·
-[发布说明](docs/release/v0.5.0-release-notes.md) ·
+[发布说明](docs/release/v0.6.0-release-notes.md) ·
 [贡献指南](CONTRIBUTING.md) ·
 [支持](SECURITY.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 | --- | --- |
-| 0.5.0 (Developer Preview) | Yes, on the target platform only — see [`docs/release/support-matrix.md`](docs/release/support-matrix.md) |
+| 0.6.0 (Developer Preview) | Yes, on the target platform only — see [`docs/release/support-matrix.md`](docs/release/support-matrix.md) |
 | 0.4.0 and earlier | No. A developer preview is superseded by the next one; there is no backport path. |
 
 There is no patch stream and no backport path. A fix ships as the next release; published

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 | Version | Supported |
 | --- | --- |
 | 0.6.0 (Developer Preview) | Yes, on the target platform only — see [`docs/release/support-matrix.md`](docs/release/support-matrix.md) |
-| 0.4.0 and earlier | No. A developer preview is superseded by the next one; there is no backport path. |
+| 0.5.0 and earlier | No. A developer preview is superseded by the next one; there is no backport path. |
 
 There is no patch stream and no backport path. A fix ships as the next release; published
 tags and release assets are immutable and are never rewritten in place.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anneal/web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -12,7 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@anneal/db": "0.5.0",
+    "@anneal/db": "0.6.0",
     "@radix-ui/react-checkbox": "^1.3.11",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,7 @@ into a provider and never reads a credential store.
 ```sh
 git clone https://github.com/mosonlab/anneal.git
 cd anneal
-git checkout v0.5.0
+git checkout v0.6.0
 npm ci
 npm run setup:local
 npm run build

--- a/docs/release/developer-preview.md
+++ b/docs/release/developer-preview.md
@@ -52,7 +52,7 @@ installation.
 ```sh
 git clone https://github.com/mosonlab/anneal.git
 cd anneal
-git checkout v0.5.0
+git checkout v0.6.0
 ```
 
 Check out the exact tag or commit the release names. A branch tip is not a

--- a/docs/release/v0.6.0-release-notes.md
+++ b/docs/release/v0.6.0-release-notes.md
@@ -1,0 +1,102 @@
+# Anneal v0.6.0 — Developer Preview 6
+
+This page is the release notes for `v0.6.0`, and the source text for the GitHub
+Release body of the same tag.
+
+Anneal is a local, single-operator control plane for handing scoped software
+tasks to coding CLIs already installed on your own machine, and for keeping what
+they did observable and durable: tasks, agents, repository and file grants,
+isolated run records, provider event streams, human questions, review gates and
+git delivery, in one workflow.
+
+**What this release is for.** The same envelope as the previews before it:
+evaluating Anneal on a machine you own, against repositories you are willing to
+have an agent write to. It is not a production install.
+
+## What changed since v0.5.0
+
+The headline is faster chain activation, visible merge-tail repair work, and
+delivery failures that say what actually happened:
+
+- **Activate parked chains in one wave.** The Todo column can start every
+  parked chain aggregate on its current page after one confirmation. Anneal
+  still checks each chain independently and names any refusal without
+  preventing the other eligible chains from starting.
+- **Active repair work stays on the chain card.** An aggregate card now shows
+  its active detached merge-tail repair, repair kind, latest Run, model and
+  reasoning effort, Codex `FAST` tier, and elapsed time. Fully archived chains
+  no longer leak back onto the active Board through a repair card.
+- **A zero-commit Run has its own outcome.** When a commit-producing Run exits
+  cleanly without advancing `HEAD`, Anneal reports `NO_CHANGES_PRODUCED` before
+  attempting a push or pull request instead of presenting GitHub's
+  `No commits between` response as the cause.
+- **Output-only Chain Steps no longer need a synthetic commit.** Canonical
+  Direct and Full Assurance Steps that publish durable output rather than
+  repository changes snapshot an explicit optional-commit contract onto each
+  Run and can publish an unchanged shared branch for the next Step. The primary
+  plan and implementation Steps, and manual Tasks, still require a commit by
+  default.
+- **Merge recovery no longer parses historical prose.** Legacy pre-intent and
+  target-branch-mismatch refusals are represented and backfilled as typed
+  codes. A stale Regression verdict rejected under the former output-only
+  delivery contract is not reused as repair evidence unless an exact repair
+  attempt consumed it.
+- **Maintainer deployment failures are bounded.** Remote-main reads retry
+  transient transport failures and can self-clear only that escalation after a
+  later successful read. Artifact, backup, migration and service-control work
+  has per-step deadlines plus a deployment-barrier watchdog. A migration
+  timeout deliberately leaves services stopped and the database barrier held
+  until the operator clears the escalation safely.
+- **Internal contracts and gate ownership are tighter.** Shared Session, Run,
+  Task, Chain, Trigger, Costs and Board wire types replace duplicate
+  projections; runner backend health and dependency-cache collaborators have
+  one owner; and the longest parallel-review database test is split for gate
+  scheduling. These changes are intended to preserve their existing external
+  behaviour.
+
+The full list, by area, is in [`CHANGELOG.md`](../../CHANGELOG.md).
+
+## Release identity
+
+| | |
+| --- | --- |
+| Version | `0.6.0` |
+| Tag | `v0.6.0` (annotated) |
+| Prerelease | Yes |
+| Release commit | The commit the `v0.6.0` tag points to, stated on the GitHub Release page. |
+
+## Install and upgrade
+
+There is no supported upgrade path between developer previews. This release
+adds four migrations, so install fresh, following the quickstart in the
+repository [`README.md`](../../README.md) — it checks out `v0.6.0`.
+
+Do not install this release over a v0.5.0 database. The supported release path
+is `npm run db:migrate:release -- --fresh` against an empty schema. The host
+warnings and verification steps in the
+[Developer Preview quickstart](developer-preview.md) apply unchanged.
+
+## Known limitations
+
+- The `NO_CHANGES_PRODUCED` classification fixes the misleading delivery
+  symptom reported in [Issue #305](https://github.com/mosonlab/anneal/issues/305),
+  not the provider-side cause. A code-producing provider can still end a
+  successful session after announcing work without writing or committing it.
+  For a manual Task, the final prose remains available in Session events but is
+  not promoted to retry handoff output.
+- There is no supported in-place upgrade from v0.5.0. Install this preview
+  against an empty schema through the fresh-install path above.
+- macOS on Apple Silicon remains the only target platform. Linux remains
+  unverified and Windows unsupported.
+- Anneal still launches coding CLIs with the operator account's authority and
+  is not a sandbox.
+
+## Support, security and licensing
+
+The [support matrix](support-matrix.md) remains the current statement of what is
+supported and on what evidence. macOS on Apple Silicon remains the only target;
+Linux is unverified and Windows unsupported. Anneal still launches coding CLIs
+with the operator account's authority and is not a sandbox.
+
+The [security](security.md), [license and assets](license-and-assets.md) and
+[migration and recovery](migration-and-recovery.md) documents remain current.

--- a/docs/release/v0.6.0-release-notes.md
+++ b/docs/release/v0.6.0-release-notes.md
@@ -34,8 +34,9 @@ delivery failures that say what actually happened:
   Direct and Full Assurance Steps that publish durable output rather than
   repository changes snapshot an explicit optional-commit contract onto each
   Run and can publish an unchanged shared branch for the next Step. The primary
-  plan and implementation Steps, and manual Tasks, still require a commit by
-  default.
+  plan and implementation Steps require a commit. A manual Task that requests a
+  pull request also requires one, while branch-only manual work retains its
+  optional-commit behaviour.
 - **Merge recovery no longer parses historical prose.** Legacy pre-intent and
   target-branch-mismatch refusals are represented and backfilled as typed
   codes. A stale Regression verdict rejected under the former output-only
@@ -45,8 +46,9 @@ delivery failures that say what actually happened:
   transient transport failures and can self-clear only that escalation after a
   later successful read. Artifact, backup, migration and service-control work
   has per-step deadlines plus a deployment-barrier watchdog. A migration
-  timeout deliberately leaves services stopped and the database barrier held
-  until the operator clears the escalation safely.
+  timeout leaves the current release active, prevents activation and restart,
+  and keeps the database barrier blocking new Run claims until the operator
+  clears the escalation safely.
 - **Internal contracts and gate ownership are tighter.** Shared Session, Run,
   Task, Chain, Trigger, Costs and Board wire types replace duplicate
   projections; runner backend health and dependency-cache collaborators have

--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -211,8 +211,10 @@ same escalation mechanism as other deployment failures.
 
 Timeouts for ordinary steps follow the normal failure path: the deployment
 process exits, its session-scoped PostgreSQL barrier is released automatically,
-and the services remain on (or return to) the current release. The
-`prisma migrate deploy` migration step is the deliberate exception. If it
+and before publication the current release remains active. After publication,
+recovery attempts to restore the prior release and services; database
+migrations are not rolled back. The `prisma migrate deploy` migration step is
+the deliberate exception. If it
 reaches its deadline, the child is terminated and the failure is written to
 `escalated.json` and notified, but the deploy process remains alive with the
 same database session and barrier held. The current release's service processes

--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -204,8 +204,8 @@ followed by `SIGKILL` if it does not exit, and is reported as a
 
 The deploy barrier also has an independent duration watchdog. It starts with
 barrier acquisition and covers hangs outside a child command, so a process
-that is no longer making step progress cannot hold the API and runner services
-stopped without an escalation. A watchdog expiry is logged, written to
+that is no longer making step progress cannot keep new Run claims closed
+without an escalation. A watchdog expiry is logged, written to
 `.agentos-deploy/escalated.json`, and sent to the operator Inbox through the
 same escalation mechanism as other deployment failures.
 
@@ -215,8 +215,10 @@ and the services remain on (or return to) the current release. The
 `prisma migrate deploy` migration step is the deliberate exception. If it
 reaches its deadline, the child is terminated and the failure is written to
 `escalated.json` and notified, but the deploy process remains alive with the
-same database session and barrier held. Services stay stopped in that safe
-state; do not restart them onto a possibly half-applied schema.
+same database session and barrier held. The current release's service processes
+remain running, but no new Run may be claimed and activation and restart do not
+proceed. The barrier is not a service-process stop; do not restart services onto
+a possibly half-applied schema.
 
 After the cause has been repaired, use the existing `--clear-escalation`
 operation. The held deploy process observes the cleared marker, releases its

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anneal",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anneal",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "workspaces": [
         "apps/*",
@@ -25,9 +25,9 @@
     },
     "apps/web": {
       "name": "@anneal/web",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
-        "@anneal/db": "0.5.0",
+        "@anneal/db": "0.6.0",
         "@radix-ui/react-checkbox": "^1.3.11",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
@@ -6216,12 +6216,12 @@
     },
     "packages/api": {
       "name": "@anneal/api",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@anneal/build-info": "0.5.0",
-        "@anneal/db": "0.5.0",
-        "@anneal/github-client": "0.5.0",
+        "@anneal/build-info": "0.6.0",
+        "@anneal/db": "0.6.0",
+        "@anneal/github-client": "0.6.0",
         "@hono/node-server": "^1.19.6",
         "cron-parser": "^5.10.0",
         "dotenv": "^17.2.3",
@@ -6230,7 +6230,7 @@
         "zod": "^4.1.12"
       },
       "devDependencies": {
-        "@anneal/runner": "0.5.0",
+        "@anneal/runner": "0.6.0",
         "@types/fs-ext": "^2.0.3",
         "@types/node": "^24.10.1",
         "tsx": "^4.20.6"
@@ -6250,11 +6250,11 @@
     },
     "packages/build-info": {
       "name": "@anneal/build-info",
-      "version": "0.5.0"
+      "version": "0.6.0"
     },
     "packages/db": {
       "name": "@anneal/db",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@prisma/client": "6.19.0",
         "zod": "^4.1.12"
@@ -6267,7 +6267,7 @@
     },
     "packages/github-client": {
       "name": "@anneal/github-client",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "devDependencies": {
         "@types/node": "^24.10.1",
         "tsx": "^4.20.6"
@@ -6275,9 +6275,9 @@
     },
     "packages/inbox": {
       "name": "@anneal/inbox",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
-        "@anneal/db": "0.5.0",
+        "@anneal/db": "0.6.0",
         "@larksuiteoapi/node-sdk": "^1.73.0",
         "dotenv": "^17.2.3"
       },
@@ -6300,10 +6300,10 @@
     },
     "packages/merge-executor": {
       "name": "@anneal/merge-executor",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
-        "@anneal/db": "0.5.0",
-        "@anneal/github-client": "0.5.0",
+        "@anneal/db": "0.6.0",
+        "@anneal/github-client": "0.6.0",
         "dotenv": "^17.2.3"
       },
       "devDependencies": {
@@ -6325,11 +6325,11 @@
     },
     "packages/runner": {
       "name": "@anneal/runner",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
-        "@anneal/build-info": "0.5.0",
-        "@anneal/db": "0.5.0",
-        "@anneal/github-client": "0.5.0",
+        "@anneal/build-info": "0.6.0",
+        "@anneal/db": "0.6.0",
+        "@anneal/github-client": "0.6.0",
         "dotenv": "^17.2.3",
         "fs-ext": "^2.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anneal",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anneal/api",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,9 +14,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anneal/build-info": "0.5.0",
-    "@anneal/db": "0.5.0",
-    "@anneal/github-client": "0.5.0",
+    "@anneal/build-info": "0.6.0",
+    "@anneal/db": "0.6.0",
+    "@anneal/github-client": "0.6.0",
     "@hono/node-server": "^1.19.6",
     "cron-parser": "^5.10.0",
     "dotenv": "^17.2.3",
@@ -25,7 +25,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@anneal/runner": "0.5.0",
+    "@anneal/runner": "0.6.0",
     "@types/fs-ext": "^2.0.3",
     "@types/node": "^24.10.1",
     "tsx": "^4.20.6"

--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anneal/build-info",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anneal/db",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -951,7 +951,8 @@ model Run {
   /// and never the live task row.
   opensPullRequest              Boolean                @default(true)
   /// Immutable delivery contract copied from the template Step at Run birth.
-  /// Manual Tasks default to requiring a commit.
+  /// For manual Tasks, Run birth derives this from the snapshotted
+  /// pull-request decision.
   requiresCommit                Boolean                @default(true)
   targetBranch                  String?
   branch                        String?

--- a/packages/db/src/open-run.test.ts
+++ b/packages/db/src/open-run.test.ts
@@ -168,13 +168,18 @@ const outputOnlyStep = {
   taskTemplate: { name: "direct-engineer-workflow" },
 };
 
-test("Run birth defaults manual Tasks to requiring a commit and snapshots an output-only Step", async () => {
+test("Run birth derives a manual commit policy from delivery shape and snapshots a template Step", async () => {
   const repo = { id: "repo-1", defaultBranch: "main" };
   const fixtures = [
     {
-      name: "manual Task",
+      name: "manual pull-request Task",
       task: taskRow({ repoId: repo.id, repo }),
       expected: true,
+    },
+    {
+      name: "manual branch-only Task",
+      task: taskRow({ repoId: repo.id, repo, opensPullRequest: false }),
+      expected: false,
     },
     {
       name: "output-only template Step",

--- a/packages/db/src/run-open.ts
+++ b/packages/db/src/run-open.ts
@@ -851,7 +851,11 @@ export const openRun = async (
     targetBranch: branches.targetBranch,
     branch: branches.branch,
     opensPullRequest: intent.kind === "integrator-authorized" ? false : task.opensPullRequest,
-    requiresCommit: task.templateStep?.requiresCommit ?? true,
+    // Canonical Steps own an explicit commit contract. A manual Task retains
+    // the pre-contract delivery boundary: asking for a pull request requires a
+    // commit, while branch-only work may complete through an external action or
+    // durable prose without inventing a repository change.
+    requiresCommit: task.templateStep?.requiresCommit ?? task.opensPullRequest,
     maxDurationMin: preservesPriorTiming ? prior?.maxDurationMin ?? task.maxDurationMin : task.maxDurationMin,
     stallTimeoutMin: preservesPriorTiming ? prior?.stallTimeoutMin ?? task.stallTimeoutMin : task.stallTimeoutMin,
     // The configured budget plus the grants already earned, not the budget

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anneal/github-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anneal/inbox",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -12,7 +12,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anneal/db": "0.5.0",
+    "@anneal/db": "0.6.0",
     "@larksuiteoapi/node-sdk": "^1.73.0",
     "dotenv": "^17.2.3"
   },

--- a/packages/merge-executor/package.json
+++ b/packages/merge-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anneal/merge-executor",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,8 +13,8 @@
     "schema-gate": "MERGE_EXECUTOR_SCHEMA_GATE_REQUIRED=1 node --import tsx --test src/schema-gate.test.ts"
   },
   "dependencies": {
-    "@anneal/db": "0.5.0",
-    "@anneal/github-client": "0.5.0",
+    "@anneal/db": "0.6.0",
+    "@anneal/github-client": "0.6.0",
     "dotenv": "^17.2.3"
   },
   "devDependencies": {

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anneal/runner",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -30,9 +30,9 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@anneal/build-info": "0.5.0",
-    "@anneal/db": "0.5.0",
-    "@anneal/github-client": "0.5.0",
+    "@anneal/build-info": "0.6.0",
+    "@anneal/db": "0.6.0",
+    "@anneal/github-client": "0.6.0",
     "dotenv": "^17.2.3",
     "fs-ext": "^2.1.1"
   },

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -64,6 +64,7 @@
     { "glob": "docs/release/v0.3.0-release-notes.md", "purpose": "the release notes for v0.3.0, and the source text for the GitHub Release body of the same tag" },
     { "glob": "docs/release/v0.4.0-release-notes.md", "purpose": "the release notes for v0.4.0, and the source text for the GitHub Release body of the same tag" },
     { "glob": "docs/release/v0.5.0-release-notes.md", "purpose": "the release notes for v0.5.0, and the source text for the GitHub Release body of the same tag" },
+    { "glob": "docs/release/v0.6.0-release-notes.md", "purpose": "the release notes for v0.6.0, and the source text for the GitHub Release body of the same tag" },
     { "glob": "docs/adr/0001-merge-lease-hold-window.md", "purpose": "diagnosis of the merge-lease hold window and the proposed narrowing of it" },
     { "glob": "docs/adr/0002-coordinate-main-delivery-with-merge-trains.md", "purpose": "accepted fixed-width cumulative-prefix design for concurrent host delivery" },
     { "glob": "docs/adr/0003-acquire-merge-lease-in-readiness.md", "purpose": "accepted readiness-owned merge-lease boundary and retry semantics" },


### PR DESCRIPTION
Prepare Anneal v0.6.0 Developer Preview 6 from main after PRs #320-#332.

Summary:

- synchronize the root and workspace versions and exact internal dependency pins at 0.6.0
- add the v0.6.0 changelog and GitHub Release source notes
- advance the English and Chinese quickstarts, support statement and issue template to Developer Preview 6
- record four new migrations, wave activation, active repair visibility, zero-commit delivery classification, output-only Step delivery and bounded maintainer deployment
- retain Issue #305 as a partial known limitation rather than claiming its provider-side cause is fixed
- preserve optional commits for manual branch-only Tasks while requiring commits for manual pull-request Tasks

Exact-head evidence for 79f46fd671f82f6a360c3b2df50b3b387f13c1ec:

- remote full merge gate: MERGE GATE: PASS 79f46fd671f82f6a360c3b2df50b3b387f13c1ec
- release documentation contract: 13/13 passed
- dependency gate: 15/15 passed
- compose binding: loopback-only PASS
- public snapshot scan: blocker=0, unclassified=0
- live GitHub schema gate: 2/2 passed
- targeted database open-run test: 9/9 passed
- database CLI typecheck: passed
- exact-head P0/P1 review: no remaining findings

Gate stability disposition:

- The first authoritative remote full gate passed for the exact head. Later local and remote reruns exposed timer-, load-, and race-sensitive test failures tracked in Issue #334.
- On 2026-08-30 the maintainer explicitly deferred these gate-stability failures to Backlog rather than treating them as a v0.6.0 product-regression blocker.
- The failed reruns are not represented as passing evidence and do not replace the earlier exact remote PASS above.

Release-only evidence waiver (v0.6.0 only):

- Step 9 real GitHub direction harness: WAIVED / NOT RUN
- Step 10 non-production end-to-end system demonstration: WAIVED / NOT RUN
- On 2026-08-30 the maintainer explicitly accepted this release-evidence gap to publish v0.6.0 as a GitHub Prerelease. These checks are not represented as passing evidence.

