### PR TITLE
fix(api): refuse malformed Route lines at direct instantiation

### DIFF
--- a/docs/BRIEF-TEMPLATE.md
+++ b/docs/BRIEF-TEMPLATE.md
@@ -79,7 +79,9 @@ is — a brief that cannot reach mechanical Acceptance is compound-shaped
 regardless of tier.
 
 Direct-template instantiation parses and validates the `Route:` line and applies
-it to the implementation step. Explicit `stepOverrides` are a separate API
+it to the implementation step. A line starting with `Route:` that does not
+match the grammar exactly is refused at instantiation rather than silently
+ignored. Explicit `stepOverrides` are a separate API
 mechanism; do not supply both for that step. Compound and custom templates do
 not interpret Route-looking prose.
 

--- a/packages/api/src/refusal.ts
+++ b/packages/api/src/refusal.ts
@@ -62,6 +62,7 @@ export const refusalResponse = (refusal: Refusal): RefusalResponse => {
     case "dispatch_conflicts_with_auto_start":
     case "implementation_route_agent_renamed":
     case "implementation_route_conflicts_with_step_override":
+    case "implementation_route_malformed":
     case "implementation_route_unknown_agent":
     case "repo_not_found":
     case "step_override_agent_archived":

--- a/packages/api/src/template-errors.ts
+++ b/packages/api/src/template-errors.ts
@@ -8,6 +8,7 @@ export type TemplateInstantiationRefusalCode =
   | "dispatch_conflicts_with_auto_start"
   | "implementation_route_agent_renamed"
   | "implementation_route_conflicts_with_step_override"
+  | "implementation_route_malformed"
   | "implementation_route_unknown_agent"
   | "repo_not_found"
   | "step_override_agent_archived"

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -19,6 +19,7 @@ import {
 
 import {
   composeTemplateTaskDescription,
+  findMalformedRouteLine,
   instantiateTemplate,
   parseImplementationRoute,
 } from "./templates.js";
@@ -68,6 +69,13 @@ test("implementation route parsing accepts the machine-readable name before an o
   assert.equal(parseImplementationRoute("Route: implementation=senior-dev "), null);
   assert.equal(parseImplementationRoute("Route: implementation=unknown"), "unknown");
   assert.equal(parseImplementationRoute(undefined), null);
+  assert.equal(findMalformedRouteLine("Build it\nRoute: implementation=senior-dev\n"), null);
+  assert.equal(findMalformedRouteLine("Route: implementation=senior-dev - reason given"), null);
+  assert.equal(findMalformedRouteLine("Route: implementation=unknown"), null);
+  assert.equal(findMalformedRouteLine("Route: senior-dev - missing the implementation= key"), "Route: senior-dev - missing the implementation= key");
+  assert.equal(findMalformedRouteLine("Route: implementation=senior-dev "), "Route: implementation=senior-dev ");
+  assert.equal(findMalformedRouteLine("Build it\nRoute:implementation=senior-dev"), "Route:implementation=senior-dev");
+  assert.equal(findMalformedRouteLine(undefined), null);
 });
 
 test("a direct brief ending in the prior-output reminder round-trips without truncation", () => {
@@ -613,6 +621,15 @@ test("an unbound direct chain omits revalidation while Route overrides the renum
   );
 
   lockedRouteAgentName = routed.name;
+  await assertTemplateRefusal(
+    () => instantiateTemplate(db, "project-1", "template-1", {
+      repoId: "repo-1",
+      variables: {},
+      description: "Build it\nRoute: senior-dev - missing the implementation= key\n",
+    }),
+    "implementation_route_malformed",
+  );
+
   for (const nonDirectName of ["custom-workflow", "compound-engineer-workflow"]) {
     templateName = nonDirectName;
     const originalOutputKind = steps[1]!.outputKind;
@@ -625,6 +642,12 @@ test("an unbound direct chain omits revalidation while Route overrides the renum
       });
       assert.equal(nonDirect.tasks.length, 3, `${nonDirectName} must ignore ${route}`);
     }
+    const malformedTolerated = await instantiateTemplate(db, "project-1", "template-1", {
+      repoId: "repo-1",
+      variables: {},
+      description: "Route: senior-dev - Route-looking prose is not parsed here",
+    });
+    assert.equal(malformedTolerated.tasks.length, 3, `${nonDirectName} must ignore malformed Route prose`);
     steps[1]!.outputKind = originalOutputKind;
   }
 });

--- a/packages/api/src/templates.ts
+++ b/packages/api/src/templates.ts
@@ -53,6 +53,21 @@ export const parseImplementationRoute = (description: string | undefined): strin
   return match?.[1] ?? null;
 };
 
+const implementationRouteLineExact = new RegExp(implementationRouteLine.source, "u");
+
+/**
+ * Finds the first line that claims to be a machine-readable route but does not
+ * match the full grammar. A near-miss must refuse loudly: silently ignoring it
+ * dispatches the implementation step on the template default agent while the
+ * brief author believes their route was applied.
+ */
+export const findMalformedRouteLine = (description: string | undefined): string | null => {
+  for (const line of (description ?? "").split("\n")) {
+    if (line.startsWith("Route:") && !implementationRouteLineExact.test(line)) return line;
+  }
+  return null;
+};
+
 type OverrideAgent = {
   id: string;
   name: string;
@@ -223,6 +238,15 @@ export const instantiateTemplate = async (
   const implementationRoute = template.name === "direct-engineer-workflow"
     ? parseImplementationRoute(input.description)
     : null;
+  if (template.name === "direct-engineer-workflow") {
+    const malformedRouteLine = findMalformedRouteLine(input.description);
+    if (malformedRouteLine !== null) {
+      throw templateRefusal(
+        "implementation_route_malformed",
+        `Malformed Route line ${JSON.stringify(malformedRouteLine)}; expected "Route: implementation=<agent> - <reason>" with agent one of senior-dev-luna, senior-dev, frontend-dev`,
+      );
+    }
+  }
   if (implementationRoute !== null && !implementationRouteAgents.has(implementationRoute)) {
     throw templateRefusal(
       "implementation_route_unknown_agent",


### PR DESCRIPTION
A `Route:`-prefixed line that does not match the full `Route: implementation=<agent> - <reason>` grammar was silently ignored during direct-template instantiation: the implementation step silently kept the template default agent (senior-dev-luna) while the brief author believed their route was applied. Chain 45e9bdd4 (2026-08-31) was misrouted exactly this way and had to be held, cancelled, and reassigned by hand.

- `findMalformedRouteLine` (exported, pure) finds the first near-miss line; direct instantiation refuses it with a 400 `implementation_route_malformed` naming the offending line and the expected grammar.
- A grammar-valid line with an unknown agent still hits the existing `implementation_route_unknown_agent` refusal.
- Compound and custom templates keep ignoring Route-looking prose (documented behavior, now covered by a test).
- docs/BRIEF-TEMPLATE.md states the refusal.

Tests: templates.test.ts 14/14 (new cases: near-miss refused, trailing-space refused, missing-space refused, valid/unknown/absent untouched, compound tolerance); @anneal/api unit suite 730 pass; npm run lint and test:snapshot-scan green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fbhp8jZP5bLJcJja7dGsCQ