### PR TITLE
fix: stop two silent failure paths found during the 2026-09-01 DB credential drift

### DIFF
--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -314,8 +314,16 @@ artifact again; and rerun `--dry-run`.
 
 Only then clear and retry:
 
+Run this from the deployment root — the directory holding `current/` and
+`.agentos-deploy/`. The marker path hangs off `AGENTOS_REPOSITORY_ROOT`, so
+without it the command resolves its state directory to `current/.agentos-deploy/`,
+deletes nothing, and prints `NO-ESCALATION-TO-CLEAR path=...` while the real
+marker stays latched. Check that path in the output before assuming the
+escalation is gone.
+
 ```sh
-node current/scripts/deploy/quiet-window-deploy.mjs --clear-escalation
+AGENTOS_REPOSITORY_ROOT="$PWD" \
+  node current/scripts/deploy/quiet-window-deploy.mjs --clear-escalation
 launchctl kickstart -k "gui/$(id -u)/com.agentos.auto-deploy"
 ```
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -194,7 +194,10 @@ const main = async (): Promise<void> => {
 
   await ownership.assertHeld();
   const reconciliation = await reconcileAtStartup(prisma);
-  console.log(`Startup reconciliation: ${reconciliation.runs} database runs reconciled, ${reconciliation.openReclaimIntents} workspace reclaim intents awaiting their runner, ${reconciliation.archivedNotices} archived-run notices`);
+  // `unavailable` rather than a number the process never read: see
+  // `StartupReconciliation` in reconcile.ts.
+  const count = (value: number | null): string => (value === null ? "unavailable" : String(value));
+  console.log(`Startup reconciliation: ${reconciliation.runs} database runs reconciled, ${count(reconciliation.openReclaimIntents)} workspace reclaim intents awaiting their runner, ${count(reconciliation.archivedNotices)} archived-run notices`);
   await ensureStartupActive();
 
   const githubReader = createGitHubReader();

--- a/packages/api/src/reconcile.test.ts
+++ b/packages/api/src/reconcile.test.ts
@@ -172,10 +172,13 @@ test("startup reconciliation does not fail when archived notice persistence fail
   console.error = (...args: unknown[]) => { logged = args.map(String).join(" "); };
   try {
     const result = await reconcileAtStartup(database);
+    // Startup still survives the failure, but the count it could not read is
+    // `null` rather than `0`: a fabricated zero is indistinguishable from a
+    // healthy idle control plane in the startup line an operator reads.
     assert.deepEqual(result, {
       runs: 0,
       openReclaimIntents: 0,
-      archivedNotices: 0,
+      archivedNotices: null,
     });
     assert.match(logged, /Archived-run startup notice failed.*audit unavailable/);
   } finally {

--- a/packages/api/src/reconcile.ts
+++ b/packages/api/src/reconcile.ts
@@ -394,20 +394,31 @@ export const reconcileDatabaseRuns = async (
  * runner asking, workspaces leak, and leaking is the direction this side of
  * the boundary is allowed to fail in.
  */
+/** A count that failed to be read is not a count of zero.
+ *
+ *  Both of these were `.catch(() => 0)`, which let a failed query render as
+ *  `0 archived-run notices` in the startup line — the shape a healthy, idle
+ *  control plane has. The 2026-09-01 credential drift was invisible partly for
+ *  that reason: the numbers a reader would have checked were manufactured by
+ *  the catch, not read from the schema. `null` keeps startup non-fatal (these
+ *  are advisory counts; `reconcileDatabaseRuns` above already throws when the
+ *  schema is unreachable) while refusing to state a number nobody read. */
+export type StartupReconciliation = {
+  runs: number;
+  openReclaimIntents: number | null;
+  archivedNotices: number | null;
+};
+
 export const reconcileAtStartup = async (
   db: PrismaClient,
-): Promise<{
-  runs: number;
-  openReclaimIntents: number;
-  archivedNotices: number;
-}> => ({
+): Promise<StartupReconciliation> => ({
   runs: await reconcileDatabaseRuns(db),
   openReclaimIntents: await openReclaimIntentCount(db).catch((error: unknown) => {
     console.error("Open reclaim intent count failed", error);
-    return 0;
+    return null;
   }),
   archivedNotices: await noteArchivedQueuedRuns(db).catch((error: unknown) => {
     console.error("Archived-run startup notice failed", error);
-    return 0;
+    return null;
   }),
 });

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -902,7 +902,18 @@ const main = async () => {
   const options = parseArgs(process.argv.slice(2));
   if (!Number.isSafeInteger(POLL_MS) || POLL_MS < 1_000) fail("environment-invalid", "QUIET_WINDOW_POLL_SECONDS-must-be-a-positive-integer");
   if (options.clearEscalation) {
-    if (existsSync(ESCALATION_PATH)) unlinkSync(ESCALATION_PATH);
+    // Removing nothing and reporting CLEARED is how this command lied on
+    // 2026-09-01: STATE_DIR hangs off AGENTOS_REPOSITORY_ROOT, so running it
+    // from a release checkout without that variable pointed it at an empty
+    // `current/.agentos-deploy/`, deleted nothing, and printed the success
+    // line anyway while the real marker kept holding the deploy. Clearing an
+    // absent marker stays exit 0 — it is idempotent, not an error — but it
+    // says which path it looked at, so a wrong root is visible immediately.
+    if (!existsSync(ESCALATION_PATH)) {
+      log(`NO-ESCALATION-TO-CLEAR path=${ESCALATION_PATH}`);
+      return 0;
+    }
+    unlinkSync(ESCALATION_PATH);
     log("CLEARED escalation operator-action-required-before-this-command");
     return 0;
   }

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -397,6 +397,29 @@ test("--clear-escalation removes any marker without deployment environment initi
   assert.match(result.stdout, /CLEARED escalation operator-action-required-before-this-command/u);
 });
 
+test("--clear-escalation reports the path it looked at when no marker exists", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "anneal-deploy-manual-clear-absent-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+
+  const result = spawnSync(process.execPath, [DEPLOY_SCRIPT, "--clear-escalation"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AGENTOS_REPOSITORY_ROOT: root,
+      QUIET_WINDOW_POLL_SECONDS: "60",
+      DATABASE_URL: "",
+      FEISHU_DEFAULT_CHAT_ID: "",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  // The failure this covers: an operator pointed at the wrong root reads
+  // "CLEARED" while the real marker is still in place.
+  assert.doesNotMatch(result.stdout, /CLEARED escalation/u);
+  assert.match(result.stdout, /NO-ESCALATION-TO-CLEAR path=/u);
+  assert.match(result.stdout, new RegExp(`path=${root.replaceAll("\\", "\\\\")}`, "u"));
+});
+
 test("service inventory covers the thirteen production labels", () => {
   assert.equal(SERVICE_LABELS.length, 13);
   assert.equal(SERVICE_LABELS[0], "com.agentos.api");


### PR DESCRIPTION
Both fixes come from diagnosing a production incident where the configured
database password no longer matched the database. The outage itself is
repaired; these are the two places that made it harder to see than it should
have been.

## `reconcileAtStartup` manufactured zeros

Two advisory counts were `.catch(() => 0)`. A failed query therefore rendered
as `0 archived-run notices` in the startup line — indistinguishable from a
healthy, idle control plane. They now return `null` and print `unavailable`.

Startup stays non-fatal for these two: they are advisory, and
`reconcileDatabaseRuns` already throws when the schema is unreachable. The
process simply no longer states a number nobody read.

The existing test asserted the old behaviour (`archivedNotices: 0` on
failure), so it is updated — it had pinned the defect in place.

## `--clear-escalation` reported success without clearing anything

`STATE_DIR` hangs off `AGENTOS_REPOSITORY_ROOT`. Run from a release checkout
without that variable, the command resolved the marker to an empty
`current/.agentos-deploy/`, deleted nothing, and still printed `CLEARED`
while the real escalation kept holding the deploy.

The runbook's own command block omitted the variable, so an operator
following it during an incident hit exactly this. That is how it was found.

Clearing an absent marker stays exit 0 — idempotent, not an error — but now
prints `NO-ESCALATION-TO-CLEAR path=...`, and the runbook block is
self-contained.

## Verification

- `npm run test:auto-deploy` — 88 pass, including a new test asserting the
  absent-marker path never prints `CLEARED`
- `npx tsx --test packages/api/src/reconcile.test.ts` — 7 pass
- `npm run typecheck -w @anneal/api` — clean
- `npm run test:snapshot-scan` — 20 pass (docs touched)
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WB7teAJphgbPxqmJEGxaYg