### PR TITLE
fix(tasks): archive chain cards atomically

### DIFF
--- a/apps/web/src/components/chain-aggregate-card.tsx
+++ b/apps/web/src/components/chain-aggregate-card.tsx
@@ -13,7 +13,7 @@ import { useT, type Translate } from "../lib/i18n";
 export type ChainAggregateActions = {
   onActivate: (taskId: string) => void;
   onFilter: (aggregate: ChainAggregate) => void;
-  onArchive: (aggregate: ChainAggregate, memberTaskIds: readonly string[]) => void;
+  onArchive: (aggregate: ChainAggregate) => void;
 };
 
 /** Every state that still names itself on the card. `running` is absent by
@@ -45,7 +45,6 @@ const routeFor = (representativeTaskId: string): string => `/tasks/${representat
 const menu = (
   aggregate: ChainAggregate,
   representativeTaskId: string,
-  memberTaskIds: readonly string[],
   actions: ChainAggregateActions,
   t: Translate,
 ): RowMenuEntry[] => [
@@ -55,7 +54,7 @@ const menu = (
     : []),
   { label: t("tasks.aggregate.menu.filter"), onSelect: () => actions.onFilter(aggregate) },
   ...(aggregate.activation.state === "settled"
-    ? [{ label: t("tasks.aggregate.menu.archive"), onSelect: () => actions.onArchive(aggregate, memberTaskIds) }]
+    ? [{ label: t("tasks.aggregate.menu.archive"), onSelect: () => actions.onArchive(aggregate) }]
     : []),
 ];
 
@@ -71,7 +70,6 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
   const position = memberPosition(aggregate, members);
   const state = aggregate.activation.state;
   const predecessor = aggregate.activation.predecessor;
-  const memberTaskIds = members.map((member) => member.id);
   const activeRepair = aggregate.activeRepair;
   const cost = usageCostAmount(aggregate.totalCost);
   const handlers: ChainAggregateActions = actions ?? { onActivate: () => undefined, onFilter: () => undefined, onArchive: () => undefined };
@@ -112,7 +110,7 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
     chainId={aggregate.chainId}
     route={routeFor(representative)}
     title={title}
-    menuItems={menu(aggregate, representative, memberTaskIds, handlers, t)}
+    menuItems={menu(aggregate, representative, handlers, t)}
     menuLabel={t("tasks.aggregate.actionsFor", { name: title })}
     metaRows={metaRows}
     failure={aggregate.frontier.failureReason === null

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -109,6 +109,7 @@ export const en = {
   "agents.tools.toggle": "Enable {tool}",
   "archived.empty": "Nothing archived yet.",
   "archived.menu.unarchive": "Unarchive",
+  "archived.menu.unarchiveChain": "Unarchive chain",
   "archived.table.agent": "Agent",
   "archived.table.archived": "Archived",
   "archived.table.chain": "Chain",

--- a/apps/web/src/locales/zh.ts
+++ b/apps/web/src/locales/zh.ts
@@ -108,6 +108,7 @@ export const zh = {
   "agents.tools.toggle": "启用{tool}",
   "archived.empty": "还没有归档任何东西。",
   "archived.menu.unarchive": "取消归档",
+  "archived.menu.unarchiveChain": "取消归档任务链",
   "archived.table.agent": "Agent",
   "archived.table.archived": "归档时间",
   "archived.table.chain": "任务链",

--- a/apps/web/src/pages/Archived.tsx
+++ b/apps/web/src/pages/Archived.tsx
@@ -38,7 +38,7 @@ export const ArchivedRow = ({ task, onUnarchive }: { task: TaskList; onUnarchive
       <TableCell>{chainMarker(task.chainProgress) ?? "—"}</TableCell>
       <TableCell>{formatDateTime(task.archivedAt)}</TableCell>
       <TableCell className={TABLE_TIGHT}>
-        <RowMenu items={[{ label: t("archived.menu.unarchive"), onSelect: () => onUnarchive(task) }]} />
+        <RowMenu items={[{ label: t(task.chainId === null ? "archived.menu.unarchive" : "archived.menu.unarchiveChain"), onSelect: () => onUnarchive(task) }]} />
       </TableCell>
     </TableRow>
   );

--- a/apps/web/src/pages/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail.tsx
@@ -449,7 +449,9 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
           </Button>
         ) : null}
         <Button type="button" variant="legacy" size="legacy" disabled={pending} onClick={() => setArchived(task.archivedAt === null)}>
-          <IconArchive />{t(task.archivedAt === null ? "tasks.menu.archive" : "archived.menu.unarchive")}
+          <IconArchive />{t(task.archivedAt === null
+            ? task.chainId === null ? "tasks.menu.archive" : "tasks.aggregate.menu.archive"
+            : task.chainId === null ? "archived.menu.unarchive" : "archived.menu.unarchiveChain")}
         </Button>
         <Button type="button" variant="legacy" size="legacy" onClick={reload}><IconRefresh />{t("common.refresh")}</Button>
       </div>

--- a/apps/web/src/pages/Tasks.tsx
+++ b/apps/web/src/pages/Tasks.tsx
@@ -445,13 +445,12 @@ export const TasksPage = (): ReactNode => {
       void run(async () => { await start.requestForMove(taskId); });
     },
     onFilter: (aggregate) => setChainFilter({ id: aggregate.chainId, name: aggregate.chainName ?? aggregate.chainId.slice(0, 8) }),
-    // The aggregate owns the visible members returned by this board read.
-    // Archived siblings are already absent; settling the rest through the
-    // existing idempotent task route removes the aggregate without inventing a
-    // second chain-execution mutation.
-    onArchive: (_aggregate, taskIds) => {
+    // One member addresses the whole Chain. The API already holds every Chain
+    // row under one transaction, so the card cannot disappear halfway through
+    // a client-side request loop.
+    onArchive: (aggregate) => {
       void run(async () => {
-        for (const taskId of taskIds) await api.post(`/tasks/${taskId}/archive`, {});
+        await api.post(`/tasks/${aggregate.detailTaskId}/archive`, {});
         reload();
       });
     },

--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -1234,6 +1234,7 @@ curl -X POST "$BASE_URL/tasks/$TASK_ID/start" -H "Authorization: Bearer $OPERATO
 ### POST `/tasks/:taskId/archive`
 
 - Required path parameter: `taskId`.
+- If the task belongs to a Chain, archives every task in that Chain atomically.
 
 ```sh
 curl -X POST "$BASE_URL/tasks/$TASK_ID/archive" -H "Authorization: Bearer $OPERATOR_TOKEN"
@@ -1242,6 +1243,7 @@ curl -X POST "$BASE_URL/tasks/$TASK_ID/archive" -H "Authorization: Bearer $OPERA
 ### POST `/tasks/:taskId/unarchive`
 
 - Required path parameter: `taskId`.
+- If the task belongs to a Chain, unarchives every task in that Chain atomically.
 
 ```sh
 curl -X POST "$BASE_URL/tasks/$TASK_ID/unarchive" -H "Authorization: Bearer $OPERATOR_TOKEN"

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -77,7 +77,7 @@ import { activityInput } from "../run-lifecycle.js";
 import { OPERATOR_NOTE_METADATA_FIELD } from "../run-claim.js";
 import { computeNextOccurrence, validateSchedule } from "../scheduler.js";
 import { patchTask, taskInput, taskPatch } from "../task-patch.js";
-import { hasActiveRun, isLiveStatus, lockTaskMutationRows, reactivationBlocked } from "../task-write.js";
+import { isLiveStatus, lockTaskMutationRows, reactivationBlocked } from "../task-write.js";
 import { readCommitted } from "../transaction.js";
 import { withoutUndefined } from "../without-undefined.js";
 import {
@@ -567,19 +567,37 @@ export const registerTasksRoutes = (app: RouteApp, deps: RouteDeps): void => {
     const result = await readCommitted(db, async (tx) => {
       const locked = await lockTaskMutationRows(tx, taskId);
       if (!locked) return refusal("not-found", "Task not found");
-      if (await hasActiveRun(tx, taskId)) {
+      const taskIds = locked.chainId === null
+        ? [taskId]
+        : (await tx.task.findMany({
+            where: { projectId: locked.projectId, chainId: locked.chainId },
+            select: { id: true },
+          })).map((task) => task.id);
+      const activeRuns = await tx.run.count({
+        where: { taskId: { in: taskIds }, status: { in: ACTIVE_RUN_STATUSES } },
+      });
+      if (activeRuns > 0) {
         return refusal("conflict", "Cannot archive a task with an active run");
       }
-      if (locked.status === TaskStatus.REVIEW) {
-        const open = await tx.inboxMessage.count({ where: { gateTaskId: taskId, status: InboxStatus.OPEN } });
+      const tasks = await tx.task.findMany({
+        where: { id: { in: taskIds } },
+        select: { id: true, status: true, archivedAt: true },
+      });
+      const reviewIds = tasks.filter((task) => task.status === TaskStatus.REVIEW).map((task) => task.id);
+      if (reviewIds.length > 0) {
+        const open = await tx.inboxMessage.count({
+          where: { gateTaskId: { in: reviewIds }, status: InboxStatus.OPEN },
+        });
         if (open > 0) return refusal("conflict", "Decide the approval gate in the Inbox first");
       }
-      if (locked.archivedAt !== null) {
-        return { task: await tx.task.findUniqueOrThrow({ where: { id: taskId } }) };
+      const archiveIds = tasks.filter((task) => task.archivedAt === null).map((task) => task.id);
+      if (archiveIds.length > 0) {
+        await tx.task.updateMany({ where: { id: { in: archiveIds } }, data: { archivedAt: new Date() } });
+        await tx.taskActivity.createMany({ data: archiveIds.map((archivedTaskId) => ({
+          taskId: archivedTaskId, actorType: "operator", body: "Task archived",
+        })) });
       }
-      const task = await tx.task.update({ where: { id: taskId }, data: { archivedAt: new Date() } });
-      await tx.taskActivity.create({ data: { taskId, actorType: "operator", body: "Task archived" } });
-      return { task };
+      return { task: await tx.task.findUniqueOrThrow({ where: { id: taskId } }) };
     });
     if ("message" in result) return refusalJson(context, result);
     return context.json(result.task);
@@ -599,16 +617,34 @@ export const registerTasksRoutes = (app: RouteApp, deps: RouteDeps): void => {
     const result = await readCommitted(db, async (tx) => {
       const locked = await lockTaskMutationRows(tx, taskId);
       if (!locked) return refusal("not-found", "Task not found");
-      if (locked.archivedAt === null) {
-        return { task: await tx.task.findUniqueOrThrow({ where: { id: taskId } }) };
-      }
-      if (isLiveStatus(locked.status)) {
-        const blocked = await reactivationBlocked(tx, locked);
+      const taskIds = locked.chainId === null
+        ? [taskId]
+        : (await tx.task.findMany({
+            where: { projectId: locked.projectId, chainId: locked.chainId },
+            select: { id: true },
+          })).map((task) => task.id);
+      const tasks = await tx.task.findMany({
+        where: { id: { in: taskIds } },
+        select: { id: true, status: true, archivedAt: true, projectId: true, assigneeAgentId: true },
+      });
+      const reactivating = tasks
+        .filter((task) => task.archivedAt !== null && isLiveStatus(task.status))
+        .sort((left, right) => (
+          (left.assigneeAgentId ?? "").localeCompare(right.assigneeAgentId ?? "")
+          || left.id.localeCompare(right.id)
+        ));
+      for (const task of reactivating) {
+        const blocked = await reactivationBlocked(tx, task);
         if (blocked) return refusal("conflict", blocked);
       }
-      const task = await tx.task.update({ where: { id: taskId }, data: { archivedAt: null } });
-      await tx.taskActivity.create({ data: { taskId, actorType: "operator", body: "Task unarchived" } });
-      return { task };
+      const unarchiveIds = tasks.filter((task) => task.archivedAt !== null).map((task) => task.id);
+      if (unarchiveIds.length > 0) {
+        await tx.task.updateMany({ where: { id: { in: unarchiveIds } }, data: { archivedAt: null } });
+        await tx.taskActivity.createMany({ data: unarchiveIds.map((unarchivedTaskId) => ({
+          taskId: unarchivedTaskId, actorType: "operator", body: "Task unarchived",
+        })) });
+      }
+      return { task: await tx.task.findUniqueOrThrow({ where: { id: taskId } }) };
     });
     if ("message" in result) return refusalJson(context, result);
     return context.json(result.task);

--- a/packages/api/src/tasks.dbtest.ts
+++ b/packages/api/src/tasks.dbtest.ts
@@ -597,6 +597,69 @@ test("archive and unarchive round-trip, and the board hides the archived task", 
   assert.equal((await call("POST", `/tasks/${context.task.id}/unarchive`)).status, 200);
 });
 
+test("archiving or unarchiving one Chain task changes the whole Chain atomically", async () => {
+  const chainId = `archive-chain-${Date.now()}`;
+  const context = await seedTask("archive-chain", { chainId, chainIndex: 0, status: "DONE" });
+  const frontier = await db.task.create({ data: {
+    projectId: context.project.id,
+    assigneeAgentId: context.agent.id,
+    repoId: context.repo.id,
+    name: "Archive Chain frontier",
+    description: "d",
+    status: "REVIEW",
+    chainId,
+    chainIndex: 1,
+    chainLayer: 1,
+  } });
+
+  assert.equal((await call("POST", `/tasks/${frontier.id}/archive`)).status, 200);
+  assert.equal((await db.task.count({ where: { chainId, archivedAt: null } })), 0);
+  assert.equal((await call("GET", `/tasks?projectId=${context.project.id}`)).body.length, 0);
+  assert.equal(await db.taskActivity.count({
+    where: { taskId: { in: [context.task.id, frontier.id] }, body: "Task archived" },
+  }), 2);
+
+  assert.equal((await call("POST", `/tasks/${context.task.id}/unarchive`)).status, 200);
+  assert.equal((await db.task.count({ where: { chainId, archivedAt: null } })), 2);
+  assert.equal((await call("GET", `/tasks?projectId=${context.project.id}`)).body.length, 2);
+  assert.equal(await db.taskActivity.count({
+    where: { taskId: { in: [context.task.id, frontier.id] }, body: "Task unarchived" },
+  }), 2);
+});
+
+test("a busy Chain member refuses the whole archive without partial writes", async () => {
+  const chainId = `archive-chain-busy-${Date.now()}`;
+  const context = await seedTask("archive-chain-busy", { chainId, chainIndex: 0, status: "DONE" });
+  const busy = await db.task.create({ data: {
+    projectId: context.project.id,
+    assigneeAgentId: context.agent.id,
+    repoId: context.repo.id,
+    name: "Busy Chain member",
+    description: "d",
+    status: "DOING",
+    chainId,
+    chainIndex: 1,
+    chainLayer: 1,
+  } });
+  await db.run.create({ data: {
+    projectId: context.project.id,
+    taskId: busy.id,
+    agentId: context.agent.id,
+    repoId: context.repo.id,
+    runNumber: 1,
+    dedupeKey: `task:${busy.id}:run:1`,
+    runner: "CLAUDE",
+    model: "claude",
+    promptHash: "h",
+    status: "RUNNING",
+  } });
+
+  const response = await call("POST", `/tasks/${context.task.id}/archive`);
+  assert.equal(response.status, 409);
+  assert.equal(response.body.error, "Cannot archive a task with an active run");
+  assert.equal((await db.task.count({ where: { chainId, archivedAt: null } })), 2);
+});
+
 test("archive refuses a task with an active run", async () => {
   const context = await seedTask("archive-busy");
   await seedRun(context, 1, "RUNNING");


### PR DESCRIPTION
## Summary
- make existing task archive and unarchive routes apply to the whole Chain
- replace the aggregate card request loop with one atomic request
- label Chain archive actions explicitly and document the route semantics

## Verification
- API and Web typecheck
- 28 targeted Web tests
- 74 targeted tasks database tests against throwaway PostgreSQL