### PR TITLE
docs(operator-api): state that a Chain step's description patch carries the brief alone

### DIFF
--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -1319,6 +1319,18 @@ must follow [Continuing from a delivered branch](BRIEF-TEMPLATE.md#continuing-fr
   `maxSessionsPerTask`, `scheduleKind`, `runAt`, `cron`, and `timezone`.
   `status` is a task status (`BACKLOG`, `TODO`, `DOING`, `REVIEW`, `DONE`);
   `failureReason` may be `null`.
+- On a Chain step that carries a feature brief, `description` is the brief
+  alone. A task with both a `templateId` and a `chainId` whose Step authors a
+  brief — every step role except readiness and integrator — keeps its stored
+  step prompt and trailing reminders, and the route reframes the submitted text
+  as the brief between `<!-- agentos:task-brief:v1 length=<characters> -->` and
+  `<!-- /agentos:task-brief:v1 -->`, counting the length itself. Send the brief
+  body only: a whole description, prompt and fence included, is not refused but
+  becomes the brief inside a second fence, so read the task back and confirm it
+  carries one. A stored description the route cannot parse, or a Chain step
+  whose template Step metadata is missing, refuses with `400 Bad Request` and
+  `Cannot rewrite task brief: <reason>`. Every other task stores `description`
+  verbatim.
 
 ```sh
 curl -X PATCH "$BASE_URL/tasks/$TASK_ID" \


### PR DESCRIPTION
`PATCH /tasks/:taskId` does not store `description` verbatim on a Chain step whose template Step authors a feature brief. `packages/api/src/task-patch.ts:227-251` routes the field through `rewriteBrief`, which keeps the stored step prompt and trailing reminders and reframes the submitted text between `<!-- agentos:task-brief:v1 length=<characters> -->` and `<!-- /agentos:task-brief:v1 -->`, counting the length itself.

The handbook only listed `description` among the patchable fields, so an operator revalidating a brief reads the task, edits the whole description, and patches it back. That is not refused: the whole description — prompt, fence and all — becomes the brief body inside a second fence, and the task ends up with nested fences. Observed on 2026-09-01 while rewriting the brief of a live Chain step.

This documents the field's scope, the recomputed fence, the read-back check, and the two `400 Bad Request` refusals (`Cannot rewrite task brief: <reason>`). No route behaviour changes.

Verification: `npm run lint` exits 0, `npm run test:snapshot-scan` exits 0 (21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tzjo9gtHYq4b3BrDEqtWGA