### PR TITLE
feat: cap Node test concurrency inside Run proofs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ checks and named test files inside a Run; for workspace lint, use
 `npm run lint -w <workspace>`. The Regression step owns repository-wide proof
 and the Merge Gate.
 
-Per-workspace `build`, `typecheck`, `lint`, `test`, and `test:db` verification inside an Anneal Run shares a host-wide pool of three proof slots by default; set `AGENTOS_HOST_PROOF_SLOTS` to an integer from 1 through 1024 to override the count. Waiting is silent and a command exits **75** after 20 minutes if no slot becomes available. Regression-owned proof and commands running outside a Run use the host fast path and execute immediately without acquiring a slot.
+Per-workspace `build`, `typecheck`, `lint`, `test`, and `test:db` verification inside an Anneal Run shares a host-wide pool of three proof slots by default; set `AGENTOS_HOST_PROOF_SLOTS` to an integer from 1 through 1024 to override the count. Waiting is silent and a command exits **75** after 20 minutes if no slot becomes available. Inside a Run the workspace `test` scripts also pass `--test-concurrency=2` to Node's test runner, so one slot holds at most two test child processes instead of the host-wide default of one per core; the same scripts outside a Run keep Node's default. Regression-owned proof and commands running outside a Run use the host fast path and execute immediately without acquiring a slot.
 
 The merge gate holds a lock, so run one gate per worktree. A verdict belongs to the exact
 commit it names — not to an earlier one on the same branch, and not to "the

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/web -- /bin/sh -c 'tsc -b && vite build'",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/web -- tsc -b --pretty false",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/web -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/web -- /bin/sh -c 'TSX_TSCONFIG_PATH=tsconfig.app.json node --conditions=development --import tsx --test \"src/**/*.test.ts\" \"src/**/*.test.tsx\"'",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/web -- /bin/sh -c 'TSX_TSCONFIG_PATH=tsconfig.app.json node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} \"src/**/*.test.ts\" \"src/**/*.test.tsx\"'",
     "dev": "vite",
     "preview": "vite preview"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/api -- /bin/sh -c 'tsc -p tsconfig.json && node ../build-info/stamp.mjs dist'",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/api -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/api -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/api -- node --conditions=development --import tsx --test src/*.test.ts src/routes/*.test.ts src/files/*.test.ts",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/api -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts src/routes/*.test.ts src/files/*.test.ts",
     "test:db": "bash ../../scripts/host-proof-slot.sh test:db @anneal/api -- node --conditions=development --import tsx scripts/dbtest.mjs",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js"

--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -11,6 +11,6 @@
   },
   "scripts": {
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/build-info -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/build-info -- node --conditions=development --test *.test.mjs"
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/build-info -- node --conditions=development --test ${AGENTOS_RUN_ID:+--test-concurrency=2} *.test.mjs"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -57,7 +57,7 @@
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/db -- /bin/sh -c 'tsc -p tsconfig.json --noEmit && npm run typecheck:cli'",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/db -- /bin/sh -c 'biome lint . && eslint .'",
     "typecheck:cli": "tsc -p tsconfig.cli.json --noEmit",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/db -- node --conditions=development --import tsx --test prisma/*.test.ts src/*.test.ts",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/db -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} prisma/*.test.ts src/*.test.ts",
     "test:db": "bash ../../scripts/host-proof-slot.sh test:db @anneal/db -- node --conditions=development --import tsx --test --test-concurrency=1 src/*.dbtest.ts",
     "db:generate": "prisma generate",
     "db:migrate": "dotenv -e ../../.env -- prisma migrate dev",

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -16,7 +16,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/github-client -- tsc -p tsconfig.json",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/github-client -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/github-client -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/github-client -- node --conditions=development --import tsx --test src/*.test.ts"
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/github-client -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",

--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -7,7 +7,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/inbox -- tsc -p tsconfig.json",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/inbox -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/inbox -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/inbox -- node --conditions=development --import tsx --test src/*.test.ts",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/inbox -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js"
   },

--- a/packages/merge-executor/package.json
+++ b/packages/merge-executor/package.json
@@ -7,7 +7,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/merge-executor -- tsc -p tsconfig.json",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/merge-executor -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/merge-executor -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/merge-executor -- node --conditions=development --import tsx --test src/*.test.ts",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/merge-executor -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
     "start": "node dist/index.js",
     "schema-gate": "MERGE_EXECUTOR_SCHEMA_GATE_REQUIRED=1 node --conditions=development --import tsx --test src/schema-gate.test.ts"
   },

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -29,7 +29,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/runner -- /bin/sh -c 'tsc -p tsconfig.json && node scripts/build-runtime-tools.mjs && node ../build-info/stamp.mjs dist'",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/runner -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/runner -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/runner -- node --conditions=development --import tsx --test src/*.test.ts src/adapters/*.test.ts scripts/*.test.mjs",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/runner -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts src/adapters/*.test.ts scripts/*.test.mjs",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js"
   },

--- a/scripts/host-proof-slot.test.mjs
+++ b/scripts/host-proof-slot.test.mjs
@@ -476,6 +476,28 @@ test("a killed holder releases its descriptor, while a live holder is never recl
   assert.equal(waiterResult.stderr, "");
 });
 
+const RUN_TEST_CONCURRENCY_CAP = "${AGENTOS_RUN_ID:+--test-concurrency=2}";
+
+test("the Run-only test concurrency cap expands under a Run and vanishes on the host fast path", async () => {
+  const command = ["/bin/sh", "-c", `printf '%s\\n' --test ${RUN_TEST_CONCURRENCY_CAP} src/*.test.ts`];
+  const slotDirectory = makeSlotDirectory(1);
+  const run = await spawnWrapper({ slotDirectory, slotCount: 1, command }).promise;
+  assert.equal(run.status, 0, run.stderr);
+  assert.equal(run.stdout, "--test\n--test-concurrency=2\nsrc/*.test.ts\n");
+
+  const host = spawn("bash", [wrapper, "test", "@anneal/test", "--", ...command], {
+    cwd: repositoryRoot,
+    env: cleanEnvironment({}),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  host.stdout.setEncoding("utf8");
+  host.stdout.on("data", (chunk) => { stdout += chunk; });
+  const status = await new Promise((resolve) => host.once("close", resolve));
+  assert.equal(status, 0);
+  assert.equal(stdout, "--test\nsrc/*.test.ts\n");
+});
+
 test("all workspace proof manifests are wrapped exactly once without changing commands or lifecycle hooks", () => {
   const expected = {
     "apps/web/package.json": {
@@ -484,7 +506,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "/bin/sh -c 'tsc -b && vite build'",
         typecheck: "tsc -b --pretty false",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "/bin/sh -c 'TSX_TSCONFIG_PATH=tsconfig.app.json node --conditions=development --import tsx --test \"src/**/*.test.ts\" \"src/**/*.test.tsx\"'",
+        test: "/bin/sh -c 'TSX_TSCONFIG_PATH=tsconfig.app.json node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} \"src/**/*.test.ts\" \"src/**/*.test.tsx\"'",
       },
       hooks: {},
     },
@@ -494,7 +516,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "/bin/sh -c 'tsc -p tsconfig.json && node ../build-info/stamp.mjs dist'",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test src/*.test.ts src/routes/*.test.ts src/files/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts src/routes/*.test.ts src/files/*.test.ts",
         "test:db": "node --conditions=development --import tsx scripts/dbtest.mjs",
       },
       hooks: {},
@@ -503,7 +525,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
       name: "@anneal/build-info",
       scripts: {
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --test *.test.mjs",
+        test: "node --conditions=development --test ${AGENTOS_RUN_ID:+--test-concurrency=2} *.test.mjs",
       },
       hooks: {},
     },
@@ -513,7 +535,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "tsc -p tsconfig.json",
         typecheck: "/bin/sh -c 'tsc -p tsconfig.json --noEmit && npm run typecheck:cli'",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test prisma/*.test.ts src/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} prisma/*.test.ts src/*.test.ts",
         "test:db": "node --conditions=development --import tsx --test --test-concurrency=1 src/*.dbtest.ts",
       },
       hooks: {},
@@ -524,7 +546,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "tsc -p tsconfig.json",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test src/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
       },
       hooks: {},
     },
@@ -534,7 +556,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "tsc -p tsconfig.json",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test src/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
       },
       hooks: {},
     },
@@ -544,7 +566,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "tsc -p tsconfig.json",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test src/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
       },
       hooks: {},
     },
@@ -554,7 +576,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "/bin/sh -c 'tsc -p tsconfig.json && node scripts/build-runtime-tools.mjs && node ../build-info/stamp.mjs dist'",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test src/*.test.ts src/adapters/*.test.ts scripts/*.test.mjs",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts src/adapters/*.test.ts scripts/*.test.mjs",
       },
       hooks: {},
     },
@@ -582,6 +604,11 @@ test("all workspace proof manifests are wrapped exactly once without changing co
       const prefix = `bash ../../scripts/host-proof-slot.sh ${scriptName} ${contract.name} -- `;
       assert.equal(manifest.scripts[scriptName], `${prefix}${innerCommand}`);
       assert.equal(manifest.scripts[scriptName].split("scripts/host-proof-slot.sh").length - 1, 1);
+      assert.equal(
+        manifest.scripts[scriptName].split(RUN_TEST_CONCURRENCY_CAP).length - 1,
+        scriptName === "test" ? 1 : 0,
+        `${contract.name} ${scriptName} must carry the Run-only test concurrency cap exactly when it is the unit test script`,
+      );
       wrappedCount += 1;
     }
     for (const [hookName, command] of Object.entries(contract.hooks)) {


### PR DESCRIPTION
## Summary

Inside an Anneal Run every workspace `test` script now passes `--test-concurrency=2` to Node's test runner via `${AGENTOS_RUN_ID:+--test-concurrency=2}`; outside a Run the scripts keep Node's default (one child per core). Combined with the three host-wide proof slots this bounds Run test children at 6 instead of 27 on the 10-core production host.

## Evidence

Measured on the production host at load 40-70 with `@anneal/runner` unit tests (peak process-tree RSS sampled every 0.5 s):

| concurrency | peak RSS | processes at peak | wall |
|---|---|---|---|
| default (9) | 1036 MB | 20 | 149 s |
| 2 | 267 MB | 4 | 173 s |

## Verification

- `npm run test:host-proof-slot`: 16 pass (adds a wrapper-level test that the cap expands under a Run and vanishes on the host fast path; manifest test asserts the cap appears exactly once in every `test` script and in no other proof script)
- End-to-end: `npm run test -w @anneal/build-info` under Run env spawns `node --conditions=development --test --test-concurrency=2 ...`; the same command outside a Run spawns without the flag
- `npm run lint` clean; `test:snapshot-scan` 21 pass; `test:frozen-docs` 28 pass

Part of the host memory audit (records/anneal/audits/AUDIT-host-memory-20260902.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UH2ckLtFykMFQjpgGJ5Ym9