### PR TITLE
feat: answer session git credentials from the runner account's home

### DIFF
--- a/packages/runner/runtime-tools/git-credential-runner.sh
+++ b/packages/runner/runtime-tools/git-credential-runner.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Git credential helper for an Agent session whose HOME has been relocated.
+#
+# Codex and PI move HOME to a per-session config root so user-level skill
+# discovery stays isolated (see adapters/codex.ts). The runner keeps Git's own
+# configuration reachable by pinning GIT_CONFIG_GLOBAL to the runner account's
+# absolute path -- but a credential helper declared there resolves its own
+# state through HOME, so that pin preserves the declaration and not the answer.
+# A public remote never noticed, because it needs no credential at all; a
+# private one failed every session with "could not read Username".
+#
+# The answer comes from asking Git again with the runner account's home
+# restored. The runner-owned GIT_CONFIG_* overrides are environment variables,
+# so an inner git would load this helper again: dropping them is what stops the
+# recursion at one level, and it also restores the account's own
+# GIT_CONFIG_GLOBAL default, which HOME now points at.
+
+set -u
+
+case "${1:-}" in
+  get) action=fill ;;
+  store) action=approve ;;
+  erase) action=reject ;;
+  # Git may add helper operations. Declining an unknown one leaves the
+  # credential unanswered, which is the same outcome as having no helper.
+  *) exit 0 ;;
+esac
+
+[ -n "${AGENTOS_RUNNER_HOME:-}" ] \
+  || { printf 'git-credential-runner: AGENTOS_RUNNER_HOME is required\n' >&2; exit 1; }
+
+while IFS= read -r name; do
+  unset "$name"
+done < <(env | sed -n 's/^\(GIT_CONFIG_[A-Za-z0-9_]*\)=.*/\1/p')
+
+export HOME="$AGENTOS_RUNNER_HOME"
+exec git credential "$action"

--- a/packages/runner/scripts/build-runtime-tools.mjs
+++ b/packages/runner/scripts/build-runtime-tools.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
  * gate-worker helper part of the runner's release contract by accident.
  */
 export const RUNTIME_TOOL_FILES = Object.freeze([
+  Object.freeze({ source: "packages/runner/runtime-tools/git-credential-runner.sh", destination: "git-credential-runner.sh" }),
   Object.freeze({ source: "packages/runner/runtime-tools/regression-verification.sh", destination: "regression-verification.sh" }),
   Object.freeze({ source: "packages/runner/runtime-tools/gate-worker/gate-dispatch.sh", destination: "gate-worker/gate-dispatch.sh" }),
   Object.freeze({ source: "packages/runner/runtime-tools/gate-worker/lib.sh", destination: "gate-worker/lib.sh" }),
@@ -51,7 +52,7 @@ const directory = (filesystem, path, label) => {
 };
 
 const expectedDirectoryEntries = new Map([
-  ["", ["gate-worker", "regression-verification.sh"]],
+  ["", ["gate-worker", "git-credential-runner.sh", "regression-verification.sh"]],
   ["gate-worker", ["gate-dispatch.sh", "lib.sh", "mirror-push.sh", "remote-gate.sh", "run-gate.sh"]],
 ]);
 

--- a/packages/runner/scripts/build-runtime-tools.test.mjs
+++ b/packages/runner/scripts/build-runtime-tools.test.mjs
@@ -87,6 +87,7 @@ test("buildRuntimeTools creates the exact byte-identical tree and purges stale f
     "gate-worker/mirror-push.sh",
     "gate-worker/remote-gate.sh",
     "gate-worker/run-gate.sh",
+    "git-credential-runner.sh",
     "regression-verification.sh",
   ]);
   for (const { source, destination } of RUNTIME_TOOL_FILES) {
@@ -146,7 +147,9 @@ test("buildRuntimeTools turns copy and byte-integrity failures into build failur
   };
   assert.throws(
     () => buildRuntimeTools({ ...context, filesystem: copyFailureFilesystem }),
-    /runner-runtime-tools: copy-failed:regression-verification\.sh/u,
+    // The first tool copied, whichever it is: the assertion is that a copy
+    // failure surfaces as a build failure, not that a given file leads.
+    new RegExp(`runner-runtime-tools: copy-failed:${RUNTIME_TOOL_FILES[0].destination.replace(".", "\\.")}`, "u"),
   );
 
   const byteMismatchFilesystem = {
@@ -158,7 +161,7 @@ test("buildRuntimeTools turns copy and byte-integrity failures into build failur
   };
   assert.throws(
     () => buildRuntimeTools({ ...context, filesystem: byteMismatchFilesystem }),
-    /runner-runtime-tools: byte-mismatch:regression-verification\.sh/u,
+    new RegExp(`runner-runtime-tools: byte-mismatch:${RUNTIME_TOOL_FILES[0].destination.replace(".", "\\.")}`, "u"),
   );
   assert.equal(existsSync(context.outputRoot), false);
 });

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -555,9 +555,27 @@ test("a credential-bearing runner proxy stays in env and out of run-as argv", ()
   assert.match(argv, /RUNNER_WORKSPACE_ROOT=/u);
   assert.match(argv, /CONTROL_PLANE_STATE_DIR=/u);
   assert.match(argv, /AGENTOS_RUN_ID=run-1/u);
-  assert.match(argv, /GIT_CONFIG_COUNT=1/u);
-  assert.match(argv, /GIT_CONFIG_KEY_0=core\.hooksPath/u);
-  assert.match(argv, /GIT_CONFIG_VALUE_0=\/work\/\.git\/anneal-hooks/u);
+  assert.match(argv, /GIT_CONFIG_COUNT=2/u);
+  assert.match(argv, /GIT_CONFIG_KEY_0=credential\.helper/u);
+  assert.match(argv, /GIT_CONFIG_VALUE_0=\S*\/git-credential-runner\.sh/u);
+  assert.match(argv, /GIT_CONFIG_KEY_1=core\.hooksPath/u);
+  assert.match(argv, /GIT_CONFIG_VALUE_1=\/work\/\.git\/anneal-hooks/u);
+});
+
+test("a session answers git credentials through the runner account's own home", () => {
+  // Codex and PI relocate HOME, so a helper declared in the account's global
+  // config resolves no credentials inside a session. Without this the platform
+  // can only ever drive public repositories.
+  const env = buildChildEnvironment(
+    { path: "/bin", home: "/runner", apiUrl: "http://api", runAsPrefix: [], workspaceRoot: productionRoot, hostProofSlots: 3 },
+    claim,
+    scratch,
+    "/work",
+  );
+  assert.equal(env.AGENTOS_RUNNER_HOME, "/runner");
+  assert.equal(env.GIT_CONFIG_COUNT, "1");
+  assert.equal(env.GIT_CONFIG_KEY_0, "credential.helper");
+  assert.equal(env.GIT_CONFIG_VALUE_0, join(scratch.toolsDir, "git-credential-runner.sh"));
 });
 
 test("the interpreter the CLI is told to run the MCP server with is overridable and published", () => {

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import { stepRole } from "@anneal/db";
 
 import type { ClaimedTask } from "./api.js";
@@ -131,6 +133,17 @@ export const buildPrompt = (claim: ClaimedTask): string => [
   ] : []),
 ].join("\n");
 
+/** Runner-owned `git -c` overrides, expressed as the environment form so they
+ *  reach every git a session runs rather than one command line. */
+const gitConfigOverrides = (entries: readonly (readonly [string, string])[]): NodeJS.ProcessEnv =>
+  Object.fromEntries([
+    ["GIT_CONFIG_COUNT", String(entries.length)],
+    ...entries.flatMap(([key, value], index) => [
+      [`GIT_CONFIG_KEY_${index}`, key],
+      [`GIT_CONFIG_VALUE_${index}`, value],
+    ]),
+  ]);
+
 export const buildChildEnvironment = (
   config: Pick<RunnerConfig, "path" | "home" | "apiUrl" | "runAsPrefix" | "workspaceRoot" | "hostProofSlots">
     & Partial<Pick<RunnerConfig, "proxyEnvironment" | "gateServer">>,
@@ -160,11 +173,20 @@ export const buildChildEnvironment = (
     AGENTOS_RUN_ID: claim.run.id,
     AGENTOS_FENCING_TOKEN: claim.fencingToken,
     AGENTOS_WORKSPACE_PATH: workspacePath,
-    ...(commitHooksPath ? {
-      GIT_CONFIG_COUNT: "1",
-      GIT_CONFIG_KEY_0: "core.hooksPath",
-      GIT_CONFIG_VALUE_0: commitHooksPath,
-    } : {}),
+    // The runner account's home, for tooling that a relocated HOME would
+    // otherwise cut off from the account's own configuration.
+    AGENTOS_RUNNER_HOME: config.home,
+    ...gitConfigOverrides([
+      // A credential helper declared in the account's global config resolves
+      // its own state through HOME, which the Codex and PI adapters relocate.
+      // Pinning GIT_CONFIG_GLOBAL preserves the declaration but not the
+      // answer, so a session could not fetch a private remote at all: the
+      // regression step's target refresh failed every Run with "could not read
+      // Username". Answer through the runner's own home instead. A public
+      // remote hid this for as long as every repository here was public.
+      ["credential.helper", join(scratch.toolsDir, "git-credential-runner.sh")] as const,
+      ...(commitHooksPath ? [["core.hooksPath", commitHooksPath] as const] : []),
+    ]),
     ...(regressionStep ? {
       AGENTOS_CHAIN_ID: claim.task.chainId!,
       AGENTOS_PULL_REQUEST_BASE: claim.run.pullRequestBase,

--- a/packages/runner/src/adapters/runtime.ts
+++ b/packages/runner/src/adapters/runtime.ts
@@ -252,8 +252,24 @@ export const promptHashFor = (prompt: string): string => createHash("sha256").up
 const COMMON_LAUNCHER_ENVIRONMENT = [
   "RUNNER_WORKSPACE_ROOT", "CONTROL_PLANE_STATE_DIR", "HOME", "GIT_CONFIG_GLOBAL", "AGENTOS_GATE_SERVER",
   "AGENTOS_RUN_ID", "AGENTOS_TOOLS", "AGENTOS_HOST_PROOF_SLOT_DIR", "AGENTOS_HOST_PROOF_SLOTS",
-  "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
+  "AGENTOS_RUNNER_HOME",
 ] as const;
+
+/**
+ * The runner's `git -c` overrides are a numbered list, so the launcher forwards
+ * as many pairs as GIT_CONFIG_COUNT declares. Naming a fixed first pair instead
+ * would silently drop every later one across the run-as boundary, and git reads
+ * GIT_CONFIG_COUNT before the pairs: a forwarded count with a missing pair is a
+ * hard git error, not a quiet default.
+ */
+const gitConfigLauncherNames = (env: NodeJS.ProcessEnv): string[] => {
+  const declared = Number(env.GIT_CONFIG_COUNT);
+  if (!Number.isSafeInteger(declared) || declared <= 0) return [];
+  return [
+    "GIT_CONFIG_COUNT",
+    ...Array.from({ length: declared }, (_unused, index) => [`GIT_CONFIG_KEY_${index}`, `GIT_CONFIG_VALUE_${index}`]).flat(),
+  ];
+};
 
 export const launchAdapterArgv = (
   config: Pick<RunnerConfig, "runAsPrefix" | "binaries">,
@@ -263,7 +279,11 @@ export const launchAdapterArgv = (
 ): { executable: string; args: string[] } => {
   const binary = config.binaries[declaration.runner];
   if (config.runAsPrefix.length === 0) return { executable: binary, args };
-  const names = [...COMMON_LAUNCHER_ENVIRONMENT, ...declaration.launcherEnvironmentVariables];
+  const names = [
+    ...COMMON_LAUNCHER_ENVIRONMENT,
+    ...gitConfigLauncherNames(env),
+    ...declaration.launcherEnvironmentVariables,
+  ];
   const assignments = names.flatMap((name) => env[name] !== undefined ? [`${name}=${env[name]}`] : []);
   return {
     executable: config.runAsPrefix[0]!,

--- a/packages/runner/src/git-credential-runner-script.test.ts
+++ b/packages/runner/src/git-credential-runner-script.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = resolve(dirname(fileURLToPath(import.meta.url)), "../runtime-tools/git-credential-runner.sh");
+
+type Fixture = { root: string; log: string; env: NodeJS.ProcessEnv };
+
+/** A git that records how the helper called it, instead of answering a real
+ *  credential. What matters is the argv and the environment it inherited. */
+const fixture = (): Fixture => {
+  const root = mkdtempSync(join(tmpdir(), "agentos-credential-helper-"));
+  const bin = join(root, "bin");
+  const log = join(root, "git.log");
+  mkdirSync(bin);
+  writeFileSync(log, "");
+  const stub = join(bin, "git");
+  writeFileSync(stub, `#!/bin/sh
+{
+  printf 'argv=%s\\n' "$*"
+  printf 'home=%s\\n' "$HOME"
+  env | sed -n 's/^\\(GIT_CONFIG_[A-Za-z0-9_]*\\)=.*/leaked=\\1/p'
+} >> "${log}"
+`);
+  chmodSync(stub, 0o755);
+  return {
+    root,
+    log,
+    env: {
+      PATH: `${bin}:/usr/bin:/bin`,
+      HOME: join(root, "session-config"),
+      AGENTOS_RUNNER_HOME: join(root, "runner-home"),
+      GIT_CONFIG_COUNT: "2",
+      GIT_CONFIG_KEY_0: "credential.helper",
+      GIT_CONFIG_VALUE_0: script,
+      GIT_CONFIG_KEY_1: "core.hooksPath",
+      GIT_CONFIG_VALUE_1: join(root, "hooks"),
+      GIT_CONFIG_GLOBAL: join(root, "session-config", ".gitconfig"),
+    },
+  };
+};
+
+const run = (seeded: Fixture, ...args: string[]) =>
+  spawnSync("bash", [script, ...args], { env: seeded.env, encoding: "utf8" });
+
+test("a credential request is answered from the runner account's home", () => {
+  const seeded = fixture();
+  assert.equal(run(seeded, "get").status, 0);
+  const recorded = readFileSync(seeded.log, "utf8");
+  assert.match(recorded, /argv=credential fill/u);
+  assert.match(recorded, new RegExp(`home=${join(seeded.root, "runner-home")}`, "u"));
+  // Left in place, the overrides that carry this helper would make the inner
+  // git call it again, forever.
+  assert.doesNotMatch(recorded, /leaked=/u);
+});
+
+test("store and erase reach git under their own names", () => {
+  const stored = fixture();
+  assert.equal(run(stored, "store").status, 0);
+  assert.match(readFileSync(stored.log, "utf8"), /argv=credential approve/u);
+
+  const erased = fixture();
+  assert.equal(run(erased, "erase").status, 0);
+  assert.match(readFileSync(erased.log, "utf8"), /argv=credential reject/u);
+});
+
+test("an unknown operation declines instead of inventing a git subcommand", () => {
+  const seeded = fixture();
+  const declined = run(seeded, "capability");
+  assert.equal(declined.status, 0);
+  assert.equal(readFileSync(seeded.log, "utf8"), "");
+  assert.equal(run(seeded).status, 0);
+  assert.equal(readFileSync(seeded.log, "utf8"), "");
+});
+
+test("a missing runner home fails loudly rather than answering as the session", () => {
+  const seeded = fixture();
+  delete seeded.env.AGENTOS_RUNNER_HOME;
+  const failed = run(seeded, "get");
+  assert.notEqual(failed.status, 0);
+  assert.match(failed.stderr, /AGENTOS_RUNNER_HOME is required/u);
+  assert.equal(readFileSync(seeded.log, "utf8"), "");
+});

--- a/packages/runner/src/git-provenance.test.ts
+++ b/packages/runner/src/git-provenance.test.ts
@@ -156,8 +156,9 @@ test("a chain provider commit pins the human identity and records its exact clai
     const claimed = claim(remote, "run-real-123");
     const workspace = await provisionWorkspace(configured, claimed);
     const env = providerEnvironment(configured, claimed, workspace);
-    assert.equal(env.GIT_CONFIG_COUNT, "1", "the task secret cannot replace runner-owned Git config injection");
-    assert.equal(env.GIT_CONFIG_KEY_0, "core.hooksPath");
+    assert.equal(env.GIT_CONFIG_COUNT, "2", "the task secret cannot replace runner-owned Git config injection");
+    assert.equal(env.GIT_CONFIG_KEY_0, "credential.helper");
+    assert.equal(env.GIT_CONFIG_KEY_1, "core.hooksPath");
     assert.equal(env.GIT_AUTHOR_NAME, undefined, "task secrets cannot override local human identity");
 
     await writeFile(join(workspace.path, "provider.txt"), "provider change\n");
@@ -278,7 +279,11 @@ test("ordinary runs stay unmarked while global runner identity is pinned locally
     const workspace = await provisionWorkspace(configured, claimed);
     assert.equal(workspace.commitHooksPath, undefined);
     const env = providerEnvironment(configured, claimed, workspace);
-    assert.equal(env.GIT_CONFIG_COUNT, undefined);
+    // The credential helper is unconditional; the hooks path is what an
+    // ordinary run leaves out.
+    assert.equal(env.GIT_CONFIG_COUNT, "1");
+    assert.equal(env.GIT_CONFIG_KEY_0, "credential.helper");
+    assert.equal(env.GIT_CONFIG_KEY_1, undefined);
     await writeFile(join(workspace.path, "ordinary.txt"), "ordinary\n");
     git(workspace.path, ["add", "ordinary.txt"], env);
     git(workspace.path, ["commit", "-m", "ordinary commit"], env);

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -152,6 +152,7 @@
     { "glob": "scripts/merge-train.mjs", "purpose": "fixed-width cumulative-prefix coordinator for concurrent host delivery" },
     { "glob": "scripts/merge-train.test.mjs", "purpose": "merge train bare-origin integration and recovery fixtures" },
     { "glob": "scripts/operator-api-docs.test.mjs", "purpose": "executable Chain Hold and Resume operator-handbook contract tests" },
+    { "glob": "packages/runner/runtime-tools/git-credential-runner.sh", "purpose": "answers a session's git credentials from the runner account's own home, which the agent adapters relocate" },
     { "glob": "packages/runner/runtime-tools/regression-verification.sh", "purpose": "token-free regression refresh, exact-head gate dispatch and verdict persistence" },
     { "glob": "scripts/merge-integrator-real-checks.mjs", "purpose": "redacted real-infrastructure merge-integrator checks" },
     { "glob": "scripts/merge-integrator-system-test.mjs", "purpose": "redacted end-to-end merge-integrator system harness" },

--- a/scripts/deploy/release-artifact.mjs
+++ b/scripts/deploy/release-artifact.mjs
@@ -15,6 +15,7 @@ const SHA = /^[0-9a-f]{40}$/u;
 const RELEASE = /^(?<commit>[0-9a-f]{40})-(?<digest>[0-9a-f]{64})$/u;
 const RUNTIME_TOOL_ROOT = "packages/runner/dist/runtime-tools";
 const RUNTIME_TOOL_DESTINATIONS = Object.freeze([
+  "git-credential-runner.sh",
   "regression-verification.sh",
   "gate-worker/gate-dispatch.sh",
   "gate-worker/lib.sh",
@@ -23,7 +24,7 @@ const RUNTIME_TOOL_DESTINATIONS = Object.freeze([
   "gate-worker/run-gate.sh",
 ]);
 const RUNTIME_TOOL_ENTRIES = new Map([
-  ["", new Set(["gate-worker", "regression-verification.sh"])],
+  ["", new Set(["gate-worker", "git-credential-runner.sh", "regression-verification.sh"])],
   ["gate-worker", new Set(["gate-dispatch.sh", "lib.sh", "mirror-push.sh", "remote-gate.sh", "run-gate.sh"])],
 ]);
 

--- a/scripts/deploy/release-snapshot.test.mjs
+++ b/scripts/deploy/release-snapshot.test.mjs
@@ -89,7 +89,7 @@ const expectedRuntimePaths = RUNTIME_TOOL_FILES
   .map(({ destination }) => `packages/runner/dist/runtime-tools/${destination}`)
   .sort();
 
-test("release snapshots and deploy releases carry exactly the six runner runtime tools", (t) => {
+test("release snapshots and deploy releases carry exactly the runner runtime tools the build declares", (t) => {
   const context = releaseFixture();
   const stageRoot = join(context.root, "stage");
   const deployRoot = join(context.root, "deploy");


### PR DESCRIPTION
## What broke

The Codex and PI adapters relocate `HOME` to a per-session config root so user-level skill discovery stays isolated. The runner compensates by pinning `GIT_CONFIG_GLOBAL` to the account's absolute path, and the comment there says this keeps credential helpers working — but a helper declared in that file resolves its *own* state through `HOME`. The pin preserves the declaration, not the answer, so a session could not authenticate to a private remote at all.

Every repository driven here was public until now, and a public remote needs no credential, so nothing surfaced. The first private repository lost three Runs of a regression step to the same `fatal: could not read Username for 'https://github.com'` — one per attempt at the step's own target refresh.

## What changes

- `packages/runner/runtime-tools/git-credential-runner.sh`: ships into the Run's tool directory and is named in the runner-owned git overrides. It re-asks git with the runner account's home restored and the runner's `GIT_CONFIG_*` dropped — which both stops the recursion at one level and restores the account's own config default.
- `adapters.ts`: the git overrides become a numbered list instead of one optional pair, carrying `credential.helper` alongside the existing `core.hooksPath`.
- `adapters/runtime.ts`: the launcher forwarded a fixed `GIT_CONFIG_KEY_0`/`VALUE_0`, so a second override would have been dropped silently across a run-as boundary while `GIT_CONFIG_COUNT` still announced it — a hard git error, not a quiet default. It now forwards as many pairs as the count declares.
- The runtime-tool inventories that pin what crosses into a Run (`build-runtime-tools.mjs`, `release-artifact.mjs`, `public-snapshot.json`) gain the new tool.

## Verification

- `MERGE GATE` on the exact head.
- `src/git-credential-runner-script.test.ts` (new, 4 cases): the request is answered from the runner's home, `store`/`erase` reach git under their own names, an unknown operation declines rather than inventing a subcommand, and a missing `AGENTOS_RUNNER_HOME` fails loudly instead of answering as the session. The recursion guard is asserted by proving no `GIT_CONFIG_*` reaches the inner git.
- `src/adapters.test.ts` 73/73, `scripts/build-runtime-tools.test.mjs` 7/7, `npm run test:snapshot-scan` 21/21, `npm run test:auto-deploy` 98/98, `npm run lint` clean.
- End to end against the private repository that exposed this: a fetch under a relocated `HOME` with the helper injected succeeds where the same environment without it fails with `could not read Username`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKCyXsheAdQRzy3a4dMdQv
