### PR TITLE
fix: give the merge lease the canonical git network retry budget

### DIFF
--- a/scripts/merge-lease.sh
+++ b/scripts/merge-lease.sh
@@ -122,20 +122,47 @@ if [ -z "$HOLDER" ]; then
   HOLDER="${holder_user}@${holder_host}"
 fi
 
+GIT_ATTEMPTS=6
+
+# The transient half of packages/runner/src/network-retry.ts, in the vocabulary
+# git writes. Only a match is retried: an authentication failure, an absent ref
+# or an unreadable remote is the remote's answer, and spending the backoff
+# budget on it only delays a failure the operator still has to read.
+GIT_TRANSIENT_RE='SSL_ERROR_SYSCALL|SSL_connect|unexpected EOF|early EOF|RPC failed|Connection (reset|refused|timed out)|Operation timed out|Failed to connect|Could not resolve host|Recv failure|ECONNRESET|ETIMEDOUT|EAI_AGAIN|HTTP( response)? 5[0-9][0-9]'
+
+# Exponential backoff with full jitter, capped per attempt, matching the clone
+# profile in network-retry.ts and the fetch budget in
+# packages/runner/runtime-tools/regression-verification.sh. This host reaches
+# GitHub through a proxy whose 443 exit drops for seconds at a time: 24 probes
+# on 2026-09-02 failed 5 times in clusters up to 5 consecutive failures, so the
+# previous budget (3 attempts, 1s apart, ~3s total) fell inside a single drop as
+# a matter of course rather than as an edge case. Waiting up to 1s,2s,4s,8s,8s
+# (~23s worst case) rides one out. Release is what makes the budget worth
+# spending: a failed status, acquire or steal changes nothing and can simply be
+# rerun, while a failed release strands the lease on origin until the 45-minute
+# machine steal threshold expires.
+git_backoff() {
+  local ceiling=$(( 1 << (($1 < 4 ? $1 : 4) - 1) ))
+  sleep "$(awk -v ceiling="$ceiling" 'BEGIN { srand(); printf "%.2f", rand() * ceiling }')"
+}
+
 RETRY_OUTPUT=""
 retry_git() {
   local label="$1" attempt status
   shift
-  for attempt in 1 2 3; do
+  for attempt in $(seq 1 "$GIT_ATTEMPTS"); do
     RETRY_OUTPUT="$(GIT_TERMINAL_PROMPT=0 "$@" 2>&1)"
     status=$?
     if [ "$status" -eq 0 ]; then
       return 0
     fi
-    if [ "$attempt" -lt 3 ]; then
-      printf 'merge-lease: %s failed; retrying attempt=%s/3\n' "$label" "$((attempt + 1))" >&2
-      sleep "$attempt"
+    if [ "$attempt" -lt "$GIT_ATTEMPTS" ] && [[ "$RETRY_OUTPUT" =~ $GIT_TRANSIENT_RE ]]; then
+      printf 'merge-lease: %s failed; retrying attempt=%s/%s\n' \
+        "$label" "$((attempt + 1))" "$GIT_ATTEMPTS" >&2
+      git_backoff "$attempt"
+      continue
     fi
+    break
   done
   [ -z "$RETRY_OUTPUT" ] || printf '%s\n' "$RETRY_OUTPUT" >&2
   return "$status"
@@ -175,11 +202,11 @@ load_lease() {
   LEASE_REASON=""
   LEASE_TOKEN=""
   LEASE_PRETTY=""
-  read_remote_sha || die "could not read ${LEASE_REF} from origin after 3 attempts"
+  read_remote_sha || die "could not read ${LEASE_REF} from origin"
   [ -n "$REMOTE_SHA" ] || return 0
   if ! git -C "$REPO_ROOT" cat-file -e "${REMOTE_SHA}^{blob}" 2>/dev/null; then
     retry_git "origin lease fetch" git -C "$REPO_ROOT" fetch --no-tags --no-write-fetch-head origin "$LEASE_REF" \
-      || die "could not fetch ${LEASE_REF} from origin after 3 attempts"
+      || die "could not fetch ${LEASE_REF} from origin"
   fi
   LEASE_JSON="$(git -C "$REPO_ROOT" cat-file blob "$REMOTE_SHA" 2>/dev/null)" \
     || die "origin lease ${REMOTE_SHA} is not a readable blob"
@@ -261,9 +288,9 @@ make_lease_blob() {
 # an operational failure. A unique token makes an ambiguous successful push
 # distinguishable from somebody else's lease.
 try_create_lease() {
-  local attempt status
-  for attempt in 1 2 3; do
-    RETRY_OUTPUT="$(GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push --porcelain origin "${NEW_SHA}:${LEASE_REF}" 2>&1)"
+  local attempt status push_output
+  for attempt in $(seq 1 "$GIT_ATTEMPTS"); do
+    push_output="$(GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push --porcelain origin "${NEW_SHA}:${LEASE_REF}" 2>&1)"
     status=$?
     read_remote_sha || return 2
     if [ "$REMOTE_SHA" = "$NEW_SHA" ]; then
@@ -276,19 +303,22 @@ try_create_lease() {
       printf 'merge-lease: push reported success but %s is absent\n' "$LEASE_REF" >&2
       return 2
     fi
-    if [ "$attempt" -lt 3 ]; then
-      printf 'merge-lease: lease create push failed; retrying attempt=%s/3\n' "$((attempt + 1))" >&2
-      sleep "$attempt"
+    if [ "$attempt" -lt "$GIT_ATTEMPTS" ] && [[ "$push_output" =~ $GIT_TRANSIENT_RE ]]; then
+      printf 'merge-lease: lease create push failed; retrying attempt=%s/%s\n' \
+        "$((attempt + 1))" "$GIT_ATTEMPTS" >&2
+      git_backoff "$attempt"
+      continue
     fi
+    break
   done
-  [ -z "$RETRY_OUTPUT" ] || printf '%s\n' "$RETRY_OUTPUT" >&2
+  [ -z "$push_output" ] || printf '%s\n' "$push_output" >&2
   return 2
 }
 
 replace_lease() {
-  local observed_sha="$1" attempt status
-  for attempt in 1 2 3; do
-    RETRY_OUTPUT="$(GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push --porcelain \
+  local observed_sha="$1" attempt status push_output
+  for attempt in $(seq 1 "$GIT_ATTEMPTS"); do
+    push_output="$(GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push --porcelain \
       --force-with-lease="${LEASE_REF}:${observed_sha}" origin "${NEW_SHA}:${LEASE_REF}" 2>&1)"
     status=$?
     read_remote_sha || die "could not verify ${LEASE_REF} after the steal push"
@@ -299,19 +329,22 @@ replace_lease() {
     if [ "$status" -eq 0 ]; then
       die "steal push reported success but the observed lease did not change"
     fi
-    if [ "$attempt" -lt 3 ]; then
-      printf 'merge-lease: lease steal push failed; retrying attempt=%s/3\n' "$((attempt + 1))" >&2
-      sleep "$attempt"
+    if [ "$attempt" -lt "$GIT_ATTEMPTS" ] && [[ "$push_output" =~ $GIT_TRANSIENT_RE ]]; then
+      printf 'merge-lease: lease steal push failed; retrying attempt=%s/%s\n' \
+        "$((attempt + 1))" "$GIT_ATTEMPTS" >&2
+      git_backoff "$attempt"
+      continue
     fi
+    break
   done
-  [ -z "$RETRY_OUTPUT" ] || printf '%s\n' "$RETRY_OUTPUT" >&2
-  die "could not steal the lease after 3 attempts"
+  [ -z "$push_output" ] || printf '%s\n' "$push_output" >&2
+  die "could not steal the lease"
 }
 
 delete_lease() {
-  local observed_sha="$1" attempt status
-  for attempt in 1 2 3; do
-    RETRY_OUTPUT="$(GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push --porcelain \
+  local observed_sha="$1" attempt status push_output
+  for attempt in $(seq 1 "$GIT_ATTEMPTS"); do
+    push_output="$(GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push --porcelain \
       --force-with-lease="${LEASE_REF}:${observed_sha}" origin ":${LEASE_REF}" 2>&1)"
     status=$?
     read_remote_sha || die "could not verify ${LEASE_REF} after the release push"
@@ -322,13 +355,16 @@ delete_lease() {
     if [ "$status" -eq 0 ]; then
       die "release push reported success but the observed lease remains"
     fi
-    if [ "$attempt" -lt 3 ]; then
-      printf 'merge-lease: lease release push failed; retrying attempt=%s/3\n' "$((attempt + 1))" >&2
-      sleep "$attempt"
+    if [ "$attempt" -lt "$GIT_ATTEMPTS" ] && [[ "$push_output" =~ $GIT_TRANSIENT_RE ]]; then
+      printf 'merge-lease: lease release push failed; retrying attempt=%s/%s\n' \
+        "$((attempt + 1))" "$GIT_ATTEMPTS" >&2
+      git_backoff "$attempt"
+      continue
     fi
+    break
   done
-  [ -z "$RETRY_OUTPUT" ] || printf '%s\n' "$RETRY_OUTPUT" >&2
-  die "could not release the lease after 3 attempts"
+  [ -z "$push_output" ] || printf '%s\n' "$push_output" >&2
+  die "could not release the lease"
 }
 
 # One release, two readers. The operator reads the prose; the merge tail, in
@@ -387,7 +423,7 @@ case "$COMMAND" in
               exit 0
             fi
           fi ;;
-        *) die "could not create ${LEASE_REF} after 3 attempts" ;;
+        *) die "could not create ${LEASE_REF}" ;;
       esac
       if [ "$(date +%s)" -ge "$deadline" ]; then
         printf 'merge-lease: timed out waiting for %s after %s minute(s)\n' "$LEASE_REF" "$TIMEOUT_MINUTES" >&2

--- a/scripts/merge-lease.test.mjs
+++ b/scripts/merge-lease.test.mjs
@@ -21,6 +21,7 @@ import {
   cpSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -74,13 +75,59 @@ const leaseFixture = (t) => {
   return { root, origin };
 };
 
-const runLease = (fixture, args, holder = "machine@fixture") =>
+const runLease = (fixture, args, holder = "machine@fixture", options = {}) =>
   spawnSync("bash", [join(fixture.root, "scripts", "merge-lease.sh"), ...args], {
     cwd: fixture.root,
     encoding: "utf8",
-    timeout: 15_000,
-    env: { ...FIXTURE_ENV, MERGE_LEASE_HOLDER: holder },
+    timeout: options.timeout ?? 15_000,
+    env: { ...FIXTURE_ENV, MERGE_LEASE_HOLDER: holder, ...options.env },
   });
+
+// A `git` that fails a chosen subcommand a chosen number of times and then
+// stands aside. The retry budget is only observable through what git says, so
+// the cases below drive the classifier with git's own transient and
+// deterministic wording rather than with a flag on the script.
+const gitShim = (t, fixture) => {
+  const bin = join(dirname(fixture.root), `shim-${Math.random().toString(16).slice(2)}`);
+  mkdirSync(bin, { recursive: true });
+  t.after(() => rmSync(bin, { recursive: true, force: true }));
+  const log = join(bin, "calls.log");
+  writeFileSync(log, "");
+  const shimPath = join(bin, "git");
+  writeFileSync(shimPath, `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "$LEASE_FIXTURE_SUBCOMMAND" ]; then
+    attempt=$(( $(wc -l < "$LEASE_FIXTURE_LOG") + 1 ))
+    printf '%s\\n' "$arg" >> "$LEASE_FIXTURE_LOG"
+    if [ "$attempt" -le "$LEASE_FIXTURE_FAILURES" ]; then
+      printf '%s\\n' "$LEASE_FIXTURE_ERROR" >&2
+      exit 128
+    fi
+    break
+  fi
+done
+exec "$LEASE_FIXTURE_GIT" "$@"
+`);
+  chmodSync(shimPath, 0o755);
+  const realGit = execFileSync("/usr/bin/env", ["sh", "-c", "command -v git"], { encoding: "utf8" }).trim();
+  return {
+    log,
+    calls: () => readFileSync(log, "utf8").split("\n").filter((line) => line !== "").length,
+    env: (subcommand, failures, error) => ({
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      LEASE_FIXTURE_GIT: realGit,
+      LEASE_FIXTURE_LOG: log,
+      LEASE_FIXTURE_SUBCOMMAND: subcommand,
+      LEASE_FIXTURE_FAILURES: String(failures),
+      LEASE_FIXTURE_ERROR: error,
+    }),
+  };
+};
+
+const TRANSIENT_GIT_ERROR =
+  "fatal: unable to access 'https://github.com/o/r.git/': LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443";
+const DETERMINISTIC_GIT_ERROR =
+  "fatal: Authentication failed for 'https://github.com/o/r.git/'";
 
 const installLease = (fixture, lease) => {
   const body = `${JSON.stringify(lease)}\n`;
@@ -476,4 +523,70 @@ test("a release refused on another machine's lease says refused in both lines", 
   );
   assert.match(refused.stderr, /^MERGE LEASE: refused holder@fixture$/mu);
   assert.deepEqual(readLease(fixture).lease, held);
+});
+
+// --- the git network retry budget -------------------------------------------
+//
+// This host reaches origin through a proxy whose 443 exit drops for seconds at
+// a time and in clusters, so the budget these cases pin is the one from
+// packages/runner/src/network-retry.ts: six attempts with jittered exponential
+// backoff, and only for the failures git writes transient words for. A release
+// that loses its push strands the lease on origin for the full 45-minute machine
+// steal threshold, which is what makes the budget worth spending.
+
+test("a transient release push failure is retried instead of stranding the lease", (t) => {
+  const fixture = leaseFixture(t);
+  const acquired = runLease(
+    fixture,
+    ["acquire", "--reason", "Flaky exit", "--task", "chain-7"],
+    "api@fixture",
+  );
+  assert.equal(acquired.status, 0, acquired.stdout + acquired.stderr);
+  const { sha } = readLease(fixture);
+
+  const shim = gitShim(t, fixture);
+  const released = runLease(fixture, ["release", "--task", "chain-7"], "api@fixture", {
+    env: shim.env("push", 2, TRANSIENT_GIT_ERROR),
+    timeout: 60_000,
+  });
+  assert.equal(released.status, 0, released.stdout + released.stderr);
+  assert.match(released.stderr, /lease release push failed; retrying attempt=3\/6/u);
+  assert.equal(shim.calls(), 3);
+  assert.match(released.stdout, new RegExp(`^MERGE LEASE: released refs/merge-lease/holder ${sha} `, "mu"));
+});
+
+test("a deterministic git failure is not retried at all", (t) => {
+  const fixture = leaseFixture(t);
+  const shim = gitShim(t, fixture);
+  const status = runLease(fixture, ["status"], "api@fixture", {
+    env: shim.env("ls-remote", 6, DETERMINISTIC_GIT_ERROR),
+    timeout: 60_000,
+  });
+  assert.notEqual(status.status, 0, status.stdout + status.stderr);
+  assert.doesNotMatch(status.stderr, /retrying attempt/u);
+  assert.match(status.stderr, /Authentication failed/u);
+  assert.equal(shim.calls(), 1, "an authentication failure is the remote's answer, not a blip");
+});
+
+test("a transient failure that outlasts the budget reports git's own words", (t) => {
+  const fixture = leaseFixture(t);
+  const acquired = runLease(
+    fixture,
+    ["acquire", "--reason", "Sustained outage", "--task", "chain-9"],
+    "api@fixture",
+  );
+  assert.equal(acquired.status, 0, acquired.stdout + acquired.stderr);
+  const original = readLease(fixture);
+
+  const shim = gitShim(t, fixture);
+  const released = runLease(fixture, ["release", "--task", "chain-9"], "api@fixture", {
+    env: shim.env("push", 6, TRANSIENT_GIT_ERROR),
+    timeout: 60_000,
+  });
+  assert.notEqual(released.status, 0, released.stdout + released.stderr);
+  assert.match(released.stderr, /lease release push failed; retrying attempt=6\/6/u);
+  assert.match(released.stderr, /SSL_ERROR_SYSCALL in connection to github.com:443/u);
+  assert.match(released.stderr, /could not release the lease/u);
+  assert.equal(shim.calls(), 6);
+  assert.deepEqual(readLease(fixture), original, "a lost release must leave the lease intact");
 });


### PR DESCRIPTION
`scripts/merge-lease.sh` retried every git network call three times a second
apart (~3s end to end) and retried any failure, including deterministic ones.
This host reaches origin through a proxy whose 443 exit drops for seconds at a
time and in clusters — 24 `git ls-remote` probes on 2026-09-02 failed 5 times
with a longest run of 5 consecutive failures — so a 3s window landing entirely
inside one drop is routine. A `merge-lease.sh status` failed all three attempts
that way today.

The consequence is asymmetric: a lost status, acquire or steal changes nothing
and can be rerun, while a lost release strands the lease on origin until the
45-minute machine steal threshold expires.

- All four sites (`retry_git` plus the create, steal and release push loops)
  take the budget from `packages/runner/src/network-retry.ts`, in the shell
  shape `packages/runner/runtime-tools/regression-verification.sh` already
  uses: six attempts, exponential backoff with full jitter capped at 8s, ~23s
  worst case.
- Only the transient words git writes are retried. An authentication failure,
  an absent ref or an unreadable remote fails on the first attempt with its own
  text.
- The push loops now hold the push's own output separately: `read_remote_sha`
  is itself a `retry_git` call and overwrote `RETRY_OUTPUT`, so the failure the
  loops printed was the ls-remote output that followed the push. The
  compare-and-swap semantics of the steal and release pushes are unchanged.
- Three new cases in `scripts/merge-lease.test.mjs` drive a `git` shim: a
  transient release push retried to success, a deterministic failure that is
  not retried at all, and an exhausted budget that carries git's own words to
  stderr while leaving the lease intact.

`npm run lint` is green; `node --test scripts/merge-lease.test.mjs` passes
19/19, and the three new cases fail against the pre-change script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FnsLWzafE8YAShobWbZJD