### PR TITLE
refactor(runner): drop the RunnerDefinition copy layer

### DIFF
--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -12,8 +12,8 @@ import {
   claudePlatformSettingsPath, inputForRunner, launchArgv, mcpConfig, mcpServerPath, nodeBinaryPath, piExtensionPath,
   PREFLIGHT_REASONS, RUNNER_DEFINITIONS, RUNNER_KINDS, runtimeDescriptor, type AdapterState, type ExitEvidence,
 } from "./adapters.js";
-import { claudeDeclaration, parseClaudeTranscript } from "./adapters/claude.js";
-import { CODEX_STARTER_MODEL, codexDeclaration, parseCodexEvent, parseCodexTranscript } from "./adapters/codex.js";
+import { parseClaudeTranscript } from "./adapters/claude.js";
+import { CODEX_STARTER_MODEL, parseCodexEvent, parseCodexTranscript } from "./adapters/codex.js";
 import { parsePiTranscript, piDeclaration } from "./adapters/pi.js";
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
@@ -1797,7 +1797,6 @@ test("an adapter is substituted by injection, never by writing over the exported
   assert.equal(Object.isFrozen(adapters), true);
   for (const runner of ["CLAUDE", "CODEX", "PI"] as const) {
     assert.equal(Object.isFrozen(adapters[runner]), true, `${runner} adapter must be frozen`);
-    assert.equal(adapters[runner], RUNNER_DEFINITIONS[runner].adapter);
   }
   assert.deepEqual(RUNNER_KINDS, ["CLAUDE", "CODEX", "PI"]);
   assert.notEqual(adapters.CLAUDE.start, adapters.CODEX.start);
@@ -1808,8 +1807,7 @@ test("an adapter is substituted by injection, never by writing over the exported
   assert.notEqual(adapters.CODEX.classifyError, adapters.PI.classifyError);
 });
 
-test("the runner registry derives session policy from provider declarations", () => {
-  const declarations = { CLAUDE: claudeDeclaration, CODEX: codexDeclaration, PI: piDeclaration } as const;
+test("the runner registry exposes provider-owned session policy", () => {
   assert.deepEqual(
     Object.fromEntries(RUNNER_KINDS.map((runner) => [runner, {
       isolatesSessionConfig: RUNNER_DEFINITIONS[runner].isolatesSessionConfig,
@@ -1822,11 +1820,6 @@ test("the runner registry derives session policy from provider declarations", ()
       PI: { isolatesSessionConfig: true, startupPreflightModel: "openai-codex/gpt-5.6-luna", binaryEnvironment: "PI_BINARY" },
     },
   );
-  for (const runner of RUNNER_KINDS) {
-    assert.equal(RUNNER_DEFINITIONS[runner].args, declarations[runner].args);
-    assert.equal(RUNNER_DEFINITIONS[runner].childEnvironment, declarations[runner].childEnvironment);
-    assert.equal(RUNNER_DEFINITIONS[runner].provisionSessionConfig, declarations[runner].provisionSessionConfig);
-  }
   assert.deepEqual(piDeclaration.protectedEnvironmentVariables, [
     "PI_CODING_AGENT_DIR", "PI_CODING_AGENT_SESSION_DIR", "AGENTOS_CODEX_SERVICE_TIER", "AGENTOS_PI_EXPECTS_OPENAI_CODEX",
   ]);

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -5,7 +5,7 @@ import { stepRole } from "@anneal/db";
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
 import { hostProofSlotDirectory } from "./host-proof-slots.js";
-import { manifestLines, toolsFor, type SessionToolTransport } from "./session-tool-contract.js";
+import { manifestLines, toolsFor } from "./session-tool-contract.js";
 import type { AgentScratch } from "./workspace.js";
 import { claudeDeclaration, claudePlatformSettingsPath } from "./adapters/claude.js";
 import { codexDeclaration, codexPlatformBaselinePath } from "./adapters/codex.js";
@@ -22,7 +22,6 @@ import {
   type ResumeSpec,
   type RunSpec,
 } from "./adapters/runtime.js";
-import type { SessionConfigOptions } from "./adapters/session-config.js";
 
 export * from "./adapters/runtime.js";
 export { claudePlatformSettingsPath } from "./adapters/claude.js";
@@ -30,7 +29,8 @@ export { piExtensionPath } from "./adapters/pi.js";
 
 export const ADAPTER_VERSION = "2.1.0";
 
-const ADAPTER_DECLARATIONS: Readonly<Record<RunnerKind, AdapterDeclaration>> = Object.freeze({
+/** The public runner registry is the set of provider-owned declarations. */
+export const RUNNER_DEFINITIONS: Readonly<Record<RunnerKind, AdapterDeclaration>> = Object.freeze({
   CLAUDE: claudeDeclaration,
   CODEX: codexDeclaration,
   PI: piDeclaration,
@@ -43,7 +43,7 @@ const COMMON_PROTECTED_SECRET_ENVIRONMENT = [
 
 const PROTECTED_SECRET_ENVIRONMENT = new Set([
   ...COMMON_PROTECTED_SECRET_ENVIRONMENT,
-  ...Object.values(ADAPTER_DECLARATIONS).flatMap((declaration) => declaration.protectedEnvironmentVariables),
+  ...Object.values(RUNNER_DEFINITIONS).flatMap((declaration) => declaration.protectedEnvironmentVariables),
 ]);
 
 const toolManifest = (claim: ClaimedTask): string[] => [
@@ -78,7 +78,7 @@ export const buildPrompt = (claim: ClaimedTask): string => [
     `- implementationBaseSha: ${claim.run.implementationBaseSha}`,
     `- implementationHeadSha: ${claim.run.implementationHeadSha}`,
   ] : []),
-  ...ADAPTER_DECLARATIONS[claim.runner].promptSections(claim),
+  ...RUNNER_DEFINITIONS[claim.runner].promptSections(claim),
   "",
   `Task: ${claim.task.name}`,
   claim.task.description,
@@ -208,7 +208,7 @@ export const launchArgv = (
   runner: RunnerKind,
   args: string[],
   env: NodeJS.ProcessEnv,
-): { executable: string; args: string[] } => launchAdapterArgv(config, ADAPTER_DECLARATIONS[runner], args, env);
+): { executable: string; args: string[] } => launchAdapterArgv(config, RUNNER_DEFINITIONS[runner], args, env);
 
 export const runtimeDescriptor = (runnerId: string, runAsPrefix: string[]): string => JSON.stringify({
   runtime: "agentos-runner",
@@ -222,45 +222,11 @@ export const runtimeDescriptor = (runnerId: string, runAsPrefix: string[]): stri
   runAsPrefix: runAsPrefix.join(" "),
 });
 
-export type RunnerDefinition = {
-  binaryEnvironment: string;
-  defaultBinary: string;
-  toolIntroduction: string;
-  toolTransport: SessionToolTransport;
-  toolEntrypoint(): string;
-  adapter: CliAdapter;
-  isolatesSessionConfig: boolean;
-  startupPreflightModel: string | null;
-  args(spec: RunSpec, resume?: ResumeSpec): string[];
-  childEnvironment(claim: Pick<ClaimedTask, "run">, scratch: AgentScratch): NodeJS.ProcessEnv;
-  provisionSessionConfig(config: RunnerConfig, scratch: AgentScratch, options?: SessionConfigOptions): Promise<void>;
-};
-
-const definitionFrom = (declaration: AdapterDeclaration): Readonly<RunnerDefinition> => Object.freeze({
-  binaryEnvironment: declaration.binaryEnvironment,
-  defaultBinary: declaration.defaultBinary,
-  toolIntroduction: declaration.toolIntroduction,
-  toolTransport: declaration.toolTransport,
-  toolEntrypoint: declaration.toolEntrypoint,
-  adapter: createCliAdapter(declaration),
-  isolatesSessionConfig: declaration.isolatesSessionConfig,
-  startupPreflightModel: declaration.startupPreflightModel,
-  args: declaration.args,
-  childEnvironment: declaration.childEnvironment,
-  provisionSessionConfig: declaration.provisionSessionConfig,
-});
-
-/** The public runner registry is a derived view of provider-owned declarations. */
-export const RUNNER_DEFINITIONS: Readonly<Record<RunnerKind, Readonly<RunnerDefinition>>> = Object.freeze({
-  CLAUDE: definitionFrom(ADAPTER_DECLARATIONS.CLAUDE),
-  CODEX: definitionFrom(ADAPTER_DECLARATIONS.CODEX),
-  PI: definitionFrom(ADAPTER_DECLARATIONS.PI),
-});
-
 export const RUNNER_KINDS = Object.freeze(Object.keys(RUNNER_DEFINITIONS) as RunnerKind[]);
 
+/** The one derived artifact: a CLI adapter per declaration, built once. */
 export const adapters: Readonly<Record<RunnerKind, CliAdapter>> = Object.freeze(Object.fromEntries(
-  RUNNER_KINDS.map((runner) => [runner, RUNNER_DEFINITIONS[runner].adapter]),
+  RUNNER_KINDS.map((runner) => [runner, createCliAdapter(RUNNER_DEFINITIONS[runner])]),
 ) as Record<RunnerKind, CliAdapter>);
 
 export const argsForRunner = (runner: RunnerKind, spec: RunSpec, resume?: ResumeSpec): string[] =>

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1156,8 +1156,7 @@ const runBackendPreflight = async (
   runner: RunnerKind,
   env = workspaceEnvironment(config),
 ) => {
-  const definition = RUNNER_DEFINITIONS[runner];
-  return definition.adapter.preflight({ config, runner, model: definition.startupPreflightModel, env });
+  return adapters[runner].preflight({ config, runner, model: RUNNER_DEFINITIONS[runner].startupPreflightModel, env });
 };
 
 /** One cheap daemon heartbeat. Every backend is attempted independently so a


### PR DESCRIPTION
Architecture deepening, lane G of wave 1.

`RUNNER_DEFINITIONS` was built by `definitionFrom`, which transcribed ten fields
of the provider-owned `AdapterDeclaration` one by one and added a single derived
field, `adapter`. The transcription carried no policy: every consumer read a
field the declaration already owned.

- `RUNNER_DEFINITIONS` is now the declaration record itself, exported directly
  (the former private `ADAPTER_DECLARATIONS`). Every existing consumer
  (`workspace.ts`, `config.ts`, `session-config-lease.ts`, `runner.ts`) keeps its
  call site unchanged.
- The one derived artifact stays the already-exported `adapters` record, which
  now calls `createCliAdapter` directly. `runBackendPreflight` reads
  `adapters[runner]` instead of `definition.adapter`; no second memo was added.
- `RunnerDefinition` and `definitionFrom` are deleted, along with the three test
  assertions that only asserted the copy equalled its original.

`adapters/runtime.ts`'s `AdapterDeclaration` and the claude/codex/pi adapters are
untouched: shape and behavior are unchanged.

Net -42 lines.

## Verification

Workspace-level only, `packages/runner`:

- `npm run typecheck -w packages/runner` — pass
- `npm run lint -w packages/runner` — pass
- `npm run build -w packages/runner` — pass
- `npm run test -w packages/runner` (with `RUNNER_WORKSPACE_ROOT` at a fresh
  temporary directory) — 488 tests, 486 pass, 0 fail, 2 skipped

Merge gate not run here; wave 1 is published by the coordinating window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8MEyCP5bBKdWDywd8Czv