### PR TITLE
fix(runner): accept a reconnect notice that names its cause

### DIFF
--- a/packages/db/src/provider-terminal.ts
+++ b/packages/db/src/provider-terminal.ts
@@ -1,3 +1,13 @@
-/** Codex reports reconnect progress through the same event shape as errors. */
+/**
+ * Codex reports reconnect progress through the same event shape as errors.
+ *
+ * The counter may be followed by a parenthesised cause: a run whose stream
+ * dropped four times reported `Reconnecting... 2/5 (stream disconnected before
+ * completion: tls handshake eof)`. An anchored counter-only pattern rejected
+ * that, so an ordinary reconnect notice latched the session's error flag and a
+ * run that reconnected, finished its turn, and committed its work was completed
+ * as PROTOCOL_ERROR. Only the trailing cause is optional; anything that does not
+ * open with the counter is still a real provider error.
+ */
 export const isCodexReconnectStatus = (message: string | null): boolean =>
-  /^Reconnecting\.\.\. \d+\/\d+$/u.test(message?.trim() ?? "");
+  /^Reconnecting\.\.\. \d+\/\d+(?: \([^\n]*\))?$/u.test(message?.trim() ?? "");

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -1546,6 +1546,34 @@ test("Codex reconnect classification follows the counter shape instead of a fixe
   }
 });
 
+test("Codex reconnect progress stays provisional when the counter carries its cause", () => {
+  const state = parseCodexTranscript([
+    { type: "error", message: "Reconnecting... 2/5 (stream disconnected before completion: tls handshake eof)" },
+    { type: "error", message: "Reconnecting... 3/5 (stream disconnected before completion: tls handshake eof)" },
+    { type: "item.completed", item: { type: "agent_message", text: "repair committed" } },
+    { type: "turn.completed" },
+  ]);
+  const evidence = evidenceFromState(state);
+
+  assert.equal(evidence.terminalSuccess, true);
+  assert.equal(adapterExecutionSucceeded(evidence), true);
+});
+
+test("Codex latches a real provider error that only resembles reconnect progress", () => {
+  const cases = [
+    "stream disconnected before completion: tls handshake eof",
+    "Reconnecting... failed (stream disconnected before completion)",
+    "Reconnect budget exhausted after Reconnecting... 5/5",
+    "Reconnecting... 5/5 (stream disconnected)\npolicy denied",
+  ] as const;
+
+  for (const message of cases) {
+    const state = parseCodexTranscript([{ type: "error", message }, { type: "turn.completed" }]);
+    assert.equal(state.terminalSuccess, false, message);
+    assert.equal(adapterExecutionSucceeded(evidenceFromState(state)), false, message);
+  }
+});
+
 test("Codex preserves reconnect evidence when the stream ends before completion", () => {
   const reconnectMessage = "Reconnecting... 3/5";
   const state = parseCodexTranscript([{ type: "error", message: reconnectMessage }]);


### PR DESCRIPTION
## What

`isCodexReconnectStatus` matched `Reconnecting... N/M` and nothing else. Codex also appends the cause, so today's notices read `Reconnecting... 2/5 (stream disconnected before completion: tls handshake eof)` and fell through the carve-out into `sawError`.

## Evidence

Four Runs on 2026-09-02 completed as PROTOCOL_ERROR this way. Their `failureEnvelope` all read `exitCode: 0, terminalEventSeen: true, terminalSuccess: false` — an explicit terminal failure, so the post-delivery disconnect recovery (which only covers `terminalEventSeen === false`) correctly did not apply.

Every `ADAPTER_ERROR` event across all four Runs — eight in total — was a reconnect notice of that shape. None was a real error, and all four reached `turn.completed` with their work committed. `cmtjyvt3l0df6mpa5wvozvs38` was the `review-fix` repair for the GATES chain: it committed `6e9a0d02`, persisted its `result` output, and the tail stopped anyway.

## Scope

Only the trailing parenthesised cause becomes optional. Nothing about failure classification is relaxed: a message that does not open with the counter still latches, and so does one carrying text after the cause. The existing assertions that `stream disconnected` alone and a bare counter-only notice keep their verdicts are unchanged.

## Verification

- `node --test packages/runner/src/adapters.test.ts` — 76 pass, including the two new tests
- `node --test packages/db/src/post-delivery-disconnect-audit.test.ts` — 5 pass
- `npm run typecheck -w @anneal/db`, `npm run typecheck -w @anneal/runner`
- `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGjVQjXUw4DzxYwA2YC4af