### PR TITLE
fix(runner): resolve the target branch in a run workspace

### DIFF
--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -195,6 +195,67 @@ test("an explicit true template step keeps the repository dependency policy path
   }
 });
 
+test("a workspace cloned from its own published head still resolves the target branch", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agentos-workspace-target-refspec-"));
+  try {
+    const remote = join(root, "origin.git");
+    const seed = join(root, "seed");
+    // Not `main`: the target branch comes from the run, and every project on
+    // the platform names its baseline itself.
+    const target = "trunk";
+    git(root, "init", "--bare", `--initial-branch=${target}`, remote);
+    git(root, "init", `--initial-branch=${target}`, seed);
+    git(seed, "config", "user.name", "Anneal Test");
+    git(seed, "config", "user.email", "runner@agentos.local");
+    await writeFile(join(seed, "tree.txt"), "base\n");
+    git(seed, "add", "tree.txt");
+    git(seed, "commit", "-m", "base");
+    git(seed, "remote", "add", "origin", remote);
+    git(seed, "push", "-u", "origin", target);
+    const targetSha = git(seed, "rev-parse", "HEAD");
+    const branch = "agentos/chain/target-refspec";
+    git(seed, "switch", "-c", branch);
+    await writeFile(join(seed, "tree.txt"), "published\n");
+    git(seed, "commit", "-am", "published before ACK loss");
+    git(seed, "push", "-u", "origin", branch);
+
+    const config = {
+      workspaceRoot: join(root, "workspaces"),
+      runAsPrefix: [],
+      path: process.env.PATH ?? "/usr/bin:/bin",
+      home: root,
+      gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
+    } as unknown as RunnerConfig;
+    const claim = workspaceClaim({
+      task: { id: "task-target-refspec" },
+      repo: { remoteUrl: remote, defaultBranch: target, dependencyProvisioning: "NONE" },
+      run: { id: "run-target-refspec", runNumber: 2, targetBranch: target, branch },
+    });
+
+    const workspace = await provisionWorkspace(config, claim);
+    assert.equal(git(workspace.path, "rev-parse", `origin/${target}`), targetSha);
+    assert.deepEqual(
+      git(workspace.path, "config", "--get-all", "remote.origin.fetch").split("\n"),
+      [
+        `+refs/heads/${branch}:refs/remotes/origin/${branch}`,
+        `+refs/heads/${target}:refs/remotes/origin/${target}`,
+      ],
+    );
+
+    // The refspec has to survive provisioning: an agent fetching the baseline
+    // mid-run must move the remote-tracking ref, not just FETCH_HEAD.
+    git(seed, "switch", target);
+    await writeFile(join(seed, "tree.txt"), "advanced\n");
+    git(seed, "commit", "-am", "advanced baseline");
+    git(seed, "push", "origin", target);
+    const advancedSha = git(seed, "rev-parse", "HEAD");
+    git(workspace.path, "fetch", "origin", target);
+    assert.equal(git(workspace.path, "rev-parse", `origin/${target}`), advancedSha);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("provisioning trusts an already-published intended head after its database ACK was lost", async () => {
   const root = await mkdtemp(join(tmpdir(), "agentos-workspace-publication-"));
   try {

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -570,6 +570,18 @@ export const provisionWorkspace = async (
         // Delivery pushes to `origin`; the mirror is a provisioning detail and
         // must never become the run's publication target.
         await execute(config, "git", ["remote", "set-url", "origin", claim.repo.remoteUrl], workspace, env);
+        // `clone --single-branch` writes one fetch refspec, covering only the
+        // branch it cloned. When that branch is the run's own published head,
+        // nothing in the workspace resolves `origin/<target>`: an agent asking
+        // for the merge base against its baseline gets `unknown revision`, and
+        // `git fetch origin <target>` cannot repair it because the refspec that
+        // would create the remote-tracking ref is not there. Add it, then fill
+        // it from the mirror so the ref exists before the agent starts.
+        if (cloneTarget !== target) {
+          const targetRefspec = `+refs/heads/${target}:refs/remotes/origin/${target}`;
+          await execute(config, "git", ["config", "--add", "remote.origin.fetch", targetRefspec], workspace, env);
+          await execute(config, "git", ["fetch", "--no-tags", mirror, targetRefspec], workspace, env);
+        }
         const baseSha = await execute(config, "git", ["rev-parse", "HEAD"], workspace, env);
         if (branch !== cloneTarget) await execute(config, "git", ["switch", "-c", branch], workspace, env);
         return { path: workspace, branch, baseSha, ...(commitHooksPath ? { commitHooksPath } : {}) };


### PR DESCRIPTION
## Problem

A run workspace is cloned with `git clone --branch <cloneTarget> --single-branch`, so `.git/config` carries exactly one fetch refspec. When the clone target is the run's own already-published head (the post-ACK-loss path), the workspace has no `+refs/heads/<target>:refs/remotes/origin/<target>` refspec at all:

```
fetch = +refs/heads/agentos/<taskId>/run-N:refs/remotes/origin/agentos/<taskId>/run-N
```

`git rev-parse origin/<target>` then fails with `unknown revision`, and `git fetch origin <target>` cannot repair it — with no matching refspec the fetch only writes `FETCH_HEAD`. A 30-day production SessionEvent audit found 120 such failures across 116 distinct Runs and all three runner kinds; agents hit it on merge-base checks and retried in a loop that could never succeed.

## Change

`packages/runner/src/workspace.ts`: when the clone target is not the run's target branch, provisioning adds the target refspec to `remote.origin.fetch` and fills the remote-tracking ref from the local mirror. The branch name comes from `run.targetBranch ?? repo.defaultBranch` — nothing is hardcoded, so multi-project repositories with a non-`main` baseline are covered. The pinned blind-review path is untouched: it deliberately builds a detached workspace with no branch tracking.

## Evidence

- New test `a workspace cloned from its own published head still resolves the target branch` uses a `trunk` baseline, asserts both refspecs are present, that `origin/trunk` resolves, and that a later `git fetch origin trunk` advances the remote-tracking ref. Reverting the source change reproduces the exact production error: `fatal: ambiguous argument 'origin/trunk': unknown revision`.
- `npm run test -w @anneal/runner`: 489 pass, 0 fail, 2 skipped (root-only).
- `npm run typecheck -w @anneal/runner`, repository `npm run lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLv5ZY7LJBmAdZLx7Gv8Z9