### PR TITLE
refactor(deploy): give the escalation marker one owner

### DIFF
--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -11,11 +11,8 @@ import {
   readdirSync,
   readFileSync,
   realpathSync,
-  renameSync,
   rmSync,
   statSync,
-  unlinkSync,
-  writeFileSync,
 } from "node:fs";
 import { constants as fsConstants } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -41,11 +38,16 @@ import { openDeploymentAttempt, parseReleaseArtifactReceipt } from "./deployment
 import { readRemoteMainRevision } from "./remote-main-read.mjs";
 import {
   checkExistingEscalation,
-  ESCALATION_RETRY_CAP,
   resolveRemoteMainTarget,
   selfClearEscalation,
   writeEscalationWithAttempts,
 } from "./quiet-window-escalation.mjs";
+import {
+  clearEscalationOnOperatorRequest,
+  ESCALATION_RETRY_CAP,
+  markEscalationNotified,
+  readEscalationRecord,
+} from "./quiet-window-escalation-record.mjs";
 import { verifyBackupConfiguration } from "./install-launchd.mjs";
 import { backupConfigurationFromEnvironment, writePgDumpBackup } from "./quiet-window-backup.mjs";
 import { createDeployInterruption } from "./quiet-window-interrupt.mjs";
@@ -455,15 +457,10 @@ const writeEscalation = async (record) => {
   log(`ESCALATED reason=${persisted.reason} from=${persisted.from} to=${persisted.to}`);
 };
 
-const markEscalationNotified = async () => {
-  const record = readJson(ESCALATION_PATH, "escalation-state-unreadable");
-  const temporary = `${ESCALATION_PATH}.${process.pid}.${randomUUID()}`;
-  writeFileSync(temporary, `${JSON.stringify({ ...record, notificationDelivered: true }, null, 2)}\n`, { mode: 0o600, flag: "wx" });
-  renameSync(temporary, ESCALATION_PATH);
-};
-
 const retryEscalationNotification = async () => {
-  const record = readJson(ESCALATION_PATH, "escalation-state-unreadable");
+  const marker = readEscalationRecord({ path: ESCALATION_PATH });
+  if (marker === null) fail("escalation-state-unreadable", "marker-absent");
+  const { record } = marker;
   if (record.notificationDelivered === true) return;
   await notify({
     outcome: "failure",
@@ -472,7 +469,7 @@ const retryEscalationNotification = async () => {
     from: String(record.from ?? "unknown"),
     to: String(record.to ?? "unknown"),
   });
-  await markEscalationNotified();
+  markEscalationNotified({ path: ESCALATION_PATH });
 };
 
 const persistAndNotifyFailure = async (failure, from, to) => {
@@ -915,7 +912,7 @@ const createDeployHost = () => {
       }
     },
     escalate: writeEscalation,
-    markEscalationNotified,
+    markEscalationNotified: async () => markEscalationNotified({ path: ESCALATION_PATH }),
     notify: notifyDeployOutcome,
     log,
   });
@@ -925,19 +922,8 @@ const main = async () => {
   const options = parseArgs(process.argv.slice(2));
   if (!Number.isSafeInteger(POLL_MS) || POLL_MS < 1_000) fail("environment-invalid", "QUIET_WINDOW_POLL_SECONDS-must-be-a-positive-integer");
   if (options.clearEscalation) {
-    // Removing nothing and reporting CLEARED is how this command lied on
-    // 2026-09-01: STATE_DIR hangs off AGENTOS_REPOSITORY_ROOT, so running it
-    // from a release checkout without that variable pointed it at an empty
-    // `current/.agentos-deploy/`, deleted nothing, and printed the success
-    // line anyway while the real marker kept holding the deploy. Clearing an
-    // absent marker stays exit 0 — it is idempotent, not an error — but it
-    // says which path it looked at, so a wrong root is visible immediately.
-    if (!existsSync(ESCALATION_PATH)) {
-      log(`NO-ESCALATION-TO-CLEAR path=${ESCALATION_PATH}`);
-      return 0;
-    }
-    unlinkSync(ESCALATION_PATH);
-    log("CLEARED escalation operator-action-required-before-this-command");
+    // Clearing an absent marker stays exit 0: it is idempotent, not an error.
+    clearEscalationOnOperatorRequest({ path: ESCALATION_PATH, log });
     return 0;
   }
   if (options.dryRun) return dryRun();

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -39,10 +39,13 @@ import { createDeploymentLedger, DEPLOYMENT_LEDGER_STATES } from "./deployment-l
 import { createProductionHost } from "./quiet-window-host.mjs";
 import {
   checkExistingEscalation,
-  ESCALATION_RETRY_CAP,
   selfClearEscalation,
   writeEscalationWithAttempts,
 } from "./quiet-window-escalation.mjs";
+import {
+  clearEscalationOnOperatorRequest,
+  ESCALATION_RETRY_CAP,
+} from "./quiet-window-escalation-record.mjs";
 import { renderLaunchdPlist } from "./install-launchd.mjs";
 import { assembleReleaseDirectory } from "./release-directory.mjs";
 import { buildReleaseArtifact, findReleaseArtifact, verifyReleaseArtifact } from "./release-artifact.mjs";
@@ -54,7 +57,6 @@ import {
 
 const revisions = { from: "a".repeat(40), to: "b".repeat(40) };
 const REPOSITORY_ROOT = fileURLToPath(new URL("../..", import.meta.url));
-const DEPLOY_SCRIPT = fileURLToPath(new URL("./quiet-window-deploy.mjs", import.meta.url));
 const EXPECTED_RUNTIME_PATHS = RUNTIME_TOOL_FILES
   .map(({ destination }) => `packages/runner/dist/runtime-tools/${destination}`)
   .sort();
@@ -402,7 +404,7 @@ test("self-clear notification failure keeps the escalation marker", async (t) =>
   assert.match(state.logs[0], /^STOP escalation-self-clear-failed /u);
 });
 
-test("--clear-escalation removes any marker without deployment environment initialization", (t) => {
+test("--clear-escalation removes a latched marker", (t) => {
   const root = mkdtempSync(join(tmpdir(), "anneal-deploy-manual-clear-"));
   const stateDir = join(root, ".agentos-deploy");
   const escalationPath = join(stateDir, "escalated.json");
@@ -412,44 +414,33 @@ test("--clear-escalation removes any marker without deployment environment initi
     attempts: ESCALATION_RETRY_CAP,
   }), { mode: 0o600 });
   t.after(() => rmSync(root, { recursive: true, force: true }));
+  const logs = [];
 
-  const result = spawnSync(process.execPath, [DEPLOY_SCRIPT, "--clear-escalation"], {
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      AGENTOS_REPOSITORY_ROOT: root,
-      QUIET_WINDOW_POLL_SECONDS: "60",
-      DATABASE_URL: "",
-      FEISHU_DEFAULT_CHAT_ID: "",
-    },
+  const cleared = clearEscalationOnOperatorRequest({
+    path: escalationPath,
+    log: (line) => { logs.push(line); },
   });
 
-  assert.equal(result.status, 0, result.stderr);
+  assert.equal(cleared, true);
   assert.equal(existsSync(escalationPath), false);
-  assert.match(result.stdout, /CLEARED escalation operator-action-required-before-this-command/u);
+  assert.deepEqual(logs, ["CLEARED escalation operator-action-required-before-this-command"]);
 });
 
 test("--clear-escalation reports the path it looked at when no marker exists", (t) => {
   const root = mkdtempSync(join(tmpdir(), "anneal-deploy-manual-clear-absent-"));
   t.after(() => rmSync(root, { recursive: true, force: true }));
+  const escalationPath = join(root, ".agentos-deploy", "escalated.json");
+  const logs = [];
 
-  const result = spawnSync(process.execPath, [DEPLOY_SCRIPT, "--clear-escalation"], {
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      AGENTOS_REPOSITORY_ROOT: root,
-      QUIET_WINDOW_POLL_SECONDS: "60",
-      DATABASE_URL: "",
-      FEISHU_DEFAULT_CHAT_ID: "",
-    },
+  const cleared = clearEscalationOnOperatorRequest({
+    path: escalationPath,
+    log: (line) => { logs.push(line); },
   });
 
-  assert.equal(result.status, 0, result.stderr);
   // The failure this covers: an operator pointed at the wrong root reads
   // "CLEARED" while the real marker is still in place.
-  assert.doesNotMatch(result.stdout, /CLEARED escalation/u);
-  assert.match(result.stdout, /NO-ESCALATION-TO-CLEAR path=/u);
-  assert.match(result.stdout, new RegExp(`path=${root.replaceAll("\\", "\\\\")}`, "u"));
+  assert.equal(cleared, false);
+  assert.deepEqual(logs, [`NO-ESCALATION-TO-CLEAR path=${escalationPath}`]);
 });
 
 test("--clear-escalation runs when invoked through the production current symlink", (t) => {
@@ -475,7 +466,13 @@ test("--clear-escalation runs when invoked through the production current symlin
   });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /NO-ESCALATION-TO-CLEAR path=/u);
+  // The marker path hangs off AGENTOS_REPOSITORY_ROOT: this is the only drive
+  // that proves the shipped entrypoint resolves it from that variable rather
+  // than from the release directory the symlink points into.
+  assert.match(
+    result.stdout,
+    new RegExp(`NO-ESCALATION-TO-CLEAR path=${root.replaceAll("\\", "\\\\")}/`, "u"),
+  );
 });
 
 test("service inventory covers the thirteen production labels", () => {

--- a/scripts/deploy/quiet-window-escalation-record.mjs
+++ b/scripts/deploy/quiet-window-escalation-record.mjs
@@ -1,17 +1,105 @@
 import { randomUUID } from "node:crypto";
-import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+
+import { DeployFailure } from "./quiet-window-lib.mjs";
+
+const fail = (reason, detail = "") => { throw new DeployFailure(reason, detail); };
+
+/** A marker at this attempt count latches for manual clearing. */
+export const ESCALATION_RETRY_CAP = 5;
+
+/** Every write of the marker replaces the whole file through a rename, so a
+ * reader never observes a partial record. */
+const replaceAtomically = (path, contents) => {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.${randomUUID()}`;
+  writeFileSync(temporary, `${JSON.stringify(contents, null, 2)}\n`, { mode: 0o600, flag: "wx" });
+  renameSync(temporary, path);
+};
 
 /** Atomically replace the active escalation with the latest terminal record.
  * A watchdog precursor must not hide the failure that ultimately stops the
  * deployment. */
 export const writeEscalationRecord = ({ path, record, now = () => new Date() }) => {
-  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  const temporary = `${path}.${process.pid}.${randomUUID()}`;
-  writeFileSync(temporary, `${JSON.stringify({
+  replaceAtomically(path, {
     notificationDelivered: false,
     ...record,
     escalatedAt: now().toISOString(),
-  }, null, 2)}\n`, { mode: 0o600, flag: "wx" });
-  renameSync(temporary, path);
+  });
+};
+
+/** Read the marker. `null` means no escalation is recorded; anything else that
+ * stops the read is a failure, never an absent marker. `snapshot` is the exact
+ * file text, which is the unit the identity comparison works in. */
+export const readEscalationRecord = ({ path }) => {
+  let snapshot;
+  try {
+    snapshot = readFileSync(path, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    fail("escalation-state-unreadable", "unreadable-or-invalid-json");
+  }
+  let record;
+  try {
+    record = JSON.parse(snapshot);
+  } catch {
+    fail("escalation-state-unreadable", "unreadable-or-invalid-json");
+  }
+  if (typeof record !== "object" || record === null || Array.isArray(record)) {
+    fail("escalation-state-unreadable", "json-root-is-not-an-object");
+  }
+  return { snapshot, record };
+};
+
+/** Record that the failure notification for this marker was delivered. This is
+ * the only field any writer changes after the create, so every other field is
+ * the marker identity below. */
+export const markEscalationNotified = ({ path }) => {
+  const marker = readEscalationRecord({ path });
+  if (marker === null) fail("escalation-state-unreadable", "marker-absent");
+  replaceAtomically(path, { ...marker.record, notificationDelivered: true });
+};
+
+/** Treat every field except the delivery flag as the marker identity, so a
+ * concurrent watchdog record cannot be admitted by one read and removed by a
+ * later retry. */
+export const escalationIdentity = (record) => JSON.stringify(
+  Object.fromEntries(Object.entries(record).filter(([key]) => key !== "notificationDelivered")),
+);
+
+/** Escalation attempts are one-based: the first persisted failure is attempt
+ * one, and a marker without the field predates the retry policy. An explicitly
+ * malformed value is `null` so it cannot bypass the cap. */
+export const escalationAttempts = (record) => {
+  if (!Object.hasOwn(record, "attempts")) return 1;
+  return Number.isSafeInteger(record.attempts) && record.attempts > 0 ? record.attempts : null;
+};
+
+/** Remove the marker. `false` means there was nothing to remove. The answer
+ * comes from the removal itself and never from a preceding existence check:
+ * `0580e08a` had to stop this command reporting a clear it never performed. */
+export const clearEscalationRecord = ({ path }) => {
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    fail("escalation-state-changed", "marker-clear-failed");
+  }
+  return true;
+};
+
+/** The `--clear-escalation` operation. Its report is part of the operation so
+ * `CLEARED` cannot be printed over a removal that did not happen, and the
+ * absent case names the path it looked at. This command lied on 2026-09-01:
+ * run from a release checkout without `AGENTOS_REPOSITORY_ROOT` it pointed at
+ * an empty `current/.agentos-deploy/`, deleted nothing, and printed the
+ * success line anyway while the real marker kept holding the deploy. */
+export const clearEscalationOnOperatorRequest = ({ path, log }) => {
+  if (clearEscalationRecord({ path })) {
+    log("CLEARED escalation operator-action-required-before-this-command");
+    return true;
+  }
+  log(`NO-ESCALATION-TO-CLEAR path=${path}`);
+  return false;
 };

--- a/scripts/deploy/quiet-window-escalation.mjs
+++ b/scripts/deploy/quiet-window-escalation.mjs
@@ -1,41 +1,18 @@
-import { existsSync, readFileSync, unlinkSync } from "node:fs";
-
 import { DeployFailure, failureOf, runLocked } from "./quiet-window-lib.mjs";
-import { writeEscalationRecord } from "./quiet-window-escalation-record.mjs";
+import {
+  clearEscalationRecord,
+  ESCALATION_RETRY_CAP,
+  escalationAttempts,
+  escalationIdentity,
+  readEscalationRecord,
+  writeEscalationRecord,
+} from "./quiet-window-escalation-record.mjs";
 
 const fail = (reason, detail = "") => { throw new DeployFailure(reason, detail); };
-export const ESCALATION_RETRY_CAP = 5;
-
-/** Escalation attempts are one-based: the first persisted failure is attempt
- * one, and a marker without the field predates the retry policy. An explicitly
- * malformed value is not allowed to bypass the cap. */
-const validAttempts = (record) => {
-  if (!Object.hasOwn(record, "attempts")) return 1;
-  return Number.isSafeInteger(record.attempts) && record.attempts > 0 ? record.attempts : null;
-};
-
-const parseEscalation = (contents) => {
-  try {
-    const value = JSON.parse(contents);
-    if (typeof value !== "object" || value === null || Array.isArray(value)) {
-      fail("escalation-state-unreadable", "json-root-is-not-an-object");
-    }
-    return value;
-  } catch (error) {
-    if (error instanceof DeployFailure) throw error;
-    fail("escalation-state-unreadable", "unreadable-or-invalid-json");
-  }
-};
-
-// Notification delivery may atomically rewrite only its delivery flag. Treat
-// every other field as the marker identity so a concurrent watchdog record
-// cannot be admitted and later removed by this retry.
-const escalationIdentity = (record) => JSON.stringify(
-  Object.fromEntries(Object.entries(record).filter(([key]) => key !== "notificationDelivered")),
-);
 
 /** Inspect and possibly clear an escalation while the caller owns the deploy
- * process lock. File comparison prevents a changed marker from being removed. */
+ * process lock. Comparing the marker identity prevents a changed marker from
+ * being removed. */
 export const checkExistingEscalation = async ({
   escalationPath,
   retryEscalationNotification,
@@ -43,16 +20,10 @@ export const checkExistingEscalation = async ({
   retryableReasons,
   retryCap = ESCALATION_RETRY_CAP,
 }) => {
-  if (!existsSync(escalationPath)) return { active: false };
-  let snapshot;
-  try {
-    snapshot = readFileSync(escalationPath, "utf8");
-  } catch {
-    fail("escalation-state-unreadable", "unreadable-or-invalid-json");
-  }
-  const escalation = parseEscalation(snapshot);
-  const attempts = validAttempts(escalation);
-  if (retryableReasons.has(escalation.reason)
+  const marker = readEscalationRecord({ path: escalationPath });
+  if (marker === null) return { active: false };
+  const attempts = escalationAttempts(marker.record);
+  if (retryableReasons.has(marker.record.reason)
     && attempts !== null
     && attempts < retryCap) {
     // A previous escalation may have been persisted while its Inbox delivery
@@ -62,28 +33,21 @@ export const checkExistingEscalation = async ({
     try {
       await retryEscalationNotification();
     } catch {
-      log(`RETRY inbox-notification-pending reason=${String(escalation.reason ?? "unknown-failure")}`);
+      log(`RETRY inbox-notification-pending reason=${String(marker.record.reason ?? "unknown-failure")}`);
     }
-    let currentSnapshot;
-    try {
-      currentSnapshot = readFileSync(escalationPath, "utf8");
-    } catch (error) {
-      if (error?.code === "ENOENT") return { active: false };
-      fail("escalation-state-unreadable", "unreadable-or-invalid-json");
-    }
-    const current = parseEscalation(currentSnapshot);
-    if (escalationIdentity(current) !== escalationIdentity(escalation)) {
+    const current = readEscalationRecord({ path: escalationPath });
+    if (current === null) return { active: false };
+    if (escalationIdentity(current.record) !== escalationIdentity(marker.record)) {
       log(`STOP escalation-active path=${escalationPath}`);
       return { active: true };
     }
-    snapshot = currentSnapshot;
     return {
       active: false,
       retryEscalation: Object.freeze({
-        record: current,
-        snapshot,
-        reason: String(current.reason ?? escalation.reason),
-        attempts: validAttempts(current) ?? attempts,
+        record: current.record,
+        snapshot: current.snapshot,
+        reason: String(current.record.reason ?? marker.record.reason),
+        attempts: escalationAttempts(current.record) ?? attempts,
       }),
     };
   }
@@ -106,14 +70,13 @@ export const selfClearEscalation = async ({
   const attempts = Number.isSafeInteger(retryEscalation?.attempts)
     && retryEscalation.attempts > 0
     ? retryEscalation.attempts
-    : validAttempts(record) ?? 1;
+    : escalationAttempts(record) ?? 1;
   try {
     let snapshot = retryEscalation?.snapshot;
     const readMarker = () => {
       try {
-        return readFileSync(escalationPath, "utf8");
-      } catch (error) {
-        if (error?.code === "ENOENT") return null;
+        return readEscalationRecord({ path: escalationPath })?.snapshot ?? null;
+      } catch {
         fail("escalation-state-changed", "marker-no-longer-readable");
       }
     };
@@ -133,12 +96,7 @@ export const selfClearEscalation = async ({
     if (current !== snapshot) {
       fail("escalation-state-changed", "marker-replaced-before-self-clear");
     }
-    try {
-      unlinkSync(escalationPath);
-    } catch (error) {
-      if (error?.code === "ENOENT") return false;
-      fail("escalation-state-changed", "marker-clear-failed");
-    }
+    if (!clearEscalationRecord({ path: escalationPath })) return false;
     log(`SELF-CLEAR escalation reason=${reason} attempts=${attempts}`);
     return true;
   } catch (error) {
@@ -176,7 +134,7 @@ export const escalationAttemptCount = ({ record, previous, retryableReasons }) =
   return 1;
 };
 
-/** Persist the terminal record through the production atomic writer while
+/** Persist the terminal record through the marker's atomic writer while
  * advancing retry state from the marker it replaces. */
 export const writeEscalationWithAttempts = ({
   escalationPath,
@@ -185,12 +143,11 @@ export const writeEscalationWithAttempts = ({
   now,
 }) => {
   let previous = null;
-  if (existsSync(escalationPath)) {
-    try {
-      previous = JSON.parse(readFileSync(escalationPath, "utf8"));
-    } catch {
-      // An unreadable marker is replaced by a fresh valid first-attempt record.
-    }
+  try {
+    previous = readEscalationRecord({ path: escalationPath })?.record ?? null;
+  } catch (error) {
+    // An unreadable marker is replaced by a fresh valid first-attempt record.
+    if (!(error instanceof DeployFailure)) throw error;
   }
   const attempts = escalationAttemptCount({ record, previous, retryableReasons });
   const persisted = attempts === null ? record : { ...record, attempts };

--- a/scripts/deploy/quiet-window-escalation.test.mjs
+++ b/scripts/deploy/quiet-window-escalation.test.mjs
@@ -1,14 +1,21 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
 import {
   checkExistingEscalation,
-  ESCALATION_RETRY_CAP,
   resolveRemoteMainTarget,
 } from "./quiet-window-escalation.mjs";
+import {
+  clearEscalationRecord,
+  ESCALATION_RETRY_CAP,
+  escalationIdentity,
+  markEscalationNotified,
+  readEscalationRecord,
+  writeEscalationRecord,
+} from "./quiet-window-escalation-record.mjs";
 
 const revision = "b".repeat(40);
 const retryableReasons = new Set(["remote-main-unreadable"]);
@@ -141,4 +148,90 @@ test("two startup invocations serialize target reads while leaving self-clear to
   assert.deepEqual(second, { ok: true, skipped: "lock-held" });
   assert.equal(existsSync(state.escalationPath), true);
   assert.equal(state.logs.filter((line) => line.startsWith("SKIP concurrent-run")).length, 1);
+});
+
+const markerFixture = (t) => {
+  const root = mkdtempSync(join(tmpdir(), "anneal-escalation-marker-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  return join(root, "state", "escalated.json");
+};
+
+test("a created marker is readable, undelivered, and stamped by the injected clock", (t) => {
+  const path = markerFixture(t);
+
+  writeEscalationRecord({
+    path,
+    record: { outcome: "failure", reason: "remote-main-unreadable", detail: "exit-128", attempts: 1 },
+    now: () => new Date("2026-09-02T04:00:00.000Z"),
+  });
+
+  const marker = readEscalationRecord({ path });
+  assert.deepEqual(marker.record, {
+    notificationDelivered: false,
+    outcome: "failure",
+    reason: "remote-main-unreadable",
+    detail: "exit-128",
+    attempts: 1,
+    escalatedAt: "2026-09-02T04:00:00.000Z",
+  });
+  assert.equal(marker.snapshot, readFileSync(path, "utf8"));
+  assert.equal(statSync(path).mode & 0o777, 0o600);
+});
+
+test("an absent marker reads as no escalation while an unreadable one fails", (t) => {
+  const path = markerFixture(t);
+
+  assert.equal(readEscalationRecord({ path }), null);
+
+  writeEscalationRecord({ path, record: { reason: "remote-main-unreadable" } });
+  writeFileSync(path, "{not json", { mode: 0o600 });
+  assert.throws(() => readEscalationRecord({ path }), {
+    name: "DeployFailure",
+    reason: "escalation-state-unreadable",
+    detail: "unreadable-or-invalid-json",
+  });
+
+  writeFileSync(path, "[]", { mode: 0o600 });
+  assert.throws(() => readEscalationRecord({ path }), {
+    name: "DeployFailure",
+    reason: "escalation-state-unreadable",
+    detail: "json-root-is-not-an-object",
+  });
+});
+
+test("marking the notification delivered changes no other field of the marker identity", (t) => {
+  const path = markerFixture(t);
+  writeEscalationRecord({
+    path,
+    record: { outcome: "failure", reason: "remote-main-unreadable", detail: "exit-128", attempts: 3 },
+    now: () => new Date("2026-09-02T04:00:00.000Z"),
+  });
+  const before = readEscalationRecord({ path }).record;
+
+  markEscalationNotified({ path });
+
+  const after = readEscalationRecord({ path }).record;
+  assert.equal(after.notificationDelivered, true);
+  assert.equal(escalationIdentity(after), escalationIdentity(before));
+  assert.equal(statSync(path).mode & 0o777, 0o600);
+});
+
+test("marking an absent marker fails rather than creating one", (t) => {
+  const path = markerFixture(t);
+
+  assert.throws(() => markEscalationNotified({ path }), {
+    name: "DeployFailure",
+    reason: "escalation-state-unreadable",
+    detail: "marker-absent",
+  });
+  assert.equal(existsSync(path), false);
+});
+
+test("clearing reports whether it removed a marker", (t) => {
+  const path = markerFixture(t);
+  writeEscalationRecord({ path, record: { reason: "remote-main-unreadable" } });
+
+  assert.equal(clearEscalationRecord({ path }), true);
+  assert.equal(existsSync(path), false);
+  assert.equal(clearEscalationRecord({ path }), false);
 });


### PR DESCRIPTION
## What changed

`scripts/deploy/quiet-window-escalation-record.mjs` is now the one owner of the
escalation marker file. Before this change the marker's schema and lifecycle
were split three ways: the record module owned the atomic create,
`quiet-window-escalation.mjs` owned parsing, `attempts`, the retry cap and the
identity rule, and `quiet-window-deploy.mjs` hand-rolled a second temp-file
rename to set `notificationDelivered`. The identity rule's comment stated a
contract ("delivery may atomically rewrite only its delivery flag") that was
enforced nowhere near the code performing that rewrite.

The record module's interface is now create, read, mark-notified and clear:

- `writeEscalationRecord` (unchanged behaviour, now built on a private
  `replaceAtomically`).
- `readEscalationRecord({ path })` returns `{ snapshot, record }` or `null` for
  an absent marker; every other read failure is a `DeployFailure`. `snapshot`
  is the exact file text, because both the identity rule and self-clear compare
  text.
- `markEscalationNotified({ path })` is the only writer that touches an
  existing marker, and it changes only `notificationDelivered`. The second
  writer in `quiet-window-deploy.mjs` is deleted.
- `clearEscalationRecord({ path })` removes the marker and answers whether it
  removed one, from the removal's own result rather than from a preceding
  existence check. `clearEscalationOnOperatorRequest({ path, log })` is the
  `--clear-escalation` operation, carrying the `0580e08a` rule (report
  `CLEARED` only over a removal that happened, name the path otherwise).
- `escalationIdentity`, `escalationAttempts` and `ESCALATION_RETRY_CAP` moved
  here, so the identity rule now sits beside the only writer it constrains.

`quiet-window-escalation.mjs` keeps the policy — admission, the retry budget,
notify-before-remove, lock ordering — and reads the marker only through the
module. `quiet-window-deploy.mjs` no longer imports `renameSync`,
`writeFileSync` or `unlinkSync`, and its `--clear-escalation` branch is one
call.

Leverage: a caller that needs the marker gets create/read/notify/clear with no
knowledge of the file format, the temp-file discipline, or which field may be
rewritten. Locality: a change to the marker's schema or to the delivery flag's
mutability is a change to one file.

## Evidence

Run in the worktree at head `70d327f5`, after the final commit, with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh `mktemp -d`:

- `npm run lint` — exit 0. biome checked 723 files, no fixes applied; eslint clean.
- `npm run typecheck` — exit 0 across all workspaces.
- `npm run test:auto-deploy` — pass 103, fail 0.
- `node --test scripts/deploy/quiet-window-escalation.test.mjs scripts/deploy/quiet-window-deploy.test.mjs`
  — pass 44, fail 0.
- Merge gate — `MERGE GATE: PASS 70d327f5d0ecd73dd84e80d61915caae3682fdb4` on `ci-desktop-worker`, baseline `34e6ba50`.

`test:db` was not run: no local PostgreSQL, and this change touches no
`*.dbtest.ts`. `npm run test:snapshot-scan` was not run: nothing under `docs/`
changed. The operator-visible log lines (`CLEARED escalation ...`,
`NO-ESCALATION-TO-CLEAR path=...`, `SELF-CLEAR escalation ...`) are byte-identical,
so `docs/runbooks/quiet-window-auto-deploy.md` stays correct as written.

New tests in `quiet-window-escalation.test.mjs`: a created marker is readable,
undelivered and stamped by the injected clock at mode 0600; an absent marker
reads as `null` while malformed JSON and a non-object root fail distinctly;
mark-notified leaves `escalationIdentity` unchanged; marking an absent marker
fails rather than creating one; clearing reports removed then not-removed.

## Decisions taken

The brief asked for all three `--clear-escalation` `spawnSync` drives in
`quiet-window-deploy.test.mjs` to become in-process calls. Two of them test the
marker lifecycle and are now in-process calls to
`clearEscalationOnOperatorRequest`. The third drives the script through a
production-shaped `current` symlink, and what it proves is not the lifecycle:
it proves the entrypoint guard still recognises itself through the symlink and
that `ESCALATION_PATH` is derived from `AGENTOS_REPOSITORY_ROOT` rather than
from the release directory the symlink points into. That is exactly the
2026-09-01 wrong-root failure, and it is unreachable in-process. Converting it
would have deleted the only end-to-end evidence for it, so it stays a spawn and
now asserts the root inside the printed path — coverage the in-process test can
no longer carry.

Two clear exports rather than one: `clearEscalationRecord` is the removal, and
`clearEscalationOnOperatorRequest` is the operator command that binds its report
to that removal's result. Self-clear needs the removal without the operator
report; the operator command needs the report inseparable from the result. Both
have a real caller today.

`ESCALATION_RETRY_CAP`, `escalationIdentity` and `escalationAttempts` are
imported from the record module by every caller rather than re-exported through
`quiet-window-escalation.mjs`. A pass-through re-export would have left two
apparent owners of the same names.

`writeEscalationWithAttempts` now reads the marker it replaces through the
module, keeping its existing tolerance for an unreadable previous marker (a
corrupt marker must not block writing a new escalation) as an explicit
`DeployFailure` catch rather than a bare `JSON.parse` try/catch.

A non-ENOENT unlink failure on the operator clear path now fails as
`escalation-state-changed: marker-clear-failed`, the same reason self-clear
already used, instead of surfacing an unnamed filesystem error.

## Fence widened

None.

## Reported but unfixed

The entrypoint catch in `scripts/deploy/quiet-window-deploy.mjs` still guards
`retryEscalationNotification` with a bare `existsSync(ESCALATION_PATH)` (and
evaluates `shouldPersistFailure` twice for the same failure). The existence
probe is a time-of-check window that the module's `null`-for-absent read could
close, but only by changing what an absent marker means to
`checkExistingEscalation`'s callers, which is startup policy rather than marker
lifecycle. Left for the lane that owns the startup path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7f2kUeVxFvDSAcAPsMEq5
