### PR TITLE
refactor(api): declare each refusal code's status family beside the code

### DIFF
--- a/packages/api/src/refusal-status.ts
+++ b/packages/api/src/refusal-status.ts
@@ -1,0 +1,8 @@
+/**
+ * The HTTP status family a refusal is answered with.
+ *
+ * Declared on its own so that every module declaring refusal codes states the
+ * family beside the code, without depending on the module that renders the
+ * response.
+ */
+export type RefusalStatus = 400 | 403 | 404 | 409 | 422;

--- a/packages/api/src/refusal.test.ts
+++ b/packages/api/src/refusal.test.ts
@@ -14,6 +14,7 @@ import {
   type WorkflowRefusalReason,
 } from "@anneal/db";
 
+import type { RefusalStatus } from "./refusal-status.js";
 import {
   type Refusal,
   type RefusalReason,
@@ -22,34 +23,23 @@ import {
 } from "./refusal.js";
 import {
   TemplateAuthoringRefusal,
-  type TemplateAuthoringRefusalCode,
+  templateAuthoringRefusalStatus,
 } from "./template-authoring-errors.js";
+import { templateInstantiationRefusalStatus } from "./template-errors.js";
 
-const authoringCodes = [
-  "template_not_in_project",
-  "template_name_taken",
-  "template_name_reserved",
-  "template_canonical",
-  "template_in_use",
-  "graph_empty",
-  "first_step_not_agent",
-  "first_layer_not_single",
-  "layer_order_invalid",
-  "base_step_invalid",
-  "prior_kind_unproduced",
-  "output_kind_duplicate",
-  "prior_kind_duplicate",
-  "approval_gate_in_parallel_layer",
-  "assignee_invalid",
-  "integrator_binding_invalid",
-] as const satisfies readonly TemplateAuthoringRefusalCode[];
-const authoringConflictCodes = new Set<TemplateAuthoringRefusalCode>([
-  "template_name_taken",
-  "template_name_reserved",
-  "template_canonical",
-  "template_in_use",
-]);
+/** One refusal per status family: the families are the contract, the codes are not. */
+const familyExample = {
+  400: { reason: "invalid-request", message: "invalid" },
+  403: { reason: "forbidden", message: "forbidden" },
+  404: { reason: "not-found", message: "missing" },
+  409: { reason: "conflict", message: "conflict" },
+  422: { reason: "graph_empty", message: "empty graph" },
+} as const satisfies Record<RefusalStatus, Refusal>;
 
+/**
+ * Every reason declared in `refusal.ts` and in `@anneal/db`. `satisfies` keeps
+ * the table total, so a reason added to either union fails to compile here.
+ */
 const refusalByReason = {
   "invalid-request": { reason: "invalid-request", message: "invalid" },
   forbidden: { reason: "forbidden", message: "forbidden" },
@@ -73,29 +63,26 @@ const refusalByReason = {
   },
 } as const satisfies Record<RefusalReason, Refusal>;
 
-test("every refusal reason has one exhaustive HTTP status", () => {
-  const statuses = Object.fromEntries(
-    Object.entries(refusalByReason).map(([reason, refusal]) => [reason, refusalResponse(refusal).status]),
-  );
-  assert.deepEqual(statuses, {
-    "invalid-request": 400,
-    forbidden: 403,
-    "not-found": 404,
-    conflict: 409,
-    "compound-implementation-assignee": 409,
-    "archived-assignee": 409,
-    "archived-task": 409,
-    "chain-held": 409,
-    "integrator-stopped": 409,
-    "pinned-base-commit": 409,
-    "merge-evidence": 409,
-    "merge-confirmation": 409,
-    "inbox-question-not-found": 409,
-    "approval-gate-decision-invalid": 409,
-    "inbox-choice-mismatch": 409,
-    "inbox-run-not-waiting": 409,
-    "approval-gate-rejection-target-missing": 409,
-  });
+const families: readonly RefusalStatus[] = [400, 403, 404, 409, 422];
+
+test("each status family answers with its own status", () => {
+  for (const [status, refusal] of Object.entries(familyExample)) {
+    assert.equal(refusalResponse(refusal).status, Number(status));
+  }
+});
+
+test("every declared refusal code answers with the family declared beside it", () => {
+  const declaredByCode = {
+    ...templateInstantiationRefusalStatus,
+    ...templateAuthoringRefusalStatus,
+  };
+  for (const [code, status] of Object.entries(declaredByCode)) {
+    const rendered = refusalResponse({ reason: code as Refusal["reason"], message: code });
+    assert.equal(rendered.status, status, code);
+  }
+  for (const [reason, refusal] of Object.entries(refusalByReason)) {
+    assert.ok(families.includes(refusalResponse(refusal).status), reason);
+  }
 });
 
 test("all seven refusal error families map through the same module", () => {
@@ -161,17 +148,13 @@ test("refusal detail is preserved beside the public error message", () => {
   });
 });
 
-test("authoring refusals render every code with its status and optional stepIndex", () => {
-  for (const code of authoringCodes) {
-    const stepIndex = code === "first_step_not_agent" ? 1 : undefined;
-    const rendered = refusalResponse(refusalFor(new TemplateAuthoringRefusal(code, code, stepIndex))!);
-    const expectedStatus = code === "template_not_in_project" ? 404
-      : authoringConflictCodes.has(code) ? 409
-      : 422;
-    assert.equal(rendered.status, expectedStatus, code);
-    assert.equal(rendered.body.error, code);
-    assert.equal(rendered.body.code, code);
-    if (stepIndex === undefined) assert.equal("stepIndex" in rendered.body, false, code);
-    else assert.equal(rendered.body.stepIndex, stepIndex);
-  }
+test("authoring refusals carry their code and optional stepIndex", () => {
+  const withStep = refusalResponse(refusalFor(new TemplateAuthoringRefusal("first_step_not_agent", "not an agent", 1))!);
+  assert.equal(withStep.body.error, "not an agent");
+  assert.equal(withStep.body.code, "first_step_not_agent");
+  assert.equal(withStep.body.stepIndex, 1);
+
+  const withoutStep = refusalResponse(refusalFor(new TemplateAuthoringRefusal("template_in_use", "in use"))!);
+  assert.equal(withoutStep.body.code, "template_in_use");
+  assert.equal("stepIndex" in withoutStep.body, false);
 });

--- a/packages/api/src/refusal.ts
+++ b/packages/api/src/refusal.ts
@@ -11,27 +11,49 @@ import {
   type WorkflowRefusalReason,
 } from "@anneal/db";
 
+import type { RefusalStatus } from "./refusal-status.js";
 import {
   isTemplateInstantiationRefusal,
+  templateInstantiationRefusalStatus,
   type TemplateInstantiationRefusalCode,
 } from "./template-errors.js";
 import {
   isTemplateAuthoringRefusal,
+  templateAuthoringRefusalStatus,
   type TemplateAuthoringRefusalCode,
 } from "./template-authoring-errors.js";
 
-export type RefusalReason =
-  | WorkflowRefusalReason
-  | "forbidden"
-  | "not-found"
-  | "compound-implementation-assignee"
-  | "archived-assignee"
-  | "archived-task"
-  | "chain-held"
-  | "integrator-stopped"
-  | "pinned-base-commit"
-  | "merge-evidence"
-  | "merge-confirmation";
+/**
+ * The status family for each reason `@anneal/db` declares in
+ * `WorkflowRefusalReason`. It is declared here rather than beside the union
+ * because the HTTP contract belongs to this workspace; `satisfies` makes a
+ * reason added there fail to compile until it has a family.
+ */
+const workflowRefusalStatus = {
+  "invalid-request": 400,
+  conflict: 409,
+  "inbox-question-not-found": 409,
+  "approval-gate-decision-invalid": 409,
+  "inbox-choice-mismatch": 409,
+  "inbox-run-not-waiting": 409,
+  "approval-gate-rejection-target-missing": 409,
+} as const satisfies Record<WorkflowRefusalReason, RefusalStatus>;
+
+/** The refusals this module declares, each with its status family. */
+const localRefusalStatus = {
+  forbidden: 403,
+  "not-found": 404,
+  "compound-implementation-assignee": 409,
+  "archived-assignee": 409,
+  "archived-task": 409,
+  "chain-held": 409,
+  "integrator-stopped": 409,
+  "pinned-base-commit": 409,
+  "merge-evidence": 409,
+  "merge-confirmation": 409,
+} as const satisfies Record<string, RefusalStatus>;
+
+export type RefusalReason = WorkflowRefusalReason | keyof typeof localRefusalStatus;
 
 export type RefusalValue =
   | string
@@ -51,105 +73,27 @@ export type Refusal = {
 
 export type RefusalResponse = {
   body: Readonly<{ error: string } & Record<string, RefusalValue>>;
-  status: 400 | 403 | 404 | 409 | 422;
+  status: RefusalStatus;
 };
 
-export const refusalResponse = (refusal: Refusal): RefusalResponse => {
-  let status: RefusalResponse["status"];
-  switch (refusal.reason) {
-    case "after_task_already_bound":
-    case "after_task_already_done":
-    case "after_task_archived":
-    case "after_task_not_chained":
-    case "after_task_not_found":
-    case "after_task_not_terminal":
-    case "dispatch_conflicts_with_auto_start":
-    case "gates_merge_step_absent":
-    case "gates_spec_step_absent":
-    case "implementation_route_agent_renamed":
-    case "implementation_route_conflicts_with_step_override":
-    case "implementation_route_malformed":
-    case "repo_not_found":
-    case "step_override_agent_archived":
-    case "step_override_agent_not_found":
-    case "step_override_compound_implementation":
-    case "step_override_integrator_binding":
-    case "step_override_invalid_key":
-    case "step_override_missing_repo_grant":
-    case "step_override_step_not_agent":
-    case "step_override_too_many":
-    case "step_override_unknown_step":
-    case "template_agent_repo_grant_missing":
-    case "template_base_reference_missing":
-    case "template_base_reference_not_earlier":
-    case "template_branch_invalid":
-    case "template_compound_implementation_assignee_invalid":
-    case "template_first_step_not_agent":
-    case "template_has_no_instantiable_steps":
-    case "template_has_no_steps":
-    case "template_integrator_binding_invalid":
-    case "template_not_found":
-    case "template_step_agent_archived":
-    case "template_step_agent_missing":
-    case "template_variables_missing":
-    case "template_variables_unknown":
-    case "invalid-request":
-      status = 400;
-      break;
-    case "template_not_in_project":
-      status = 404;
-      break;
-    case "forbidden":
-      status = 403;
-      break;
-    case "not-found":
-      status = 404;
-      break;
-    case "conflict":
-    case "compound-implementation-assignee":
-    case "archived-assignee":
-    case "archived-task":
-    case "chain-held":
-    case "integrator-stopped":
-    case "pinned-base-commit":
-    case "merge-evidence":
-    case "merge-confirmation":
-    case "inbox-question-not-found":
-    case "approval-gate-decision-invalid":
-    case "inbox-choice-mismatch":
-    case "inbox-run-not-waiting":
-    case "approval-gate-rejection-target-missing":
-    case "template_name_taken":
-    case "template_name_reserved":
-    case "template_canonical":
-    case "template_in_use":
-      status = 409;
-      break;
-    case "graph_empty":
-    case "first_step_not_agent":
-    case "first_layer_not_single":
-    case "layer_order_invalid":
-    case "base_step_invalid":
-    case "prior_kind_unproduced":
-    case "output_kind_duplicate":
-    case "prior_kind_duplicate":
-    case "approval_gate_in_parallel_layer":
-    case "assignee_invalid":
-    case "integrator_binding_invalid":
-      status = 422;
-      break;
-    default: {
-      const unhandled: never = refusal.reason;
-      return unhandled;
-    }
-  }
-  return {
-    body: refusal.detail === undefined
-      ? { error: refusal.message }
-      : { error: refusal.message, ...refusal.detail },
-    status,
-  };
+/**
+ * Every refusal code that can reach a route, resolved to the family declared
+ * beside it. The annotation is the exhaustiveness check: a code without a
+ * declared family fails to compile here.
+ */
+const statusByReason: Record<Refusal["reason"], RefusalStatus> = {
+  ...workflowRefusalStatus,
+  ...localRefusalStatus,
+  ...templateInstantiationRefusalStatus,
+  ...templateAuthoringRefusalStatus,
 };
+
+export const refusalResponse = (refusal: Refusal): RefusalResponse => ({
+  body: refusal.detail === undefined
+    ? { error: refusal.message }
+    : { error: refusal.message, ...refusal.detail },
+  status: statusByReason[refusal.reason],
+});
 
 export const refusalFor = (error: unknown): Refusal | null => {
   if (isTemplateAuthoringRefusal(error)) {

--- a/packages/api/src/template-authoring-errors.ts
+++ b/packages/api/src/template-authoring-errors.ts
@@ -1,27 +1,34 @@
+import type { RefusalStatus } from "./refusal-status.js";
+
 /**
- * Stable refusal codes for the operator template-authoring surface.
+ * Stable refusal codes for the operator template-authoring surface, each
+ * declared with the HTTP status family it is answered with. The code union is
+ * derived from this table, so a code cannot exist without a status family.
  *
  * These are deliberately separate from TemplateInstantiationRefusalCode: a
  * malformed or conflicting authoring request has a different contract and
  * status family from a template that cannot be materialised into a Chain.
  */
-export type TemplateAuthoringRefusalCode =
-  | "template_not_in_project"
-  | "template_name_taken"
-  | "template_name_reserved"
-  | "template_canonical"
-  | "template_in_use"
-  | "graph_empty"
-  | "first_step_not_agent"
-  | "first_layer_not_single"
-  | "layer_order_invalid"
-  | "base_step_invalid"
-  | "prior_kind_unproduced"
-  | "output_kind_duplicate"
-  | "prior_kind_duplicate"
-  | "approval_gate_in_parallel_layer"
-  | "assignee_invalid"
-  | "integrator_binding_invalid";
+export const templateAuthoringRefusalStatus = {
+  template_not_in_project: 404,
+  template_name_taken: 409,
+  template_name_reserved: 409,
+  template_canonical: 409,
+  template_in_use: 409,
+  graph_empty: 422,
+  first_step_not_agent: 422,
+  first_layer_not_single: 422,
+  layer_order_invalid: 422,
+  base_step_invalid: 422,
+  prior_kind_unproduced: 422,
+  output_kind_duplicate: 422,
+  prior_kind_duplicate: 422,
+  approval_gate_in_parallel_layer: 422,
+  assignee_invalid: 422,
+  integrator_binding_invalid: 422,
+} as const satisfies Record<string, RefusalStatus>;
+
+export type TemplateAuthoringRefusalCode = keyof typeof templateAuthoringRefusalStatus;
 
 /** A stable, machine-readable refusal raised while authoring a template. */
 export class TemplateAuthoringRefusal extends Error {

--- a/packages/api/src/template-errors.ts
+++ b/packages/api/src/template-errors.ts
@@ -1,40 +1,50 @@
-export type TemplateInstantiationRefusalCode =
-  | "after_task_already_bound"
-  | "after_task_already_done"
-  | "after_task_archived"
-  | "after_task_not_chained"
-  | "after_task_not_found"
-  | "after_task_not_terminal"
-  | "dispatch_conflicts_with_auto_start"
-  | "gates_merge_step_absent"
-  | "gates_spec_step_absent"
-  | "implementation_route_agent_renamed"
-  | "implementation_route_conflicts_with_step_override"
-  | "implementation_route_malformed"
-  | "repo_not_found"
-  | "step_override_agent_archived"
-  | "step_override_agent_not_found"
-  | "step_override_compound_implementation"
-  | "step_override_integrator_binding"
-  | "step_override_invalid_key"
-  | "step_override_missing_repo_grant"
-  | "step_override_step_not_agent"
-  | "step_override_too_many"
-  | "step_override_unknown_step"
-  | "template_agent_repo_grant_missing"
-  | "template_base_reference_missing"
-  | "template_base_reference_not_earlier"
-  | "template_branch_invalid"
-  | "template_compound_implementation_assignee_invalid"
-  | "template_first_step_not_agent"
-  | "template_has_no_instantiable_steps"
-  | "template_has_no_steps"
-  | "template_integrator_binding_invalid"
-  | "template_not_found"
-  | "template_step_agent_archived"
-  | "template_step_agent_missing"
-  | "template_variables_missing"
-  | "template_variables_unknown";
+import type { RefusalStatus } from "./refusal-status.js";
+
+/**
+ * Every refusal raised while materialising a template chain, each declared with
+ * the HTTP status family it is answered with. The code union is derived from
+ * this table, so a code cannot exist without a status family.
+ */
+export const templateInstantiationRefusalStatus = {
+  after_task_already_bound: 400,
+  after_task_already_done: 400,
+  after_task_archived: 400,
+  after_task_not_chained: 400,
+  after_task_not_found: 400,
+  after_task_not_terminal: 400,
+  dispatch_conflicts_with_auto_start: 400,
+  gates_merge_step_absent: 400,
+  gates_spec_step_absent: 400,
+  implementation_route_agent_renamed: 400,
+  implementation_route_conflicts_with_step_override: 400,
+  implementation_route_malformed: 400,
+  repo_not_found: 400,
+  step_override_agent_archived: 400,
+  step_override_agent_not_found: 400,
+  step_override_compound_implementation: 400,
+  step_override_integrator_binding: 400,
+  step_override_invalid_key: 400,
+  step_override_missing_repo_grant: 400,
+  step_override_step_not_agent: 400,
+  step_override_too_many: 400,
+  step_override_unknown_step: 400,
+  template_agent_repo_grant_missing: 400,
+  template_base_reference_missing: 400,
+  template_base_reference_not_earlier: 400,
+  template_branch_invalid: 400,
+  template_compound_implementation_assignee_invalid: 400,
+  template_first_step_not_agent: 400,
+  template_has_no_instantiable_steps: 400,
+  template_has_no_steps: 400,
+  template_integrator_binding_invalid: 400,
+  template_not_found: 400,
+  template_step_agent_archived: 400,
+  template_step_agent_missing: 400,
+  template_variables_missing: 400,
+  template_variables_unknown: 400,
+} as const satisfies Record<string, RefusalStatus>;
+
+export type TemplateInstantiationRefusalCode = keyof typeof templateInstantiationRefusalStatus;
 
 /** A stable, machine-readable refusal raised while materialising a template chain. */
 export class TemplateInstantiationRefusal extends Error {


### PR DESCRIPTION
## What changed

`refusalResponse` in `packages/api/src/refusal.ts` was a 95-line switch that
re-listed about 70 refusal codes as bare `case` labels to pick one of five HTTP
statuses. Every code was written twice — once as a union member at its
declaration, once as a `case` here — and the `const unhandled: never` at the end
enforced that duplication instead of removing it. The module's interface asked a
caller adding a refusal code to know about a second, distant place.

Each refusal code now declares its status family where the code is declared, on
the shape `run-open.ts` uses for `OpenRunRefusalShape<Code, Reason>`: the pair is
stated once.

- `template-errors.ts` declares `templateInstantiationRefusalStatus` (36 codes,
  all 400) and derives `TemplateInstantiationRefusalCode` from it.
- `template-authoring-errors.ts` declares `templateAuthoringRefusalStatus` (16
  codes: one 404, four 409, eleven 422) and derives
  `TemplateAuthoringRefusalCode` from it. The file comment already claimed these
  codes have "a different status family"; now that family is in the file.
- `refusal.ts` declares the family for the reasons it owns, plus one table for
  `WorkflowRefusalReason` (declared in `@anneal/db`), and derives `RefusalReason`
  from the local table.
- New `refusal-status.ts` declares `RefusalStatus = 400 | 403 | 404 | 409 | 422`,
  the one type the three declaration sites share. It is its own module so a
  declaration site does not have to import from the module that renders the
  response.

The exhaustiveness check moved to the declaration side and got stronger: because
each code union is `keyof typeof <table>`, a code without a status family does
not exist as a code. The two unions this workspace does not declare are pinned by
`satisfies Record<WorkflowRefusalReason, RefusalStatus>`, so a reason added in
`@anneal/db` fails to compile here until it is given a family. `const unhandled:
never` is deleted; `refusalResponse` is now four lines that read the merged
table.

Response bodies and statuses are unchanged. `docs/operator-api.md` is untouched,
as are `routes/templates.ts` and its test.

## Evidence

Base `34e6ba50`, head `c414ccd8`. All commands run in the worktree after the
final commit, with `RUNNER_WORKSPACE_ROOT` pointed at a fresh `mktemp -d`.

- `npm run lint` (root) — pass. `Checked 724 files in 25s. No fixes applied.`,
  then `eslint .` clean, exit 0.
- `npm run typecheck` (root) — pass, exit 0.
- `npm run test -w @anneal/api` — `tests 810, pass 809, fail 0, skipped 1`,
  duration 41.7s. (The one skip is pre-existing and unrelated.)
- Statuses did not move: I extracted the code-to-status table from the switch at
  the base commit (`git show 34e6ba50:packages/api/src/refusal.ts`, 69 codes) and
  drove `refusalResponse` with every one of them against this branch.
  `checked 69 codes, mismatches 0`. The script was a scratch file and is not
  committed.
- Not run: `test:db`. There is no local PostgreSQL and no `*.dbtest.ts` changed.

## Decisions taken

`WorkflowRefusalReason` (7 of the ~70 codes) is declared in
`packages/db/src/run-open.ts`, which lane t3 owns and which is not yet merged, so
I did not move its status families to their declaration. They are declared in
`refusal.ts` in one table constrained by `satisfies Record<WorkflowRefusalReason,
RefusalStatus>`. That keeps the compile-time guarantee the brief asks for — a new
db reason cannot reach a route without a family — at the cost of one table not
being adjacent to its union. If t3 or a later lane wants it adjacent, the table
moves to `run-open.ts` unchanged.

`RefusalStatus` is a new 8-line module rather than a type exported from
`refusal.ts`. Exporting it from `refusal.ts` would make the two declaration
modules import from the module that imports them; the alternative of restating
the literal union in three files is the duplication this change removes.

Tests are now per status family rather than per code, as the brief asks. The
former `refusal.test.ts` pinned an expected status for each of the 17
`RefusalReason` values and for each of the 16 authoring codes — a third copy of
the roster. It is replaced by: one example per family pinning the five statuses;
one table over the declared codes asserting each answers with the family declared
beside it, plus a `satisfies Record<RefusalReason, Refusal>` table that fails to
compile if a reason is added. The per-code behavioural pins that live outside
this file (`templates.test.ts` asserting instantiation refusals answer 400,
`routes/templates.test.ts`) are unchanged and still pass.

## Fence widened

`packages/api/src/refusal-status.ts` is new. `QUEUE.md` assigns it to no lane, so
per the common rules I took it. No existing file outside the t2 fence was edited.

## Reported but unfixed

- `packages/api/src/routes/support.ts:47` `refusal(reason: RefusalReason, ...)`
  accepts only the reasons declared in `refusal.ts`, not the two template code
  unions, while `Refusal["reason"]` accepts all three. Template refusals reach a
  response through `refusalFor` instead. This is not a defect today, but the two
  entry points into the same type disagree about the roster; a route that wanted
  to raise a template code directly could not use `refusal()`. Left alone:
  `routes/support.ts` is outside the t2 fence and nothing currently needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167M7tzwNAqviXZeLoz8okc
