### PR TITLE
refactor(web): one rule for Chain control admissibility

### DIFF
--- a/apps/web/src/components/chain-aggregate-card.tsx
+++ b/apps/web/src/components/chain-aggregate-card.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { type ChainControlAction, chainControlAction, chainStepPosition } from "../lib/chain-aggregate";
 import { timeAgo, usageCostAmount } from "../lib/format";
 import type { BoardTask, ChainAggregate, ChainAggregateState } from "../lib/types";
 import { navigate } from "../lib/router";
@@ -34,49 +35,20 @@ const STATE_TONE: Record<Exclude<ChainAggregateState, "running">, "green" | "amb
 
 const chainName = (aggregate: ChainAggregate): string => aggregate.chainName ?? aggregate.chainId.slice(0, 8);
 
-const memberPosition = (aggregate: ChainAggregate, members: readonly BoardTask[]): number => {
-  const fromFrontier = aggregate.frontier.position;
-  if (fromFrontier !== null && fromFrontier !== undefined) return fromFrontier;
-  const frontier = members.find((member) => member.id === aggregate.frontier.taskId);
-  const fromMember = frontier === undefined
-    ? null
-    : frontier.chainProgress?.position ?? (frontier.chainIndex === null ? null : frontier.chainIndex + 1);
-  if (fromMember !== null && fromMember !== undefined) return fromMember;
-  const done = aggregate.statusCounts.DONE;
-  return aggregate.stepCount === 0 ? 0 : Math.min(aggregate.stepCount, done + 1);
-};
-
 const routeFor = (representativeTaskId: string): string => `/tasks/${representativeTaskId}`;
-
-type ChainControlAction = { kind: "hold" | "resume"; taskId: string } | null;
-
-/** One action decision feeds both the visible control and its menu mirror. */
-const controlActionFor = (activation: ChainAggregate["activation"]): ChainControlAction => {
-  if (activation.taskId === null) return null;
-  if (activation.hold === null
-    && (activation.state === "waiting-on-predecessor" || activation.state === "running")) {
-    return { kind: "hold", taskId: activation.taskId };
-  }
-  if (activation.state === "held" || (activation.state === "running" && activation.hold !== null)) {
-    return { kind: "resume", taskId: activation.taskId };
-  }
-  return null;
-};
 
 const menu = (
   aggregate: ChainAggregate,
   representativeTaskId: string,
   actions: ChainAggregateActions,
   t: Translate,
-  controlAction: ChainControlAction,
+  controlAction: ChainControlAction | null,
 ): RowMenuEntry[] => {
-  const activation = aggregate.activation;
-  const state = activation.state;
-  const controlTaskId = activation.taskId;
+  const state = aggregate.activation.state;
   return [
     { label: t("tasks.aggregate.menu.open"), onSelect: () => navigate(routeFor(representativeTaskId)) },
-    ...(state === "parked-unactivated" && controlTaskId !== null
-      ? [{ label: t("tasks.aggregate.menu.activate"), onSelect: () => actions.onActivate(controlTaskId) }]
+    ...(controlAction?.kind === "activate"
+      ? [{ label: t("tasks.aggregate.menu.activate"), onSelect: () => actions.onActivate(controlAction.taskId) }]
       : []),
     ...(controlAction?.kind === "hold"
       ? [{ label: t("tasks.aggregate.menu.hold"), onSelect: () => actions.onHold(controlAction.taskId) }]
@@ -100,7 +72,7 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
   const t = useT();
   const representative = representativeTaskId ?? aggregate.frontier.taskId;
   const title = chainName(aggregate);
-  const position = memberPosition(aggregate, members);
+  const position = chainStepPosition(aggregate, members);
   const state = aggregate.activation.state;
   const predecessor = aggregate.activation.predecessor;
   const hold = aggregate.activation.hold;
@@ -113,7 +85,7 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
     onFilter: () => undefined,
     onArchive: () => undefined,
   };
-  const controlAction = controlActionFor(aggregate.activation);
+  const controlAction = chainControlAction(aggregate.activation);
   const holdPill = state === "running" && hold !== null
     ? <Pill tone="amber" data-chain-hold-state="pending">{t("tasks.aggregate.state.stopsAfter")}</Pill>
     : state === "held" && hold !== null
@@ -145,8 +117,8 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
           <RunLine run={activeRepair.latestRun} showElapsed showModel />
         </span>,
       ]),
-      ...(state === "parked-unactivated" && aggregate.activation.taskId !== null ? [
-          <Button type="button" variant="legacyPrimary" size="legacySmall" onClick={(event) => { event.stopPropagation(); handlers.onActivate(aggregate.activation.taskId!); }}>
+      ...(controlAction?.kind === "activate" ? [
+          <Button type="button" variant="legacyPrimary" size="legacySmall" onClick={(event) => { event.stopPropagation(); handlers.onActivate(controlAction.taskId); }}>
             {t("tasks.aggregate.activate")}
           </Button>,
       ] : state === "waiting-on-predecessor" && predecessor !== null ? [

--- a/apps/web/src/lib/board.ts
+++ b/apps/web/src/lib/board.ts
@@ -1,3 +1,4 @@
+import { type ChainControlActionKind, chainControlAction } from "./chain-aggregate";
 import { formatDateTime, formatT } from "./format";
 import { cronProse } from "./schedule";
 import type { BoardTask, ChainAggregate, RunStatus, TaskStatus } from "./types";
@@ -156,40 +157,33 @@ export type ParkedChain = { chainId: string; name: string; stepCount: number; ta
  * board can keep one small, named projection for both column-head waves. */
 export type HoldableChain = ParkedChain;
 
-const chainHold = (aggregate: ChainAggregate): ChainAggregate["activation"]["hold"] =>
-  aggregate.activation.hold;
-
-/**
- * The chains a column would activate, in the order they are read.
- *
- * Only `parked-unactivated` aggregates: a `waiting-on-predecessor` chain
- * dispatches itself when its predecessor completes, so offering to start it
- * would be offering to do something the control plane already owns. Single-task
- * cards are not chains and are not included either.
- */
-export const parkedChains = (entries: readonly (BoardEntry | BoardTask)[]): ParkedChain[] =>
+/** Every chain in these entries whose admissible action is `kind`, in the order
+ * they are read. Single-task cards are not chains and never appear. The rule
+ * itself lives in `chain-aggregate.ts`, so a column head and the card it sits
+ * above can never answer differently. */
+const chainWave = (
+  entries: readonly (BoardEntry | BoardTask)[],
+  kind: ChainControlActionKind,
+): ParkedChain[] =>
   normalizeBoardEntries(entries).flatMap((entry) => {
     if (entry.kind !== "chain") return [];
-    const { activation, chainId, chainName, stepCount } = entry.aggregate;
-    if (activation.state !== "parked-unactivated" || activation.taskId === null || chainHold(entry.aggregate) !== null) return [];
-    return [{ chainId, name: chainBindingLabel({ id: chainId, name: chainName }), stepCount, taskId: activation.taskId }];
+    const { chainId, chainName, stepCount } = entry.aggregate;
+    const action = chainControlAction(entry.aggregate.activation);
+    if (action?.kind !== kind) return [];
+    return [{ chainId, name: chainBindingLabel({ id: chainId, name: chainName }), stepCount, taskId: action.taskId }];
   });
 
-/** The chains a Doing column can hold in one operator wave. A persisted hold is
- * the source of truth, so a stale card already marked held never gets sent a
- * second request by the column head. */
+/** The chains the Todo column head would activate: a `waiting-on-predecessor`
+ * chain dispatches itself when its predecessor completes, so offering to start
+ * it would be offering to do something the control plane already owns. */
+export const parkedChains = (entries: readonly (BoardEntry | BoardTask)[]): ParkedChain[] =>
+  chainWave(entries, "activate");
+
+/** The chains the Doing column head can hold in one operator wave. A chain
+ * already carrying a persisted hold is offered Resume instead, so the column
+ * head never sends a second hold request to one. */
 export const heldChains = (entries: readonly (BoardEntry | BoardTask)[]): HoldableChain[] =>
-  normalizeBoardEntries(entries).flatMap((entry) => {
-    if (entry.kind !== "chain" || chainHold(entry.aggregate) !== null) return [];
-    const { activation, chainId, chainName, stepCount } = entry.aggregate;
-    if (activation.taskId === null) return [];
-    return [{
-      chainId,
-      name: chainBindingLabel({ id: chainId, name: chainName }),
-      stepCount,
-      taskId: activation.taskId,
-    }];
-  });
+  chainWave(entries, "hold");
 
 /* ------------------------------------------------------------- the schedule */
 

--- a/apps/web/src/lib/chain-aggregate.ts
+++ b/apps/web/src/lib/chain-aggregate.ts
@@ -1,0 +1,89 @@
+import type { BoardTask, ChainAggregate } from "./types";
+
+/**
+ * The one place the client reads an operator-facing answer off a Chain
+ * aggregate: which control action is admissible on it, and which Step number
+ * its card names.
+ *
+ * "Can this Chain be held right now?" used to be answered twice — once by the
+ * aggregate card, which read `activation.state`, and once by the Doing column
+ * head, which read only `activation.hold`. The two rules disagreed for a
+ * `settled` or `idle` Chain with a non-null `activation.taskId`: the column
+ * swept it into the Hold-all wave while its own card offered no Hold button.
+ * One module, one answer, three renders.
+ */
+
+export type ChainControlActionKind = "activate" | "hold" | "resume";
+
+/** At most one action is admissible at a time: the states that admit Activate
+ *  are disjoint from those that admit Hold or Resume, so the card, the column
+ *  head and the page all decide from the same single answer. `taskId` is the
+ *  activation Task every chain control route is addressed to; it names the
+ *  first primary Step, which keeps the request independent of whichever
+ *  frontier happens to be visible. */
+export type ChainControlAction = { kind: ChainControlActionKind; taskId: string };
+
+/**
+ * The action an operator may take on this Chain, or `null` for none.
+ *
+ * The full matrix of `activation.state` by `activation.hold`:
+ *
+ * | state                  | hold null | hold set |
+ * | ---------------------- | --------- | -------- |
+ * | parked-unactivated     | activate  | none     |
+ * | waiting-on-predecessor | hold      | none     |
+ * | running                | hold      | resume   |
+ * | held                   | none      | resume   |
+ * | idle                   | none      | none     |
+ * | settled                | none      | none     |
+ *
+ * Half of that matrix the board projection cannot produce: it derives `held`
+ * from a persisted hold and `running` from an active member, so a non-null
+ * `hold` never arrives on any other state. Those cells offer nothing rather
+ * than guessing an action for a shape the projection forbids.
+ *
+ * `settled` matches the server, which refuses a Hold on a completed Chain
+ * outright ("there is nothing left to hold"). `idle` is the narrower client
+ * rule: the server would accept a Hold there, but an `idle` Chain has no
+ * admitted layer in flight and no predecessor about to release it, and the
+ * board offers Hold all on Doing only, which an `idle` aggregate never reaches.
+ */
+export const chainControlAction = (
+  activation: ChainAggregate["activation"],
+): ChainControlAction | null => {
+  const { hold, state, taskId } = activation;
+  if (taskId === null) return null;
+  if (hold === null) {
+    if (state === "parked-unactivated") return { kind: "activate", taskId };
+    if (state === "waiting-on-predecessor" || state === "running") return { kind: "hold", taskId };
+    return null;
+  }
+  // A hold on a Chain that is still running is a barrier after the current
+  // layer, not a cancellation: the Run keeps going, so the only thing left to
+  // offer is lifting the barrier.
+  if (state === "held" || state === "running") return { kind: "resume", taskId };
+  return null;
+};
+
+/**
+ * The dense one-based Step number the aggregate card names, counting down three
+ * sources in order of directness: the position the projection computed, the
+ * position carried by the frontier member itself, and finally the count of
+ * settled Steps. The last is a floor, not a measurement — a Chain whose
+ * frontier is missing from the rendered members still says which Step it is on
+ * rather than saying nothing.
+ */
+export const chainStepPosition = (
+  aggregate: ChainAggregate,
+  members: readonly BoardTask[],
+): number => {
+  const fromFrontier = aggregate.frontier.position;
+  if (fromFrontier !== null && fromFrontier !== undefined) return fromFrontier;
+  const frontier = members.find((member) => member.id === aggregate.frontier.taskId);
+  const fromMember = frontier === undefined
+    ? null
+    : frontier.chainProgress?.position ?? (frontier.chainIndex === null ? null : frontier.chainIndex + 1);
+  if (fromMember !== null && fromMember !== undefined) return fromMember;
+  const done = aggregate.statusCounts.DONE;
+  return aggregate.stepCount === 0 ? 0 : Math.min(aggregate.stepCount, done + 1);
+};

--- a/apps/web/src/tests/chain-aggregate-board.test.tsx
+++ b/apps/web/src/tests/chain-aggregate-board.test.tsx
@@ -148,9 +148,8 @@ test("aggregate card exposes progress, frontier, activation/lock state, and no d
   assert.doesNotMatch(waitingMarkup, />Activate<\/button>/);
 });
 
-test("aggregate card mirrors Hold and Resume across running and held states", () => {
+test("the hold pill and Resume follow the persisted hold, running or held", () => {
   const running = renderToStaticMarkup(<ChainAggregateCard aggregate={aggregate()} />);
-  assert.match(running, /data-chain-hold=""/u);
   assert.match(running, />Stop after current step<\/button>/u);
 
   const held = renderToStaticMarkup(<ChainAggregateCard aggregate={aggregate({
@@ -171,7 +170,42 @@ test("aggregate card mirrors Hold and Resume across running and held states", ()
   })} />);
   assert.match(runningHeld, /data-slot="badge"[^>]*>Stops after step/u);
   assert.match(runningHeld, /data-chain-resume=""/u);
-  assert.doesNotMatch(runningHeld, /data-chain-hold=""/u);
+});
+
+/** The Doing column head, which is the only other surface that decides whether
+ *  a chain can be held. `onHoldAll` is what makes the head offer the wave at
+ *  all, so a column rendered without it proves nothing. */
+const holdColumn = (entries: readonly BoardEntry[]): string => {
+  const definition = COLUMNS.find((candidate) => candidate.status === "DOING")!;
+  return renderToStaticMarkup(<BoardColumn column={definition} tasks={entries} loading={false} dragOver={null} onDragOver={noop} onDragLeave={noop} onDrop={noop} onArchiveDone={noop} onActivateAll={noop} onHoldAll={noop} actions={actions} />);
+};
+
+const offersButton = (markup: string, label: string): boolean =>
+  [...new JSDOM(`<!doctype html><html><body>${markup}</body></html>`).window.document.querySelectorAll("button")]
+    .some((button) => button.textContent === label);
+
+test("the card and the Doing column head offer Hold for exactly the same chains", () => {
+  // Both surfaces used to restate the rule, and they disagreed: the column head
+  // read only the persisted hold, so a `settled` or `idle` chain carrying an
+  // activation task id joined the wave while its own card offered no button.
+  const cases: Array<[ChainAggregate["activation"], boolean]> = [
+    [{ state: "running", predecessor: null, taskId: "step-1", hold: null }, true],
+    [{ state: "waiting-on-predecessor", predecessor: { taskId: "previous", taskName: "Prepare release" }, taskId: "step-1", hold: null }, true],
+    [{ state: "running", predecessor: null, taskId: "step-1", hold: { heldLayer: 2, heldAt: "2026-08-28T01:00:00.000Z", holdReason: null } }, false],
+    [{ state: "held", predecessor: null, taskId: "step-1", hold: { heldLayer: 2, heldAt: "2026-08-28T01:00:00.000Z", holdReason: null } }, false],
+    [{ state: "settled", predecessor: null, taskId: "step-1", hold: null }, false],
+    [{ state: "idle", predecessor: null, taskId: "step-1", hold: null }, false],
+    [{ state: "parked-unactivated", predecessor: null, taskId: "step-1", hold: null }, false],
+    [{ state: "running", predecessor: null, taskId: null, hold: null }, false],
+  ];
+  for (const [activation, offered] of cases) {
+    const projection = aggregate({ activation, status: "DOING" });
+    const card = renderToStaticMarkup(<ChainAggregateCard aggregate={projection} />);
+    const head = holdColumn(boardEntries([chainStep("step-3", 3, "DOING", projection)]));
+    const onCard = offersButton(card, translate("en", activation.state === "running" ? "tasks.aggregate.stopAfter" : "tasks.aggregate.hold"));
+    assert.equal(onCard, offered, `card, ${activation.state}`);
+    assert.equal(offersButton(head, translate("en", "tasks.holdAll")), offered, `column head, ${activation.state}`);
+  }
 });
 
 const element = (markup: string, selector: string): Element => {

--- a/apps/web/src/tests/chain-aggregate.test.ts
+++ b/apps/web/src/tests/chain-aggregate.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { type ChainControlActionKind, chainControlAction, chainStepPosition } from "../lib/chain-aggregate";
+import type { BoardTask, ChainAggregate, ChainAggregateState } from "../lib/types";
+
+const HOLD = { heldLayer: 2, heldAt: "2026-08-16T00:00:00.000Z", holdReason: null };
+
+const activation = (
+  state: ChainAggregateState,
+  hold: ChainAggregate["activation"]["hold"],
+): ChainAggregate["activation"] => ({
+  state,
+  predecessor: state === "waiting-on-predecessor" ? { taskId: "previous", taskName: "Prepare release" } : null,
+  taskId: "step-1",
+  hold,
+});
+
+/** Every `activation.state` by every `activation.hold`. The cells a non-null
+ *  hold pairs with anything but `held` or `running` are shapes the board
+ *  projection cannot emit; they are pinned here so the rule stays total and
+ *  offers nothing rather than guessing. */
+const MATRIX: Array<[ChainAggregateState, ChainControlActionKind | null, ChainControlActionKind | null]> = [
+  // state,                    hold null,  hold set
+  ["parked-unactivated", "activate", null],
+  ["waiting-on-predecessor", "hold", null],
+  ["running", "hold", "resume"],
+  ["held", null, "resume"],
+  ["idle", null, null],
+  ["settled", null, null],
+];
+
+test("one rule answers which control action a Chain admits, for every state and hold", () => {
+  for (const [state, released, holdingBarrier] of MATRIX) {
+    for (const [hold, expected] of [[null, released], [HOLD, holdingBarrier]] as const) {
+      const action = chainControlAction(activation(state, hold));
+      assert.equal(action?.kind ?? null, expected, `${state} with hold ${hold === null ? "null" : "set"}`);
+      if (action !== null) assert.equal(action.taskId, "step-1");
+    }
+  }
+});
+
+test("a Chain with no activation task admits nothing, whatever its state says", () => {
+  for (const [state] of MATRIX) {
+    assert.equal(chainControlAction({ ...activation(state, null), taskId: null }), null, state);
+    assert.equal(chainControlAction({ ...activation(state, HOLD), taskId: null }), null, state);
+  }
+});
+
+const member = (overrides: Partial<BoardTask> = {}): BoardTask => ({
+  id: "step-3", name: "Release: Implement", displayName: "Implement", status: "TODO", moveTargets: [],
+  failureReason: null, assigneeType: "AGENT", createdAt: "2026-08-28T00:00:00.000Z",
+  updatedAt: "2026-08-28T01:00:00.000Z", scheduleKind: "NOW", runAt: null, cron: null, timezone: null,
+  approvalGate: false, templateId: null, source: "MANUAL", chainId: "chain-1", chainIndex: null,
+  chainName: "Release", assigneeAgent: null, chainProgress: null, latestRun: null, taskCost: null,
+  blockedOn: null, mergeOutcome: null, repairOf: null, chainAggregate: null, ...overrides,
+});
+
+const aggregate = (position: number | null, done: number): ChainAggregate => ({
+  chainId: "chain-1", chainName: "Release", stepCount: 12,
+  statusCounts: { BACKLOG: 0, TODO: 12 - done, DOING: 0, REVIEW: 0, DONE: done },
+  detailTaskId: "step-3", status: "TODO",
+  frontier: { taskId: "step-3", title: "Implement release", status: "TODO", latestRun: null, mergeOutcome: null, failureReason: null, position },
+  activeRepair: null, activation: activation("running", null), totalCost: null,
+  createdAt: "2026-08-28T00:00:00.000Z", updatedAt: "2026-08-28T01:00:00.000Z",
+});
+
+test("the Step a card names falls back from the projection to the member to the settled count", () => {
+  assert.equal(chainStepPosition(aggregate(3, 2), []), 3);
+  assert.equal(chainStepPosition(aggregate(null, 2), [member({ chainProgress: {
+    chainId: "chain-1", done: 2, total: 12, activeStepName: "Implement release", activeStatus: "TODO",
+    currentLayer: 5, layerCount: 12, position: 5,
+  } })]), 5);
+  assert.equal(chainStepPosition(aggregate(null, 2), [member({ chainIndex: 6 })]), 7);
+  // No frontier among the rendered members: the settled count is a floor, and a
+  // fully settled chain never claims a Step beyond its last.
+  assert.equal(chainStepPosition(aggregate(null, 2), []), 3);
+  assert.equal(chainStepPosition(aggregate(null, 12), []), 12);
+});

--- a/apps/web/src/tests/tasks-board.test.tsx
+++ b/apps/web/src/tests/tasks-board.test.tsx
@@ -983,24 +983,27 @@ test("parkedChains projects exactly the chains an operator can start", () => {
   assert.deepEqual(parkedChains(unnamed).map((chain) => chain.name), ["c1234567"]);
 });
 
-test("held Chains are excluded from Todo activation and Doing exposes only released chains", () => {
-  const parked = chainRow({ chainId: "parked", name: "Parked", stepCount: 2, state: "parked-unactivated" });
-  const held = task({
-    ...parked,
-    chainAggregate: {
-      ...parked.chainAggregate!,
-      activation: {
-        ...parked.chainAggregate!.activation,
-        hold: { heldLayer: 0, heldAt: "2026-08-16T00:00:00.000Z", holdReason: null },
-      },
-    } as BoardTask["chainAggregate"],
+test("held, settled and idle Chains stay out of both column-head waves", () => {
+  // A parked chain an operator has held arrives as `held`: the projection
+  // derives the state from the persisted hold, which outranks the parked check.
+  const held = chainRow({
+    chainId: "parked", name: "Parked", stepCount: 2, state: "held",
+    hold: { heldLayer: 0, heldAt: "2026-08-16T00:00:00.000Z", holdReason: null },
   });
   assert.deepEqual(parkedChains(boardEntries([held])), []);
 
   const running = chainRow({ chainId: "running", name: "Running", stepCount: 3, state: "running", status: "DOING" });
-  const runningEntry = boardEntries([running]);
-  assert.deepEqual(heldChains(runningEntry), [{ chainId: "running", name: "Running", stepCount: 3, taskId: "running-head" }]);
-  assert.deepEqual(heldChains(boardEntries([held, running])), [{ chainId: "running", name: "Running", stepCount: 3, taskId: "running-head" }]);
+  const runningWave = [{ chainId: "running", name: "Running", stepCount: 3, taskId: "running-head" }];
+  assert.deepEqual(heldChains(boardEntries([running])), runningWave);
+  assert.deepEqual(heldChains(boardEntries([held, running])), runningWave);
+
+  // The divergence the one rule closes: both carry an activation task id, and a
+  // wave that read the persisted hold alone swept them in while their own cards
+  // offered no Hold button.
+  const settled = chainRow({ chainId: "settled", name: "Settled", stepCount: 2, state: "settled", status: "DOING" });
+  const idle = chainRow({ chainId: "idle", name: "Idle", stepCount: 2, state: "idle", status: "DOING" });
+  assert.deepEqual(heldChains(boardEntries([settled, idle])), []);
+  assert.deepEqual(parkedChains(boardEntries([settled, idle])), []);
 });
 
 test("Doing offers Hold all only for chains without a persisted hold", async () => {
@@ -1008,13 +1011,9 @@ test("Doing offers Hold all only for chains without a persisted hold", async () 
   const definition = COLUMNS.find((candidate) => candidate.status === "DOING");
   assert.ok(definition);
   const running = chainRow({ chainId: "running", name: "Running", stepCount: 3, state: "running", status: "DOING" });
-  const held = task({
-    id: "held-head", name: "Held: Implementation", displayName: "Implementation", status: "DOING",
-    chainId: "held", chainName: "Held", chainIndex: 0, chainProgress: progress({ chainId: "held" }),
-    chainAggregate: {
-      ...running.chainAggregate!, chainId: "held", chainName: "Held", detailTaskId: "held-head",
-      activation: { ...running.chainAggregate!.activation, taskId: "held-head", hold: { heldLayer: 1, heldAt: "2026-08-16T00:00:00.000Z", holdReason: null } },
-    } as BoardTask["chainAggregate"],
+  const held = chainRow({
+    chainId: "held", name: "Held", stepCount: 3, state: "running", status: "DOING",
+    hold: { heldLayer: 1, heldAt: "2026-08-16T00:00:00.000Z", holdReason: null },
   });
   const heldIds: string[][] = [];
   const root = (await reactDom()).createRoot(container);


### PR DESCRIPTION
## What changed

"Can this Chain be held right now?" was answered twice, with different rules.
The aggregate card's `controlActionFor` read `activation.state`; `board.ts`'s
`heldChains` read only `activation.hold`. A `settled` or `idle` Chain with a
non-null `activation.taskId` therefore entered the Doing column's Hold-all wave
while its own card offered no Hold button. `parkedChains` and the card's
Activate branch were a third and fourth statement of the same kind of rule,
currently in agreement.

`apps/web/src/lib/chain-aggregate.ts` is now the one module that answers, for a
`ChainAggregate`, which control action is admissible (`activate`, `hold`,
`resume`, or none) and which task id it addresses. Its interface is the full
`activation.state` by `activation.hold` matrix, stated as a table in the module
and pinned by a table-driven test. Three surfaces render that one answer:

- `chain-aggregate-card.tsx` renders the action as a button and mirrors it in
  the row menu. Its `controlActionFor`, its `ChainControlAction` type and its
  Activate predicate are deleted, and with them the `aggregate.activation.taskId!`
  non-null assertion: the module hands the card a task id or nothing.
- `board.ts` projects the same answer into both column-head waves. `parkedChains`
  and `heldChains` are now one internal `chainWave(entries, kind)` and the local
  `chainHold` predicate is deleted.
- `pages/Tasks.tsx` and `desktop-board.tsx` are unchanged: they already posted to
  the task id the projection named, and that id now comes from the one rule.

The card's three-step Step-position fallback ladder (`memberPosition`) moves into
the same module as `chainStepPosition` and gains its first test of the two lower
rungs.

The module is the depth: callers ask one question and get one answer, and the
leverage is that no surface can restate the rule and drift from another.

## Evidence

All four commands run in the worktree after the final commit (`3c63fb38`), with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh `mktemp -d`.

- `npm run lint` (root): PASS. `biome lint` checked 725 files in 76s, no fixes
  applied; `eslint .` then ran and reported nothing. The root script is
  `lint:biome && lint:types`, so `lint:types` running at all is proof biome
  passed, and eslint printing nothing is proof it found nothing.
- `npm run typecheck` (root): PASS. Every workspace typechecked in sequence
  through `@anneal/runner`, the last one; npm stops the sequence at the first
  failing workspace, so reaching the last is proof all of them passed.
- `npm run test -w @anneal/web`: PASS. `tests 610, pass 606, fail 0, skipped 4,
  duration_ms 68060`. The four skips are the pre-existing browser/e2e skips, not
  anything this change touches.
- New tests seen passing by name: `one rule answers which control action a Chain
  admits, for every state and hold`; `a Chain with no activation task admits
  nothing, whatever its state says`; `the Step a card names falls back from the
  projection to the member to the settled count`; `the card and the Doing column
  head offer Hold for exactly the same chains`; `held, settled and idle Chains
  stay out of both column-head waves`; `the hold pill and Resume follow the
  persisted hold, running or held`.

Not run: `test:db`. There is no local PostgreSQL and no `*.dbtest.ts` was
touched; database proof is merge gate evidence. Nothing under `docs/` changed,
so `test:snapshot-scan` does not apply, and no HTTP route was added or renamed.

Anchors re-verified on the base (`34e6ba50`) before editing: `board.ts:170-176`
`parkedChains` and `:181-192` `heldChains` (both present, unchanged from the
findings); `chain-aggregate-card.tsx:54-64` `controlActionFor` and `:37-47` the
position ladder (both present); the two `as BoardTask["chainAggregate"]` casts in
`tasks-board.test.tsx` (both present, both now gone).

## Decisions taken

**The rule is the card's, narrowed by the server for `settled` only.** The brief
said to decide on the card's side (state must be `waiting-on-predecessor` or
`running`) unless the server contract says otherwise. The server contract says
less than the card, not more: `holdChain` in `packages/db/src/chain-control.ts`
refuses exactly one case, `chainRows.every(row => row.status === DONE)` with
"Cannot hold a completed Chain; there is nothing left to hold". It would accept
a Hold on an `idle` Chain. I kept the card's narrower rule rather than widening
Hold to `idle`, for three reasons: the board only offers Hold all on Doing, and
an `idle` aggregate is never placed there (`packages/api/src/board.ts` derives
the DOING column from `active`, which is exactly what makes the state `running`);
`idle` means no admitted layer is in flight and no predecessor is about to
release one, so the barrier would change nothing an operator can see; and the
two-verb card ruling (Activate/Resume and Hold) is settled product shape, not
something to widen inside a deepening lane. Widening Hold to `idle` remains
available as a one-line change to the table if that is later wanted.

**Impossible cells offer nothing rather than guessing.** The projection derives
`held` from a persisted hold and `running` from an active member, so a non-null
`activation.hold` never arrives on `parked-unactivated`, `waiting-on-predecessor`,
`idle` or `settled`. The rule is total over the matrix and returns no action for
those cells, which preserves the behaviour `parkedChains` had when it checked
the hold separately. The table test pins every one of them.

**The divergence was latent, not live.** A `settled` or `idle` aggregate cannot
currently reach the Doing column, so no operator has held a settled chain. The
fix is still the point: two surfaces each restating the rule is what makes a
latent divergence a live one after the next projection change. The new fixtures
place `settled` and `idle` aggregates in the Doing column deliberately, and both
surfaces now refuse them from the same line of code.

**Test shape.** The admissibility matrix is a table-driven unit test in a new
`apps/web/src/tests/chain-aggregate.test.ts`, alongside the existing
`merge-outcome.test.tsx` convention of one test file per `lib/` module. The
per-surface `data-chain-hold` probes are gone: one DOM test now renders the card
and the Doing column head from the same fixture and asserts they offer Hold for
exactly the same chains, and the card's remaining hold test covers only the pill
and Resume, which no other surface renders.

## Fence widened

Two new files that no lane in `QUEUE.md` owns:

- `apps/web/src/lib/chain-aggregate.ts` (the module the brief asked for)
- `apps/web/src/tests/chain-aggregate.test.ts` (the table-driven matrix test)

No file owned by another lane was edited. `apps/web/src/lib/board.ts` is shared
with lane b3, which waits on this lane; the change there is confined to
`parkedChains`/`heldChains` and one new import.

## Reported but unfixed

- `POST /tasks/:taskId/chain/hold` accepts a Hold on an `idle` Chain that the
  scheduler will re-admit (step 1 DONE, step 2 back in TODO with run history),
  and no client surface offers it: the card's rule excludes `idle`, and the
  Todo column head has no Hold all by ruling. If an operator needs to stop such
  a chain before it is re-admitted, they have no button. This is a product
  question about the two-verb card, not a contract divergence, so it is reported
  rather than decided here.
- `apps/web/src/components/chain-aggregate-card.tsx` still reads
  `aggregate.activation.state` directly for its state pill, its lock row and its
  `settled`-only Archive menu entry. Those are presentation facts, not
  admissibility, so they stay on the card; they are named here because a future
  reader may expect the module to own every `activation.state` read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A97kfz4njsKaebYG2spm74
