### PR TITLE
refactor(db): give permitted canonical drift one adoption rule

### DIFF
--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -12,41 +12,25 @@ import { resolve } from "node:path";
 import { catalogRunnerForModel } from "../src/agent-contract.js";
 import { loadAgentSources, roleSourceStructureDifferences, type AgentSources, type RoleSource } from "../src/agent-sources.js";
 import {
+  canonicalStepAdoptions,
+  canonicalStepDrift,
+  REGRESSION_VERIFIER_AGENT_NAME,
+  SPEC_REVALIDATOR_AGENT_NAME,
+} from "../src/canonical-step-adoption.js";
+import {
   applyCanonicalInstallation,
-  isCanonicalReviewStep,
   planCanonicalInstallation,
   type CanonicalInstallationAction,
   type CanonicalInstallationRow,
 } from "../src/canonical-template-installation.js";
 import {
   loadAllTemplateStepSources,
-  LEGACY_ALL_PRIOR_OUTPUTS,
-  templateStepStructureDifferences,
   type CanonicalTemplateName,
   type TemplateStepSource,
 } from "../src/template-sources.js";
 
-const REGRESSION_AGENT_NAME = "regression-verifier";
 const REGRESSION_AGENT_SOURCE = "review-coordinator-sol";
-const SPEC_REVALIDATOR_AGENT_NAME = "spec-revalidator";
 const SPEC_REVALIDATOR_AGENT_SOURCE = "review-coordinator-sol";
-
-type AssigneeTransition = { from: readonly (string | null)[]; to: string };
-const ASSIGNEE_TRANSITIONS = new Map<string, AssigneeTransition>([
-  ["compound-engineer-workflow:10", { from: ["review-coordinator-opus", "review-coordinator-sol"], to: REGRESSION_AGENT_NAME }],
-  ["direct-engineer-workflow:6", { from: ["review-coordinator-opus", "review-coordinator-sol"], to: REGRESSION_AGENT_NAME }],
-  ["direct-engineer-workflow:1", { from: [null], to: SPEC_REVALIDATOR_AGENT_NAME }],
-]);
-
-const STEP_NAME_TRANSITIONS = new Map([
-  ["compound-engineer-workflow:11", { from: "Merge readiness", to: "Merge authorization" }],
-  ["direct-engineer-workflow:7", { from: "Merge readiness", to: "Merge authorization" }],
-]);
-
-const STEP_BASE_TRANSITIONS = new Map([
-  ["compound-engineer-workflow:6", { from: null, to: 5 }],
-  ["direct-engineer-workflow:3", { from: null, to: 2 }],
-]);
 
 const runtimeConfigRefusal = (agent: { model: string; runnerPreference: RunnerPreference }): string | null => {
   const expected = catalogRunnerForModel(agent.model);
@@ -322,8 +306,8 @@ const migrateSpecialCanonicalAgents = async (
   rolesByName: ReadonlyMap<string, RoleSource>,
   countersByProject: Map<string, ProjectCounters>,
 ): Promise<void> => {
-  const regressionRole = rolesByName.get(REGRESSION_AGENT_NAME);
-  if (!regressionRole) throw projectError(canonicalProject, `Canonical role ${REGRESSION_AGENT_NAME} was not found`);
+  const regressionRole = rolesByName.get(REGRESSION_VERIFIER_AGENT_NAME);
+  if (!regressionRole) throw projectError(canonicalProject, `Canonical role ${REGRESSION_VERIFIER_AGENT_NAME} was not found`);
   const regression = await createSpecialCanonicalAgent(
     tx,
     canonicalProject,
@@ -615,86 +599,38 @@ const syncCanonicalTemplates = async (
           }
           throw projectError(project, `Template ${templateName} (${template.id}) step ${step.stepIndex} was not found`);
         }
-        const differences = templateStepStructureDifferences(persisted, step);
-        const transition = ASSIGNEE_TRANSITIONS.get(`${templateName}:${step.stepIndex}`);
-        const adoptsCanonicalAssignee = differences.includes("agent")
-          && transition?.from.includes(persisted.assigneeAgent?.name ?? null) === true
-          && transition.to === step.agentName;
-        const baseTransition = STEP_BASE_TRANSITIONS.get(`${templateName}:${step.stepIndex}`);
-        const adoptsCanonicalBase = differences.includes("baseFromStepIndex")
-          && baseTransition?.from === persisted.baseFromStepIndex
-          && baseTransition.to === step.baseFromStepIndex;
-        const adoptsCanonicalPriorOutput = differences.includes("priorOutputKinds")
-          && persisted.priorOutputKinds.length === 1
-          && persisted.priorOutputKinds[0] === LEGACY_ALL_PRIOR_OUTPUTS;
-        const adoptsCanonicalDependencyProvisioning = differences.includes("provisionDependencies")
-          && isCanonicalReviewStep(templateName, step.stepIndex)
-          && persisted.provisionDependencies === true
-          && step.provisionDependencies === false;
-        const nameTransition = STEP_NAME_TRANSITIONS.get(`${templateName}:${step.stepIndex}`);
-        const adoptsCanonicalName = differences.includes("name")
-          && nameTransition?.from === persisted.name
-          && nameTransition.to === step.name;
-        const adoptedDifferences = new Set([
-          ...(adoptsCanonicalAssignee ? ["agent"] : []),
-          ...(adoptsCanonicalBase ? ["baseFromStepIndex"] : []),
-          ...(adoptsCanonicalPriorOutput ? ["priorOutputKinds"] : []),
-          ...(adoptsCanonicalDependencyProvisioning ? ["provisionDependencies"] : []),
-          ...(adoptsCanonicalName ? ["name"] : []),
-        ]);
-        if (differences.some((difference) => !adoptedDifferences.has(difference))) {
+        const drift = canonicalStepDrift(templateName, persisted, step, "adopt");
+        if (drift.length > 0) {
           throw projectError(
             project,
-            `Template ${templateName} (${template.id}), ${templateName} step ${step.stepIndex} (${persisted.id}) differs from canonical Markdown structure: ${differences.join(", ")}`,
+            `Template ${templateName} (${template.id}), ${templateName} step ${step.stepIndex} (${persisted.id}) differs from canonical Markdown structure: ${drift.join(", ")}`,
           );
         }
-        const protectInUse = (): void => {
-          if (persisted._count.tasks > 0) {
+        for (const adoption of canonicalStepAdoptions(templateName, persisted, step)) {
+          if (adoption.refusesReferencedStep && persisted._count.tasks > 0) {
             throw projectError(
               project,
               `Template ${templateName} (${template.id}), ${templateName} step ${step.stepIndex} (${persisted.id}) is referenced by instantiated tasks; canonical sync will not mutate it`,
             );
           }
-        };
-        if (adoptsCanonicalAssignee) {
-          protectInUse();
-          const assignee = step.agentName === null
-            ? null
-            : await tx.agent.findFirst({
-              where: { projectId: template.projectId, name: transition!.to, archivedAt: null },
+          if (adoption.write.kind === "bind-agent") {
+            const assignee = await tx.agent.findFirst({
+              where: { projectId: template.projectId, name: adoption.write.agentName, archivedAt: null },
               select: { id: true },
             });
-          if (step.agentName !== null && !assignee) {
-            throw projectError(
-              project,
-              `Template ${templateName} (${template.id}), ${templateName} step ${step.stepIndex} (${persisted.id}) cannot adopt ${transition!.to}: active target Agent was not found`,
-            );
+            if (!assignee) {
+              throw projectError(
+                project,
+                `Template ${templateName} (${template.id}), ${templateName} step ${step.stepIndex} (${persisted.id}) cannot adopt ${adoption.write.agentName}: active target Agent was not found`,
+              );
+            }
+            await tx.taskTemplateStep.update({ where: { id: persisted.id }, data: { assigneeAgentId: assignee.id } });
+          } else {
+            await tx.taskTemplateStep.update({ where: { id: persisted.id }, data: adoption.write.data });
           }
-          await tx.taskTemplateStep.update({ where: { id: persisted.id }, data: { assigneeAgentId: assignee?.id ?? null } });
-          increment(countersByProject, project.id, "adoptedAssignees");
+          increment(countersByProject, project.id, adoption.counter);
         }
-        if (adoptsCanonicalBase) {
-          protectInUse();
-          await tx.taskTemplateStep.update({ where: { id: persisted.id }, data: { baseFromStepIndex: baseTransition!.to } });
-          increment(countersByProject, project.id, "adoptedStepBases");
-        }
-        if (adoptsCanonicalPriorOutput) {
-          await tx.taskTemplateStep.update({ where: { id: persisted.id }, data: { priorOutputKinds: step.priorOutputKinds } });
-          increment(countersByProject, project.id, "adoptedPriorOutputDeclarations");
-        }
-        if (adoptsCanonicalDependencyProvisioning) {
-          await tx.taskTemplateStep.update({
-            where: { id: persisted.id },
-            data: { provisionDependencies: step.provisionDependencies },
-          });
-          increment(countersByProject, project.id, "adoptedDependencyProvisioning");
-        }
-        if (adoptsCanonicalName) {
-          protectInUse();
-          await tx.taskTemplateStep.update({ where: { id: persisted.id }, data: { name: nameTransition!.to } });
-          increment(countersByProject, project.id, "renamedSteps");
-        }
-        if (step.agentName === REGRESSION_AGENT_NAME) {
+        if (step.agentName === REGRESSION_VERIFIER_AGENT_NAME) {
           regressionSteps.push({
             id: persisted.id,
             templateName,
@@ -726,13 +662,13 @@ const migrateRegressionTasks = async (
 ): Promise<void> => {
   for (const step of regressionSteps) {
     const target = await tx.agent.findFirst({
-      where: { projectId: project.id, name: REGRESSION_AGENT_NAME, archivedAt: null },
+      where: { projectId: project.id, name: REGRESSION_VERIFIER_AGENT_NAME, archivedAt: null },
       select: { id: true },
     });
     if (!target) {
       throw projectError(
         project,
-        `Template ${step.templateName} (${step.templateId}), ${step.templateName} step ${step.stepIndex} (${step.id}) has no active ${REGRESSION_AGENT_NAME} Agent`,
+        `Template ${step.templateName} (${step.templateId}), ${step.templateName} step ${step.stepIndex} (${step.id}) has no active ${REGRESSION_VERIFIER_AGENT_NAME} Agent`,
       );
     }
     const tasks = await tx.task.findMany({
@@ -784,7 +720,7 @@ const migrateRegressionTasks = async (
       await tx.taskActivity.create({ data: {
         taskId: task.id,
         actorType: "control-plane",
-        body: `Canonical routing reassigned this unstarted regression step to ${REGRESSION_AGENT_NAME}`,
+        body: `Canonical routing reassigned this unstarted regression step to ${REGRESSION_VERIFIER_AGENT_NAME}`,
         metadata: {
           kind: "canonicalRouting.regressionVerifier",
           schemaVersion: 1,

--- a/packages/db/prisma/verify-agent-template.ts
+++ b/packages/db/prisma/verify-agent-template.ts
@@ -7,6 +7,7 @@ import {
   isTemplateRunnerInherited,
 } from "../src/agent-contract.js";
 import { loadAgentSources, roleSourceStructureDifferences, type RoleSource } from "../src/agent-sources.js";
+import { canonicalStepDrift } from "../src/canonical-step-adoption.js";
 import {
   INTEGRATOR_AGENT_NAME,
   INTEGRATOR_OUTPUT_KIND,
@@ -18,8 +19,8 @@ import {
 import {
   loadAllTemplateStepSources,
   templateMetadataDifferences,
-  templateStepStructureDifferences,
   type CanonicalTemplateName,
+  type PersistedTemplateStepStructure,
   type TemplateStepSource,
 } from "../src/template-sources.js";
 
@@ -54,7 +55,7 @@ type TemplateStepRow = {
   approvalGate: boolean;
   attachmentsFromPrevious: boolean;
   priorOutputKinds: string[];
-  spawnPolicy: Parameters<typeof templateStepStructureDifferences>[0]["spawnPolicy"];
+  spawnPolicy: PersistedTemplateStepStructure["spawnPolicy"];
   runner: RunnerKind | null;
   outputKind: string;
   opensPullRequest: boolean;
@@ -140,13 +141,19 @@ const verifyTemplateMetadata = (
   }
 };
 
+/**
+ * The verifier states the zero-tolerance stance against the same adoption
+ * roster the plan and the sync consult: a persisted step that the sync would
+ * still have to adopt has not been installed yet, so it is drift here.
+ */
 const verifyTemplateStep = (
   template: TemplateRow,
+  templateName: CanonicalTemplateName,
   step: TemplateStepRow,
   expected: TemplateStepSource,
   context: VerificationContext,
 ): void => {
-  const differences = templateStepStructureDifferences(step, expected);
+  const differences = canonicalStepDrift(templateName, step, expected, "refuse-all");
   if (step.stepIndex !== expected.stepIndex) differences.unshift("stepIndex");
   if (!isTemplateRunnerInherited(step.runner)) differences.push("runner");
   if (step.prompt !== expected.prompt) differences.push("prompt");
@@ -187,7 +194,7 @@ const verifyTemplate = (
         context.partial ? `${templateLabel(template)} is missing step ${expected.stepIndex}` : message,
       ));
     }
-    verifyTemplateStep(template, step, expected, context);
+    verifyTemplateStep(template, templateName, step, expected, context);
   }
 };
 

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -1080,222 +1080,91 @@ test("sync recreates a missing spec revalidator with read-only repository covera
   }), [{ mountPath: repo.mountPath, permissions: RepoPermission.GIT_READ }]);
 });
 
-test("sync adopts review dependency provisioning across current templates with referenced tasks", async () => {
-  const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
-  const reviewSteps = new Map([
-    ["compound-engineer-workflow", new Set([6, 7])],
-    ["direct-engineer-workflow", new Set([3, 4])],
-    ["pr-engineer-workflow", new Set([2, 3])],
-  ]);
-  const templates = await prisma.taskTemplate.findMany({
-    where: { projectId: project.id, name: { in: [...reviewSteps.keys()] } },
-    include: { steps: { include: { assigneeAgent: true } } },
-  });
-  assert.equal(templates.length, reviewSteps.size);
-  const foreignProject = await prisma.project.create({
-    data: { name: "Foreign dependency adoption", slug: `foreign-dependency-${randomBytes(4).toString("hex")}` },
-  });
-  const foreignEnvironment = await prisma.environment.create({
-    data: { projectId: foreignProject.id, name: "local", allowedHosts: [] },
-  });
-  const foreignAgents = new Map<string, string>();
-  const taskIds: string[] = [];
-  try {
-    for (const source of templates.flatMap(({ steps }) => steps.map(({ assigneeAgent }) => assigneeAgent!))) {
-      if (foreignAgents.has(source.name)) continue;
-      const created = await prisma.agent.create({ data: {
-        projectId: foreignProject.id,
-        environmentId: foreignEnvironment.id,
-        name: source.name,
-        title: source.title,
-        model: source.model,
-        runnerPreference: source.runnerPreference,
-        inboxAccess: source.inboxAccess,
-        foundationalPrompt: source.foundationalPrompt,
-        rolePrompt: source.rolePrompt,
-        disabledTools: source.disabledTools,
-      } });
-      foreignAgents.set(source.name, created.id);
-    }
-
-    for (const template of templates) {
-      const indexes = reviewSteps.get(template.name)!;
-      const foreignTemplate = await prisma.taskTemplate.create({ data: {
-        projectId: foreignProject.id,
-        name: template.name,
-        description: template.description,
-        variables: template.variables,
-      } });
-      for (const step of template.steps.filter(({ stepIndex }) => indexes.has(stepIndex))) {
-        await prisma.taskTemplateStep.update({
-          where: { id: step.id },
-          data: { provisionDependencies: true },
-        });
-        const task = await prisma.task.create({ data: {
-          projectId: project.id,
-          templateId: template.id,
-          templateStepId: step.id,
-          name: `dependency-provisioning-review-${template.name}-${step.stepIndex}`,
-          description: "dependency-provisioning canonical sync fixture",
-          assigneeAgentId: step.assigneeAgentId,
-          assigneeType: step.assigneeType,
-          status: TaskStatus.TODO,
-        } });
-        taskIds.push(task.id);
-      }
-      for (const step of template.steps) {
-        const foreignStep = await prisma.taskTemplateStep.create({ data: {
-          taskTemplateId: foreignTemplate.id,
-          stepIndex: step.stepIndex,
-          layer: step.layer,
-          name: step.name,
-          assigneeAgentId: foreignAgents.get(step.assigneeAgent!.name)!,
-          assigneeType: step.assigneeType,
-          runner: step.runner,
-          approvalGate: step.approvalGate,
-          outputKind: step.outputKind,
-          prompt: step.prompt,
-          opensPullRequest: step.opensPullRequest,
-          requiresCommit: step.requiresCommit,
-          provisionDependencies: true,
-          attachmentsFromPrevious: step.attachmentsFromPrevious,
-          priorOutputKinds: step.priorOutputKinds,
-          baseFromStepIndex: step.baseFromStepIndex,
-          spawnPolicy: step.spawnPolicy === null ? Prisma.JsonNull : step.spawnPolicy,
-        } });
-        if (!indexes.has(step.stepIndex)) continue;
-        await prisma.task.create({ data: {
-          projectId: foreignProject.id,
-          templateId: foreignTemplate.id,
-          templateStepId: foreignStep.id,
-          name: `dependency-provisioning-review-foreign-${template.name}-${step.stepIndex}`,
-          description: "foreign dependency-provisioning canonical sync fixture",
-          assigneeAgentId: foreignStep.assigneeAgentId,
-          assigneeType: foreignStep.assigneeType,
-          status: TaskStatus.TODO,
-        } });
-      }
-    }
-
-    const synced = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
-    assert.equal(synced.status, 0, synced.output);
-    assert.match(synced.output, /"adoptedDependencyProvisioning":12/u);
-
-    const current = await prisma.taskTemplate.findMany({
-      where: { projectId: { in: [project.id, foreignProject.id] }, name: { in: [...reviewSteps.keys()] } },
-      include: { steps: { orderBy: { stepIndex: "asc" } } },
-    });
-    assert.equal(current.length, reviewSteps.size * 2);
-    for (const template of current) {
-      const indexes = reviewSteps.get(template.name)!;
-      assert.ok(template.steps.filter(({ stepIndex }) => indexes.has(stepIndex))
-        .every(({ provisionDependencies }) => provisionDependencies === false));
-      assert.ok(template.steps.filter(({ stepIndex }) => !indexes.has(stepIndex))
-        .every(({ provisionDependencies }) => provisionDependencies === true));
-    }
-
-    const second = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
-    assert.equal(second.status, 0, second.output);
-    assert.match(second.output, /"adoptedDependencyProvisioning":0/u);
-  } finally {
-    await prisma.task.deleteMany({ where: { id: { in: taskIds } } });
-    await prisma.project.delete({ where: { id: foreignProject.id } });
-  }
-});
-
-test("sync refuses mixed dependency provisioning drift before mutation", async () => {
+test("canonical sync adopts the tolerated differences and refuses every other one before mutating", async () => {
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   const template = await prisma.taskTemplate.findUniqueOrThrow({
     where: { projectId_name: { projectId: project.id, name: "direct-engineer-workflow" } },
     include: { steps: { orderBy: { stepIndex: "asc" } } },
   });
-  const reviewStep = template.steps.find(({ stepIndex }) => stepIndex === 3)!;
-  const implementationStep = template.steps.find(({ stepIndex }) => stepIndex === 2)!;
-  await prisma.taskTemplateStep.update({
-    where: { id: reviewStep.id },
-    data: { provisionDependencies: true },
-  });
-  await prisma.taskTemplateStep.update({
-    where: { id: implementationStep.id },
-    data: { provisionDependencies: false },
-  });
-  try {
-    const before = await prisma.taskTemplateStep.findMany({
-      where: { taskTemplateId: template.id },
-      select: { id: true, provisionDependencies: true },
-      orderBy: { stepIndex: "asc" },
-    });
-
-    const refused = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
-    assert.notEqual(refused.status, 0, refused.output);
-    assert.match(refused.output, /direct-engineer-workflow.*provisionDependencies/u);
-    assert.deepEqual(await prisma.taskTemplateStep.findMany({
-      where: { taskTemplateId: template.id },
-      select: { id: true, provisionDependencies: true },
-      orderBy: { stepIndex: "asc" },
-    }), before);
-  } finally {
-    await prisma.taskTemplateStep.update({
-      where: { id: reviewStep.id },
-      data: { provisionDependencies: false },
-    });
-    await prisma.taskTemplateStep.update({
-      where: { id: implementationStep.id },
-      data: { provisionDependencies: true },
-    });
-  }
-});
-
-test("sync refuses canonical step drift when instantiated tasks would be mutated", async () => {
-  const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
-  const source = await prisma.agent.findUniqueOrThrow({
+  const step = (stepIndex: number) => {
+    const found = template.steps.find((candidate) => candidate.stepIndex === stepIndex);
+    assert.ok(found, `direct-engineer-workflow must contain step ${stepIndex}`);
+    return found;
+  };
+  const reviewStep = step(3);
+  const implementationStep = step(2);
+  const regressionStep = step(6);
+  assert.equal(regressionStep.outputKind, "regression-verification-v2");
+  const retiredReviewer = await prisma.agent.findUniqueOrThrow({
     where: { projectId_name: { projectId: project.id, name: "review-coordinator-sol" } },
   });
-  const template = await prisma.taskTemplate.findUniqueOrThrow({
-    where: { projectId_name: { projectId: project.id, name: "direct-engineer-workflow" } },
+  const verifier = await prisma.agent.findUniqueOrThrow({
+    where: { projectId_name: { projectId: project.id, name: "regression-verifier" } },
   });
-  const step = await prisma.taskTemplateStep.findFirstOrThrow({
-    where: { taskTemplateId: template.id, outputKind: "regression-verification-v2" },
-  });
-  await prisma.taskTemplateStep.update({ where: { id: step.id }, data: { assigneeAgentId: source.id } });
-  const task = await prisma.task.create({ data: {
+  const provisioning = async (stepId: string): Promise<boolean> => (
+    await prisma.taskTemplateStep.findUniqueOrThrow({ where: { id: stepId } })
+  ).provisionDependencies;
+  const assignee = async (stepId: string): Promise<string | null> => (
+    await prisma.taskTemplateStep.findUniqueOrThrow({ where: { id: stepId } })
+  ).assigneeAgentId;
+
+  // A review step may carry the retired dependency provisioning; an implementation
+  // step may not drop it. The refusal stands and the tolerated difference is not written.
+  await prisma.taskTemplateStep.update({ where: { id: reviewStep.id }, data: { provisionDependencies: true } });
+  await prisma.taskTemplateStep.update({ where: { id: implementationStep.id }, data: { provisionDependencies: false } });
+  const refusedDrift = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
+  assert.notEqual(refusedDrift.status, 0, refusedDrift.output);
+  assert.match(refusedDrift.output, /direct-engineer-workflow step 2 \([^)]+\) differs from the canonical source in provisionDependencies/u);
+  assert.equal(await provisioning(reviewStep.id), true);
+  assert.equal(await provisioning(implementationStep.id), false);
+  await prisma.taskTemplateStep.update({ where: { id: implementationStep.id }, data: { provisionDependencies: true } });
+
+  // An adoption that rewrites a column instantiated Tasks copy refuses a referenced step.
+  await prisma.taskTemplateStep.update({ where: { id: regressionStep.id }, data: { assigneeAgentId: retiredReviewer.id } });
+  const referenced = await prisma.task.create({ data: {
     projectId: project.id,
     templateId: template.id,
-    templateStepId: step.id,
+    templateStepId: regressionStep.id,
     name: "referenced regression",
     description: "operator-owned evidence",
-    assigneeAgentId: source.id,
+    assigneeAgentId: retiredReviewer.id,
     assigneeType: "AGENT",
     status: TaskStatus.TODO,
   } });
-  const refused = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
-  assert.notEqual(refused.status, 0, refused.output);
-  assert.match(refused.output, /referenced by instantiated tasks/u);
-  assert.equal((await prisma.taskTemplateStep.findUniqueOrThrow({ where: { id: step.id } })).assigneeAgentId, source.id);
-  assert.equal((await prisma.task.findUniqueOrThrow({ where: { id: task.id } })).description, "operator-owned evidence");
-  const canonicalRegression = await prisma.agent.findUniqueOrThrow({
-    where: { projectId_name: { projectId: project.id, name: "regression-verifier" } },
-    select: { id: true },
-  });
-  await prisma.taskTemplateStep.update({ where: { id: step.id }, data: { assigneeAgentId: canonicalRegression.id } });
-});
+  const refusedReferenced = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
+  assert.notEqual(refusedReferenced.status, 0, refusedReferenced.output);
+  assert.match(refusedReferenced.output, /referenced by instantiated tasks/u);
+  assert.equal(await assignee(regressionStep.id), retiredReviewer.id);
+  // The tolerated review-step write happened earlier in the same transaction and rolled back with it.
+  assert.equal(await provisioning(reviewStep.id), true);
+  assert.equal((await prisma.task.findUniqueOrThrow({ where: { id: referenced.id } })).description, "operator-owned evidence");
+  await prisma.task.delete({ where: { id: referenced.id } });
 
-test("sync refuses an eight-step canonical shape with structural drift before mutation", async () => {
-  const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
-  const template = await prisma.taskTemplate.findUniqueOrThrow({
-    where: { projectId_name: { projectId: project.id, name: "direct-engineer-workflow" } },
-  });
-  const step = await prisma.taskTemplateStep.findUniqueOrThrow({
-    where: { taskTemplateId_stepIndex: { taskTemplateId: template.id, stepIndex: 7 } },
-  });
-  await prisma.taskTemplateStep.update({ where: { id: step.id }, data: { outputKind: "drifted-output" } });
-  const beforeLegacyCount = await prisma.taskTemplate.count({ where: { projectId: project.id, name: { startsWith: "direct-engineer-workflow-legacy" } } });
-  const refused = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
-  assert.notEqual(refused.status, 0, refused.output);
-  assert.match(
-    refused.output,
-    new RegExp(`Project ${project.slug}: Template direct-engineer-workflow \\(${template.id}\\), direct-engineer-workflow step 7 \\(${step.id}\\) differs from the canonical source in outputKind`, "u"),
-  );
-  assert.equal(await prisma.taskTemplate.count({ where: { projectId: project.id, name: { startsWith: "direct-engineer-workflow-legacy" } } }), beforeLegacyCount);
-  assert.equal((await prisma.taskTemplateStep.findUniqueOrThrow({ where: { id: step.id } })).outputKind, "drifted-output");
+  // Both differences are now adoptable; the dependency-provisioning write does not
+  // protect a referenced step, so an instantiated Task does not stop it.
+  const reviewTask = await prisma.task.create({ data: {
+    projectId: project.id,
+    templateId: template.id,
+    templateStepId: reviewStep.id,
+    name: "referenced review",
+    description: "dependency-provisioning canonical sync fixture",
+    assigneeAgentId: reviewStep.assigneeAgentId,
+    assigneeType: reviewStep.assigneeType,
+    status: TaskStatus.TODO,
+  } });
+  try {
+    const synced = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
+    assert.equal(synced.status, 0, synced.output);
+    assert.match(synced.output, /"adoptedDependencyProvisioning":1,/u);
+    assert.match(synced.output, /"adoptedAssignees":1,/u);
+    assert.equal(await provisioning(reviewStep.id), false);
+    assert.equal(await assignee(regressionStep.id), verifier.id);
+
+    const second = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
+    assert.equal(second.status, 0, second.output);
+    assert.match(second.output, /"adoptedDependencyProvisioning":0,/u);
+    assert.match(second.output, /"adoptedAssignees":0,/u);
+  } finally {
+    await prisma.task.delete({ where: { id: reviewTask.id } });
+  }
 });

--- a/packages/db/src/canonical-step-adoption.test.ts
+++ b/packages/db/src/canonical-step-adoption.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canonicalStepAdoptions,
+  canonicalStepDrift,
+  REGRESSION_VERIFIER_AGENT_NAME,
+  SPEC_REVALIDATOR_AGENT_NAME,
+  type CanonicalStepAdoption,
+} from "./canonical-step-adoption.js";
+import {
+  LEGACY_ALL_PRIOR_OUTPUTS,
+  loadAllTemplateStepSources,
+  type CanonicalTemplateName,
+  type PersistedTemplateStepStructure,
+  type TemplateStepSource,
+} from "./template-sources.js";
+
+const sources = await loadAllTemplateStepSources();
+
+const sourceStep = (templateName: CanonicalTemplateName, stepIndex: number): TemplateStepSource => {
+  const step = sources.get(templateName)!.find((candidate) => candidate.stepIndex === stepIndex);
+  assert.ok(step, `${templateName} must declare step ${stepIndex}`);
+  return step;
+};
+
+/** A persisted row that matches its source exactly; each case drifts one column. */
+const asPersisted = (source: TemplateStepSource): PersistedTemplateStepStructure => ({
+  name: source.name,
+  assigneeAgent: source.agentName === null ? null : { name: source.agentName },
+  assigneeType: source.agentName === null ? "HUMAN" : "AGENT",
+  layer: source.layer,
+  approvalGate: source.approvalGate,
+  outputKind: source.outputKind,
+  attachmentsFromPrevious: source.attachmentsFromPrevious,
+  priorOutputKinds: source.priorOutputKinds,
+  opensPullRequest: source.opensPullRequest,
+  requiresCommit: source.requiresCommit,
+  provisionDependencies: source.provisionDependencies,
+  baseFromStepIndex: source.baseFromStepIndex,
+  spawnPolicy: source.spawnPolicy as PersistedTemplateStepStructure["spawnPolicy"],
+});
+
+const onlyAdoption = (
+  templateName: CanonicalTemplateName,
+  actual: PersistedTemplateStepStructure,
+  source: TemplateStepSource,
+): CanonicalStepAdoption => {
+  const adoptions = canonicalStepAdoptions(templateName, actual, source);
+  assert.equal(adoptions.length, 1, `expected exactly one adoption, found ${adoptions.map(({ difference }) => difference).join(", ")}`);
+  assert.deepEqual(canonicalStepDrift(templateName, actual, source, "adopt"), []);
+  return adoptions[0]!;
+};
+
+const refuses = (
+  templateName: CanonicalTemplateName,
+  actual: PersistedTemplateStepStructure,
+  source: TemplateStepSource,
+  difference: string,
+): void => {
+  assert.deepEqual(canonicalStepAdoptions(templateName, actual, source), []);
+  assert.deepEqual(canonicalStepDrift(templateName, actual, source, "adopt"), [difference]);
+};
+
+test("a step that matches its source offers no adoption and no drift", () => {
+  for (const [templateName, steps] of sources) {
+    for (const source of steps) {
+      assert.deepEqual(canonicalStepAdoptions(templateName, asPersisted(source), source), [], `${templateName}:${source.stepIndex}`);
+      assert.deepEqual(canonicalStepDrift(templateName, asPersisted(source), source, "adopt"), [], `${templateName}:${source.stepIndex}`);
+      assert.deepEqual(canonicalStepDrift(templateName, asPersisted(source), source, "refuse-all"), [], `${templateName}:${source.stepIndex}`);
+    }
+  }
+});
+
+test("the regression steps adopt the verifier Agent from either retired review role", () => {
+  for (const [templateName, stepIndex] of [
+    ["compound-engineer-workflow", 10],
+    ["direct-engineer-workflow", 6],
+  ] as const) {
+    const source = sourceStep(templateName, stepIndex);
+    assert.equal(source.agentName, REGRESSION_VERIFIER_AGENT_NAME);
+    for (const retired of ["review-coordinator-opus", "review-coordinator-sol"]) {
+      const actual = { ...asPersisted(source), assigneeAgent: { name: retired } };
+      assert.deepEqual(onlyAdoption(templateName, actual, source), {
+        difference: "agent",
+        counter: "adoptedAssignees",
+        refusesReferencedStep: true,
+        write: { kind: "bind-agent", agentName: REGRESSION_VERIFIER_AGENT_NAME },
+      });
+    }
+    refuses(templateName, { ...asPersisted(source), assigneeAgent: { name: "senior-dev" } }, source, "agent");
+  }
+});
+
+test("the direct revalidation step adopts the revalidator Agent only from an unbound row", () => {
+  const source = sourceStep("direct-engineer-workflow", 1);
+  assert.equal(source.agentName, SPEC_REVALIDATOR_AGENT_NAME);
+  assert.deepEqual(onlyAdoption("direct-engineer-workflow", { ...asPersisted(source), assigneeAgent: null }, source), {
+    difference: "agent",
+    counter: "adoptedAssignees",
+    refusesReferencedStep: true,
+    write: { kind: "bind-agent", agentName: SPEC_REVALIDATOR_AGENT_NAME },
+  });
+  refuses("direct-engineer-workflow", { ...asPersisted(source), assigneeAgent: { name: "senior-dev" } }, source, "agent");
+});
+
+test("an unbound row on any other step is drift, not an assignee adoption", () => {
+  const source = sourceStep("compound-engineer-workflow", 1);
+  refuses("compound-engineer-workflow", { ...asPersisted(source), assigneeAgent: null }, source, "agent");
+});
+
+test("the merge authorization steps adopt their canonical name from the retired one", () => {
+  for (const [templateName, stepIndex] of [
+    ["compound-engineer-workflow", 11],
+    ["direct-engineer-workflow", 7],
+  ] as const) {
+    const source = sourceStep(templateName, stepIndex);
+    assert.equal(source.name, "Merge authorization");
+    assert.deepEqual(onlyAdoption(templateName, { ...asPersisted(source), name: "Merge readiness" }, source), {
+      difference: "name",
+      counter: "renamedSteps",
+      refusesReferencedStep: true,
+      write: { kind: "set-columns", data: { name: "Merge authorization" } },
+    });
+    refuses(templateName, { ...asPersisted(source), name: "Some other name" }, source, "name");
+  }
+});
+
+test("a Merge readiness name on any other step is drift, not a rename adoption", () => {
+  const source = sourceStep("direct-engineer-workflow", 5);
+  refuses("direct-engineer-workflow", { ...asPersisted(source), name: "Merge readiness" }, source, "name");
+});
+
+test("the fix steps adopt their canonical step base from an absent one", () => {
+  for (const [templateName, stepIndex, base] of [
+    ["compound-engineer-workflow", 6, 5],
+    ["direct-engineer-workflow", 3, 2],
+  ] as const) {
+    const source = sourceStep(templateName, stepIndex);
+    assert.equal(source.baseFromStepIndex, base);
+    assert.deepEqual(onlyAdoption(templateName, { ...asPersisted(source), baseFromStepIndex: null }, source), {
+      difference: "baseFromStepIndex",
+      counter: "adoptedStepBases",
+      refusesReferencedStep: true,
+      write: { kind: "set-columns", data: { baseFromStepIndex: base } },
+    });
+    refuses(templateName, { ...asPersisted(source), baseFromStepIndex: 1 }, source, "baseFromStepIndex");
+  }
+});
+
+test("an absent step base on any other step is drift, not a base adoption", () => {
+  const source = sourceStep("compound-engineer-workflow", 7);
+  assert.notEqual(source.baseFromStepIndex, null);
+  refuses("compound-engineer-workflow", { ...asPersisted(source), baseFromStepIndex: null }, source, "baseFromStepIndex");
+});
+
+test("every canonical review step adopts the canonical absence of dependency provisioning", () => {
+  const reviewSteps = [
+    ["compound-engineer-workflow", 6], ["compound-engineer-workflow", 7],
+    ["direct-engineer-workflow", 3], ["direct-engineer-workflow", 4],
+    ["pr-engineer-workflow", 2], ["pr-engineer-workflow", 3],
+  ] as const;
+  for (const [templateName, stepIndex] of reviewSteps) {
+    const source = sourceStep(templateName, stepIndex);
+    assert.equal(source.provisionDependencies, false);
+    assert.deepEqual(onlyAdoption(templateName, { ...asPersisted(source), provisionDependencies: true }, source), {
+      difference: "provisionDependencies",
+      counter: "adoptedDependencyProvisioning",
+      refusesReferencedStep: false,
+      write: { kind: "set-columns", data: { provisionDependencies: false } },
+    });
+  }
+
+  const reviewIdentities = new Set(reviewSteps.map(([templateName, stepIndex]) => `${templateName}:${stepIndex}`));
+  for (const [templateName, steps] of sources) {
+    for (const source of steps) {
+      if (reviewIdentities.has(`${templateName}:${source.stepIndex}`)) continue;
+      assert.equal(source.provisionDependencies, true, `${templateName}:${source.stepIndex}`);
+      refuses(templateName, { ...asPersisted(source), provisionDependencies: false }, source, "provisionDependencies");
+    }
+  }
+});
+
+test("the retired all-output handoff marker is adopted wherever it survives", () => {
+  for (const [templateName, steps] of sources) {
+    for (const source of steps) {
+      const actual = { ...asPersisted(source), priorOutputKinds: [LEGACY_ALL_PRIOR_OUTPUTS] };
+      assert.deepEqual(onlyAdoption(templateName, actual, source), {
+        difference: "priorOutputKinds",
+        counter: "adoptedPriorOutputDeclarations",
+        refusesReferencedStep: false,
+        write: { kind: "set-columns", data: { priorOutputKinds: source.priorOutputKinds } },
+      });
+      refuses(templateName, { ...asPersisted(source), priorOutputKinds: ["drifted-output"] }, source, "priorOutputKinds");
+    }
+  }
+});
+
+test("refuse-all reports the differences adopt forgives, and offers nothing to write", () => {
+  const source = sourceStep("direct-engineer-workflow", 3);
+  const actual = {
+    ...asPersisted(source),
+    provisionDependencies: true,
+    baseFromStepIndex: null,
+    priorOutputKinds: [LEGACY_ALL_PRIOR_OUTPUTS],
+  };
+  assert.deepEqual(canonicalStepDrift("direct-engineer-workflow", actual, source, "adopt"), []);
+  assert.deepEqual(
+    canonicalStepDrift("direct-engineer-workflow", actual, source, "refuse-all").sort(),
+    ["baseFromStepIndex", "priorOutputKinds", "provisionDependencies"],
+  );
+});
+
+test("a refused difference alongside an adoptable one leaves the refusal standing", () => {
+  const source = sourceStep("direct-engineer-workflow", 3);
+  const actual = { ...asPersisted(source), provisionDependencies: true, outputKind: "drifted-output" };
+  assert.deepEqual(canonicalStepDrift("direct-engineer-workflow", actual, source, "adopt"), ["outputKind"]);
+  assert.deepEqual(
+    canonicalStepAdoptions("direct-engineer-workflow", actual, source).map(({ difference }) => difference),
+    ["provisionDependencies"],
+  );
+});

--- a/packages/db/src/canonical-step-adoption.ts
+++ b/packages/db/src/canonical-step-adoption.ts
@@ -1,0 +1,170 @@
+import type { Prisma } from "@prisma/client";
+
+import {
+  LEGACY_ALL_PRIOR_OUTPUTS,
+  templateStepStructureDifferences,
+  type CanonicalTemplateName,
+  type PersistedTemplateStepStructure,
+  type TemplateStepSource,
+} from "./template-sources.js";
+
+/**
+ * The complete set of differences between a persisted canonical template step
+ * and its Markdown source that the platform forgives, and the write that
+ * resolves each. Every reader of canonical drift consults this module:
+ * `planCanonicalInstallation` to decide that a row is current,
+ * `sync-canonical-prompts.ts` to perform the write, and
+ * `verify-agent-template.ts` with `refuse-all` so the verifier's zero-tolerance
+ * stance is stated against the same roster instead of restating the rules.
+ *
+ * An adoption is permitted only from an exact retired value to an exact
+ * canonical value at a named step. Any other difference is drift and is
+ * refused.
+ */
+
+export const REGRESSION_VERIFIER_AGENT_NAME = "regression-verifier";
+export const SPEC_REVALIDATOR_AGENT_NAME = "spec-revalidator";
+
+/** Roles that carried regression verification before it became its own Agent. */
+const RETIRED_REGRESSION_ROLES: readonly (string | null)[] = ["review-coordinator-opus", "review-coordinator-sol"];
+
+/** The sync report counter one adoption increments. */
+export type CanonicalAdoptionCounter =
+  | "adoptedAssignees"
+  | "adoptedStepBases"
+  | "adoptedPriorOutputDeclarations"
+  | "adoptedDependencyProvisioning"
+  | "renamedSteps";
+
+/**
+ * The write that resolves one tolerated difference. `bind-agent` needs the
+ * caller's transaction to resolve the named active Agent to its id; every
+ * other adoption is a column value taken from the canonical source.
+ */
+export type CanonicalAdoptionWrite =
+  | Readonly<{ kind: "bind-agent"; agentName: string }>
+  | Readonly<{ kind: "set-columns"; data: Prisma.TaskTemplateStepUncheckedUpdateInput }>;
+
+export type CanonicalStepAdoption = Readonly<{
+  /** The `templateStepStructureDifferences` field this adoption forgives. */
+  difference: string;
+  counter: CanonicalAdoptionCounter;
+  /** The write changes a column instantiated Tasks copy; refuse a referenced step instead of mutating it. */
+  refusesReferencedStep: boolean;
+  write: CanonicalAdoptionWrite;
+}>;
+
+/** Whether the reader forgives what an adoption resolves, or refuses every difference. */
+export type CanonicalAdoptionTolerance = "adopt" | "refuse-all";
+
+type AdoptionRule = Readonly<{
+  difference: string;
+  counter: CanonicalAdoptionCounter;
+  refusesReferencedStep: boolean;
+  matches: (actual: PersistedTemplateStepStructure, source: TemplateStepSource) => boolean;
+  write: (source: TemplateStepSource) => CanonicalAdoptionWrite;
+}>;
+
+const adoptsAgent = (from: readonly (string | null)[], to: string): AdoptionRule => ({
+  difference: "agent",
+  counter: "adoptedAssignees",
+  refusesReferencedStep: true,
+  matches: (actual, source) => from.includes(actual.assigneeAgent?.name ?? null) && source.agentName === to,
+  write: () => ({ kind: "bind-agent", agentName: to }),
+});
+
+const adoptsStepName = (from: string, to: string): AdoptionRule => ({
+  difference: "name",
+  counter: "renamedSteps",
+  refusesReferencedStep: true,
+  matches: (actual, source) => actual.name === from && source.name === to,
+  write: (source) => ({ kind: "set-columns", data: { name: source.name } }),
+});
+
+const adoptsStepBase = (from: number | null, to: number): AdoptionRule => ({
+  difference: "baseFromStepIndex",
+  counter: "adoptedStepBases",
+  refusesReferencedStep: true,
+  matches: (actual, source) => actual.baseFromStepIndex === from && source.baseFromStepIndex === to,
+  write: (source) => ({ kind: "set-columns", data: { baseFromStepIndex: source.baseFromStepIndex } }),
+});
+
+/** Review steps read the tree only; they drop the provisioning their predecessors carried. */
+const ADOPTS_REVIEW_PROVISIONING: AdoptionRule = {
+  difference: "provisionDependencies",
+  counter: "adoptedDependencyProvisioning",
+  refusesReferencedStep: false,
+  matches: (actual, source) => actual.provisionDependencies === true && source.provisionDependencies === false,
+  write: (source) => ({ kind: "set-columns", data: { provisionDependencies: source.provisionDependencies } }),
+};
+
+/**
+ * The retired all-output handoff marker is a repository-wide migration state,
+ * not a transition at one named step, so it is permitted wherever it survives.
+ */
+const ADOPTS_PRIOR_OUTPUT_WHITELIST: AdoptionRule = {
+  difference: "priorOutputKinds",
+  counter: "adoptedPriorOutputDeclarations",
+  refusesReferencedStep: false,
+  matches: (actual) => actual.priorOutputKinds.length === 1 && actual.priorOutputKinds[0] === LEGACY_ALL_PRIOR_OUTPUTS,
+  write: (source) => ({ kind: "set-columns", data: { priorOutputKinds: source.priorOutputKinds } }),
+};
+
+const ADOPTIONS_AT_EVERY_STEP: readonly AdoptionRule[] = [ADOPTS_PRIOR_OUTPUT_WHITELIST];
+
+/** Keyed by `templateName:stepIndex`. This is the roster of canonical review steps too. */
+const ADOPTIONS_BY_STEP: ReadonlyMap<string, readonly AdoptionRule[]> = new Map([
+  ["compound-engineer-workflow:6", [ADOPTS_REVIEW_PROVISIONING, adoptsStepBase(null, 5)]],
+  ["compound-engineer-workflow:7", [ADOPTS_REVIEW_PROVISIONING]],
+  ["compound-engineer-workflow:10", [adoptsAgent(RETIRED_REGRESSION_ROLES, REGRESSION_VERIFIER_AGENT_NAME)]],
+  ["compound-engineer-workflow:11", [adoptsStepName("Merge readiness", "Merge authorization")]],
+  ["direct-engineer-workflow:1", [adoptsAgent([null], SPEC_REVALIDATOR_AGENT_NAME)]],
+  ["direct-engineer-workflow:3", [ADOPTS_REVIEW_PROVISIONING, adoptsStepBase(null, 2)]],
+  ["direct-engineer-workflow:4", [ADOPTS_REVIEW_PROVISIONING]],
+  ["direct-engineer-workflow:6", [adoptsAgent(RETIRED_REGRESSION_ROLES, REGRESSION_VERIFIER_AGENT_NAME)]],
+  ["direct-engineer-workflow:7", [adoptsStepName("Merge readiness", "Merge authorization")]],
+  ["pr-engineer-workflow:2", [ADOPTS_REVIEW_PROVISIONING]],
+  ["pr-engineer-workflow:3", [ADOPTS_REVIEW_PROVISIONING]],
+]);
+
+/**
+ * The adoptions that resolve the differences between one persisted step and
+ * its canonical source, in the order their writes may be applied.
+ */
+export const canonicalStepAdoptions = (
+  templateName: CanonicalTemplateName,
+  actual: PersistedTemplateStepStructure,
+  source: TemplateStepSource,
+): readonly CanonicalStepAdoption[] => {
+  const differences = templateStepStructureDifferences(actual, source);
+  if (differences.length === 0) return [];
+  const rules = [
+    ...ADOPTIONS_AT_EVERY_STEP,
+    ...ADOPTIONS_BY_STEP.get(`${templateName}:${source.stepIndex}`) ?? [],
+  ];
+  return rules
+    .filter((rule) => differences.includes(rule.difference) && rule.matches(actual, source))
+    .map((rule) => ({
+      difference: rule.difference,
+      counter: rule.counter,
+      refusesReferencedStep: rule.refusesReferencedStep,
+      write: rule.write(source),
+    }));
+};
+
+/**
+ * The differences the reader must refuse. Under `adopt`, the differences an
+ * adoption resolves are absent; under `refuse-all`, every difference is
+ * reported and no adoption is offered.
+ */
+export const canonicalStepDrift = (
+  templateName: CanonicalTemplateName,
+  actual: PersistedTemplateStepStructure,
+  source: TemplateStepSource,
+  tolerance: CanonicalAdoptionTolerance,
+): string[] => {
+  const differences = templateStepStructureDifferences(actual, source);
+  if (tolerance === "refuse-all") return differences;
+  const adopted = new Set(canonicalStepAdoptions(templateName, actual, source).map(({ difference }) => difference));
+  return differences.filter((difference) => !adopted.has(difference));
+};

--- a/packages/db/src/canonical-template-installation.ts
+++ b/packages/db/src/canonical-template-installation.ts
@@ -1,5 +1,6 @@
 import { AssigneeType, Prisma, RunStatus, TaskStatus } from "@prisma/client";
 
+import { canonicalStepDrift } from "./canonical-step-adoption.js";
 import {
   legacyTemplateName,
   LEGACY_TEMPLATE_GENERATIONS,
@@ -9,9 +10,7 @@ import {
   type PersistedTransitionStep,
 } from "./canonical-template-transition.js";
 import {
-  LEGACY_ALL_PRIOR_OUTPUTS,
   canonicalTemplateSourceSpec,
-  templateStepStructureDifferences,
   type CanonicalTemplateName,
   type TemplateStepSource,
 } from "./template-sources.js";
@@ -48,50 +47,6 @@ export type CanonicalInstallationAction =
 export type CanonicalInstallationPlan = readonly CanonicalInstallationAction[];
 export type CanonicalInstallationSources = ReadonlyMap<CanonicalTemplateName, readonly TemplateStepSource[]>;
 
-export const CANONICAL_REVIEW_STEP_IDENTITIES: ReadonlySet<string> = new Set([
-  "compound-engineer-workflow:6",
-  "compound-engineer-workflow:7",
-  "direct-engineer-workflow:3",
-  "direct-engineer-workflow:4",
-  "pr-engineer-workflow:2",
-  "pr-engineer-workflow:3",
-]);
-
-export const isCanonicalReviewStep = (templateName: CanonicalTemplateName, stepIndex: number): boolean =>
-  CANONICAL_REVIEW_STEP_IDENTITIES.has(`${templateName}:${stepIndex}`);
-
-const adoptionDifferenceAllowed = (
-  templateName: CanonicalTemplateName,
-  actual: PersistedTransitionStep,
-  source: TemplateStepSource,
-  difference: string,
-): boolean => {
-  if (difference === "name") return actual.name === "Merge readiness" && source.name === "Merge authorization";
-  if (difference === "priorOutputKinds") {
-    return actual.priorOutputKinds.length === 1 && actual.priorOutputKinds[0] === LEGACY_ALL_PRIOR_OUTPUTS;
-  }
-  if (difference === "agent") {
-    const from = actual.assigneeAgent?.name;
-    return (source.agentName === "regression-verifier"
-      && (from === "review-coordinator-opus" || from === "review-coordinator-sol"))
-      || (templateName === "direct-engineer-workflow"
-        && actual.stepIndex === 1
-        && from === undefined
-        && source.agentName === "spec-revalidator");
-  }
-  if (difference === "baseFromStepIndex") {
-    return actual.baseFromStepIndex === null
-      && ((templateName === "compound-engineer-workflow" && actual.stepIndex === 6 && source.baseFromStepIndex === 5)
-        || (templateName === "direct-engineer-workflow" && actual.stepIndex === 3 && source.baseFromStepIndex === 2));
-  }
-  if (difference === "provisionDependencies") {
-    return isCanonicalReviewStep(templateName, actual.stepIndex)
-      && actual.provisionDependencies === true
-      && source.provisionDependencies === false;
-  }
-  return false;
-};
-
 const currentGraphRefusal = (
   templateName: CanonicalTemplateName,
   templateId: string,
@@ -108,8 +63,7 @@ const currentGraphRefusal = (
   }
   for (const [index, step] of ordered.entries()) {
     const source = sources[index]!;
-    const differences = templateStepStructureDifferences(step, source)
-      .filter((difference) => !adoptionDifferenceAllowed(templateName, step, source, difference));
+    const differences = canonicalStepDrift(templateName, step, source, "adopt");
     if (differences.length > 0) {
       return `Template ${templateName} (${templateId}), ${templateName} step ${step.stepIndex} (${step.id}) differs from the canonical source in ${differences.join(", ")}`;
     }

--- a/packages/db/src/verify-agent-template.dbtest.ts
+++ b/packages/db/src/verify-agent-template.dbtest.ts
@@ -21,6 +21,7 @@ import {
 } from "./canonical-template-installation.js";
 import { PR_TEMPLATE_NAME } from "./agent-contract.js";
 import {
+  LEGACY_ALL_PRIOR_OUTPUTS,
   canonicalTemplateSourceSpec,
   loadAllTemplateStepSources,
   templateMetadataDifferences,
@@ -473,6 +474,31 @@ test("--project rejects every canonical template step field with template/step i
       assert.match(result.output, projectErrorPattern(fixture), mutation.name);
       assert.match(result.output, templateIdentifierPattern(fixture), mutation.name);
       assert.match(result.output, /pr-engineer-workflow step \d+ \([^)]+\)/u, mutation.name);
+    });
+  }
+});
+
+test("--project refuses the differences canonical sync would adopt", async () => {
+  const mutations: ReadonlyArray<{ name: string; stepIndex: number; data: Prisma.TaskTemplateStepUpdateInput }> = [
+    { name: "provisionDependencies", stepIndex: 2, data: { provisionDependencies: true } },
+    { name: "priorOutputKinds", stepIndex: 3, data: { priorOutputKinds: [LEGACY_ALL_PRIOR_OUTPUTS] } },
+  ];
+
+  for (const mutation of mutations) {
+    await withProject({ agents: partialRoleNames, template: true }, async (fixture) => {
+      const step = await prisma.taskTemplateStep.findUniqueOrThrow({
+        where: { taskTemplateId_stepIndex: { taskTemplateId: fixture.templateId!, stepIndex: mutation.stepIndex } },
+      });
+      await prisma.taskTemplateStep.update({ where: { id: step.id }, data: mutation.data });
+      const result = verify(fixture.id);
+      assert.notEqual(result.status, 0, `${mutation.name}: ${result.output}`);
+      assert.match(result.output, projectErrorPattern(fixture), mutation.name);
+      assert.match(result.output, templateIdentifierPattern(fixture), mutation.name);
+      assert.match(
+        result.output,
+        new RegExp(`${PR_TEMPLATE_NAME} step ${mutation.stepIndex} \\([^)]+\\) differs from canonical Markdown structure: ${mutation.name}`, "u"),
+        mutation.name,
+      );
     });
   }
 });


### PR DESCRIPTION
## What changed

The set of tolerated differences between a persisted canonical template step and
its Markdown source, and the write that resolves each, is now one module:
`packages/db/src/canonical-step-adoption.ts`. It exports the roster as data
(`templateName:stepIndex` to the adoptions permitted at that step, plus the one
adoption permitted at every step) and two readers over it:

- `canonicalStepAdoptions(templateName, actual, source)` returns the adoptions
  that apply, each naming the difference it forgives, the report counter it
  increments, whether its write may touch a step that instantiated Tasks
  reference, and the write itself (`bind-agent` or `set-columns`).
- `canonicalStepDrift(templateName, actual, source, tolerance)` returns the
  differences the reader must refuse, under `adopt` or `refuse-all`.

Three readers consult it and none of them restates a rule:

- `planCanonicalInstallation` (`currentGraphRefusal`) calls
  `canonicalStepDrift(..., "adopt")` to decide `current`. Its private
  `adoptionDifferenceAllowed` is deleted, and with it the exported
  `isCanonicalReviewStep` / `CANONICAL_REVIEW_STEP_IDENTITIES` that existed only
  so the sync script could restate the review-step rule; the roster of canonical
  review steps is now the set of identities carrying the dependency-provisioning
  adoption.
- `sync-canonical-prompts.ts` drops `ASSIGNEE_TRANSITIONS`,
  `STEP_NAME_TRANSITIONS`, `STEP_BASE_TRANSITIONS`, the five `adoptsCanonical*`
  predicates, `adoptedDifferences`, and the five hand-written write blocks. It
  now refuses `canonicalStepDrift(..., "adopt")` and applies each adoption the
  module returns, incrementing the counter the adoption names.
- `verify-agent-template.ts` calls `canonicalStepDrift(..., "refuse-all")`, so
  its zero-tolerance stance is stated against the same roster rather than being
  an accident of calling the base diff directly.

The base diff `templateStepStructureDifferences` stays in `template-sources.ts`.

Leverage: adding or retiring one permitted drift is now one entry in one table
instead of three edits that must be kept in agreement by hand. Locality: the
rule, its counter, its referenced-step protection and its write sit on one line
of the roster.

## Evidence

Run in the worktree after the final commit, with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh temporary directory.

- `npm run lint` (root) — pass, `Checked 725 files`, `eslint .` exit 0.
- `npm run typecheck` (root) — pass, all workspaces.
- `npm run typecheck:cli -w @anneal/db` — pass (the prisma scripts).
- `npm run test -w @anneal/db` — pass, 357 tests, 0 fail, including the new
  `canonical-step-adoption.test.ts` (12 cases, no database).
- `npm run test:db` was not run: there is no local PostgreSQL. The changed
  `*.dbtest.ts` files typecheck; the merge gate runs them.
- Merge gate dispatched for this exact head; verdict recorded in the lane status
  file.

Tests:

- New `packages/db/src/canonical-step-adoption.test.ts` covers every adoption
  rule without a database: both regression steps from either retired review
  role, the direct revalidation step from an unbound row, both merge
  authorization renames, both fix-step bases, all six review steps'
  dependency provisioning, and the retired all-output handoff marker at every
  canonical step. Each rule is also tested for the negative: the same column
  drifted to a value the rule does not name, and the same drift at a step the
  rule does not name, are refused. Two further cases pin that `refuse-all`
  reports what `adopt` forgives, and that a refused difference alongside an
  adoptable one leaves the refusal standing.
- The four drift dbtests at `canonical-prompt-sync.dbtest.ts:1083-1301` collapse
  into one end-to-end case with three phases against the real script: an
  unforgiven difference refuses and the tolerated sibling is not written; an
  adoption whose write would touch a referenced step refuses and the earlier
  tolerated write in the same transaction rolls back; both differences are then
  adopted, with the second run reporting zero.
- `verify-agent-template.dbtest.ts` gains `--project refuses the differences
  canonical sync would adopt`, which is the case that pins the verifier's
  `refuse-all` stance: a canonical review step carrying dependency provisioning
  and a step carrying the retired all-output marker are both rejected.

## Decisions taken

- **Module shape.** The rule set is data (a `templateName:stepIndex` map plus
  the one repository-wide rule) read by two functions rather than a predicate
  per caller. `canonicalStepDrift` takes an explicit
  `"adopt" | "refuse-all"` because the verifier is a real second reader with a
  different stance, not a hypothetical one.
- **The plan's rules were not step-pinned; the unified rules are.** The
  installation module previously allowed the `agent` and `name` adoptions at any
  step whose canonical source happened to name `regression-verifier` or
  `Merge authorization`; the sync script pinned them to named steps. Unifying on
  the pinned form is a strict tightening and is behaviour-identical against the
  canonical sources, where those values occur only at the pinned steps. The
  retired all-output handoff marker keeps its unpinned form deliberately: it is
  a repository-wide migration state, not a transition at one named step, and
  pinning it would silently retire the whitelist adoption elsewhere.
- **Two call sites of one rule are kept.** `main` computes the plan from a read
  taken before `applyCanonicalInstallation`, and `syncCanonicalTemplates` walks
  a fresher read after it. Both now consult the same module, so the duplication
  the finding names (the rule) is gone; the second check is not a second
  mechanism but the write loop refusing to touch a row it does not fully
  understand. Deleting it would leave the writes ungated against the read they
  actually operate on.
- **A dead write branch was removed.** The old assignee adoption carried an
  `agentName === null` unbinding path; no transition targets `HUMAN`, so
  `bind-agent` now always resolves an active Agent and fails loudly when it is
  absent.
- **The module is not exported from `packages/db/src/index.ts`.** Its only
  callers are inside `@anneal/db` (the installation module and the two prisma
  scripts). `isCanonicalReviewStep` and `CANONICAL_REVIEW_STEP_IDENTITIES` were
  reachable through the index but had no consumer outside the package.
- **The collapsed dbtest drops the foreign-project dimension** the old
  dependency-provisioning dbtest carried. Adoption across a second project is
  already asserted end to end by
  `canonical-prompt-sync-multi-project.dbtest.ts:656-662`, which is lane t4's
  file and was not edited.
- **Refusal message texts were left alone.** The plan says "differs from the
  canonical source in X", the sync and the verifier say "differs from canonical
  Markdown structure: X". Unifying the wording is churn across three scripts and
  their tests for no leverage; the rule, not the sentence, was the duplication.

## Fence widened

None. `packages/db/src/canonical-step-adoption.ts` and its test are new files
under `packages/db/src/`, which the brief names as the module's home; no other
lane owns them. Every other edited file is listed under lane t1 in `QUEUE.md`.

## Reported but unfixed

- `packages/db/prisma/sync-canonical-prompts.ts` still threads
  `Map<projectId, ProjectCounters>` through every helper even though each
  transaction handles exactly one project, and the report is still a
  `console.log` of an untyped object literal. That is Candidate T4 and lane t4
  owns the file; untouched here beyond the adoption walk.
- The retired dbtest "sync refuses an eight-step canonical shape with structural
  drift before mutation" left `outputKind: "drifted-output"` persisted on
  `direct-engineer-workflow` step 7 with no restore. It was the last test in the
  file, so nothing observed the leak. The replacement case restores every column
  it drifts; no fix is outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzGUSZJEwYYyqssGaKTkyd
