### PR TITLE
fix(runner): materialize the session git credential helper

### DIFF
--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -6,6 +6,7 @@ import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
 import { hostProofSlotDirectory } from "./host-proof-slots.js";
 import { manifestLines, toolsFor } from "./session-tool-contract.js";
+import { gitCredentialHelperTool } from "./runtime-tools.js";
 import type { AgentScratch } from "./workspace.js";
 import { claudeDeclaration, claudePlatformSettingsPath } from "./adapters/claude.js";
 import { codexDeclaration, codexPlatformBaselinePath } from "./adapters/codex.js";
@@ -189,7 +190,7 @@ export const buildChildEnvironment = (
       // regression step's target refresh failed every Run with "could not read
       // Username". Answer through the runner's own home instead. A public
       // remote hid this for as long as every repository here was public.
-      ["credential.helper", join(scratch.toolsDir, "git-credential-runner.sh")] as const,
+      ["credential.helper", join(scratch.toolsDir, gitCredentialHelperTool)] as const,
       ...(commitHooksPath ? [["core.hooksPath", commitHooksPath] as const] : []),
     ]),
     ...(regressionStep ? {

--- a/packages/runner/src/runtime-tools.ts
+++ b/packages/runner/src/runtime-tools.ts
@@ -1,0 +1,33 @@
+/**
+ * The inventory of scripts that cross from the release bundle into a Run's
+ * scratch tools directory.
+ *
+ * It lives apart from both consumers because they would otherwise import each
+ * other: `workspace.ts` materializes exactly these paths, and `adapters.ts`
+ * pins one of them into a session's git configuration.
+ */
+
+/**
+ * The credential helper the agent adapters pin into a session's git config.
+ * Naming it here keeps the pinned path provably one of the materialized tools:
+ * a helper the materialization never copies makes every authenticated fetch in
+ * a session fail with git's non-interactive credential error, and a public
+ * remote hides that for as long as the helper is never consulted.
+ */
+export const gitCredentialHelperTool = "git-credential-runner.sh";
+
+/**
+ * The exact inventory a Run receives. It must stay equal to the release bundle
+ * manifest in `packages/runner/scripts/build-runtime-tools.mjs`: the
+ * materialization copies, verifies and mode-checks precisely these paths and
+ * rejects any other entry at the destination.
+ */
+export const runtimeToolPaths = Object.freeze([
+  gitCredentialHelperTool,
+  "regression-verification.sh",
+  "gate-worker/gate-dispatch.sh",
+  "gate-worker/lib.sh",
+  "gate-worker/mirror-push.sh",
+  "gate-worker/remote-gate.sh",
+  "gate-worker/run-gate.sh",
+]);

--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -9,6 +9,7 @@ import test from "node:test";
 import type { RunnerConfig } from "./config.js";
 import { CLONE_COMMAND_TIMEOUT_MS } from "./network-retry.js";
 import { runCommand } from "./exec.js";
+import { runtimeToolPaths } from "./runtime-tools.js";
 import {
   cleanupAgentScratch, materializeRuntimeTools, provisionAgentScratch, provisionSessionConfig, provisionWorkspace, sessionConfigBaselineRoot,
   workspaceEnvironment, writeSessionCredentials,
@@ -17,14 +18,8 @@ import {
 
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 
-const canonicalRuntimeTools = [
-  ["regression-verification.sh", "../runtime-tools/regression-verification.sh"],
-  ["gate-worker/gate-dispatch.sh", "../runtime-tools/gate-worker/gate-dispatch.sh"],
-  ["gate-worker/lib.sh", "../runtime-tools/gate-worker/lib.sh"],
-  ["gate-worker/mirror-push.sh", "../runtime-tools/gate-worker/mirror-push.sh"],
-  ["gate-worker/remote-gate.sh", "../runtime-tools/gate-worker/remote-gate.sh"],
-  ["gate-worker/run-gate.sh", "../runtime-tools/gate-worker/run-gate.sh"],
-] as const;
+const canonicalRuntimeTools = runtimeToolPaths.map((relativePath) =>
+  [relativePath, `../runtime-tools/${relativePath}`] as const);
 
 const createRuntimeToolsFixture = async (): Promise<string> => {
   const root = await mkdtemp(join(tmpdir(), "agentos-runtime-tools-source-"));
@@ -914,7 +909,7 @@ for (const runAsPrefix of [[], ["/usr/bin/env", "--"]]) {
       assert.equal(scratch.toolsDir.startsWith(`${checkout}${sep}`), false);
       assert.deepEqual(
         (await readdir(scratch.toolsDir)).sort(),
-        ["gate-worker", "regression-verification.sh"],
+        ["gate-worker", "git-credential-runner.sh", "regression-verification.sh"],
       );
       assert.deepEqual(
         (await readdir(join(scratch.toolsDir, "gate-worker"))).sort(),
@@ -1073,7 +1068,7 @@ test("runtime-tool materialization ignores unrelated release-source entries", as
   try {
     await writeFile(join(sourceRoot, ".incidental"), "not part of the bundle\n");
     await materializeRuntimeTools(config, scratch, { sourceRoot });
-    assert.deepEqual((await readdir(scratch.toolsDir)).sort(), ["gate-worker", "regression-verification.sh"]);
+    assert.deepEqual((await readdir(scratch.toolsDir)).sort(), ["gate-worker", "git-credential-runner.sh", "regression-verification.sh"]);
   } finally {
     await cleanupAgentScratch(config, scratch);
     await rm(sourceRoot, { recursive: true, force: true });

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -9,6 +9,7 @@ import { RUNNER_DEFINITIONS } from "./adapters.js";
 import { workspaceEnvironment } from "./adapters/environment.js";
 import type { SessionConfigOptions } from "./adapters/session-config.js";
 import { defaultSessionConfigBaselineRoot, type RunnerConfig, type RunnerKind } from "./config.js";
+import { runtimeToolPaths } from "./runtime-tools.js";
 import { materializeWorkspaceDependencies, type DependencyCacheOptions } from "./dependency-cache.js";
 import { platformCommitArgs, runCommand, type CommandOptions } from "./exec.js";
 import {
@@ -195,12 +196,7 @@ require_file() {
   [ -f "$1" ] && [ ! -L "$1" ] || fail "expected a regular file: $1"
 }
 
-tool_paths='regression-verification.sh
-gate-worker/gate-dispatch.sh
-gate-worker/lib.sh
-gate-worker/mirror-push.sh
-gate-worker/remote-gate.sh
-gate-worker/run-gate.sh'
+tool_paths='${runtimeToolPaths.join("\n")}'
 
 is_tool_path() {
   for tool_path in $tool_paths; do


### PR DESCRIPTION
## Problem

`packages/runner/src/adapters.ts` pins a session's `credential.helper` at
`$AGENTOS_TOOLS/git-credential-runner.sh`, but the scratch materialization
allowlist in `workspace.ts` listed only six tools and never copied that file.
The helper shipped in the release bundle and was absent from every Run.

A public remote never consults the helper, so the gap was invisible. It became
fatal as soon as a private repository joined the platform: on the Word Factory
project, the regression step's `prepare` target fetch exited 128 with git's
non-interactive credential error before any verification began, burning all
five Runs of a chain's regression step with an identical `protocol-error`.

## Change

Move the tool inventory into a small `runtime-tools.ts` module so the
materialization and the adapter that pins one of its entries read the same
list instead of two literals that drifted, and add the helper to it. The test
fixture inventory now derives from the same constant.

## Verification

- `npm run typecheck -w @anneal/runner`
- `npm run lint` (root, biome + eslint)
- `npm run test -w @anneal/runner` — 489 pass, 2 skipped, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUVSuhCtyfufcrs89Cwwc1