### PR TITLE
refactor(db): own the operator console wire contract in one module

### DIFF
--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,17 +1,10 @@
 /** Wire shapes as serialised by the control plane (packages/db/prisma/schema.prisma).
- *  Decimal columns arrive as strings, DateTime as ISO strings. */
-
-import type { AssigneeType } from "@anneal/db/board-contract";
-import type {
-  Agent,
-  GoalStatus,
-  InboxDeliveryStatus,
-  InboxKind,
-  InboxStatus,
-  RepoPermission,
-  RunnerKind,
-  RunnerPreference,
-} from "@anneal/db/wire-contract";
+ *  Decimal columns arrive as strings, DateTime as ISO strings.
+ *
+ *  Nothing is declared here. Every shape the console reads is owned by a
+ *  contract module in `@anneal/db`, and the routes that produce them are bound
+ *  to the same declaration, so a server-side rename reaches this file as a
+ *  compile error instead of as a silently absent field. */
 
 export type {
   AssigneeType,
@@ -72,214 +65,25 @@ export type {
   SessionExecutionStatus,
   Skill,
 } from "@anneal/db/wire-contract";
-
-export type SessionEvent = {
-  id: string;
-  sessionId: string;
-  runId: string;
-  seq: number;
-  at: string;
-  source: string;
-  type: string;
-  toolCallId: string | null;
-  payload: unknown;
-};
-
-export type TaskTemplateStep = {
-  id: string;
-  stepIndex: number;
-  name: string;
-  assigneeType: AssigneeType;
-  prompt: string;
-  approvalGate: boolean;
-  outputKind: string;
-  priorOutputKinds: string[];
-  baseFromStepIndex: number | null;
-  runner: RunnerKind | null;
-  assigneeAgentId: string | null;
-  assigneeAgent: Agent | null;
-};
-
-export type TaskTemplate = {
-  id: string;
-  projectId: string;
-  name: string;
-  description: string;
-  variables: string[];
-  steps: TaskTemplateStep[];
-};
-
-export type InboxChoice = { id: string; label: string };
-
-export type InboxDecision = {
-  id: string;
-  inboxMessageId: string;
-  runId: string;
-  externalEventId: string;
-  decision: string;
-  actorOpenId: string | null;
-  createdAt: string;
-};
-
-export type InboxMessage = {
-  id: string;
-  from: "AGENT" | "HUMAN";
-  agentId: string | null;
-  sessionId: string | null;
-  taskId: string | null;
-  goalId: string | null;
-  gateTaskId: string | null;
-  /** Derived by the API: this open card has a consumer for operator text. */
-  acceptsFreeText: boolean;
-  /** Derived by the API: no decision is owed on this card and no suspended run
-   *  resumes on it, so the operator may archive it outright. */
-  dismissible: boolean;
-  /** Approval gates only: the task whose step output the gate is asking about,
-   *  derived by the API from the card's session. Absent on non-gate cards. */
-  artifactTaskId: string | null;
-  threadId: string | null;
-  replyToMessageId: string | null;
-  kind: InboxKind;
-  body: string;
-  choices: InboxChoice[] | null;
-  selectedChoiceId: string | null;
-  status: InboxStatus;
-  channel: string;
-  deliveryStatus: InboxDeliveryStatus;
-  deliveryAttempts: number;
-  lastDeliveryError: string | null;
-  createdAt: string;
-  answeredAt: string | null;
-  decisions?: InboxDecision[];
-  replies?: InboxMessage[];
-};
-
-/** `GET /inbox/messages/summary`: the sidebar badge's whole payload.
- *
- *  The badge used to be a by-product of `GET /inbox/messages`, which every page
- *  polled every 5s for the complete message history — 490 KB and 231 messages
- *  to render one number. The count is the same one `needsReply` computes card by
- *  card; the API applies that rule server-side. */
-export type InboxSummary = {
-  needsReply: number;
-};
-
-export type Goal = {
-  id: string;
-  projectId: string;
-  title: string;
-  spec: string;
-  dodApproved: boolean;
-  status: GoalStatus;
-  spendCap: string | null;
-  spendUsd: string;
-  maxDurationMin: number | null;
-  stallTimeoutMin: number;
-  stuckThreshold: number;
-  runnerPreference: RunnerPreference;
-  sharedFolderPath: string | null;
-  startedAt: string | null;
-  endedAt: string | null;
-  createdAt: string;
-  updatedAt: string;
-  definitionOfDone?: GoalDefinitionItem[];
-  progressLog?: GoalProgressEntry[];
-};
-
-export type GoalDefinitionItem = {
-  id: string;
-  goalId: string;
-  itemIndex: number;
-  text: string;
-  done: boolean;
-};
-
-export type GoalProgressEntry = {
-  id: string;
-  goalId: string;
-  sessionId: string | null;
-  body: string;
-  createdAt: string;
-};
-
-export type Health = { status: string; database: string; checkedAt: string };
-
-/**
- * `GET /version`: the product build identity of the control plane answering
- * this page — what an operator quotes in a report. Distinct from the runner
- * daemon and CLI versions, which describe machines and backends, not the build.
- */
-export type VersionInfo = {
-  service: string;
-  version: string | null;
-  buildSha: string;
-  commit: string | null;
-  dirty: boolean;
-  stamped: boolean;
-  builtAt: string | null;
-};
-
-export type DaemonStatus = {
-  runnerId: string;
-  lastSeenAt: string;
-  online: boolean;
-  busy: boolean;
-  activeRuns: number;
-  daemonVersion: string | null;
-  diskFreeBytes: number | null;
-  pollIntervalMs: number | null;
-  workspaceRoot: string | null;
-};
-
-export type BackendStatus = {
-  runner: RunnerKind;
-  cliVersion: string | null;
-  authMode: string | null;
-  lastPreflightAt: string | null;
-  lastPreflightOk: boolean | null;
-  circuitOpen: boolean | null;
-  circuitReason: string | null;
-};
-
-export type RunnersResponse = {
-  checkedAt: string;
-  online: number;
-  total: number;
-  daemons: DaemonStatus[];
-  backends: BackendStatus[];
-};
-
-/**
- * The first-run installation contract (`GET`/`POST /onboarding`).
- *
- * Deliberately narrow: the control plane returns public identities and nothing
- * else — no prompt, no remote URL, no internal column — so that everything the
- * wizard holds is safe in a browser, a screenshot and release evidence.
- */
-export type OnboardingDisclosure = {
-  environmentNetworking: "OPEN";
-  filesystemGrantCreated: false;
-  repoPermission: RepoPermission;
-  codexSandbox: "none";
-  runsWithHostUserAuthority: boolean;
-  supportedScope: string;
-  embeddedRemoteCredentialsRejected: boolean;
-};
-
-export type OnboardingStatus = {
-  complete: boolean;
-  project: { id: string; name: string; slug: string } | null;
-  /** `null` when the control plane cannot read its own starter source. Never a
-   *  reason to withhold `complete`, and never a reason to block an install. */
-  starter: { name: string; title: string; model: string; runnerPreference: RunnerPreference } | null;
-  disclosure: OnboardingDisclosure;
-};
-
-export type OnboardingInstallation = {
-  complete: true;
-  project: { id: string; name: string; slug: string };
-  environment: { id: string; name: string; networking: string; allowedHosts: string[] };
-  agent: { id: string; name: string; title: string; model: string; runnerPreference: RunnerPreference };
-  repo: { id: string; name: string; defaultBranch: string; mountPath: string };
-  access: { agentId: string; repoId: string; permissions: RepoPermission; mountPath: string };
-};
+export type {
+  BackendStatus,
+  DaemonStatus,
+  Goal,
+  GoalDefinitionItem,
+  GoalProgressEntry,
+  Health,
+  InboxChoice,
+  InboxDecision,
+  InboxMessage,
+  InboxReply,
+  InboxSummary,
+  OnboardingDisclosure,
+  OnboardingInstallation,
+  OnboardingStatus,
+  RunnersResponse,
+  SessionEvent,
+  SessionEventSource,
+  TaskTemplate,
+  TaskTemplateStep,
+  VersionInfo,
+} from "@anneal/db/console-contract";

--- a/apps/web/src/tests/inbox-free-text.test.tsx
+++ b/apps/web/src/tests/inbox-free-text.test.tsx
@@ -13,7 +13,7 @@ const card = (overrides: Partial<InboxMessage> & Pick<InboxMessage, "id" | "body
   taskId: "task-1", goalId: null, gateTaskId: null, acceptsFreeText: true, dismissible: false,
   artifactTaskId: null, threadId: "thread-1", replyToMessageId: null, kind: "MULTIPLE_CHOICE",
   choices: [{ id: "continue", label: "Continue" }, { id: "revise", label: "Revise" }],
-  selectedChoiceId: null, status: "OPEN", channel: "WEB", deliveryStatus: "DELIVERED",
+  selectedChoiceId: null, status: "OPEN", channel: "FEISHU", deliveryStatus: "DELIVERED",
   deliveryAttempts: 1, lastDeliveryError: null, createdAt: now, answeredAt: null, decisions: [], replies: [],
   ...overrides,
 });

--- a/packages/api/src/app.test.ts
+++ b/packages/api/src/app.test.ts
@@ -83,7 +83,7 @@ test("heavy polled collection routes validate unchanged payloads and change vali
       agent: { findMany: async () => [{ id: `agent-${version}`, name: "worker" }] },
       repo: { findMany: async () => [{ id: `repo-${version}` }] },
       inboxMessage: { findMany: async () => [{
-        id: `message-${version}`, status: "OPEN", from: "AGENT", kind: "CHOICE",
+        id: `message-${version}`, status: "OPEN", from: "AGENT", kind: "CHOICE", choices: null,
         gateTaskId: null, replyToMessageId: null, decisions: [], replies: [], session: null,
       }] },
       session: { findMany: async () => [] },

--- a/packages/api/src/control-plane.test.ts
+++ b/packages/api/src/control-plane.test.ts
@@ -113,8 +113,8 @@ test("an approval gate card carries the producing step's task, so the board can 
     // whose run opened it, reachable only through the card's session.
     const database = {
       inboxMessage: { findMany: async () => [
-        { id: "gate-1", from: "AGENT", kind: "MULTIPLE_CHOICE", replyToMessageId: null, gateTaskId: "gate-task", taskId: "gate-task", session: { taskId: "producing-task" } },
-        { id: "plain-1", from: "AGENT", kind: "TEXT", replyToMessageId: null, gateTaskId: null, taskId: "some-task", session: { taskId: "some-task" } },
+        { id: "gate-1", from: "AGENT", kind: "MULTIPLE_CHOICE", choices: null, replyToMessageId: null, gateTaskId: "gate-task", taskId: "gate-task", session: { taskId: "producing-task" } },
+        { id: "plain-1", from: "AGENT", kind: "TEXT", choices: null, replyToMessageId: null, gateTaskId: null, taskId: "some-task", session: { taskId: "some-task" } },
       ] },
       session: { findMany: async () => [] },
     } as unknown as PrismaClient;
@@ -139,7 +139,7 @@ test("Inbox list applies project scope and returns stored human replies", async 
     const database = {
       inboxMessage: { findMany: async (arguments_: Record<string, unknown>) => {
         query = arguments_;
-        return [{ id: "question-1", from: "AGENT", replies: [{ id: "reply-1", from: "HUMAN", body: "continue" }] }];
+        return [{ id: "question-1", from: "AGENT", choices: null, replies: [{ id: "reply-1", from: "HUMAN", body: "continue" }] }];
       } },
       session: { findMany: async () => [] },
     } as unknown as PrismaClient;

--- a/packages/api/src/onboarding.ts
+++ b/packages/api/src/onboarding.ts
@@ -34,11 +34,15 @@ import {
   Prisma,
   type PrismaClient,
   RepoPermission,
-  type RunnerPreference,
   STARTER_MOUNT_PATH,
   type StarterAgentSource,
   loadStarterAgentSource,
 } from "@anneal/db";
+import type {
+  OnboardingDisclosure,
+  OnboardingInstallation,
+  OnboardingStatus,
+} from "@anneal/db/console-contract";
 import { z } from "zod";
 
 import { isValidBranchName } from "./branch-name.js";
@@ -243,46 +247,7 @@ export const onboardingInput = z.object({
 
 export type OnboardingInput = z.infer<typeof onboardingInput>;
 
-/** Public identities only. No prompt, no remote URL, no token, no internal
- *  column: everything here is safe in a browser, a log, and release evidence. */
-export interface OnboardingInstallation {
-  complete: true;
-  project: { id: string; name: string; slug: string };
-  environment: { id: string; name: string; networking: NetworkingMode; allowedHosts: string[] };
-  agent: { id: string; name: string; title: string; model: string; runnerPreference: RunnerPreference };
-  repo: { id: string; name: string; defaultBranch: string; mountPath: string };
-  access: { agentId: string; repoId: string; permissions: RepoPermission; mountPath: string };
-}
-
-export interface OnboardingStatus {
-  complete: boolean;
-  project: { id: string; name: string; slug: string } | null;
-  /** `null` when this process cannot read `agents/`. Never a reason to withhold
-   *  `complete`, which is derived from the Project row alone. */
-  starter: { name: string; title: string; model: string; runnerPreference: RunnerPreference } | null;
-  disclosure: StarterDisclosure;
-}
-
-/**
- * What the confirmation screen must say, as facts rather than prose, so the
- * wizard cannot soften them into a claim the runtime does not honour. Every
- * value is a statement about this build's actual behaviour.
- */
-export interface StarterDisclosure {
-  environmentNetworking: "OPEN";
-  filesystemGrantCreated: false;
-  repoPermission: "GIT_WRITE";
-  codexSandbox: "none";
-  runsWithHostUserAuthority: true;
-  /** A statement about the supported v0.1 deployment, not about what this
-   *  process binds to: the transport boundary itself is Step 2's, and saying
-   *  "loopbackOnly: true" here would read as an enforcement claim this module
-   *  does not make. */
-  supportedScope: "loopback-only";
-  embeddedRemoteCredentialsRejected: true;
-}
-
-export const STARTER_DISCLOSURE: StarterDisclosure = {
+export const STARTER_DISCLOSURE: OnboardingDisclosure = {
   environmentNetworking: "OPEN",
   filesystemGrantCreated: false,
   repoPermission: "GIT_WRITE",

--- a/packages/api/src/routes/goals.test.ts
+++ b/packages/api/src/routes/goals.test.ts
@@ -1,0 +1,66 @@
+import "../test-workspace-root.js";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Prisma, type PrismaClient } from "@anneal/db";
+
+import { createApp } from "../test-app.js";
+import { withTokens } from "./test-support.js";
+
+const goalRow = (status: string) => ({
+  id: "goal-1",
+  projectId: "project-1",
+  title: "Ship",
+  spec: "Do it",
+  dodApproved: false,
+  status,
+  spendCap: null,
+  spendUsd: new Prisma.Decimal("1.25"),
+  maxDurationMin: 240,
+  stallTimeoutMin: 10,
+  maxSessionsPerTask: 3,
+  stuckThreshold: 19,
+  runnerPreference: "AUTO",
+  sharedFolderPath: null,
+  goalGeneration: 1,
+  nextGoalIteration: 1,
+  startedAt: null,
+  endedAt: null,
+  createdAt: new Date("2026-09-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-09-01T00:00:00.000Z"),
+  definitionOfDone: [],
+  progressLog: [],
+});
+
+const listGoals = async (status: string): Promise<Response> => {
+  const database = {
+    goal: { findMany: async () => [goalRow(status)] },
+  } as unknown as PrismaClient;
+  return await createApp(database).request("/projects/project-1/goals", {
+    headers: { Authorization: "Bearer operator-unit-token" },
+  });
+};
+
+test("a Goal list answers with the console contract, Decimal columns as strings", async () => {
+  await withTokens(async () => {
+    const response = await listGoals("ACTIVE");
+    assert.equal(response.status, 200);
+    const [goal] = await response.json() as Array<Record<string, unknown>>;
+    assert.equal(goal?.status, "ACTIVE");
+    assert.equal(goal?.spendUsd, "1.25");
+    assert.equal(goal?.spendCap, null);
+  });
+});
+
+/* The console names three of the eight persisted GoalStatus values on purpose
+ * (`wire-contract.ts`). A row carrying one of the other five means a writer
+ * appeared without the console decision that goes with it: the route says so
+ * instead of sending a status with no label, tone or legend behind it. */
+test("a persisted Goal status the console does not name is refused, not sent", async () => {
+  await withTokens(async () => {
+    for (const status of ["STOPPED_SPEND", "STOPPED_TIME", "STOPPED_STUCK", "FAILED", "CANCELLED"]) {
+      const response = await listGoals(status);
+      assert.equal(response.status, 500, status);
+    }
+  });
+});

--- a/packages/api/src/routes/goals.ts
+++ b/packages/api/src/routes/goals.ts
@@ -3,6 +3,11 @@ import {
   Prisma,
   RunnerPreference,
 } from "@anneal/db";
+import type {
+  Goal as GoalContract,
+  GoalDefinitionItem as GoalDefinitionItemContract,
+  GoalProgressEntry as GoalProgressEntryContract,
+} from "@anneal/db/console-contract";
 import type { Context } from "hono";
 import { z } from "zod";
 
@@ -55,19 +60,45 @@ const goalInclude = {
   progressLog: { orderBy: { createdAt: "asc" as const } },
 };
 
+type GoalResponse = GoalContract<Date, Prisma.Decimal>;
+type GoalDefinitionItemResponse = GoalDefinitionItemContract;
+type GoalProgressEntryResponse = GoalProgressEntryContract<Date>;
+type PersistedGoalStatus = (typeof GoalStatus)[keyof typeof GoalStatus];
+
+/**
+ * The console spelling of a persisted Goal status.
+ *
+ * Five of the eight values in `schema.prisma` are deliberately absent from the
+ * console contract because nothing in this repository writes them (the reasons
+ * are in `wire-contract.ts`). Reading one here means a writer appeared without
+ * the console decision that goes with it, so the route says so instead of
+ * sending a status the console has no label, tone or legend for.
+ */
+const consoleGoalStatus = (status: PersistedGoalStatus): GoalResponse["status"] => {
+  if (status === GoalStatus.ACTIVE || status === GoalStatus.PAUSED || status === GoalStatus.COMPLETED) return status;
+  throw new Error(`Goal status ${status} has no console wire spelling`);
+};
+
+const goalResponse = <T extends { status: PersistedGoalStatus }>(
+  goal: T,
+): Omit<T, "status"> & { status: GoalResponse["status"] } => ({
+  ...goal,
+  status: consoleGoalStatus(goal.status),
+});
+
 export const registerGoalsRoutes = (app: RouteApp, deps: RouteDeps): void => {
   const { db } = deps;
 
-  app.get("/projects/:projectId/goals", async (context) => context.json(await db.goal.findMany({
+  app.get("/projects/:projectId/goals", async (context) => context.json((await db.goal.findMany({
     where: { projectId: id.parse(context.req.param("projectId")) },
     include: goalInclude,
     orderBy: { createdAt: "asc" },
-  })));
+  })).map(goalResponse) satisfies GoalResponse[]));
   app.post("/projects/:projectId/goals", async (context) => {
     const projectId = id.parse(context.req.param("projectId"));
     const body = await readJson(context.req.raw, goalInput);
     const { definitionOfDone, ...fields } = body;
-    return context.json(await db.goal.create({
+    return context.json(goalResponse(await db.goal.create({
       data: {
         ...fields,
         projectId,
@@ -76,19 +107,19 @@ export const registerGoalsRoutes = (app: RouteApp, deps: RouteDeps): void => {
         },
       },
       include: goalInclude,
-    }), 201);
+    })) satisfies GoalResponse, 201);
   });
   app.get("/goals/:goalId", async (context) => {
     const goal = await db.goal.findUnique({
       where: { id: id.parse(context.req.param("goalId")) }, include: goalInclude,
     });
-    return goal ? context.json(goal) : context.json({ error: "Goal not found" }, 404);
+    return goal ? context.json(goalResponse(goal) satisfies GoalResponse) : context.json({ error: "Goal not found" }, 404);
   });
-  app.patch("/goals/:goalId", async (context) => context.json(await db.goal.update({
+  app.patch("/goals/:goalId", async (context) => context.json(goalResponse(await db.goal.update({
     where: { id: id.parse(context.req.param("goalId")) },
     data: withoutUndefined(await readJson(context.req.raw, goalPatch)) as Prisma.GoalUncheckedUpdateInput,
     include: goalInclude,
-  })));
+  })) satisfies GoalResponse));
   app.delete("/goals/:goalId", async (context) => {
     await db.goal.delete({ where: { id: id.parse(context.req.param("goalId")) } });
     return context.body(null, 204);
@@ -104,7 +135,7 @@ export const registerGoalsRoutes = (app: RouteApp, deps: RouteDeps): void => {
     if (goal.definitionOfDone.length === 0) return context.json({ error: "Definition of Done must contain at least one item" }, 409);
     const completed = goal.definitionOfDone.every((item) => item.done);
     const now = new Date();
-    return context.json(await db.goal.update({
+    return context.json(goalResponse(await db.goal.update({
       where: { id: goalId },
       data: {
         dodApproved: true,
@@ -113,7 +144,7 @@ export const registerGoalsRoutes = (app: RouteApp, deps: RouteDeps): void => {
         endedAt: completed ? now : null,
       },
       include: goalInclude,
-    }));
+    })) satisfies GoalResponse);
   };
   app.post("/goals/:goalId/approve-dod", approveGoalDod);
 
@@ -124,13 +155,15 @@ export const registerGoalsRoutes = (app: RouteApp, deps: RouteDeps): void => {
       data: { status: GoalStatus.PAUSED },
     });
     if (updated.count !== 1) return context.json({ error: "Only an active Goal can be paused" }, 409);
-    return context.json(await db.goal.findUniqueOrThrow({ where: { id: goalId }, include: goalInclude }));
+    return context.json(goalResponse(
+      await db.goal.findUniqueOrThrow({ where: { id: goalId }, include: goalInclude }),
+    ) satisfies GoalResponse);
   };
   app.post("/goals/:goalId/pause", pauseGoal);
 
-  app.get("/goals/:goalId/definition-of-done", async (context) => context.json(await db.goalDefinitionItem.findMany({
+  app.get("/goals/:goalId/definition-of-done", async (context) => context.json((await db.goalDefinitionItem.findMany({
     where: { goalId: id.parse(context.req.param("goalId")) }, orderBy: { itemIndex: "asc" },
-  })));
+  })) satisfies GoalDefinitionItemResponse[]));
   app.post("/goals/:goalId/definition-of-done", async (context) => {
     const goalId = id.parse(context.req.param("goalId"));
     const body = await readJson(context.req.raw, definitionItemText);
@@ -143,7 +176,7 @@ export const registerGoalsRoutes = (app: RouteApp, deps: RouteDeps): void => {
       }
       return item;
     });
-    return context.json(result, 201);
+    return context.json(result satisfies GoalDefinitionItemResponse, 201);
   });
   app.patch("/goals/:goalId/definition-of-done/:itemId", async (context) => {
     const goalId = id.parse(context.req.param("goalId"));
@@ -170,7 +203,9 @@ export const registerGoalsRoutes = (app: RouteApp, deps: RouteDeps): void => {
       }
       return item;
     });
-    return result ? context.json(result) : context.json({ error: "Definition of Done item not found" }, 404);
+    return result
+      ? context.json(result satisfies GoalDefinitionItemResponse)
+      : context.json({ error: "Definition of Done item not found" }, 404);
   });
   app.delete("/goals/:goalId/definition-of-done/:itemId", async (context) => {
     const goalId = id.parse(context.req.param("goalId"));
@@ -194,9 +229,9 @@ export const registerGoalsRoutes = (app: RouteApp, deps: RouteDeps): void => {
     return deleted ? context.body(null, 204) : context.json({ error: "Definition of Done item not found" }, 404);
   });
 
-  app.get("/goals/:goalId/progress-log", async (context) => context.json(await db.goalProgressEntry.findMany({
+  app.get("/goals/:goalId/progress-log", async (context) => context.json((await db.goalProgressEntry.findMany({
     where: { goalId: id.parse(context.req.param("goalId")) }, orderBy: { createdAt: "asc" },
-  })));
+  })) satisfies GoalProgressEntryResponse[]));
   app.post("/goals/:goalId/progress-log", async (context) => {
     const goalId = id.parse(context.req.param("goalId"));
     const body = await readJson(context.req.raw, progressInput);
@@ -204,11 +239,11 @@ export const registerGoalsRoutes = (app: RouteApp, deps: RouteDeps): void => {
       const session = await db.session.findFirst({ where: { id: body.sessionId, goalId }, select: { id: true } });
       if (!session) return context.json({ error: "Session does not belong to this Goal" }, 400);
     }
-    return context.json(await db.goalProgressEntry.create({ data: {
+    return context.json((await db.goalProgressEntry.create({ data: {
       goalId,
       sessionId: body.sessionId ?? null,
       body: body.body,
       ...(body.metadata ? { metadata: jsonValue(body.metadata) } : {}),
-    } }), 201);
+    } })) satisfies GoalProgressEntryResponse, 201);
   });
 };

--- a/packages/api/src/routes/inbox.test.ts
+++ b/packages/api/src/routes/inbox.test.ts
@@ -67,27 +67,27 @@ test("Inbox read models expose the server-owned free-text capability", async () 
   await withTokens(async () => {
     const messages = [
       {
-        id: "waiting-choice", status: "OPEN", from: "AGENT", kind: "MULTIPLE_CHOICE",
+        id: "waiting-choice", status: "OPEN", from: "AGENT", kind: "MULTIPLE_CHOICE", choices: null,
         gateTaskId: null, replyToMessageId: null, dedupeKey: "question:choice",
         session: { taskId: "task-1", waitingOnMessageId: "waiting-choice" },
       },
       {
-        id: "open-gate", status: "OPEN", from: "AGENT", kind: "MULTIPLE_CHOICE",
+        id: "open-gate", status: "OPEN", from: "AGENT", kind: "MULTIPLE_CHOICE", choices: null,
         gateTaskId: "gate-task", replyToMessageId: null, dedupeKey: "gate:1",
         session: { taskId: "producing-task", waitingOnMessageId: null },
       },
       {
-        id: "stop-question", status: "OPEN", from: "AGENT", kind: "TEXT",
+        id: "stop-question", status: "OPEN", from: "AGENT", kind: "TEXT", choices: null,
         gateTaskId: null, replyToMessageId: null, dedupeKey: "merge-stop:stop-1",
         session: { taskId: "task-1", waitingOnMessageId: "stop-question" },
       },
       {
-        id: "answered", status: "ANSWERED", from: "AGENT", kind: "TEXT",
+        id: "answered", status: "ANSWERED", from: "AGENT", kind: "TEXT", choices: null,
         gateTaskId: null, replyToMessageId: null, dedupeKey: "question:answered",
         session: { taskId: "task-1", waitingOnMessageId: "answered" },
       },
       {
-        id: "detached", status: "OPEN", from: "AGENT", kind: "TEXT",
+        id: "detached", status: "OPEN", from: "AGENT", kind: "TEXT", choices: null,
         gateTaskId: null, replyToMessageId: null, dedupeKey: "notification:1", session: null,
       },
     ];
@@ -403,6 +403,44 @@ test("archived successor errors from gate approve and reject map to named 409 re
       const response = await gateResponse(decision);
       assert.equal(response.status, 409);
       assert.match(String((await response.json() as { error: string }).error), /Archived Gate Agent.*archived/);
+    }
+  });
+});
+
+/* `InboxMessage.choices` is a `Json` column, and the console contract declares
+ * it as a choice list. The route is where that becomes true: a row no writer in
+ * this repository could have produced is reported rather than rendered as a
+ * card with no answers on it. */
+test("a card's choice list is narrowed out of its Json column, and a malformed one is refused", async () => {
+  await withTokens(async () => {
+    const card = (choices: unknown) => ({
+      id: "message-1", status: "OPEN", from: "AGENT", kind: "MULTIPLE_CHOICE",
+      gateTaskId: null, replyToMessageId: null, dedupeKey: "question:1", choices,
+      session: { taskId: "task-1" },
+    });
+    const listWith = async (choices: unknown): Promise<Response> => {
+      const database = {
+        inboxMessage: { findMany: async () => [card(choices)] },
+        session: { findMany: async () => [] },
+      } as unknown as PrismaClient;
+      return await createApp(database).request("/inbox/messages", {
+        headers: { Authorization: "Bearer operator-unit-token" },
+      });
+    };
+
+    const answered = await listWith([{ id: "approve", label: "Approve" }]);
+    assert.equal(answered.status, 200);
+    assert.deepEqual(
+      (await answered.json() as Array<{ choices: unknown }>)[0]?.choices,
+      [{ id: "approve", label: "Approve" }],
+    );
+
+    const empty = await listWith(null);
+    assert.equal(empty.status, 200);
+    assert.equal((await empty.json() as Array<{ choices: unknown }>)[0]?.choices, null);
+
+    for (const malformed of [{ approve: "Approve" }, [{ id: 1, label: "Approve" }], ["approve"]]) {
+      assert.equal((await listWith(malformed)).status, 500, JSON.stringify(malformed));
     }
   });
 });

--- a/packages/api/src/routes/inbox.ts
+++ b/packages/api/src/routes/inbox.ts
@@ -8,6 +8,11 @@ import {
   Prisma,
   type PrismaClient,
 } from "@anneal/db";
+import type {
+  InboxChoice,
+  InboxMessage as InboxMessageContract,
+  InboxSummary as InboxSummaryContract,
+} from "@anneal/db/console-contract";
 import { z } from "zod";
 
 import { supersedeTaskInboxMessage } from "../inbox.js";
@@ -81,17 +86,43 @@ const withDismissible = <T extends {
     && !blocked.has(message.id),
 });
 
+/**
+ * The card's choice list, narrowed out of its `Json` column.
+ *
+ * Every writer of `InboxMessage.choices` in this repository stores
+ * `Array<{ id, label }>` or nothing, and the console has always read the column
+ * as that shape. Narrowing it here is what makes the console's declaration
+ * true; a row that does not match it means a writer bypassed that shape, which
+ * is reported rather than rendered as a card with no answers on it.
+ */
+const isInboxChoice = (value: Prisma.JsonValue): value is Prisma.JsonObject & InboxChoice =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+  && typeof value.id === "string" && typeof value.label === "string";
+
+const inboxChoices = (choices: Prisma.JsonValue, messageId: string): InboxChoice[] | null => {
+  if (choices === null) return null;
+  const parsed = Array.isArray(choices)
+    ? choices.flatMap((choice) => isInboxChoice(choice) ? [{ id: choice.id, label: choice.label }] : [])
+    : [];
+  if (!Array.isArray(choices) || parsed.length !== choices.length) {
+    throw new Error(`Inbox message ${messageId} stores a malformed choice list`);
+  }
+  return parsed;
+};
+
 const withInboxReadModel = <T extends {
   id: string;
   status: InboxStatus;
   from: InboxSender;
   kind: InboxKind;
+  choices: Prisma.JsonValue;
   gateTaskId: string | null;
   dedupeKey: string | null;
   replyToMessageId: string | null;
   session: { taskId: string | null } | null;
 }>(message: T, blocked: ReadonlySet<string>) => withDismissible({
   ...withArtifactTask(message),
+  choices: inboxChoices(message.choices, message.id),
   acceptsFreeText: acceptsFreeText(message, blocked),
 }, blocked);
 
@@ -140,6 +171,8 @@ const inboxProjectPredicate = (projectId: string): Prisma.InboxMessageWhereInput
   ],
 });
 
+type InboxCard = InboxMessageContract<Date>;
+
 export const registerInboxRoutes = (app: RouteApp, { db }: RouteDeps): void => {
   app.get("/inbox/messages/summary", async (context) => {
     const projectId = context.req.query("projectId");
@@ -155,7 +188,7 @@ export const registerInboxRoutes = (app: RouteApp, { db }: RouteDeps): void => {
     const needsReply = messages.filter((message) => (
       message.status === InboxStatus.OPEN && !withDismissible(message, blocked).dismissible
     )).length;
-    return validated(context, { needsReply });
+    return validated(context, { needsReply } satisfies InboxSummaryContract);
   });
   app.get("/inbox/messages", async (context) => {
     const projectId = context.req.query("projectId");
@@ -168,7 +201,7 @@ export const registerInboxRoutes = (app: RouteApp, { db }: RouteDeps): void => {
       orderBy: { createdAt: "desc" },
     });
     const blocked = await blockedMessageIds(db, messages.map((message) => message.id));
-    return validated(context, messages.map((message) => withInboxReadModel(message, blocked)));
+    return validated(context, messages.map((message) => withInboxReadModel(message, blocked)) satisfies InboxCard[]);
   });
   app.get("/inbox/messages/:messageId", async (context) => {
     const message = await db.inboxMessage.findUnique({
@@ -181,7 +214,7 @@ export const registerInboxRoutes = (app: RouteApp, { db }: RouteDeps): void => {
       },
     });
     if (!message) return context.json({ error: "Inbox message not found" }, 404);
-    return context.json(withInboxReadModel(message, await blockedMessageIds(db, [message.id])));
+    return context.json(withInboxReadModel(message, await blockedMessageIds(db, [message.id])) satisfies InboxCard);
   });
   app.post("/inbox/messages/:messageId/decision", async (context) => {
     const input = await readJson(context.req.raw, inboxDecisionInput);

--- a/packages/api/src/routes/system.ts
+++ b/packages/api/src/routes/system.ts
@@ -1,4 +1,11 @@
 import { RunnerKind } from "@anneal/db";
+import type {
+  Health,
+  OnboardingInstallation,
+  OnboardingStatus,
+  RunnersResponse,
+  VersionInfo,
+} from "@anneal/db/console-contract";
 import { getMimeType } from "hono/utils/mime";
 import { z } from "zod";
 
@@ -41,17 +48,20 @@ export const registerSystemRoutes = (app: RouteApp, deps: RouteDeps): (() => voi
   app.get("/health", async (context) => {
     try {
       await db.$queryRaw`SELECT 1`;
-      return context.json({ status: "ok", database: "connected", checkedAt: new Date().toISOString() });
+      return context.json({ status: "ok", database: "connected", checkedAt: new Date().toISOString() } satisfies Health);
     } catch (error: unknown) {
       console.error("Health check failed", error);
-      return context.json({ status: "error", database: "disconnected", checkedAt: new Date().toISOString() }, 503);
+      return context.json(
+        { status: "error", database: "disconnected", checkedAt: new Date().toISOString() } satisfies Health,
+        503,
+      );
     }
   });
   // Provenance, not status: which commit this dist was built from (issue #140).
   // Unauthenticated and free of state so that whoever is checking whether a
   // restart took the new build can ask the running process directly instead of
   // hashing artefacts by hand, which is what the 2026-08-17 incident cost.
-  app.get("/version", (context) => context.json(versionPayload()));
+  app.get("/version", (context) => context.json(versionPayload() satisfies VersionInfo));
   app.get("/runners", async (context) => {
     const now = new Date();
     const daemons = runners.snapshot(now);
@@ -76,7 +86,7 @@ export const registerSystemRoutes = (app: RouteApp, deps: RouteDeps): (() => voi
       }),
       backends: Object.values(RunnerKind).map((runner) =>
         projectRunnerBackend(runner, backendsByRunner.get(runner) ?? null)),
-    });
+    } satisfies RunnersResponse);
   });
 
   // registerTemplateRoutes registers the webhook route between /runners and the
@@ -159,7 +169,7 @@ export const registerSystemRoutes = (app: RouteApp, deps: RouteDeps): (() => voi
     // auth.ts. Everything these routes decide lives in onboarding.ts.
     app.get("/onboarding", async (context) => {
       if (context.get("principal").kind !== "operator") return context.json({ error: "Forbidden for principal" }, 403);
-      return context.json(await onboardingStatus(db));
+      return context.json(await onboardingStatus(db) satisfies OnboardingStatus);
     });
     app.post("/onboarding", async (context) => {
       if (context.get("principal").kind !== "operator") return context.json({ error: "Forbidden for principal" }, 403);
@@ -180,7 +190,7 @@ export const registerSystemRoutes = (app: RouteApp, deps: RouteDeps): (() => voi
       if (!result.ok) {
         return refusalJson(context, refusal("conflict", "An installation already exists", { code: result.code }));
       }
-      return context.json(result.installation, 201);
+      return context.json(result.installation satisfies OnboardingInstallation, 201);
     });
   };
 };

--- a/packages/api/src/version.ts
+++ b/packages/api/src/version.ts
@@ -1,4 +1,5 @@
 import { type BuildInfo, buildSha, formatBuildLine, readBuildInfo } from "@anneal/build-info";
+import type { VersionInfo } from "@anneal/db/console-contract";
 
 /** What this process calls itself in its startup line and on `/version`. The
  *  package name in the stamp says what was built; this says what is running,
@@ -15,16 +16,6 @@ const info: BuildInfo = readBuildInfo(import.meta.url);
 export const apiBuildLine = (buildInfo: BuildInfo = info): string =>
   `Anneal API build: ${formatBuildLine(buildInfo)}`;
 
-export type VersionPayload = {
-  service: string;
-  version: string | null;
-  buildSha: string;
-  commit: string | null;
-  dirty: boolean;
-  stamped: boolean;
-  builtAt: string | null;
-};
-
 /**
  * The public version document.
  *
@@ -36,7 +27,7 @@ export type VersionPayload = {
  * useless to an attacker and needed by whoever is trying to find out whether a
  * restart actually took.
  */
-export const versionPayload = (buildInfo: BuildInfo = info): VersionPayload => ({
+export const versionPayload = (buildInfo: BuildInfo = info): VersionInfo => ({
   service: API_SERVICE,
   version: buildInfo.version,
   buildSha: buildSha(buildInfo),

--- a/packages/build-info/exports.test.mjs
+++ b/packages/build-info/exports.test.mjs
@@ -15,6 +15,7 @@ const mappings = [
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./model-routing", source: "./src/model-routing.ts", dist: "./dist/model-routing.js" },
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./agent-message", source: "./src/agent-message.ts", dist: "./dist/agent-message.js" },
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./board-contract", source: "./src/board-contract.ts", dist: "./dist/board-contract.js" },
+  { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./console-contract", source: "./src/console-contract.ts", dist: "./dist/console-contract.js" },
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./chain-order", source: "./src/chain-order.ts", dist: "./dist/chain-order.js" },
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./chain-hold", source: "./src/chain-hold.ts", dist: "./dist/chain-hold.js" },
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./gate-toggle", source: "./src/gate-toggle.ts", dist: "./dist/gate-toggle.js" },
@@ -28,7 +29,7 @@ const mappings = [
   { packageName: "@anneal/github-client", packageDirectory: "packages/github-client", subpath: ".", source: "./src/index.ts", dist: "./dist/index.js" },
 ];
 
-assert.equal(mappings.length, 16);
+assert.equal(mappings.length, 17);
 
 const packageSpecifier = ({ packageName, subpath }) =>
   subpath === "." ? packageName : `${packageName}/${subpath.slice(2)}`;
@@ -77,7 +78,7 @@ const resolveInChild = (conditions) => {
   return JSON.parse(execFileSync(process.execPath, args, { cwd: repositoryRoot, encoding: "utf8" }));
 };
 
-test("all sixteen source-backed exports have ordered development targets", () => {
+test("all seventeen source-backed exports have ordered development targets", () => {
   const entriesByPackage = new Map();
   for (const mapping of mappings) {
     const manifest = readManifest(mapping.packageDirectory);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -31,6 +31,11 @@
       "development": "./src/board-contract.ts",
       "import": "./dist/board-contract.js"
     },
+    "./console-contract": {
+      "types": "./src/console-contract.ts",
+      "development": "./src/console-contract.ts",
+      "import": "./dist/console-contract.js"
+    },
     "./chain-order": {
       "types": "./src/chain-order.ts",
       "development": "./src/chain-order.ts",

--- a/packages/db/src/console-contract.test.ts
+++ b/packages/db/src/console-contract.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const source = readFileSync(fileURLToPath(new URL("./console-contract.ts", import.meta.url)), "utf8");
+
+test("the browser-safe console contract imports only types", () => {
+  const runtimeSpecifiers = [
+    ...source.matchAll(/(?:^|\n)\s*import(?!\s+type\b)[^;]*?from\s+"([^"]+)"/gu),
+    ...source.matchAll(/(?:^|\n)\s*import\s+"([^"]+)"/gu),
+    ...source.matchAll(/(?:^|\n)\s*export(?!\s+type\b)[^;]*?from\s+"([^"]+)"/gu),
+    ...source.matchAll(/\brequire\s*\(\s*"([^"]+)"/gu),
+    ...source.matchAll(/\bimport\s*\(\s*"([^"]+)"/gu),
+  ].map((match) => match[1]);
+  assert.deepEqual(runtimeSpecifiers, []);
+
+  const typeSpecifiers = [
+    ...source.matchAll(/(?:^|\n)\s*import\s+type\b[^;]*?from\s+"([^"]+)"/gu),
+  ].map((match) => match[1]);
+  assert.deepEqual(typeSpecifiers, ["@prisma/client", "./wire-contract.js"]);
+});
+
+test("the package publishes the console contract as an isolated subpath", () => {
+  const manifest = JSON.parse(readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8"));
+  assert.deepEqual(manifest.exports["./console-contract"], {
+    types: "./src/console-contract.ts",
+    development: "./src/console-contract.ts",
+    import: "./dist/console-contract.js",
+  });
+});

--- a/packages/db/src/console-contract.ts
+++ b/packages/db/src/console-contract.ts
@@ -1,0 +1,282 @@
+/**
+ * Browser-safe serialized contracts for the operator console's Inbox, Goal,
+ * Session-event, Task-template, system and first-run installation reads.
+ *
+ * The same rules as `board-contract.ts` apply. Prisma is imported as types
+ * only, so a browser consumer receives no generated client code while a
+ * persisted enum widening becomes a compile-time change at this seam. A type
+ * here is the view the console may rely on, not a transcript of the row: a
+ * route may send more fields than the contract names, and `satisfies` on the
+ * route proves that everything named is present with the type named. The
+ * `DateTime` parameter is the ISO string produced on the HTTP wire, and a
+ * server projection instantiates it with `Date` before JSON serialization.
+ *
+ * Fields the API computes rather than reads are declared here, next to the
+ * persisted ones, so the console's use of them is bound to the route that
+ * produces them instead of to a comment.
+ */
+
+import type {
+  AssigneeType as PrismaAssigneeType,
+  InboxChannel as PrismaInboxChannel,
+  InboxDeliveryStatus as PrismaInboxDeliveryStatus,
+  InboxKind as PrismaInboxKind,
+  InboxSender as PrismaInboxSender,
+  InboxStatus as PrismaInboxStatus,
+  NetworkingMode as PrismaNetworkingMode,
+  RepoPermission as PrismaRepoPermission,
+  RunnerKind as PrismaRunnerKind,
+  RunnerPreference as PrismaRunnerPreference,
+  SessionEventSource as PrismaSessionEventSource,
+} from "@prisma/client";
+
+import type { Agent, GoalStatus } from "./wire-contract.js";
+
+export type SessionEventSource = PrismaSessionEventSource;
+export type InboxSender = PrismaInboxSender;
+export type InboxChannel = PrismaInboxChannel;
+
+/** One line of a Session's transcript. `payload` is `unknown` on purpose: its
+ *  shape is the runner adapter's, and `session-stream.ts` in the console is the
+ *  one module allowed to interpret it. */
+export type SessionEvent<DateTime = string> = {
+  id: string;
+  sessionId: string;
+  runId: string;
+  seq: number;
+  at: DateTime;
+  source: SessionEventSource;
+  type: string;
+  toolCallId: string | null;
+  payload: unknown;
+};
+
+export type TaskTemplateStep<DateTime = string> = {
+  id: string;
+  stepIndex: number;
+  name: string;
+  assigneeType: PrismaAssigneeType;
+  prompt: string;
+  approvalGate: boolean;
+  outputKind: string;
+  priorOutputKinds: string[];
+  baseFromStepIndex: number | null;
+  runner: PrismaRunnerKind | null;
+  assigneeAgentId: string | null;
+  assigneeAgent: Agent<DateTime> | null;
+};
+
+export type TaskTemplate<DateTime = string> = {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string;
+  variables: string[];
+  steps: TaskTemplateStep<DateTime>[];
+};
+
+export type InboxChoice = { id: string; label: string };
+
+export type InboxDecision<DateTime = string> = {
+  id: string;
+  inboxMessageId: string;
+  runId: string;
+  externalEventId: string;
+  decision: string;
+  actorOpenId: string | null;
+  createdAt: DateTime;
+};
+
+/**
+ * An operator answer already recorded under a card.
+ *
+ * A reply is returned as the persisted row it is: the API derives
+ * `acceptsFreeText`, `dismissible` and `artifactTaskId` for the card the
+ * operator acts on, never for the answers underneath it. The console renders a
+ * reply as author, time and body, and this contract says so.
+ */
+export type InboxReply<DateTime = string> = {
+  id: string;
+  from: InboxSender;
+  body: string;
+  createdAt: DateTime;
+};
+
+export type InboxMessage<DateTime = string> = {
+  id: string;
+  from: InboxSender;
+  agentId: string | null;
+  sessionId: string | null;
+  taskId: string | null;
+  goalId: string | null;
+  gateTaskId: string | null;
+  /** Derived by the API: this open card has a consumer for operator text. */
+  acceptsFreeText: boolean;
+  /** Derived by the API: no decision is owed on this card and no suspended run
+   *  resumes on it, so the operator may archive it outright. */
+  dismissible: boolean;
+  /** Approval gates only: the task whose step output the gate is asking about,
+   *  derived by the API from the card's session. `null` on non-gate cards. */
+  artifactTaskId: string | null;
+  threadId: string | null;
+  replyToMessageId: string | null;
+  kind: PrismaInboxKind;
+  body: string;
+  /** Narrowed from the persisted `Json` column by the route that reads it, so a
+   *  malformed row fails there rather than rendering an empty choice list. */
+  choices: InboxChoice[] | null;
+  selectedChoiceId: string | null;
+  status: PrismaInboxStatus;
+  channel: InboxChannel;
+  deliveryStatus: PrismaInboxDeliveryStatus;
+  deliveryAttempts: number;
+  lastDeliveryError: string | null;
+  createdAt: DateTime;
+  answeredAt: DateTime | null;
+  decisions?: InboxDecision<DateTime>[];
+  replies?: InboxReply<DateTime>[];
+};
+
+/** `GET /inbox/messages/summary`: the sidebar badge's whole payload.
+ *
+ *  The badge used to be a by-product of `GET /inbox/messages`, which every page
+ *  polled every 5s for the complete message history — 490 KB and 231 messages
+ *  to render one number. The count is the same one `needsReply` computes card by
+ *  card; the API applies that rule server-side. */
+export type InboxSummary = {
+  needsReply: number;
+};
+
+export type Goal<DateTime = string, DecimalValue = string> = {
+  id: string;
+  projectId: string;
+  title: string;
+  spec: string;
+  dodApproved: boolean;
+  /** The deliberately narrow console spelling; see `GoalStatus` in
+   *  `wire-contract.ts`. The goals routes narrow the persisted column to it. */
+  status: GoalStatus;
+  spendCap: DecimalValue | null;
+  spendUsd: DecimalValue;
+  maxDurationMin: number | null;
+  stallTimeoutMin: number;
+  stuckThreshold: number;
+  runnerPreference: PrismaRunnerPreference;
+  sharedFolderPath: string | null;
+  startedAt: DateTime | null;
+  endedAt: DateTime | null;
+  createdAt: DateTime;
+  updatedAt: DateTime;
+  definitionOfDone?: GoalDefinitionItem[];
+  progressLog?: GoalProgressEntry<DateTime>[];
+};
+
+export type GoalDefinitionItem = {
+  id: string;
+  goalId: string;
+  itemIndex: number;
+  text: string;
+  done: boolean;
+};
+
+export type GoalProgressEntry<DateTime = string> = {
+  id: string;
+  goalId: string;
+  sessionId: string | null;
+  body: string;
+  createdAt: DateTime;
+};
+
+export type Health = { status: string; database: string; checkedAt: string };
+
+/**
+ * `GET /version`: the product build identity of the control plane answering
+ * this page — what an operator quotes in a report. Distinct from the runner
+ * daemon and CLI versions, which describe machines and backends, not the build.
+ */
+export type VersionInfo = {
+  service: string;
+  version: string | null;
+  buildSha: string;
+  commit: string | null;
+  dirty: boolean;
+  stamped: boolean;
+  builtAt: string | null;
+};
+
+/** Timestamps here are ISO strings in both directions: `/runners` serializes
+ *  the daemon registry and the backend health rows before it answers. */
+export type DaemonStatus = {
+  runnerId: string;
+  lastSeenAt: string;
+  online: boolean;
+  busy: boolean;
+  activeRuns: number;
+  daemonVersion: string | null;
+  diskFreeBytes: number | null;
+  pollIntervalMs: number | null;
+  workspaceRoot: string | null;
+};
+
+export type BackendStatus = {
+  runner: PrismaRunnerKind;
+  cliVersion: string | null;
+  authMode: string | null;
+  lastPreflightAt: string | null;
+  lastPreflightOk: boolean | null;
+  circuitOpen: boolean | null;
+  circuitReason: string | null;
+};
+
+export type RunnersResponse = {
+  checkedAt: string;
+  online: number;
+  total: number;
+  daemons: DaemonStatus[];
+  backends: BackendStatus[];
+};
+
+/**
+ * What the confirmation screen must say, as facts rather than prose, so the
+ * wizard cannot soften them into a claim the runtime does not honour. Every
+ * value is a statement about this build's actual behaviour, which is why each
+ * one is a literal and not its widened type.
+ */
+export type OnboardingDisclosure = {
+  environmentNetworking: "OPEN";
+  filesystemGrantCreated: false;
+  repoPermission: Extract<PrismaRepoPermission, "GIT_WRITE">;
+  codexSandbox: "none";
+  runsWithHostUserAuthority: true;
+  /** A statement about the supported v0.1 deployment, not about what this
+   *  process binds to: the transport seam itself is Step 2's, and saying
+   *  "loopbackOnly: true" here would read as an enforcement claim the
+   *  installation module does not make. */
+  supportedScope: "loopback-only";
+  embeddedRemoteCredentialsRejected: true;
+};
+
+/**
+ * The first-run installation contract (`GET`/`POST /onboarding`).
+ *
+ * Deliberately narrow: the control plane returns public identities and nothing
+ * else — no prompt, no remote URL, no internal column — so that everything the
+ * wizard holds is safe in a browser, a screenshot and release evidence.
+ */
+export type OnboardingStatus = {
+  complete: boolean;
+  project: { id: string; name: string; slug: string } | null;
+  /** `null` when the control plane cannot read its own starter source. Never a
+   *  reason to withhold `complete`, and never a reason to block an install. */
+  starter: { name: string; title: string; model: string; runnerPreference: PrismaRunnerPreference } | null;
+  disclosure: OnboardingDisclosure;
+};
+
+export type OnboardingInstallation = {
+  complete: true;
+  project: { id: string; name: string; slug: string };
+  environment: { id: string; name: string; networking: PrismaNetworkingMode; allowedHosts: string[] };
+  agent: { id: string; name: string; title: string; model: string; runnerPreference: PrismaRunnerPreference };
+  repo: { id: string; name: string; defaultBranch: string; mountPath: string };
+  access: { agentId: string; repoId: string; permissions: PrismaRepoPermission; mountPath: string };
+};


### PR DESCRIPTION
## What changed

`packages/db/src/console-contract.ts` is a new module: the one home for the
serialized shapes the operator console reads from Inbox, Goal, Session-event,
Task-template, system and first-run installation routes. It follows
`board-contract.ts` exactly — Prisma imported as types only, so a browser
consumer receives no generated client code while a persisted enum widening
becomes a compile-time change at this seam, and a `DateTime` / `DecimalValue`
parameter that a server projection instantiates with its native values.

The interface that used to be stated three times is now stated once:

- `apps/web/src/lib/types.ts` declares nothing. It was 210 lines of hand-copied
  shapes; it is now a re-export list, the state the C8 board work already left
  the first half of the file in.
- `packages/api/src/routes/{inbox,goals,system}.ts` project through the contract
  with `satisfies`, the way `routes/tasks.ts` does. `grep -c "satisfies\|Contract"`:
  inbox 0 -> 6, goals 0 -> 17, system 0 -> 6.
- `packages/api/src/onboarding.ts` and `version.ts` no longer declare their own
  `OnboardingStatus`, `OnboardingInstallation`, `StarterDisclosure` and
  `VersionPayload`; the old declarations are deleted, not aliased.

The three fields the API derives for an Inbox card — `artifactTaskId`,
`acceptsFreeText`, `dismissible` — are named in the contract next to the
persisted ones, so renaming one in `routes/inbox.ts` is now a compile error in
the console instead of a field that silently stops arriving. Their reasoning
stays where the derivation is.

Leverage: one declaration serves both sides of the wire. Locality: a field
addition touches the contract and the one module that projects it.

Three claims the console made that the server did not keep are now true at the
seam rather than by assumption:

- `InboxMessage.choices` is a `Json` column the browser has always read as a
  choice list. `routes/inbox.ts` narrows it where it reads it; a row no writer
  in this repository could have produced is reported rather than rendered as a
  card with no answers on it.
- `GoalStatus` deliberately names three of the eight persisted values
  (`wire-contract.ts`). The goals routes narrow the column to those three and
  refuse the rest, instead of sending a status the console has no label, tone or
  legend for.
- A reply is declared as `InboxReply` — the persisted row it is. The old
  `replies?: InboxMessage[]` claimed replies carry the three derived fields;
  the route has never put them there, and the console reads only author, time
  and body.

## Evidence

Run in the worktree on the merged head (`0d78c0b`, after `git merge origin/main`
brought in `298a87d2`), with `RUNNER_WORKSPACE_ROOT` pointed at a fresh
`mktemp -d`:

- `npm run lint` (root) — exit 0. Biome checked 726 files, no fixes; eslint clean.
- `npm run typecheck` (root) — exit 0 across every workspace.
- `npm run test -w @anneal/api` — exit 0. 812 tests, 811 pass, 0 fail, 1 skipped.
- `npm run test -w @anneal/db` — exit 0. 347 tests, 347 pass, 0 fail. Includes
  the two new `console-contract.test.ts` cases.
- `npm run test -w @anneal/web` — exit 0. 606 tests, 602 pass, 0 fail, 4 skipped.

`test:db` was not run: there is no local PostgreSQL, and the database tests are
merge gate evidence. No `*.dbtest.ts` file changed.

Merge gate, dispatched for the exact head: **`MERGE GATE: PASS
d96c4d7a345d5dbb764bc497c98447464b7bda1b`**. The first dispatch (`0d78c0b`)
returned `FAIL (unit tests (all workspaces))` on
`packages/build-info/exports.test.mjs`: that file keeps the source-backed export
list explicit on purpose, so adding `@anneal/db/console-contract` to
`packages/db/package.json` owed it a mapping and a resolution proof. `d96c4d7a`
adds them and the gate passes. Nothing else in the run changed; the database
tests (db + api) step passed on both dispatches.

`docs/operator-api.md` is untouched and `test:snapshot-scan` was not needed: no
route was added, removed or renamed, and no response body changed. Every
`satisfies` binds a subset view of what the route already sent; the two
narrowings (`choices`, `Goal.status`) return the identical value for every
state a writer in this repository can produce.

New tests:

- `packages/db/src/console-contract.test.ts` — the contract imports only types,
  and the package publishes it as an isolated subpath. Same two cases
  `board-contract.test.ts` runs.
- `packages/api/src/routes/goals.test.ts` (the brief notes goals had none) — a
  Goal list answers with the contract and serializes `Decimal` as a string; each
  of the five unwired `GoalStatus` values is refused rather than sent.
- `packages/api/src/routes/inbox.test.ts` — a well-formed choice list passes
  through unchanged, a null column stays null, and three malformed shapes are
  refused.

Fixtures updated because the change necessarily breaks them: five Inbox rows in
`routes/inbox.test.ts` and three in `control-plane.test.ts` / `app.test.ts` now
carry the `choices` column the real row always has, and
`apps/web/src/tests/inbox-free-text.test.tsx` no longer sets `channel: "WEB"` —
the single occurrence of that value in the repository, read by no assertion, and
impossible for any row to carry since `InboxChannel` has one member.

## Decisions taken

**`routes/runner.ts` gets no binding, and the brief's grep criterion is wrong
about it.** The brief requires all four route files to leave zero on
`grep -c "satisfies\|Contract"`; `runner.ts` is still at zero and should be. It
serves the runner daemon, not the browser: none of the shapes in the finding's
list is produced there. `RunnersResponse` is built in `routes/system.ts:79-89`,
which the finding mis-attributed. Where `runner.ts` does return a structured
payload it already delegates to the module that owns the contract —
`run-claim.ts:1024` closes with `satisfies ClaimContract` — which is the shape
this program is asking for, expressed one level down. Manufacturing a browser
contract for a runner-facing route to move a grep count would put a type in
`@anneal/db` that no browser reads. The other three files carry the binding.

**The two narrowings fail loudly rather than degrade.** Both could have been
written as a tolerant read (`Array.isArray(x) ? x : []`, or a status passed
through unchecked), and both would then keep the console's declaration a claim
that nothing checks. The repository rule is to handle and report or fail loudly,
and the precedent is already here: `runner-backend-health.ts:49` throws on a
malformed `capabilities.cliAvailability`. Each is one place, reached by every
writer, and unreachable for data this repository produces. Recorded as a
deliberate behaviour change: a malformed Inbox row, or a Goal in one of the five
unwired states, now answers 500 with a named error in the log instead of
rendering a broken card.

**`BackendStatus` stays the seven-field view the console reads.** The wire
carries twelve (`RunnerBackendProjection`). A contract here is the view a caller
may rely on, not a transcript of the payload — `Environment` and `Agent` in
`wire-contract.ts` are subsets of their rows in exactly the same way — and
`satisfies` proves every field named is present with the type named. Widening
the console's view to twelve would have churned six test fixtures to declare
fields nothing reads.

**Enums are narrowed to their persisted spelling where the console had `string`.**
`SessionEvent.source` and `InboxMessage.channel` were `string`; both are Prisma
enums, and every value used anywhere in the repository is a member. This is the
`board-contract.ts` doctrine: a persisted widening becomes a compile-time change
at the seam.

## Fence widened

Three files outside lane b1's owned paths. `QUEUE.md` assigns none of them to
any lane, so rule 1 applies.

- `packages/api/src/onboarding.ts` — deleted `OnboardingStatus`,
  `OnboardingInstallation` and `StarterDisclosure`; the module imports them from
  the contract. Leaving both would have been the duplication this change exists
  to remove. `StarterDisclosure`'s literal types are preserved in the contract
  as `OnboardingDisclosure`, so the server keeps its discipline and the console
  stops widening them to `boolean` / `string`.
- `packages/api/src/version.ts` — deleted `VersionPayload` (one internal caller)
  for the contract's `VersionInfo`.
- `packages/api/src/app.test.ts` and `packages/api/src/control-plane.test.ts` —
  Inbox row fixtures gained the `choices` column, as tests the change breaks.
- `packages/build-info/exports.test.mjs` — the explicit source-backed export list
  gained the `./console-contract` mapping and went from sixteen to seventeen.
  The gate found this; the list exists precisely so that a new export cannot
  arrive without a development target and a resolution proof.

## Reported but unfixed

- **`SessionEvent` and `TaskTemplate` have no server-side binding.** Both shapes
  are now declared in the contract and re-exported by the console, but the
  routes that project them — `packages/api/src/routes/session.ts:643` and
  `routes/templates.ts:148-160` — are inside lane b4's and lane a2's owned
  paths, so this lane did not touch them. A follow-up adds
  `satisfies SessionEventContract<Date>[]` and
  `satisfies TaskTemplateContract<Date>[]` there; the types are in place and
  parameterized for it.
- **`POST /runner/availability` answers with an unnamed row echo.**
  `routes/runner.ts:125` returns `{ ...state, revalidatePreflight }` — the whole
  `RunnerBackendState` row, including `capabilities` and `circuitOpenedAt` —
  where the only consumer, `packages/runner/src/api.ts:553`, reads one boolean.
  Narrowing it is a runner wire-contract question, not a console one, and
  changing the response body is outside this brief.
- **`apps/web/src/lib/api.ts:164` casts parsed JSON.** Every field the console
  reads is a compile-time claim over `JSON.parse(text) as T`. The findings file
  scopes runtime validation as a separate question and the brief forbids adding
  Zod on the browser side; this change makes the claim consistent across the
  wire, not checked at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pqi2dUUQiVrKndAr9Dbb8e
