### PR TITLE
refactor(deploy): decide the invocation before any deployment host exists

### DIFF
--- a/scripts/deploy/deploy-phases.mjs
+++ b/scripts/deploy/deploy-phases.mjs
@@ -9,9 +9,6 @@ const phase = (scope, name, hostMethod, mutating, ledgerState = null) => Object.
 /** The full ordered deployment. Every row names a host method that receives
  * the DeploymentAttempt and returns the facts it established. */
 export const DEPLOY_PHASES = Object.freeze([
-  phase("prefix", "parse-arguments", "parseArgs", false),
-  phase("prefix", "check-escalation", "checkEscalation", false),
-  phase("prefix", "acquire-deploy-lock", "acquireLock", false),
   phase("prefix", "read-revisions", "readRevisions", false),
   phase("prefix", "check-already-deployed", "checkAlreadyDeployed", false),
   phase("prefix", "start-deployment-ledger", "startDeploymentLedger", false, "STARTED"),

--- a/scripts/deploy/quiet-window-deadlines.test.mjs
+++ b/scripts/deploy/quiet-window-deadlines.test.mjs
@@ -46,7 +46,6 @@ const timeoutUpgrade = ({ phase, run, escalationFails = false, wait, barrierHeld
   };
   const host = {};
   for (const { hostMethod } of DEPLOY_PHASES) host[hostMethod] = async () => undefined;
-  host.acquireLock = async () => ({ resources: [{ release: async () => { calls.push("release-lock"); } }] });
   host.readRevisions = async () => ({ revisions });
   host.startDeploymentLedger = async () => ({ ledger: { start: async () => undefined, record: async () => undefined } });
   host.waitForQuiet = async () => ({ barrier, resources: [barrier] });

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -21,11 +21,12 @@ import { fileURLToPath } from "node:url";
 import {
   DeployFailure,
   SERVICE_LABELS,
+  decideInvocation,
   deployedBuildStampRefusal,
   dryRunDecision,
   executeUpgrade,
   failureOf,
-  runLocked,
+  parseDeployArguments,
   shouldPersistFailure,
 } from "./quiet-window-lib.mjs";
 import {
@@ -38,7 +39,6 @@ import { openDeploymentAttempt, parseReleaseArtifactReceipt } from "./deployment
 import { readRemoteMainRevision } from "./remote-main-read.mjs";
 import {
   checkExistingEscalation,
-  resolveRemoteMainTarget,
   selfClearEscalation,
   writeEscalationWithAttempts,
 } from "./quiet-window-escalation.mjs";
@@ -71,7 +71,14 @@ import { verifyServiceInventory } from "./launchd-service-wrapper.mjs";
 import { serviceWrapperPath } from "./install-launchd.mjs";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
-const REPOSITORY_ROOT = resolve(process.env.AGENTOS_REPOSITORY_ROOT ?? resolve(SCRIPT_DIR, "../.."));
+
+/** The deploy root is the operator's appliance root, not the directory this
+ * script was reached through: an invocation through the `current` symlink
+ * resolves its state, marker and release paths from the configured root. */
+export const deployRootFromEnvironment = (environment, scriptDir) =>
+  resolve(environment.AGENTOS_REPOSITORY_ROOT ?? resolve(scriptDir, "../.."));
+
+const REPOSITORY_ROOT = deployRootFromEnvironment(process.env, SCRIPT_DIR);
 const STATE_DIR = join(REPOSITORY_ROOT, ".agentos-deploy");
 const LOCK_PATH = join(STATE_DIR, "lock");
 const ESCALATION_PATH = join(STATE_DIR, "escalated.json");
@@ -487,18 +494,23 @@ const persistAndNotifyFailure = async (failure, from, to) => {
   }
 };
 
-const parseArgs = (args) => {
-  const allowed = new Set(["--dry-run", "--clear-escalation", "--prune-history"]);
-  const unknown = args.find((argument) => !allowed.has(argument));
-  if (unknown) fail("usage", `unknown-argument-${unknown}`);
-  const modes = ["--dry-run", "--clear-escalation", "--prune-history"].filter((mode) => args.includes(mode));
-  if (modes.length > 1) fail("usage", "modes-are-mutually-exclusive");
-  return {
-    dryRun: args.includes("--dry-run"),
-    clearEscalation: args.includes("--clear-escalation"),
-    pruneHistory: args.includes("--prune-history"),
-  };
-};
+const createDeployStartup = () => ({
+  pollIntervalMs: POLL_MS,
+  log,
+  clearEscalation: () => clearEscalationOnOperatorRequest({ path: ESCALATION_PATH, log }),
+  loadEnvironment,
+  loadBinaries,
+  acquireLock,
+  checkEscalation: () => checkExistingEscalation({
+    escalationPath: ESCALATION_PATH,
+    retryEscalationNotification,
+    log,
+    retryableReasons: RETRYABLE_ESCALATION_REASONS,
+    retryCap: ESCALATION_RETRY_CAP,
+  }),
+  readRemoteMain: remoteMainRevision,
+  persistFailure: (failure) => persistAndNotifyFailure(failure, "unknown", "unknown"),
+});
 
 const pruneHistory = () => {
   const result = pruneDeployHistory({ stateDir: STATE_DIR });
@@ -550,17 +562,37 @@ const verifyStableServicePaths = async () => {
   }
 };
 
-const dryRun = async () => {
-  await loadEnvironment();
-  loadBinaries();
-  const from = readDeployedRevision();
-  const to = await remoteMainRevision();
-  const result = await dryRunDecision({
-    revisions: async () => ({ from, to }),
+const makeWritable = (root) => {
+  const visit = (path) => {
+    const status = lstatSync(path);
+    if (status.isSymbolicLink()) return;
+    chmodSync(path, status.mode & 0o777 | (status.isDirectory() ? 0o700 : 0o600));
+    if (status.isDirectory()) for (const entry of readdirSync(path)) visit(join(path, entry));
+  };
+  visit(root);
+};
+
+const createDeployHost = () => {
+  let canonicalSyncRefusals = [];
+  const notifyDeployOutcome = async (record) => notify(canonicalSyncNoticeRecord(record, canonicalSyncRefusals));
+  return createProductionHost({
+    selfClearEscalation: async (attempt) => {
+      const pending = attempt.fact("retryEscalation");
+      if (!pending) return false;
+      return selfClearEscalation({
+        escalationPath: ESCALATION_PATH,
+        retryEscalation: pending,
+        notify,
+        log,
+      });
+    },
     blockingRuns,
-    artifactState: async () => {
+    artifactState: async (attempt) => {
       try {
-        const artifact = findReleaseArtifact({ deployRoot: REPOSITORY_ROOT, revision: to });
+        const artifact = findReleaseArtifact({
+          deployRoot: attempt.deployRoot,
+          revision: attempt.targetCommit,
+        });
         return { ok: true, releaseName: artifact.releaseName };
       } catch (error) {
         const failure = failureOf(error);
@@ -580,68 +612,6 @@ const dryRun = async () => {
           reason: error instanceof Error ? error.message : String(error),
         };
       }
-    },
-  });
-  for (const line of result.lines) log(line);
-  return !result.artifact.ok || !result.services.ok || !result.backup.ok ? 1 : 0;
-};
-
-const makeWritable = (root) => {
-  const visit = (path) => {
-    const status = lstatSync(path);
-    if (status.isSymbolicLink()) return;
-    chmodSync(path, status.mode & 0o777 | (status.isDirectory() ? 0o700 : 0o600));
-    if (status.isDirectory()) for (const entry of readdirSync(path)) visit(join(path, entry));
-  };
-  visit(root);
-};
-
-const createDeployHost = () => {
-  let retryEscalation = null;
-  let canonicalSyncRefusals = [];
-  const notifyDeployOutcome = async (record) => notify(canonicalSyncNoticeRecord(record, canonicalSyncRefusals));
-  return createProductionHost({
-    parseArgs: async () => ({ options: parseArgs(process.argv.slice(2)) }),
-    checkEscalation: async () => {
-      const escalation = await checkExistingEscalation({
-        escalationPath: ESCALATION_PATH,
-        retryEscalationNotification,
-        log,
-        retryableReasons: RETRYABLE_ESCALATION_REASONS,
-        retryCap: ESCALATION_RETRY_CAP,
-      });
-      if (!escalation.active) {
-        retryEscalation = escalation.retryEscalation ?? null;
-        return;
-      }
-      retryEscalation = null;
-      return { skip: "escalation-active", exitCode: 2 };
-    },
-    selfClearEscalation: async () => {
-      const pending = retryEscalation;
-      retryEscalation = null;
-      if (!pending) return false;
-      return selfClearEscalation({
-        escalationPath: ESCALATION_PATH,
-        retryEscalation: pending,
-        notify,
-        log,
-      });
-    },
-    acquireLock: async () => {
-      const lock = await acquireLock();
-      if (lock === null) {
-        log("SKIP concurrent-run lock-held");
-        return { skip: "lock-held" };
-      }
-      if (lock.recovered) {
-        await lock.release();
-        throw new DeployFailure(
-          "stale-deploy-owner-recovered",
-          `pid-${lock.recovered.pid ?? "unknown"}`,
-        );
-      }
-      return { lock, resources: [lock] };
     },
     readRevisions: async (attempt) => ({
       revisions: { from: readDeployedRevision(), to: attempt.targetCommit },
@@ -918,51 +888,40 @@ const createDeployHost = () => {
   });
 };
 
+// The failure path outside the deployment attempt has to know whether this
+// process was a dry run, which must never leave an escalation behind.
+let deployMode = null;
+
 const main = async () => {
-  const options = parseArgs(process.argv.slice(2));
-  if (!Number.isSafeInteger(POLL_MS) || POLL_MS < 1_000) fail("environment-invalid", "QUIET_WINDOW_POLL_SECONDS-must-be-a-positive-integer");
-  if (options.clearEscalation) {
-    // Clearing an absent marker stays exit 0: it is idempotent, not an error.
-    clearEscalationOnOperatorRequest({ path: ESCALATION_PATH, log });
+  deployMode = parseDeployArguments(process.argv.slice(2));
+  const invocation = await decideInvocation(createDeployStartup(), deployMode);
+  if (invocation.exitCode !== undefined) return invocation.exitCode;
+  if (invocation.mode === "prune-history") {
+    try {
+      pruneHistory();
+    } finally {
+      await invocation.lock.release();
+    }
     return 0;
   }
-  if (options.dryRun) return dryRun();
-  if (options.pruneHistory) {
-    loadBinaries();
-    const result = await runLocked({ acquireLock, log }, async () => {
-      pruneHistory();
-      return { ok: true };
-    });
-    return result.ok ? 0 : 1;
-  }
-
-  await loadEnvironment();
-  loadBinaries();
-  const startup = await resolveRemoteMainTarget({
-    acquireLock,
-    log,
-    checkEscalation: () => checkExistingEscalation({
-      escalationPath: ESCALATION_PATH,
-      retryEscalationNotification,
-      log,
-      retryableReasons: RETRYABLE_ESCALATION_REASONS,
-      retryCap: ESCALATION_RETRY_CAP,
-    }),
-    readRemoteMain: remoteMainRevision,
-    persistFailure: (failure) => persistAndNotifyFailure(failure, "unknown", "unknown"),
-  });
-  if (startup.skipped === "lock-held") return 0;
-  if (startup.exitCode) return startup.exitCode;
-  const targetCommit = startup.targetCommit;
-
   const attempt = openDeploymentAttempt({
     deployRoot: REPOSITORY_ROOT,
-    targetCommit,
+    targetCommit: invocation.targetCommit,
     transactionId: randomUUID(),
   });
-  const result = await executeUpgrade(createDeployHost(), attempt);
+  attempt.establish({
+    retryEscalation: invocation.retryEscalation,
+    ...(invocation.lock === null ? {} : { resources: [invocation.lock] }),
+  });
+  const host = createDeployHost();
+  if (invocation.mode === "dry-run") {
+    const decision = await dryRunDecision(host, attempt);
+    for (const line of decision.lines) log(line);
+    return !decision.artifact.ok || !decision.services.ok || !decision.backup.ok ? 1 : 0;
+  }
+  const result = await executeUpgrade(host, attempt);
   if (result.ok && !result.skipped) pruneHistory();
-  return result.ok ? (attempt.fact("exitCode") ?? 0) : 1;
+  return result.ok ? 0 : 1;
 };
 
 const entrypoint = (() => {
@@ -991,7 +950,7 @@ if (entrypoint) {
   } catch (error) {
     const failure = failureOf(error);
     log(`STOP ${failure.reason}${failure.detail ? ` detail=${failure.detail}` : ""}`);
-    const dryRunMode = process.argv.includes("--dry-run");
+    const dryRunMode = deployMode === "dry-run";
     if (shouldPersistFailure({ dryRun: dryRunMode, reason: failure.reason })) {
       await writeEscalation({ outcome: "failure", reason: failure.reason, detail: failure.detail, from: "unknown", to: "unknown" })
         .catch((writeError) => log(`STOP escalation-write-failed detail=${writeError instanceof Error ? writeError.name : "unknown"}`));

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
 import {
   chmodSync,
   cpSync,
@@ -14,7 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -24,9 +23,11 @@ import { openDeploymentAttempt, parseReleaseArtifactReceipt } from "./deployment
 import {
   DeployFailure,
   SERVICE_LABELS,
+  decideInvocation,
   deployedBuildStampRefusal,
   dryRunDecision,
   executeUpgrade,
+  parseDeployArguments,
   quietWindowIsOpen,
 } from "./quiet-window-lib.mjs";
 import {
@@ -53,6 +54,7 @@ import {
   autoDeployNoticeBody,
   canonicalSyncNoticeRecord,
   canonicalSyncRefusedLines,
+  deployRootFromEnvironment,
 } from "./quiet-window-deploy.mjs";
 
 const revisions = { from: "a".repeat(40), to: "b".repeat(40) };
@@ -61,9 +63,6 @@ const EXPECTED_RUNTIME_PATHS = RUNTIME_TOOL_FILES
   .map(({ destination }) => `packages/runner/dist/runtime-tools/${destination}`)
   .sort();
 const EXPECTED_PHASES = [
-  "parse-arguments",
-  "check-escalation",
-  "acquire-deploy-lock",
   "read-revisions",
   "check-already-deployed",
   "start-deployment-ledger",
@@ -82,6 +81,8 @@ const EXPECTED_PHASES = [
   "restart-services",
   "verify-services",
 ];
+
+const RETRY_ESCALATION = Object.freeze({ reason: "remote-main-unreadable", attempts: 2 });
 
 const fixture = ({ failure = null, builderOutput = null } = {}) => {
   const calls = [];
@@ -117,9 +118,13 @@ const fixture = ({ failure = null, builderOutput = null } = {}) => {
     record: (name, metadata) => { records.push({ state: name, metadata }); },
   };
   const host = {
-    parseArgs: step("parse-arguments", async () => ({ options: {} })),
-    checkEscalation: step("check-escalation"),
-    acquireLock: step("acquire-deploy-lock", async () => ({ lock, resources: [lock] })),
+    blockingRuns: support("blocking-runs", async () => []),
+    artifactState: support("artifact-state", async (attempt) => ({
+      ok: true,
+      releaseName: `${attempt.targetCommit}-${"c".repeat(64)}`,
+    })),
+    serviceState: support("service-state", async () => ({ ok: true })),
+    backupState: support("backup-state", async () => ({ ok: true, mode: "container" })),
     readRevisions: step("read-revisions", async (attempt) => ({
       revisions: { from: revisions.from, to: attempt.targetCommit },
     })),
@@ -187,14 +192,16 @@ const fixture = ({ failure = null, builderOutput = null } = {}) => {
     escalate: async (record) => { calls.push("escalate"); state.escalated = record; },
     notify: async (record) => { calls.push(`notify-${record.outcome}`); },
   };
-  return { host, calls, phaseCalls, records, state, ledger };
+  const attempt = openDeploymentAttempt({
+    deployRoot: "/fixture",
+    targetCommit: revisions.to,
+    transactionId: "fixture-transaction",
+  });
+  // Startup decides the invocation and hands the phases the lock it already
+  // holds; no phase acquires one.
+  attempt.establish({ retryEscalation: RETRY_ESCALATION, resources: [lock] });
+  return { host, attempt, calls, phaseCalls, records, state, ledger };
 };
-
-const attempt = () => openDeploymentAttempt({
-  deployRoot: "/fixture",
-  targetCommit: revisions.to,
-  transactionId: "fixture-transaction",
-});
 
 const minimalBuildTree = (root, revision) => {
   const dist = join(root, "packages/api/dist");
@@ -233,6 +240,181 @@ const removeTree = (root) => {
   makeWritable(root);
   rmSync(root, { recursive: true, force: true });
 };
+
+const startupFixture = (overrides = {}) => {
+  const calls = [];
+  const logs = [];
+  const lock = { release: async () => { calls.push("release-lock"); } };
+  return {
+    calls,
+    logs,
+    lock,
+    startup: {
+      pollIntervalMs: 60_000,
+      log: (line) => { logs.push(line); },
+      clearEscalation: () => { calls.push("clear-escalation"); },
+      loadEnvironment: async () => { calls.push("load-environment"); },
+      loadBinaries: () => { calls.push("load-binaries"); },
+      acquireLock: async () => { calls.push("acquire-lock"); return lock; },
+      checkEscalation: async () => {
+        calls.push("check-escalation");
+        return { active: false, retryEscalation: RETRY_ESCALATION };
+      },
+      readRemoteMain: async () => { calls.push("read-remote-main"); return revisions.to; },
+      persistFailure: async (failure) => { calls.push(`persist-failure-${failure.reason}`); },
+      ...overrides,
+    },
+  };
+};
+
+test("argv names exactly one mode", () => {
+  assert.equal(parseDeployArguments([]), "upgrade");
+  assert.equal(parseDeployArguments(["--dry-run"]), "dry-run");
+  assert.equal(parseDeployArguments(["--clear-escalation"]), "clear-escalation");
+  assert.equal(parseDeployArguments(["--prune-history"]), "prune-history");
+  assert.throws(
+    () => parseDeployArguments(["--force"]),
+    (error) => error instanceof DeployFailure
+      && error.reason === "usage"
+      && error.detail === "unknown-argument---force",
+  );
+  assert.throws(
+    () => parseDeployArguments(["--dry-run", "--prune-history"]),
+    (error) => error.reason === "usage" && error.detail === "modes-are-mutually-exclusive",
+  );
+});
+
+test("an upgrade decides mode, target and escalation state under one lock acquisition", async () => {
+  const state = startupFixture();
+
+  const invocation = await decideInvocation(state.startup, parseDeployArguments([]));
+
+  assert.deepEqual(invocation, {
+    mode: "upgrade",
+    targetCommit: revisions.to,
+    lock: state.lock,
+    retryEscalation: RETRY_ESCALATION,
+  });
+  // The failure this covers: the target read and the deployment each ran their
+  // own escalation check, argv parse and lock acquisition. Every one of these
+  // happens once, and the lock the phases run under is still held.
+  assert.deepEqual(state.calls, [
+    "load-environment",
+    "load-binaries",
+    "acquire-lock",
+    "check-escalation",
+    "read-remote-main",
+  ]);
+});
+
+test("a held deploy lock ends the invocation without reading the target", async () => {
+  const state = startupFixture({
+    acquireLock: async () => null,
+    readRemoteMain: async () => assert.fail("a held lock must not read the target"),
+  });
+
+  assert.deepEqual(await decideInvocation(state.startup, "upgrade"), { mode: "upgrade", exitCode: 0 });
+  assert.deepEqual(state.logs, ["SKIP concurrent-run lock-held"]);
+});
+
+test("a recovered stale owner releases the lock and refuses the invocation", async () => {
+  const state = startupFixture({
+    checkEscalation: async () => assert.fail("a reclaimed owner must not admit a deployment"),
+  });
+  state.lock.recovered = { pid: 4242 };
+
+  await assert.rejects(
+    decideInvocation(state.startup, "upgrade"),
+    (error) => error instanceof DeployFailure
+      && error.reason === "stale-deploy-owner-recovered"
+      && error.detail === "pid-4242",
+  );
+  assert.deepEqual(state.calls, ["load-environment", "load-binaries", "acquire-lock", "release-lock"]);
+});
+
+test("an active escalation releases the lock and stops before the target read", async () => {
+  const state = startupFixture({
+    checkEscalation: async () => ({ active: true }),
+    readRemoteMain: async () => assert.fail("an active escalation must not read the target"),
+  });
+
+  assert.deepEqual(await decideInvocation(state.startup, "upgrade"), { mode: "upgrade", exitCode: 2 });
+  assert.deepEqual(state.calls, ["load-environment", "load-binaries", "acquire-lock", "release-lock"]);
+});
+
+test("an unreadable target persists the failure and releases the lock", async () => {
+  const state = startupFixture({
+    readRemoteMain: async () => { throw new DeployFailure("remote-main-unreadable", "exit-128"); },
+  });
+
+  assert.deepEqual(await decideInvocation(state.startup, "upgrade"), { mode: "upgrade", exitCode: 1 });
+  assert.deepEqual(state.calls, [
+    "load-environment",
+    "load-binaries",
+    "acquire-lock",
+    "check-escalation",
+    "persist-failure-remote-main-unreadable",
+    "release-lock",
+  ]);
+});
+
+test("dry-run resolves the same target without taking the deploy lock", async () => {
+  const state = startupFixture({
+    acquireLock: async () => assert.fail("dry-run must not take the deploy lock"),
+  });
+
+  assert.deepEqual(await decideInvocation(state.startup, "dry-run"), {
+    mode: "dry-run",
+    targetCommit: revisions.to,
+    lock: null,
+    retryEscalation: null,
+  });
+  assert.deepEqual(state.calls, ["load-environment", "load-binaries", "read-remote-main"]);
+});
+
+test("clear-escalation finishes startup without the environment, binaries or the lock", async () => {
+  const state = startupFixture({
+    loadEnvironment: async () => assert.fail("clearing a marker must not require the environment"),
+    loadBinaries: () => assert.fail("clearing a marker must not require the binaries"),
+    acquireLock: async () => assert.fail("clearing a marker must not take the deploy lock"),
+  });
+
+  assert.deepEqual(await decideInvocation(state.startup, "clear-escalation"), {
+    mode: "clear-escalation",
+    exitCode: 0,
+  });
+  assert.deepEqual(state.calls, ["clear-escalation"]);
+});
+
+test("prune-history holds the lock without the environment or an escalation check", async () => {
+  const state = startupFixture({
+    loadEnvironment: async () => assert.fail("retention must stay usable while configuration is repaired"),
+    checkEscalation: async () => assert.fail("retention consumes no escalation state"),
+    readRemoteMain: async () => assert.fail("retention has no target commit"),
+  });
+
+  assert.deepEqual(await decideInvocation(state.startup, "prune-history"), {
+    mode: "prune-history",
+    lock: state.lock,
+    retryEscalation: null,
+  });
+  assert.deepEqual(state.calls, ["load-binaries", "acquire-lock"]);
+});
+
+test("an unusable poll interval refuses before any mode work", async () => {
+  const state = startupFixture({
+    pollIntervalMs: Number.NaN,
+    clearEscalation: () => assert.fail("an unusable poll interval must refuse first"),
+  });
+
+  await assert.rejects(
+    decideInvocation(state.startup, "clear-escalation"),
+    (error) => error instanceof DeployFailure
+      && error.reason === "environment-invalid"
+      && error.detail === "QUIET_WINDOW_POLL_SECONDS-must-be-a-positive-integer",
+  );
+  assert.deepEqual(state.calls, []);
+});
 
 const RETRYABLE_ESCALATION_REASONS = new Set([
   "remote-main-unreadable",
@@ -443,35 +625,20 @@ test("--clear-escalation reports the path it looked at when no marker exists", (
   assert.deepEqual(logs, [`NO-ESCALATION-TO-CLEAR path=${escalationPath}`]);
 });
 
-test("--clear-escalation runs when invoked through the production current symlink", (t) => {
-  const root = mkdtempSync(join(tmpdir(), "anneal-deploy-current-entrypoint-"));
-  const release = join(root, "releases", "reviewed");
-  mkdirSync(join(root, "releases"));
-  symlinkSync(REPOSITORY_ROOT, release);
-  symlinkSync("releases/reviewed", join(root, "current"));
-  t.after(() => rmSync(root, { recursive: true, force: true }));
-
-  const result = spawnSync(process.execPath, [
-    join(root, "current", "scripts", "deploy", "quiet-window-deploy.mjs"),
-    "--clear-escalation",
-  ], {
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      AGENTOS_REPOSITORY_ROOT: root,
-      QUIET_WINDOW_POLL_SECONDS: "60",
-      DATABASE_URL: "",
-      FEISHU_DEFAULT_CHAT_ID: "",
-    },
-  });
-
-  assert.equal(result.status, 0, result.stderr);
-  // The marker path hangs off AGENTOS_REPOSITORY_ROOT: this is the only drive
-  // that proves the shipped entrypoint resolves it from that variable rather
-  // than from the release directory the symlink points into.
-  assert.match(
-    result.stdout,
-    new RegExp(`NO-ESCALATION-TO-CLEAR path=${root.replaceAll("\\", "\\\\")}/`, "u"),
+test("the deploy root is the configured appliance root, not the path reached through", () => {
+  // The failure this covers: an invocation through `current` resolved its
+  // state, marker and release paths inside the release directory the symlink
+  // points into instead of the operator root that owns them.
+  assert.equal(
+    deployRootFromEnvironment(
+      { AGENTOS_REPOSITORY_ROOT: "/srv/anneal" },
+      "/srv/anneal/releases/reviewed/scripts/deploy",
+    ),
+    "/srv/anneal",
+  );
+  assert.equal(
+    deployRootFromEnvironment({}, join(REPOSITORY_ROOT, "scripts", "deploy")),
+    resolve(REPOSITORY_ROOT),
   );
 });
 
@@ -507,9 +674,19 @@ test("canonical sync refusal output reaches the successful deploy Inbox notice",
   );
 });
 
-test("production host requires every deploy phase", () => {
-  assert.throws(() => createProductionHost({}), /production-host-adapter-missing:parseArgs/u);
-  for (const { hostMethod } of DEPLOY_PHASES) {
+test("production host requires every deploy phase and every read-only method", () => {
+  assert.throws(() => createProductionHost({}), /production-host-adapter-missing:readRevisions/u);
+  const required = [
+    ...DEPLOY_PHASES.map(({ hostMethod }) => hostMethod),
+    "blockingRuns",
+    "artifactState",
+    "serviceState",
+    "backupState",
+    "restorePreviousServices",
+    "escalate",
+    "notify",
+  ];
+  for (const hostMethod of required) {
     const { host } = fixture();
     delete host[hostMethod];
     assert.throws(
@@ -569,8 +746,8 @@ test("release artifact inventory copies and verifies deploy runtime and workspac
 });
 
 test("fixture executes the whole deploy sequence with explicit attempt facts", async () => {
-  const { host, calls, phaseCalls, records } = fixture();
-  assert.deepEqual(await executeUpgrade(host, attempt()), { ok: true });
+  const { host, attempt, calls, phaseCalls, records } = fixture();
+  assert.deepEqual(await executeUpgrade(host, attempt), { ok: true });
   assert.deepEqual(phaseCalls, EXPECTED_PHASES);
   assert.deepEqual(calls, [
     ...EXPECTED_PHASES,
@@ -585,44 +762,37 @@ test("fixture executes the whole deploy sequence with explicit attempt facts", a
 });
 
 test("a successful attempt invokes self-clear before releasing its resources", async () => {
-  const { host, calls } = fixture();
+  const { host, attempt, calls } = fixture();
   let clearCalls = 0;
-  host.selfClearEscalation = async () => {
+  // Startup decided the retryable escalation; the phases read it off the
+  // attempt rather than out of host state.
+  host.selfClearEscalation = async (deployment) => {
+    assert.equal(deployment.fact("retryEscalation"), RETRY_ESCALATION);
     clearCalls += 1;
     calls.push("self-clear");
   };
-  assert.deepEqual(await executeUpgrade(host, attempt()), { ok: true });
+  assert.deepEqual(await executeUpgrade(host, attempt), { ok: true });
   assert.equal(clearCalls, 1);
   assert.ok(calls.indexOf("self-clear") < calls.indexOf("release-lock"));
 });
 
 test("an already-deployed no-op also invokes self-clear", async () => {
-  const { host, calls } = fixture();
+  const { host, attempt, calls } = fixture();
   let clearCalls = 0;
   host.checkAlreadyDeployed = async () => ({ skip: "already-deployed" });
   host.selfClearEscalation = async () => {
     clearCalls += 1;
     calls.push("self-clear");
   };
-  const result = await executeUpgrade(host, attempt());
+  const result = await executeUpgrade(host, attempt);
   assert.deepEqual(result, { ok: true, skipped: "already-deployed" });
   assert.equal(clearCalls, 1);
   assert.ok(calls.indexOf("self-clear") < calls.indexOf("release-lock"));
 });
 
-test("a lock-held skip does not self-clear a retryable escalation", async () => {
-  const { host } = fixture();
-  let clearCalls = 0;
-  host.acquireLock = async () => ({ skip: "lock-held" });
-  host.selfClearEscalation = async () => { clearCalls += 1; };
-  const result = await executeUpgrade(host, attempt());
-  assert.deepEqual(result, { ok: true, skipped: "lock-held" });
-  assert.equal(clearCalls, 0);
-});
-
 test("missing artifact records FAILED without quiet-window, build, or activation", async () => {
-  const { host, calls, records } = fixture({ failure: "verify-release-artifact" });
-  const result = await executeUpgrade(host, attempt());
+  const { host, attempt, calls, records } = fixture({ failure: "verify-release-artifact" });
+  const result = await executeUpgrade(host, attempt);
   assert.equal(result.ok, false);
   assert.equal(result.failure.reason, "verify-release-artifact-failed");
   assert.equal(calls.includes("acquire-quiet-window"), false);
@@ -632,8 +802,8 @@ test("missing artifact records FAILED without quiet-window, build, or activation
 });
 
 test("malformed builder receipt records FAILED before the quiet window opens", async () => {
-  const { host, calls, records } = fixture({ builderOutput: "RELEASE-ARTIFACT {not-json}\n" });
-  const result = await executeUpgrade(host, attempt());
+  const { host, attempt, calls, records } = fixture({ builderOutput: "RELEASE-ARTIFACT {not-json}\n" });
+  const result = await executeUpgrade(host, attempt);
   assert.equal(result.ok, false);
   assert.equal(result.failure.reason, "release-artifact-build-failed");
   assert.equal(result.failure.detail, "builder-receipt-invalid");
@@ -643,16 +813,16 @@ test("malformed builder receipt records FAILED before the quiet window opens", a
 
 test("each independently listed deploy phase stops execution at its first failure", async () => {
   for (const [index, name] of EXPECTED_PHASES.entries()) {
-    const { host, phaseCalls } = fixture({ failure: name });
-    const result = await executeUpgrade(host, attempt());
+    const { host, attempt, phaseCalls } = fixture({ failure: name });
+    const result = await executeUpgrade(host, attempt);
     assert.equal(result.ok, false, name);
     assert.deepEqual(phaseCalls, EXPECTED_PHASES.slice(0, index + 1), name);
   }
 });
 
 test("service verification failure rolls back before restoring services", async () => {
-  const { host, calls, state } = fixture({ failure: "verify-services" });
-  const result = await executeUpgrade(host, attempt());
+  const { host, attempt, calls, state } = fixture({ failure: "verify-services" });
+  const result = await executeUpgrade(host, attempt);
   assert.equal(result.ok, false);
   assert.equal(state.serving, "previous");
   assert.ok(calls.indexOf("rollback-build") < calls.indexOf("restore-services"));
@@ -821,23 +991,25 @@ test("artifact verification reports content digest mismatch distinctly", () => {
   removeTree(deployRoot);
 });
 
-test("dry-run reports artifact readiness and performs no mutation", async () => {
-  const calls = [];
-  const execution = fixture();
-  assert.deepEqual(await executeUpgrade(execution.host, attempt()), { ok: true });
-  const result = await dryRunDecision({
-    revisions: async () => ({ from: revisions.from, to: revisions.to }),
-    blockingRuns: async () => [],
-    artifactState: async () => { calls.push("artifact"); return { ok: true, releaseName: "fixture" }; },
-    serviceState: async () => ({ ok: true }),
-    backupState: async () => ({ ok: true, mode: "container" }),
-  });
+test("dry-run reads the deployment host and drives no mutating phase", async () => {
+  const { host, attempt, calls } = fixture();
+
+  const result = await dryRunDecision(host, attempt);
+
   assert.equal(result.artifact.ok, true);
-  assert.deepEqual(calls, ["artifact"]);
+  assert.equal(result.artifact.releaseName, `${revisions.to}-${"c".repeat(64)}`);
+  assert.deepEqual(result.revisions, { from: revisions.from, to: revisions.to });
+  assert.equal(result.quiet, true);
+  // The mutating phases are reported, never called: the whole dry-run drive is
+  // the four read-only methods plus the shared revision read.
+  assert.deepEqual(
+    [...calls].sort(),
+    ["artifact-state", "backup-state", "blocking-runs", "read-revisions", "service-state"],
+  );
   const plannedPhases = result.lines
     .filter((line) => line.startsWith("DRY-RUN plan step="))
     .map((line) => line.match(/^DRY-RUN plan step=([^ ]+) mutation=skipped$/u)?.[1]);
-  assert.deepEqual(plannedPhases, EXPECTED_PHASES.slice(7));
+  assert.deepEqual(plannedPhases, EXPECTED_PHASES.slice(4));
 });
 
 test("deploy history prunes recognized backups and leaves unrelated entries", () => {

--- a/scripts/deploy/quiet-window-escalation.mjs
+++ b/scripts/deploy/quiet-window-escalation.mjs
@@ -1,4 +1,4 @@
-import { DeployFailure, failureOf, runLocked } from "./quiet-window-lib.mjs";
+import { DeployFailure, failureOf } from "./quiet-window-lib.mjs";
 import {
   clearEscalationRecord,
   ESCALATION_RETRY_CAP,
@@ -105,25 +105,6 @@ export const selfClearEscalation = async ({
     return false;
   }
 };
-
-/** Serialize escalation recovery and the target read under the deploy process
- * lock. A concurrent invocation observes the normal lock-held skip. */
-export const resolveRemoteMainTarget = async ({
-  acquireLock,
-  log,
-  checkEscalation,
-  readRemoteMain,
-  persistFailure,
-}) => runLocked({ acquireLock, log }, async () => {
-  const escalation = await checkEscalation();
-  if (escalation.active) return { exitCode: 2 };
-  try {
-    return { targetCommit: await readRemoteMain() };
-  } catch (error) {
-    await persistFailure(failureOf(error));
-    return { exitCode: 1 };
-  }
-});
 
 /** Compute the next one-based attempt count from the marker being replaced. */
 export const escalationAttemptCount = ({ record, previous, retryableReasons }) => {

--- a/scripts/deploy/quiet-window-escalation.test.mjs
+++ b/scripts/deploy/quiet-window-escalation.test.mjs
@@ -4,10 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import {
-  checkExistingEscalation,
-  resolveRemoteMainTarget,
-} from "./quiet-window-escalation.mjs";
+import { checkExistingEscalation } from "./quiet-window-escalation.mjs";
 import {
   clearEscalationRecord,
   ESCALATION_RETRY_CAP,
@@ -112,42 +109,6 @@ test("an escalation outside the shipped allowlist stays latched", async (t) => {
   assert.deepEqual(result, { active: true });
   assert.equal(existsSync(state.escalationPath), true);
   assert.equal(state.retryCalls(), 1);
-});
-
-test("two startup invocations serialize target reads while leaving self-clear to full-run success", async (t) => {
-  const state = fixture(t);
-  let held = false;
-  let releaseRead;
-  let signalReadStarted;
-  const readStarted = new Promise((resolve) => { signalReadStarted = resolve; });
-  const readReleased = new Promise((resolve) => { releaseRead = resolve; });
-  const acquireLock = async () => {
-    if (held) return null;
-    held = true;
-    return { release: async () => { held = false; } };
-  };
-  const options = {
-    acquireLock,
-    log: state.options.log,
-    checkEscalation: () => checkExistingEscalation(state.options),
-    readRemoteMain: async () => {
-      signalReadStarted();
-      await readReleased;
-      return revision;
-    },
-    persistFailure: async () => assert.fail("a successful target read must not persist a failure"),
-  };
-
-  const first = resolveRemoteMainTarget(options);
-  await readStarted;
-  const second = await resolveRemoteMainTarget(options);
-  releaseRead();
-  const firstResult = await first;
-
-  assert.deepEqual(firstResult, { targetCommit: revision });
-  assert.deepEqual(second, { ok: true, skipped: "lock-held" });
-  assert.equal(existsSync(state.escalationPath), true);
-  assert.equal(state.logs.filter((line) => line.startsWith("SKIP concurrent-run")).length, 1);
 });
 
 const markerFixture = (t) => {

--- a/scripts/deploy/quiet-window-host.mjs
+++ b/scripts/deploy/quiet-window-host.mjs
@@ -1,11 +1,21 @@
 import { DEPLOY_PHASES } from "./deploy-phases.mjs";
 
-/** Import-safe production adapter for the deployment host seam. */
+/** Import-safe production adapter for the deployment host seam. Every phase
+ * method, the read-only methods dry-run drives, and the recovery and
+ * notification methods must all be present before a deployment starts. */
 export const createProductionHost = (adapters) => {
   for (const { hostMethod: method } of DEPLOY_PHASES) {
     if (typeof adapters[method] !== "function") throw new TypeError(`production-host-adapter-missing:${method}`);
   }
-  for (const method of ["restorePreviousServices", "escalate", "notify"]) {
+  for (const method of [
+    "blockingRuns",
+    "artifactState",
+    "serviceState",
+    "backupState",
+    "restorePreviousServices",
+    "escalate",
+    "notify",
+  ]) {
     if (typeof adapters[method] !== "function") throw new TypeError(`production-host-adapter-missing:${method}`);
   }
   return Object.freeze({ ...adapters });

--- a/scripts/deploy/quiet-window-lib.mjs
+++ b/scripts/deploy/quiet-window-lib.mjs
@@ -68,6 +68,73 @@ const resourceReleaseFailureOf = (error) => {
   return deployFailure ?? failureOf(error);
 };
 
+const DEPLOY_MODE_ARGUMENTS = Object.freeze(["--dry-run", "--clear-escalation", "--prune-history"]);
+
+/** The requested mode, read from argv exactly once per process. */
+export const parseDeployArguments = (args) => {
+  const allowed = new Set(DEPLOY_MODE_ARGUMENTS);
+  const unknown = args.find((argument) => !allowed.has(argument));
+  if (unknown) throw new DeployFailure("usage", `unknown-argument-${unknown}`);
+  const modes = DEPLOY_MODE_ARGUMENTS.filter((mode) => args.includes(mode));
+  if (modes.length > 1) throw new DeployFailure("usage", "modes-are-mutually-exclusive");
+  return modes.length === 0 ? "upgrade" : modes[0].slice("--".length);
+};
+
+/** Decide the whole invocation before any deployment host exists: the mode,
+ * the commit it targets, the retryable escalation the run may self-clear, and
+ * the one process lock a locked mode holds until its resources are released.
+ * The environment, the binaries, the escalation check and the lock are each
+ * reached once per process. An invocation carrying `exitCode` is already
+ * finished and opens no attempt; otherwise it carries the lock it acquired,
+ * and its caller owns releasing it. */
+export const decideInvocation = async (startup, mode) => {
+  if (!Number.isSafeInteger(startup.pollIntervalMs) || startup.pollIntervalMs < 1_000) {
+    throw new DeployFailure("environment-invalid", "QUIET_WINDOW_POLL_SECONDS-must-be-a-positive-integer");
+  }
+  if (mode === "clear-escalation") {
+    // Clearing an absent marker stays exit 0: it is idempotent, not an error.
+    startup.clearEscalation();
+    return { mode, exitCode: 0 };
+  }
+  // Retention runs against the filesystem alone and must stay usable while the
+  // operator configuration the other modes require is being repaired.
+  if (mode !== "prune-history") await startup.loadEnvironment();
+  startup.loadBinaries();
+  if (mode === "dry-run") {
+    return { mode, targetCommit: await startup.readRemoteMain(), lock: null, retryEscalation: null };
+  }
+  const lock = await startup.acquireLock();
+  if (lock === null) {
+    // A held lock is an observable skip, not a second failed attempt: the
+    // owner is still responsible for the eventual outcome.
+    startup.log("SKIP concurrent-run lock-held");
+    return { mode, exitCode: 0 };
+  }
+  try {
+    if (lock.recovered) {
+      throw new DeployFailure("stale-deploy-owner-recovered", `pid-${lock.recovered.pid ?? "unknown"}`);
+    }
+    if (mode === "prune-history") return { mode, lock, retryEscalation: null };
+    const escalation = await startup.checkEscalation();
+    if (escalation.active) {
+      await lock.release();
+      return { mode, exitCode: 2 };
+    }
+    let targetCommit;
+    try {
+      targetCommit = await startup.readRemoteMain();
+    } catch (error) {
+      await startup.persistFailure(failureOf(error));
+      await lock.release();
+      return { mode, exitCode: 1 };
+    }
+    return { mode, targetCommit, lock, retryEscalation: escalation.retryEscalation ?? null };
+  } catch (error) {
+    await lock.release();
+    throw error;
+  }
+};
+
 /** Execute the full deployment attempt through the host seam. Every phase
  * receives the attempt and establishes facts for the phases that follow. */
 export const executeUpgrade = async (host, attempt) => {
@@ -199,34 +266,13 @@ export const executeUpgrade = async (host, attempt) => {
   }
 };
 
-/** One process owns the lock. A held lock is an observable skip, not a second
- * failed attempt: the owner is still responsible for the eventual outcome. */
-export const runLocked = async (host, work) => {
-  const lock = await host.acquireLock();
-  if (lock === null) {
-    host.log("SKIP concurrent-run lock-held");
-    return { ok: true, skipped: "lock-held" };
-  }
-  if (lock.recovered) {
-    await lock.release();
-    throw new DeployFailure(
-      "stale-deploy-owner-recovered",
-      `pid-${lock.recovered.pid ?? "unknown"}`,
-    );
-  }
-  try {
-    return await work();
-  } finally {
-    await lock.release();
-  }
-};
-
-/** Dry-run deliberately has no mutating host methods in its interface. */
-export const dryRunDecision = async (host) => {
-  const [revisions, runs, artifact, services, backup] = await Promise.all([
-    host.revisions(),
+/** Dry-run reads the deployment host every upgrade uses, calling only the
+ * methods that establish no facts and mutate nothing. */
+export const dryRunDecision = async (host, attempt) => {
+  const [{ revisions }, runs, artifact, services, backup] = await Promise.all([
+    host.readRevisions(attempt),
     host.blockingRuns(),
-    host.artifactState(),
+    host.artifactState(attempt),
     host.serviceState(),
     host.backupState(),
   ]);


### PR DESCRIPTION
## What changed

`quiet-window-deploy.mjs` `main` was a second, unseamed orchestrator in front of
`executeUpgrade`. Argv was parsed at `main` and again by the `parseArgs` phase;
the identical `checkExistingEscalation` bundle was built twice; the process lock
was acquired by `resolveRemoteMainTarget` through `runLocked`, released in its
`finally`, and reacquired by the `acquireLock` phase; and `dryRun` built a third
host with its own five-method interface.

Startup is now one module in `quiet-window-lib.mjs` that answers the whole
question before any host exists: `parseDeployArguments` reads the mode from argv
once, and `decideInvocation` reaches the environment, the binaries, the
escalation check (through d4's `checkExistingEscalation`) and the lock exactly
once each, returning either a finished invocation (`exitCode`) or the live one:
mode, target commit, held lock, and the retryable escalation the run may
self-clear. Its interface: an invocation carrying `exitCode` opens no attempt;
otherwise the caller owns releasing the lock it carries.

The lock is now held continuously from the escalation check through the
attempt's resource release, instead of being taken, dropped and retaken. That
retires three phases: `parse-arguments`, `check-escalation` and
`acquire-deploy-lock` are gone from `deploy-phases.mjs`, `runLocked` and
`resolveRemoteMainTarget` are deleted, and the retryable escalation reaches
`selfClearEscalation` as an attempt fact instead of mutable host state.

Dry-run stops being a parallel universe: `dryRunDecision(host, attempt)` drives
the same production host, reusing its `readRevisions` phase method and four
read-only methods (`blockingRuns`, `artifactState`, `serviceState`,
`backupState`) that are now part of the one host interface `createProductionHost`
proves before a deployment starts.

The `--clear-escalation` root-resolution decision that this region got wrong
before is now the exported `deployRootFromEnvironment`, covered in process
rather than by a subprocess drive.

## Evidence

Base `f9034d7ea5657f5381e425f602acd829091003d6`; `origin/main` had not moved when
the branch was pushed, so nothing was merged in. Every anchor in
`FINDINGS-R-D-runner-deploy.md` "Candidate D5" was re-read on the base before
editing and all four were still present (`main` argv parse, the duplicated
escalation bundle, the `runLocked` plus `acquireLock` pair, the third `dryRun`
host).

Run after the final commit, with `RUNNER_WORKSPACE_ROOT` pointed at a fresh
temporary directory:

- `npm run lint` — exit 0 (biome: 724 files, no fixes; eslint clean).
- `npm run typecheck` — exit 0.
- `npm run test:auto-deploy` — exit 0, 111 tests, 111 pass, 0 fail.

Test changes inside `quiet-window-deploy.test.mjs`: the fake host loses its
`parseArgs`, `checkEscalation` and `acquireLock` stubs and gains the four
read-only methods; the fixture now hands back the attempt that already carries
the lock and the retryable escalation, which is what startup does in production;
the separate `dryRunDecision` fake host is gone and the dry-run test drives the
fixture host, asserting that the whole drive is the five read-only calls; the
`--clear-escalation` `spawnSync` subprocess drive is gone, replaced by in-process
`deployRootFromEnvironment` assertions covering the same failure (an invocation
through `current` resolving its marker inside the release directory). Startup has
ten new in-process tests: mode selection, one lock acquisition for an upgrade,
held lock, reclaimed stale owner, active escalation, unreadable target,
dry-run without the lock, clear-escalation without environment or lock,
prune-history without the environment, and an unusable poll interval.
`quiet-window-escalation.test.mjs` loses the `resolveRemoteMainTarget`
serialization test; its property (a concurrent invocation observes one
`SKIP concurrent-run lock-held` and never reads the target) is now a startup
test.

Not run: `test:db` (no local PostgreSQL; merge gate evidence). No `docs/` file
changed, so `test:snapshot-scan` does not apply; no HTTP route was added or
renamed.

## Decisions taken

The brief names `parseArgs` and `checkEscalation` as the phases that go. The
`acquire-deploy-lock` phase goes with them, because "the lock happening exactly
once" cannot be satisfied any other way: a single acquisition has to span from
before the escalation check to the end of the upgrade, so startup acquires it
and the attempt owns its release. `deploy-phases.mjs` is edited only to remove
rows, as instructed.

Startup lives in `quiet-window-lib.mjs` rather than a new sibling file. That
file is already the pure orchestration across the host seam (`executeUpgrade`,
`dryRunDecision`, and the now-deleted `runLocked`), the startup decision is the
same kind of thing, and keeping it there also keeps every edit inside the lane's
declared fence.

Dry-run reuses the production host rather than running `executeUpgrade` against
a no-op adapter set. Driving the phase sequence would either build the release
artifact (which dry-run must not do, and which costs minutes) or need a
skip-mutations flag inside `executeUpgrade`; reading the one host through its
read-only methods removes the third host without either.

Per-mode requirements are kept as they were rather than unified:
`--prune-history` still runs without the operator `.env`, so retention stays
usable while configuration is being repaired, and `--dry-run` still takes no
lock. Both are stated in `decideInvocation` at the point of decision.

`main` records the decided mode in one module binding so the entrypoint failure
path can ask whether this was a dry run without reading `process.argv` a third
time. A failure before the mode is known is not a dry run, which is the old
behaviour for every mode whose argv could not be parsed.

## Fence widened

- `scripts/deploy/quiet-window-host.mjs` (owned by no lane): the four read-only
  methods dry-run drives are added to the adapter set `createProductionHost`
  requires, so a missing one refuses at host construction rather than as a
  `TypeError` mid dry-run.
- `scripts/deploy/quiet-window-escalation.test.mjs` (lane d4, `merged`): the
  `resolveRemoteMainTarget` test is removed with the function it drives.
- `scripts/deploy/quiet-window-deadlines.test.mjs` (owned by no lane): one line
  stubbing the removed `acquireLock` phase on its fake host is removed.

## Reported but unfixed

- `PREFIX_DEPLOY_PHASES` in `scripts/deploy/deploy-phases.mjs` is exported and
  has no consumer anywhere in the repository. It was already unused before this
  change; the brief restricts edits to that file to removing retired phases, so
  it is left in place.
- `createDeployHost` still closes over the mutable `canonicalSyncRefusals`, set
  by the `canonical-prompt-sync` phase and read by the outcome notification.
  It is the summary-consumer surface lane t4 owns, so it is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WWkQpJ7szjmiMuPJd5i4h
