### PR TITLE
refactor(runner): decide dependency provisioning once at claim admission

### DIFF
--- a/packages/api/src/chain-branch.dbtest.ts
+++ b/packages/api/src/chain-branch.dbtest.ts
@@ -1277,14 +1277,23 @@ test("T21: a claimed database chain run is the exact provenance recorded by its 
     };
     const runnerWorkspaceUrl = new URL("../../runner/src/workspace.js", import.meta.url).href;
     const { provisionWorkspace } = await import(runnerWorkspaceUrl) as {
-      provisionWorkspace: (config: RunnerConfig, claim: ClaimedTask) => Promise<{
+      provisionWorkspace: (
+        config: RunnerConfig,
+        claim: ClaimedTask,
+        provisioning: { provision: false; evidence: string },
+      ) => Promise<{
         path: string;
         branch: string;
         baseSha: string;
         commitHooksPath?: string;
       }>;
     };
-    const workspace = await provisionWorkspace(configured, claimed);
+    // The dependency decision is made when the claim is admitted; this test
+    // provisions a chain branch, not dependencies.
+    const workspace = await provisionWorkspace(configured, claimed, {
+      provision: false,
+      evidence: "Dependency provisioning skipped: Repo.dependencyProvisioning=NONE",
+    });
     const childEnvironment = buildChildEnvironment(configured, claimed, {
       base: join(root, "scratch"),
       workspaceRoot: join(root, "scratch", "workspaces"),

--- a/packages/runner/src/dependency-cache.test.ts
+++ b/packages/runner/src/dependency-cache.test.ts
@@ -210,7 +210,7 @@ const publishFixtureVersions = async (root: string, versions: string[]) => {
     await createFixture(workspace);
     await writeFile(join(workspace, "package-lock.json"), packageLock(version));
     const result = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(result.key);
@@ -266,7 +266,7 @@ test("a miss publishes complete root and workspace targets, then a hit restores 
     const events: DependencyCacheProgress[] = [];
     const configured = config(root);
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(first.status, "installed");
@@ -291,7 +291,7 @@ test("a miss publishes complete root and workspace targets, then a hit restores 
     await writeFile(join(workspace, "node_modules/fake-package/index.js"), "workspace mutation\n");
 
     const second = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(second.status, "restored");
@@ -313,36 +313,6 @@ test("a miss publishes complete root and workspace targets, then a hit restores 
   }
 });
 
-test("NONE skips dependency discovery, cache access, toolchain probes, and npm", async () => {
-  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-none-"));
-  try {
-    const workspace = join(root, "workspace");
-    await mkdir(workspace);
-    // A malformed manifest proves that NONE does not inspect the workspace.
-    await writeFile(join(workspace, "package.json"), "not-json\n");
-    const fake = fakeInstallExecutor();
-    const events: DependencyCacheProgress[] = [];
-    const configured = config(root);
-    const result = await materializeWorkspaceDependencies(
-      configured,
-      workspace,
-      "NONE",
-      workspaceEnvironment(configured),
-      { execute: fake.execute },
-      { report: (event) => events.push(event) },
-    );
-    assert.deepEqual(result, { status: "not-applicable", condition: "dependency-provisioning-none" });
-    assert.deepEqual(events.filter(({ event }) => event === "miss"), [
-      { event: "miss", condition: "dependency-provisioning-none" },
-    ]);
-    assert.equal(events.filter(({ event }) => event === "elapsed").length, 1);
-    assert.deepEqual(fake.calls, []);
-    await assert.rejects(lstat(join(root, "cache")), /ENOENT/u, "NONE must not initialize the dependency cache");
-  } finally {
-    await cleanupRoot(root);
-  }
-});
-
 test("NPM_CI fails loudly when the root package manifest is missing and audits the miss", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-manifest-missing-"));
   try {
@@ -356,7 +326,6 @@ test("NPM_CI fails loudly when the root package manifest is missing and audits t
       materializeWorkspaceDependencies(
         configured,
         workspace,
-        "NPM_CI",
         workspaceEnvironment(configured),
         { execute: fake.execute },
         { report: (event) => events.push(event) },
@@ -402,7 +371,7 @@ test("a cache hit rebuilds binding.gyp workspaces whose install artifacts live o
     const configured = config(root);
 
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute },
+      configured, workspace, workspaceEnvironment(configured), { execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(first.status, "installed");
@@ -410,7 +379,7 @@ test("a cache hit rebuilds binding.gyp workspaces whose install artifacts live o
     await rm(join(workspace, "apps/web/build"), { recursive: true });
 
     const second = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute },
+      configured, workspace, workspaceEnvironment(configured), { execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(second.status, "restored");
@@ -462,7 +431,7 @@ test("the shipped cache key stays byte-identical to the recorded fixture key", a
     const configured = config(root);
     const fake = fakeInstallExecutor();
     const shipped = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(shipped.key, FIXTURE_CACHE_KEY, "a changed key misses every published cache entry");
@@ -512,7 +481,7 @@ test("missing required inputs are named misses while unreadable or ambiguous inp
     const configured = config(root);
     const events: DependencyCacheProgress[] = [];
     const installed = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(installed.status, "installed");
@@ -560,16 +529,16 @@ test("effective user npm configuration and the child Node tuple determine the pr
       return fake.execute(runnerConfig, executable, args, cwd, env, options);
     };
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute }, { report: () => undefined },
+      configured, workspace, workspaceEnvironment(configured), { execute }, { report: () => undefined },
     );
     await writeFile(join(home, ".npmrc"), "omit=dev\n//registry.npmjs.org/:_authToken=second-secret\n");
     const configDrift = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute }, { report: () => undefined },
+      configured, workspace, workspaceEnvironment(configured), { execute }, { report: () => undefined },
     );
     assert.notEqual(configDrift.key, first.key, "effective user config drift must change the key");
     child = { ...child, node: "v23.0.0", architecture: "x64" };
     const childDrift = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute }, { report: () => undefined },
+      configured, workspace, workspaceEnvironment(configured), { execute }, { report: () => undefined },
     );
     assert.notEqual(childDrift.key, configDrift.key, "the key must follow child Node coordinates");
     assert.equal(fake.installs(), 3);
@@ -598,7 +567,7 @@ test("non-Prisma and alternate-schema repositories install and key their actual 
     const configured = config(root);
     const events: DependencyCacheProgress[] = [];
     const plain = await materializeWorkspaceDependencies(
-      configured, nonPrisma, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, nonPrisma, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(plain.status, "installed");
@@ -635,7 +604,7 @@ test("symlinked workspace targets and cache roots are rejected without following
     const configured = config(root);
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
+        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
       ),
       /Dependency target is a symlink: node_modules/u,
     );
@@ -647,7 +616,7 @@ test("symlinked workspace targets and cache roots are rejected without following
     await symlink(join(root, "outside-cache"), join(root, "cache-link"));
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
         { cacheRoot: join(root, "cache-link"), toolchain: TOOLCHAIN, report: () => undefined },
       ),
       /Dependency cache root is a symlink/u,
@@ -721,14 +690,14 @@ for (const corruption of corruptions) test(`refuses ${corruption.name} cache ent
     const fake = fakeInstallExecutor();
     const configured = config(root);
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(first.key);
     await corruption.corrupt(entryPath(root, first.key), root);
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /(?:integrity|cache).*?(?:refusal|unsafe|malformed|missing|mismatch|escape|directory)/iu,
@@ -750,11 +719,11 @@ test("an unrelated malformed retention entry refuses the pass after a valid hit"
     await Promise.all([createFixture(firstWorkspace), createFixture(secondWorkspace)]);
     await writeFile(join(secondWorkspace, "package-lock.json"), packageLock("2.0.0"));
     const first = await materializeWorkspaceDependencies(
-      configured, firstWorkspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, firstWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     const second = await materializeWorkspaceDependencies(
-      configured, secondWorkspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, secondWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     const firstKey = first.key;
@@ -766,7 +735,7 @@ test("an unrelated malformed retention entry refuses the pass after a valid hit"
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, secondWorkspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+        configured, secondWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /(?:integrity|retention|malformed|unsafe)/iu,
@@ -818,7 +787,7 @@ for (const malformed of malformedRetentionMetadata) {
       const events: DependencyCacheProgress[] = [];
       await assert.rejects(
         materializeWorkspaceDependencies(
-          configured, current.workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+          configured, current.workspace, workspaceEnvironment(configured), { execute: fake.execute },
           { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
         ),
         /metadata-malformed/u,
@@ -908,7 +877,7 @@ for (const corruption of unrelatedRetentionCorruptions) {
       const events: DependencyCacheProgress[] = [];
       await assert.rejects(
         materializeWorkspaceDependencies(
-          configured, current.workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+          configured, current.workspace, workspaceEnvironment(configured), { execute: fake.execute },
           { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
         ),
         corruption.condition,
@@ -936,7 +905,7 @@ test("orphan publication stages and non-key usage files do not brick retention",
     await writeFile(strayUsage, "not a cache usage marker\n");
 
     const result = await materializeWorkspaceDependencies(
-      configured, current.workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, current.workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
 
@@ -985,11 +954,11 @@ test("an unsafe usage marker refuses retention instead of allowing an over-budge
     await Promise.all([createFixture(firstWorkspace), createFixture(secondWorkspace)]);
     await writeFile(join(secondWorkspace, "package-lock.json"), packageLock("2.1.0"));
     const first = await materializeWorkspaceDependencies(
-      configured, firstWorkspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, firstWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     const second = await materializeWorkspaceDependencies(
-      configured, secondWorkspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, secondWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     const firstKey = first.key;
@@ -1001,7 +970,7 @@ test("an unsafe usage marker refuses retention instead of allowing an over-budge
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, secondWorkspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+        configured, secondWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /(?:integrity|usage|marker|unsafe)/iu,
@@ -1021,7 +990,7 @@ test("a selected unsafe usage marker refuses before a missing entry can trigger 
     const configured = config(root);
     const fake = fakeInstallExecutor();
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(first.key);
@@ -1034,7 +1003,7 @@ test("a selected unsafe usage marker refuses before a missing entry can trigger 
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /unsafe-usage-marker/u,
@@ -1058,11 +1027,11 @@ test("dependency-cache audit payloads retain stable event names and fields", asy
     const configured = config(root);
     const events: DependencyCacheProgress[] = [];
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     const second = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(second.status, "restored");
@@ -1104,7 +1073,7 @@ test("cache materialization blocks behind an existing exclusive root lock", asyn
     const configured = config(root);
     const fake = fakeInstallExecutor();
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(first.key);
@@ -1112,7 +1081,7 @@ test("cache materialization blocks behind an existing exclusive root lock", asyn
     try {
       let settled = false;
       const blocked = materializeWorkspaceDependencies(
-        configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
         { toolchain: TOOLCHAIN, report: () => undefined },
       ).finally(() => { settled = true; });
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -1149,7 +1118,7 @@ test("concurrent publishers converge on one valid immutable entry", async () => 
     });
     const configured = config(root);
     const results = await Promise.all(workspaces.map((workspace) => materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
     )));
     assert.equal(fake.installs(), 2);
     assert.equal(new Set(results.map(({ key }) => key)).size, 1);
@@ -1386,7 +1355,7 @@ test("over-budget enforcement waits for an active restore and evicts only the sa
       return fake.execute(...args);
     };
     const restoring = materializeWorkspaceDependencies(
-      configured, active.workspace, "NPM_CI", workspaceEnvironment(configured), { execute },
+      configured, active.workspace, workspaceEnvironment(configured), { execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     await restoreStarted;
@@ -1442,7 +1411,7 @@ test("over-budget enforcement waits for concurrent publication convergence and p
       await writeFile(join(cwd, "packages/db/node_modules/nested-package/index.js"), "converged nested\n");
     });
     const resultsPromise = Promise.all(workspaces.map((workspace) => materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     )));
     await publishersStarted;
@@ -1484,7 +1453,7 @@ test("allocated-byte accounting includes metadata, trees, and safe symlink inode
     });
     const configured = config(root);
     const result = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(result.key);
@@ -1513,7 +1482,7 @@ test("allocated-byte accounting rejects special files instead of treating them a
     const fake = fakeInstallExecutor();
     const configured = config(root);
     const result = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(result.key);
@@ -1544,7 +1513,7 @@ test("a malformed unrelated size walk emits integrity refusal without invoking n
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, current.workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+        configured, current.workspace, workspaceEnvironment(configured), { execute: fake.execute },
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /special-file/u,
@@ -1569,10 +1538,10 @@ test("workspace mutations always flow through the configured run-as execution id
     const configured = config(root, prefix);
     const fake = fakeInstallExecutor();
     await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
     );
     await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
     );
     const mutations = fake.calls.filter(({ executable, args }) =>
       (executable === "npm" && args[0] === "ci") || ["/bin/rm", "/bin/cp", "/bin/chmod"].includes(executable));
@@ -1603,7 +1572,7 @@ test("dependency discovery does not enumerate a workspace root without read perm
     });
     const configured = config(root);
     const result = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(result.status, "installed");
@@ -1644,13 +1613,13 @@ test("a distinct run-as uid restores readable cache entries and owns the workspa
       return realExecutor(runnerConfig, executable, args, cwd, env, options);
     };
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute },
+      configured, workspace, workspaceEnvironment(configured), { execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(first.status, "installed");
     await runCommand(configured.runAsPrefix, "/bin/sh", ["-c", "printf changed > node_modules/owned-package/index.js"], workspace, workspaceEnvironment(configured));
     const second = await materializeWorkspaceDependencies(
-      configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute },
+      configured, workspace, workspaceEnvironment(configured), { execute },
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(second.status, "restored");
@@ -1678,7 +1647,7 @@ test("a non-terminating npm install receives a process-group timeout", async () 
     const started = Date.now();
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, "NPM_CI", workspaceEnvironment(configured), { execute },
+        configured, workspace, workspaceEnvironment(configured), { execute },
         {
           toolchain: TOOLCHAIN,
           installRetryOptions: { attempts: 1, commandTimeoutMs: 50, budgetMs: 10_000 },
@@ -1733,7 +1702,7 @@ test("branch and pinned-detached provisioning materialize a usable scratch repos
       runner: "CODEX",
       specificationMaterialization: null,
       task: { id: "cache-task", chainId: null, chainIndex: null, templateStep: null },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NPM_CI" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
         id: "branch-run",
         runNumber: 1,
@@ -1748,6 +1717,7 @@ test("branch and pinned-detached provisioning materialize a usable scratch repos
     const branchWorkspace = await provisionWorkspace(
       configured,
       branchClaim,
+      { provision: true },
       {
         execute,
         retryOptions: { attempts: 1 },
@@ -1769,7 +1739,7 @@ test("branch and pinned-detached provisioning materialize a usable scratch repos
       runner: "CODEX",
       specificationMaterialization: null,
       task: { id: "cache-review", chainId: null, chainIndex: null, templateStep: null },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NPM_CI" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
         id: "pinned-run",
         runNumber: 1,
@@ -1784,6 +1754,7 @@ test("branch and pinned-detached provisioning materialize a usable scratch repos
     const pinnedWorkspace = await provisionWorkspace(
       configured,
       pinnedClaim,
+      { provision: true },
       {
         execute,
         retryOptions: { attempts: 1 },

--- a/packages/runner/src/dependency-cache.ts
+++ b/packages/runner/src/dependency-cache.ts
@@ -8,7 +8,6 @@ import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:p
 
 import { flock } from "fs-ext";
 
-import type { DependencyProvisioning } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import type { CommandOptions } from "./exec.js";
 import {
@@ -111,7 +110,7 @@ export type DependencyCacheOptions = {
 };
 
 export type DependencyCacheResult = {
-  status: "not-applicable" | "restored" | "installed";
+  status: "restored" | "installed";
   key?: string;
   condition?: string;
 };
@@ -128,8 +127,8 @@ export class DependencyCacheInputMissError extends Error {
 
 /**
  * NPM_CI cannot be honoured without a root package manifest. This is a
- * repository-policy failure, not an optional cache miss: falling through to
- * `not-applicable` would let the provider start with an incomplete workspace.
+ * repository-policy failure, not an optional cache miss: installing nothing
+ * would let the provider start with an incomplete workspace.
  */
 export const DEPENDENCY_PROVISIONING_MANIFEST_MISSING = "dependency-provisioning-manifest-missing" as const;
 
@@ -1322,10 +1321,15 @@ const rebuildNativeWorkspaces = async (
   }
 };
 
+/**
+ * Install the workspace's dependencies under the repository's NPM_CI policy.
+ *
+ * Whether a Run provisions at all is decided when its claim is admitted
+ * (`dependency-provisioning.ts`); reaching here means the answer was yes.
+ */
 export const materializeWorkspaceDependencies = async (
   config: RunnerConfig,
   workspacePath: string,
-  dependencyProvisioning: DependencyProvisioning,
   env: NodeJS.ProcessEnv,
   dependencies: DependencyCacheDependencies,
   options: DependencyCacheOptions = {},
@@ -1333,14 +1337,6 @@ export const materializeWorkspaceDependencies = async (
   const execute = dependencies.execute;
   const started = Date.now();
   const report = options.report ?? progressReporter;
-  if (dependencyProvisioning === "NONE") {
-    try {
-      report({ event: "miss", condition: "dependency-provisioning-none" });
-      return { status: "not-applicable", condition: "dependency-provisioning-none" };
-    } finally {
-      report({ event: "elapsed", elapsedMs: Date.now() - started });
-    }
-  }
   const requestedWorkspace = resolve(workspacePath);
   if (await pathKind(requestedWorkspace) !== "directory" || (await lstat(requestedWorkspace)).isSymbolicLink()) {
     throw new Error("Run workspace is not a real directory");

--- a/packages/runner/src/dependency-provisioning.test.ts
+++ b/packages/runner/src/dependency-provisioning.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DependencyProvisioningManifestMissingError } from "./dependency-cache.js";
+import {
+  classifyDependencyProvisioningFailure,
+  decideDependencyProvisioning,
+  type DependencyProvisioningAdmission,
+} from "./dependency-provisioning.js";
+
+const claimOf = (templateStep: unknown, dependencyProvisioning: unknown): Parameters<
+  typeof decideDependencyProvisioning
+>[0] => ({ task: { templateStep }, repo: { dependencyProvisioning } });
+
+const step = (provisionDependencies: unknown): Record<string, unknown> => ({
+  name: "Implementation",
+  outputKind: "result",
+  provisionDependencies,
+  taskTemplate: { name: "implementation-workflow" },
+});
+
+const REFUSED_TEMPLATE_STEP: DependencyProvisioningAdmission = {
+  admitted: false,
+  condition: "template-step-provision-dependencies-missing",
+};
+const REFUSED_POLICY: DependencyProvisioningAdmission = {
+  admitted: false,
+  condition: "dependency-provisioning-missing",
+};
+const PROVISION: DependencyProvisioningAdmission = { admitted: true, decision: { provision: true } };
+const SKIP_TEMPLATE_STEP: DependencyProvisioningAdmission = {
+  admitted: true,
+  decision: {
+    provision: false,
+    evidence: "Dependency provisioning skipped: TaskTemplateStep.provisionDependencies=false",
+  },
+};
+const SKIP_POLICY: DependencyProvisioningAdmission = {
+  admitted: true,
+  decision: { provision: false, evidence: "Dependency provisioning skipped: Repo.dependencyProvisioning=NONE" },
+};
+
+// The template step's explicit decision by the repository's policy. The
+// refusals come first: a claim shape the runner cannot read is not a policy
+// question, and no default is safe for either input.
+const TABLE: Array<{ name: string; templateStep: unknown; policy: unknown; expected: DependencyProvisioningAdmission }> = [
+  { name: "an absent template step field", templateStep: undefined, policy: "NPM_CI", expected: REFUSED_TEMPLATE_STEP },
+  { name: "an absent step decision", templateStep: step(undefined), policy: "NPM_CI", expected: REFUSED_TEMPLATE_STEP },
+  { name: "a non-boolean step decision", templateStep: step("yes"), policy: "NPM_CI", expected: REFUSED_TEMPLATE_STEP },
+  // The template step is read first, so a claim that is malformed in both
+  // inputs is refused for the step, not for the policy.
+  { name: "both inputs malformed", templateStep: step("yes"), policy: undefined, expected: REFUSED_TEMPLATE_STEP },
+  { name: "an absent policy", templateStep: null, policy: undefined, expected: REFUSED_POLICY },
+  { name: "an unknown policy", templateStep: null, policy: "PYTHON", expected: REFUSED_POLICY },
+  { name: "a non-string policy", templateStep: step(true), policy: 1, expected: REFUSED_POLICY },
+  { name: "NPM_CI under a step that opts in", templateStep: step(true), policy: "NPM_CI", expected: PROVISION },
+  // No step means no opt-out, so the repository policy governs on its own.
+  { name: "NPM_CI under no template step", templateStep: null, policy: "NPM_CI", expected: PROVISION },
+  { name: "NPM_CI under a step that opts out", templateStep: step(false), policy: "NPM_CI", expected: SKIP_TEMPLATE_STEP },
+  // Both say skip: the step is the more specific answer and owns the evidence.
+  { name: "NONE under a step that opts out", templateStep: step(false), policy: "NONE", expected: SKIP_TEMPLATE_STEP },
+  { name: "NONE under a step that opts in", templateStep: step(true), policy: "NONE", expected: SKIP_POLICY },
+  { name: "NONE under no template step", templateStep: null, policy: "NONE", expected: SKIP_POLICY },
+];
+
+for (const { name, templateStep, policy, expected } of TABLE) {
+  test(`the dependency decision for ${name}`, () => {
+    assert.deepEqual(decideDependencyProvisioning(claimOf(templateStep, policy)), expected);
+  });
+}
+
+test("a claim with no repository at all is refused rather than defaulted", () => {
+  assert.deepEqual(
+    decideDependencyProvisioning({ task: { templateStep: null } }),
+    REFUSED_POLICY,
+  );
+});
+
+test("a missing NPM_CI manifest is a non-retryable protocol failure", () => {
+  assert.deepEqual(
+    classifyDependencyProvisioningFailure(new DependencyProvisioningManifestMissingError()),
+    { failureClass: "PROTOCOL_ERROR", retryable: false },
+  );
+});
+
+test("any other failure is left to the adapter to classify", () => {
+  assert.equal(classifyDependencyProvisioningFailure(new Error("git failed (128)")), null);
+  assert.equal(classifyDependencyProvisioningFailure("not an error"), null);
+});

--- a/packages/runner/src/dependency-provisioning.ts
+++ b/packages/runner/src/dependency-provisioning.ts
@@ -1,0 +1,90 @@
+/**
+ * The dependency-provisioning decision: does this Run install dependencies,
+ * and what does a provisioning failure mean.
+ *
+ * The question has two inputs that only the claim carries — the template
+ * step's explicit decision and the repository's policy — and it is answered
+ * once, when the claim is admitted, before any workspace, scratch, child
+ * environment or adapter work exists. Everything downstream receives the
+ * decided value: `provisionWorkspace` gates the materializer on it, and the
+ * runner's failure path asks this module to classify a provisioning failure
+ * rather than reading the dependency cache's error taxonomy itself.
+ */
+
+import type { ClassifiedFailure } from "./adapters/runtime.js";
+import { isDependencyProvisioning } from "./api.js";
+import { DependencyProvisioningManifestMissingError } from "./dependency-cache.js";
+
+/**
+ * What the workspace does about dependencies. A skip carries the evidence line
+ * the Run records, so no caller has to know which of the two inputs produced
+ * it.
+ */
+export type DependencyProvisioningDecision =
+  | { readonly provision: true }
+  | { readonly provision: false; readonly evidence: string };
+
+/**
+ * The claim shapes this module refuses. Both are protocol violations: a
+ * missing or malformed value cannot be defaulted, because either default
+ * silently changes whether a repository's dependencies are installed.
+ */
+export type DependencyProvisioningRefusal =
+  | "template-step-provision-dependencies-missing"
+  | "dependency-provisioning-missing";
+
+export type DependencyProvisioningAdmission =
+  | { readonly admitted: true; readonly decision: DependencyProvisioningDecision }
+  | { readonly admitted: false; readonly condition: DependencyProvisioningRefusal };
+
+/** The two claim fields the decision reads, typed as they arrive over the wire. */
+export type DependencyProvisioningClaim = {
+  readonly task: { readonly templateStep?: unknown };
+  readonly repo?: { readonly dependencyProvisioning?: unknown } | null;
+};
+
+export const decideDependencyProvisioning = (
+  claim: DependencyProvisioningClaim,
+): DependencyProvisioningAdmission => {
+  // A template step carries an explicit dependency decision. A missing or
+  // malformed value is a protocol violation: no default is safe because it
+  // could either strip dependencies from an implementation step or expose a
+  // review step to the dependency materializer. A null step is not malformed —
+  // it means no step, and the repository policy governs.
+  const templateStep = claim.task.templateStep as { provisionDependencies?: unknown } | null | undefined;
+  if (templateStep === undefined
+    || (templateStep !== null && typeof templateStep.provisionDependencies !== "boolean")) {
+    return { admitted: false, condition: "template-step-provision-dependencies-missing" };
+  }
+  // Dependency provisioning is a required claim contract. A runner build that
+  // predates this field must fail closed rather than pick a policy.
+  const policy = claim.repo?.dependencyProvisioning;
+  if (!isDependencyProvisioning(policy)) return { admitted: false, condition: "dependency-provisioning-missing" };
+  if (templateStep?.provisionDependencies === false) {
+    return {
+      admitted: true,
+      decision: {
+        provision: false,
+        evidence: "Dependency provisioning skipped: TaskTemplateStep.provisionDependencies=false",
+      },
+    };
+  }
+  if (policy === "NONE") {
+    return {
+      admitted: true,
+      decision: { provision: false, evidence: "Dependency provisioning skipped: Repo.dependencyProvisioning=NONE" },
+    };
+  }
+  return { admitted: true, decision: { provision: true } };
+};
+
+/**
+ * The failure class a provisioning failure carries, or null when the error did
+ * not come from provisioning and the adapter's own classification applies.
+ * NPM_CI without a root manifest is a repository-policy violation, so retrying
+ * it on another host would only repeat it.
+ */
+export const classifyDependencyProvisioningFailure = (error: unknown): ClassifiedFailure | null =>
+  error instanceof DependencyProvisioningManifestMissingError
+    ? { failureClass: "PROTOCOL_ERROR", retryable: false }
+    : null;

--- a/packages/runner/src/git-provenance.test.ts
+++ b/packages/runner/src/git-provenance.test.ts
@@ -8,6 +8,7 @@ import test from "node:test";
 import { buildChildEnvironment } from "./adapters.js";
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
+import type { DependencyProvisioningDecision } from "./dependency-provisioning.js";
 import { platformCommitArgs } from "./exec.js";
 import { provisionWorkspace, workspaceEnvironment, type Workspace } from "./workspace.js";
 
@@ -148,6 +149,12 @@ const providerEnvironment = (configured: RunnerConfig, claimed: ClaimedTask, wor
     configRoot: join(configured.workspaceRoot, "scratch", "config"),
   }, workspace.path, workspace.commitHooksPath);
 
+/** Provenance is what these tests provision for; no Run installs here. */
+const NO_DEPENDENCIES = {
+  provision: false,
+  evidence: "Dependency provisioning skipped: Repo.dependencyProvisioning=NONE",
+} as const satisfies DependencyProvisioningDecision;
+
 const commitMessage = (cwd: string): string => git(cwd, ["show", "-s", "--format=%B", "HEAD"]);
 
 test("a chain provider commit pins the human identity and records its exact claimed run provenance", async () => {
@@ -156,7 +163,7 @@ test("a chain provider commit pins the human identity and records its exact clai
     const remote = await seedRemote(root);
     const configured = config(root);
     const claimed = claim(remote, "run-real-123");
-    const workspace = await provisionWorkspace(configured, claimed);
+    const workspace = await provisionWorkspace(configured, claimed, NO_DEPENDENCIES);
     const env = providerEnvironment(configured, claimed, workspace);
     assert.equal(env.GIT_CONFIG_COUNT, "2", "the task secret cannot replace runner-owned Git config injection");
     assert.equal(env.GIT_CONFIG_KEY_0, "credential.helper");
@@ -198,7 +205,7 @@ test("the provider hook covers an in-workspace linked worktree but refuses a nes
     const remote = await seedRemote(root);
     const configured = config(root);
     const claimed = claim(remote, "run-linked-456");
-    const workspace = await provisionWorkspace(configured, claimed);
+    const workspace = await provisionWorkspace(configured, claimed, NO_DEPENDENCIES);
     const env = providerEnvironment(configured, claimed, workspace);
     const linked = join(workspace.path, "worktrees", "linked");
     await mkdir(join(workspace.path, "worktrees"));
@@ -228,7 +235,7 @@ test("rewrite operations remain unmarked and conflicting provenance fails the co
     const remote = await seedRemote(root);
     const configured = config(root);
     const claimed = claim(remote, "run-rewrite-789");
-    const workspace = await provisionWorkspace(configured, claimed);
+    const workspace = await provisionWorkspace(configured, claimed, NO_DEPENDENCIES);
     const env = providerEnvironment(configured, claimed, workspace);
 
     await writeFile(join(workspace.path, "provider.txt"), "provider change\n");
@@ -278,7 +285,7 @@ test("ordinary runs stay unmarked while global runner identity is pinned locally
     git(root, ["config", "--global", "user.name", HUMAN.name], globalEnv);
     git(root, ["config", "--global", "user.email", HUMAN.email], globalEnv);
     const claimed = claim(remote, "run-ordinary", { chainId: null, chainIndex: null, templateStep: null });
-    const workspace = await provisionWorkspace(configured, claimed);
+    const workspace = await provisionWorkspace(configured, claimed, NO_DEPENDENCIES);
     assert.equal(workspace.commitHooksPath, undefined);
     const env = providerEnvironment(configured, claimed, workspace);
     // The credential helper is unconditional; the hooks path is what an

--- a/packages/runner/src/provision-failure.test.ts
+++ b/packages/runner/src/provision-failure.test.ts
@@ -154,6 +154,8 @@ test("a transient mirror fetch failure escapes provisioning as a transient error
   const escaped = await provisionWorkspace(
     config(root),
     claim("https://example.test/repo.git"),
+    // The mirror fetch fails before dependencies are ever reached.
+    { provision: false, evidence: "Dependency provisioning skipped: Repo.dependencyProvisioning=NONE" },
     {
       execute: async (executorConfig, executable, args, cwd, env) => {
         // Only git is faked: the mirror's own filesystem bookkeeping is real work

--- a/packages/runner/src/repo-mirror.test.ts
+++ b/packages/runner/src/repo-mirror.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import type { RunnerConfig } from "./config.js";
+import type { DependencyProvisioningDecision } from "./dependency-provisioning.js";
 import { runCommand } from "./exec.js";
 import {
   mirrorRevisionsPresent, repoMirrorPath, RepoMirrorError, withRepoMirror,
@@ -49,12 +50,18 @@ const fixture = async (label: string): Promise<Fixture> => {
   return { root, remote, seed, config, mirrorRoot, mirror: repoMirrorPath(mirrorRoot, remote) };
 };
 
+/** Mirror behaviour is what these tests provision for; no Run installs here. */
+const NO_DEPENDENCIES = {
+  provision: false,
+  evidence: "Dependency provisioning skipped: Repo.dependencyProvisioning=NONE",
+} as const satisfies DependencyProvisioningDecision;
+
 const claimFor = (remote: string, id: string): WorkspaceProvisionClaim => ({
   executionMode: "agent",
   runner: "CODEX",
   specificationMaterialization: null,
   task: { id: `task-${id}`, chainId: null, chainIndex: null, templateStep: null },
-  repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NONE" },
+  repo: { remoteUrl: remote, defaultBranch: "main" },
   run: {
     id: `run-${id}`,
     runNumber: 1,
@@ -83,7 +90,7 @@ const silent = (): ((progress: RepoMirrorProgress) => void) => (): void => undef
 test("the second run reuses the machine's mirror and fetches only what changed", async () => {
   const { root, remote, seed, config, mirror } = await fixture("reuse");
   try {
-    await provisionWorkspace(config, claimFor(remote, "one"), { mirrorOptions: { report: silent() } });
+    await provisionWorkspace(config, claimFor(remote, "one"), NO_DEPENDENCIES, { mirrorOptions: { report: silent() } });
     const created = (await stat(mirror)).birthtimeMs;
 
     await writeFile(join(seed, "tree.txt"), "second\n");
@@ -95,6 +102,7 @@ test("the second run reuses the machine's mirror and fetches only what changed",
     const workspace = await provisionWorkspace(
       config,
       claimFor(remote, "two"),
+      NO_DEPENDENCIES,
       { execute: recorded(calls), mirrorOptions: { report: silent() } },
     );
 
@@ -123,7 +131,7 @@ test("the mirror carries branches and tags but not the remote's other refs", asy
     // would make every fetch pay for the repository's whole review history.
     git(seed, "push", "origin", "HEAD:refs/pull/7/head");
 
-    await provisionWorkspace(config, claimFor(remote, "refspec"), { mirrorOptions: { report: silent() } });
+    await provisionWorkspace(config, claimFor(remote, "refspec"), NO_DEPENDENCIES, { mirrorOptions: { report: silent() } });
 
     const refs = git(mirror, "for-each-ref", "--format=%(refname)").split("\n");
     assert.equal(refs.includes("refs/heads/main"), true);
@@ -137,12 +145,13 @@ test("the mirror carries branches and tags but not the remote's other refs", asy
 test("a mirror pointing at a different remote is refused instead of quietly re-cloning", async () => {
   const { root, remote, config, mirror } = await fixture("mismatch");
   try {
-    await provisionWorkspace(config, claimFor(remote, "first"), { mirrorOptions: { report: silent() } });
+    await provisionWorkspace(config, claimFor(remote, "first"), NO_DEPENDENCIES, { mirrorOptions: { report: silent() } });
     git(mirror, "remote", "set-url", "origin", "https://github.com/acme/somewhere-else.git");
 
     const failure = await provisionWorkspace(
       config,
       claimFor(remote, "second"),
+      NO_DEPENDENCIES,
       { mirrorOptions: { report: silent() } },
     ).then(() => null, (error: unknown) => error);
     assert.equal(failure instanceof RepoMirrorError, true);
@@ -162,6 +171,7 @@ test("a mirror that is not a readable git repository is refused, not rebuilt", a
     const failure = await provisionWorkspace(
       config,
       claimFor(remote, "corrupt"),
+      NO_DEPENDENCIES,
       { mirrorOptions: { report: silent() } },
     ).then(() => null, (error: unknown) => error);
     assert.equal(failure instanceof RepoMirrorError, true);
@@ -255,7 +265,7 @@ test("the mirror is private to the account that runs the tasks", async () => {
   const { root, remote, config, mirror, mirrorRoot } = await fixture("private");
   const previous = process.umask(0o022);
   try {
-    await provisionWorkspace(config, claimFor(remote, "private"), { mirrorOptions: { report: silent() } });
+    await provisionWorkspace(config, claimFor(remote, "private"), NO_DEPENDENCIES, { mirrorOptions: { report: silent() } });
     // The mirror carries the same history as the run workspace and lives in the
     // task account's own home. Nothing outside that account has business
     // reading it, and a permissive umask must not decide otherwise.
@@ -280,7 +290,7 @@ test("every mirror command runs through the run-as prefix, so the account with t
     const isolated = { ...config, runAsPrefix: [launcher] } as RunnerConfig;
     await mkdir(config.workspaceRoot, { recursive: true });
 
-    await provisionWorkspace(isolated, claimFor(remote, "run-as"), { mirrorOptions: { report: silent() } });
+    await provisionWorkspace(isolated, claimFor(remote, "run-as"), NO_DEPENDENCIES, { mirrorOptions: { report: silent() } });
 
     const argv = await readFile(log, "utf8");
     assert.match(argv, /git init --bare/u);

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -195,112 +195,106 @@ test("a mechanical claim is refused before any adapter, workspace or child envir
   assert.deepEqual(await readdir(workspaceRoot), []);
 });
 
-const malformedDependencyProvisioningClaim = (value: unknown): ClaimedTask => {
+// Which values are refused is a table in `dependency-provisioning.test.ts`.
+// What this test owns is the order: a refusal reaches the control plane before
+// the runner has provisioned, installed or launched anything.
+const claimWithoutRepositoryPolicy = (): ClaimedTask => {
   const repo = { ...mechanicalClaim.repo } as Record<string, unknown>;
-  if (value === undefined) delete repo.dependencyProvisioning;
-  else repo.dependencyProvisioning = value;
-  return {
-    ...agentClaim,
-    repo,
-  } as unknown as ClaimedTask;
+  delete repo.dependencyProvisioning;
+  return { ...agentClaim, repo } as unknown as ClaimedTask;
 };
 
-for (const [label, value] of [["missing", undefined], ["unknown", "PYTHON"]] as const) {
-  test(`a ${label} dependency-provisioning claim is rejected before provisioning or adapter launch`, async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), `runner-dependency-protocol-${label}-`));
-    const commandRoot = await mkdtemp(join(tmpdir(), `runner-dependency-command-${label}-`));
-    const npmSentinel = join(commandRoot, "npm-called");
-    const npm = join(commandRoot, "npm");
-    await writeFile(npm, `#!/bin/sh\nprintf called > ${JSON.stringify(npmSentinel)}\n`);
-    await chmod(npm, 0o755);
-    const controlPlane = createControlPlaneDouble();
-    let adapterCalls = 0;
-    const adapter: CliAdapter = {
-      ...adapters.CLAUDE,
-      preflight: async () => {
-        adapterCalls += 1;
-        throw new Error("adapter preflight must not be reached for a malformed dependency claim");
-      },
-      start: async () => {
-        adapterCalls += 1;
-        throw new Error("adapter start must not be reached for a malformed dependency claim");
-      },
-    };
+test("a refused dependency-provisioning claim is rejected before provisioning or adapter launch", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "runner-dependency-protocol-"));
+  const commandRoot = await mkdtemp(join(tmpdir(), "runner-dependency-command-"));
+  const npmSentinel = join(commandRoot, "npm-called");
+  const npm = join(commandRoot, "npm");
+  await writeFile(npm, `#!/bin/sh\nprintf called > ${JSON.stringify(npmSentinel)}\n`);
+  await chmod(npm, 0o755);
+  const controlPlane = createControlPlaneDouble();
+  let adapterCalls = 0;
+  const adapter: CliAdapter = {
+    ...adapters.CLAUDE,
+    preflight: async () => {
+      adapterCalls += 1;
+      throw new Error("adapter preflight must not be reached for a malformed dependency claim");
+    },
+    start: async () => {
+      adapterCalls += 1;
+      throw new Error("adapter start must not be reached for a malformed dependency claim");
+    },
+  };
 
-    try {
-      await executeClaimProduction(
-        { ...config(workspaceRoot), path: commandRoot },
-        malformedDependencyProvisioningClaim(value),
-        { adapter, controlPlane: controlPlane.controlPlane },
-      );
-      const completion = controlPlane.completions.at(-1);
-      assert.ok(completion, "malformed claims must complete the run");
-      assert.equal(completion.outcome.case, "terminal-protocol-failure");
-      assert.equal(failureReasonOf(completion.outcome), "dependency-provisioning-missing");
-      assert.equal(completion.terminationReason, "dependency-provisioning-missing");
-      assert.equal(completion.cleanupStatus, "SUCCEEDED");
-      assert.equal(completion.workspaceRetained, false);
-      assert.equal(adapterCalls, 0, "malformed claims must not reach adapter preflight or launch");
-      assert.deepEqual(await readdir(workspaceRoot), [], "malformed claims must not provision a workspace");
-      await assert.rejects(access(npmSentinel), { code: "ENOENT" }, "malformed claims must not invoke npm");
-    } finally {
-      await Promise.all([
-        rm(workspaceRoot, { recursive: true, force: true }),
-        rm(commandRoot, { recursive: true, force: true }),
-      ]);
-    }
-  });
-}
+  try {
+    await executeClaimProduction(
+      { ...config(workspaceRoot), path: commandRoot },
+      claimWithoutRepositoryPolicy(),
+      { adapter, controlPlane: controlPlane.controlPlane },
+    );
+    const completion = controlPlane.completions.at(-1);
+    assert.ok(completion, "malformed claims must complete the run");
+    assert.equal(completion.outcome.case, "terminal-protocol-failure");
+    assert.equal(failureReasonOf(completion.outcome), "dependency-provisioning-missing");
+    assert.equal(completion.terminationReason, "dependency-provisioning-missing");
+    assert.equal(completion.cleanupStatus, "SUCCEEDED");
+    assert.equal(completion.workspaceRetained, false);
+    assert.equal(adapterCalls, 0, "malformed claims must not reach adapter preflight or launch");
+    assert.deepEqual(await readdir(workspaceRoot), [], "malformed claims must not provision a workspace");
+    await assert.rejects(access(npmSentinel), { code: "ENOENT" }, "malformed claims must not invoke npm");
+  } finally {
+    await Promise.all([
+      rm(workspaceRoot, { recursive: true, force: true }),
+      rm(commandRoot, { recursive: true, force: true }),
+    ]);
+  }
+});
 
-const malformedTemplateProvisionDependenciesClaim = (value: unknown): ClaimedTask => {
+const claimWithoutTemplateStepDecision = (): ClaimedTask => {
   const templateStep = { ...mechanicalClaim.task.templateStep! } as Record<string, unknown>;
-  if (value === undefined) delete templateStep.provisionDependencies;
-  else templateStep.provisionDependencies = value;
+  delete templateStep.provisionDependencies;
   return {
     ...agentClaim,
     task: { ...mechanicalClaim.task, templateStep },
   } as unknown as ClaimedTask;
 };
 
-for (const [label, value] of [["missing", undefined], ["unknown", "yes"]] as const) {
-  test(`a ${label} template-step dependency decision is rejected before workspace or adapter work`, async () => {
-    const workspaceRoot = await mkdtemp(join(tmpdir(), `runner-template-step-protocol-${label}-`));
-    const controlPlane = createControlPlaneDouble();
-    let preflightCalls = 0;
-    let startCalls = 0;
-    const adapter: CliAdapter = {
-      ...adapters.CLAUDE,
-      preflight: async () => {
-        preflightCalls += 1;
-        throw new Error("adapter preflight must not be reached for a malformed template step");
-      },
-      start: async () => {
-        startCalls += 1;
-        throw new Error("provider start must not be reached for a malformed template step");
-      },
-    };
+test("a refused template-step dependency decision is rejected before workspace or adapter work", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "runner-template-step-protocol-"));
+  const controlPlane = createControlPlaneDouble();
+  let preflightCalls = 0;
+  let startCalls = 0;
+  const adapter: CliAdapter = {
+    ...adapters.CLAUDE,
+    preflight: async () => {
+      preflightCalls += 1;
+      throw new Error("adapter preflight must not be reached for a malformed template step");
+    },
+    start: async () => {
+      startCalls += 1;
+      throw new Error("provider start must not be reached for a malformed template step");
+    },
+  };
 
-    try {
-      await executeClaimProduction(
-        config(workspaceRoot),
-        malformedTemplateProvisionDependenciesClaim(value),
-        { adapter, controlPlane: controlPlane.controlPlane },
-      );
-      const completion = controlPlane.completions.at(-1);
-      assert.ok(completion, "malformed claims must complete the run");
-      assert.equal(completion.outcome.case, "terminal-protocol-failure");
-      assert.equal(failureReasonOf(completion.outcome), "template-step-provision-dependencies-missing");
-      assert.equal(completion.terminationReason, "template-step-provision-dependencies-missing");
-      assert.equal(completion.cleanupStatus, "SUCCEEDED");
-      assert.equal(completion.workspaceRetained, false);
-      assert.equal(preflightCalls, 0);
-      assert.equal(startCalls, 0);
-      assert.deepEqual(await readdir(workspaceRoot), [], "malformed claims must not provision a workspace");
-    } finally {
-      await rm(workspaceRoot, { recursive: true, force: true });
-    }
-  });
-}
+  try {
+    await executeClaimProduction(
+      config(workspaceRoot),
+      claimWithoutTemplateStepDecision(),
+      { adapter, controlPlane: controlPlane.controlPlane },
+    );
+    const completion = controlPlane.completions.at(-1);
+    assert.ok(completion, "malformed claims must complete the run");
+    assert.equal(completion.outcome.case, "terminal-protocol-failure");
+    assert.equal(failureReasonOf(completion.outcome), "template-step-provision-dependencies-missing");
+    assert.equal(completion.terminationReason, "template-step-provision-dependencies-missing");
+    assert.equal(completion.cleanupStatus, "SUCCEEDED");
+    assert.equal(completion.workspaceRetained, false);
+    assert.equal(preflightCalls, 0);
+    assert.equal(startCalls, 0);
+    assert.deepEqual(await readdir(workspaceRoot), [], "malformed claims must not provision a workspace");
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
 
 test("a review step records the dependency skip before fake adapter preflight and launch", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-review-dependency-activity-"));

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -25,7 +25,6 @@ import {
   type RuntimeHandle,
 } from "./adapters.js";
 import {
-  isDependencyProvisioning,
   openControlPlane,
   retriableStartupError,
   type ClaimedTask,
@@ -44,6 +43,10 @@ import {
 import { evaluateBudget } from "./budget.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
 import { deliverWorkspace, type PrWorkflowOutput } from "./delivery.js";
+import {
+  classifyDependencyProvisioningFailure,
+  decideDependencyProvisioning,
+} from "./dependency-provisioning.js";
 import { disposeWorkspace, type WorkspaceDisposal } from "./dispose-workspace.js";
 import {
   buildFailureEnvelope,
@@ -57,7 +60,6 @@ import { createRunLease, deliverUnderLease, type RunLease } from "./run-lease.js
 import { openSessionConfig, type SessionConfigLease } from "./session-config-lease.js";
 import { readRegressionOutputHandoff } from "./regression-output-handoff.js";
 import { readTaskOutputReceipt } from "./task-output-receipt.js";
-import { DependencyProvisioningManifestMissingError } from "./dependency-cache.js";
 import {
   captureWorkspaceResult, captureWorkspaceSnapshot, cleanupAgentScratch, materializeRuntimeTools, provisionAgentScratch, provisionSessionConfig,
   provisionWorkspace, reuseWorkspace, workspaceEnvironment, writeSessionCredentials,
@@ -299,38 +301,17 @@ export const executeClaim = async (
   };
 
   try {
-    // A template step carries an explicit dependency decision. A missing or
-    // malformed value is a protocol violation: no default is safe because it
-    // could either strip dependencies from an implementation step or expose a
-    // review step to the dependency materializer. Validate before any runner
-    // workspace, dependency, adapter, or provider operation.
-    const claimedTemplateStep = claim.task.templateStep as {
-      provisionDependencies?: unknown;
-    } | null | undefined;
-    if (claimedTemplateStep === undefined
-      || (claimedTemplateStep !== null && typeof claimedTemplateStep.provisionDependencies !== "boolean")) {
-      const condition = "template-step-provision-dependencies-missing";
+    // The dependency decision is made once, here, and passed down. It is the
+    // first thing this function does: a refused claim shape must not reach a
+    // runner workspace, scratch, child environment, adapter preflight or
+    // provider launch, and the condition goes in both terminal fields so old
+    // and new control planes can expose it.
+    const provisioning = decideDependencyProvisioning(claim);
+    if (!provisioning.admitted) {
       await session.finish({
-        outcome: { case: "terminal-protocol-failure", reason: condition },
+        outcome: { case: "terminal-protocol-failure", reason: provisioning.condition },
         exitCode: null,
-        terminationReason: condition,
-        cleanupStatus: "SUCCEEDED",
-        workspaceRetained: false,
-      });
-      return;
-    }
-    // Dependency provisioning is a required claim contract. A runner build
-    // that predates this field must fail closed: treating an omitted value as
-    // either policy would silently change whether a repository's dependencies
-    // are installed. Validate before any workspace, scratch, child environment
-    // or adapter preflight/launch work can happen, and keep the condition in
-    // both terminal fields so old and new control planes can expose it.
-    if (!isDependencyProvisioning((claim.repo as { dependencyProvisioning?: unknown } | undefined)?.dependencyProvisioning)) {
-      const condition = "dependency-provisioning-missing";
-      await session.finish({
-        outcome: { case: "terminal-protocol-failure", reason: condition },
-        exitCode: null,
-        terminationReason: condition,
+        terminationReason: provisioning.condition,
         cleanupStatus: "SUCCEEDED",
         workspaceRetained: false,
       });
@@ -373,15 +354,14 @@ export const executeClaim = async (
       return;
     }
 
-    workspace = claim.resume ? await reuseWorkspace(config, claim) : await provisionWorkspace(config, claim);
-    if (claim.task.templateStep?.provisionDependencies === false) {
+    workspace = claim.resume
+      ? await reuseWorkspace(config, claim)
+      : await provisionWorkspace(config, claim, provisioning.decision);
+    if (!provisioning.decision.provision) {
       // This is deliberately a fenced activity write with no fallback: the
-      // reviewer must have durable evidence of the dependency-free checkout
+      // agent must have durable evidence of the dependency-free checkout
       // before its adapter is preflighted or launched.
-      await session.note(
-        "Dependency provisioning skipped: TaskTemplateStep.provisionDependencies=false",
-        { stream: "runner" },
-      );
+      await session.note(provisioning.decision.evidence, { stream: "runner" });
     }
     const prompt = buildPrompt(claim);
     scratch = await provisionAgentScratch(config, claim.session.id);
@@ -966,9 +946,7 @@ export const executeClaim = async (
       return;
     }
     const evidence = preflightEvidence(message);
-    const classified = error instanceof DependencyProvisioningManifestMissingError
-      ? { failureClass: "PROTOCOL_ERROR" as const, retryable: false }
-      : adapter.classifyError(evidence);
+    const classified = classifyDependencyProvisioningFailure(error) ?? adapter.classifyError(evidence);
     const worktreeReport = await worktreeContainmentReport();
     const cleaned = await cleanup(config, claim, workspace, config.failedWorkspaceRetention > 0, false, controlPlane);
     const { salvage, ...finishedCleanup } = cleaned;

--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import type { RunnerConfig } from "./config.js";
+import type { DependencyProvisioningDecision } from "./dependency-provisioning.js";
 import { CLONE_COMMAND_TIMEOUT_MS } from "./network-retry.js";
 import { runCommand } from "./exec.js";
 import { runtimeToolPaths } from "./runtime-tools.js";
@@ -87,6 +88,21 @@ const workspaceClaim = (fixture: WorkspaceClaimFixture): WorkspaceProvisionClaim
   },
 });
 
+/**
+ * The decision most of these tests provision under. It is made when the claim
+ * is admitted, so provisioning takes it as an argument instead of re-reading
+ * the template step or the repository policy.
+ */
+const NO_DEPENDENCIES = {
+  provision: false,
+  evidence: "Dependency provisioning skipped: Repo.dependencyProvisioning=NONE",
+} as const satisfies DependencyProvisioningDecision;
+
+const NO_DEPENDENCIES_FOR_REVIEW = {
+  provision: false,
+  evidence: "Dependency provisioning skipped: TaskTemplateStep.provisionDependencies=false",
+} as const satisfies DependencyProvisioningDecision;
+
 const seedPackageRemote = async (root: string): Promise<string> => {
   const remote = join(root, "origin.git");
   const seed = join(root, "seed");
@@ -138,9 +154,9 @@ test("an explicit false template step skips all dependency inspection after chec
         id: "task-review",
         templateStep: { name: "Code review", outputKind: "result", provisionDependencies: false, taskTemplate: { name: "review-workflow" } },
       },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NPM_CI" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: { id: "run-review", runNumber: 1, targetBranch: "main", branch: "main" },
-    }), {
+    }), NO_DEPENDENCIES_FOR_REVIEW, {
       execute,
       dependencyCacheOptions: { cacheRoot: join(root, "dependency-cache"), report: (event) => progress.push(event) },
     });
@@ -172,9 +188,9 @@ test("an explicit true template step keeps the repository dependency policy path
         id: "task-implementation",
         templateStep: { name: "Implementation", outputKind: "result", provisionDependencies: true, taskTemplate: { name: "implementation-workflow" } },
       },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NPM_CI" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: { id: "run-implementation", runNumber: 1, targetBranch: "main", branch: "main" },
-    }), {
+    }), { provision: true }, {
       dependencyCacheOptions: {
         cacheRoot: join(root, "dependency-cache"),
         report: (event) => progress.push(event),
@@ -223,11 +239,11 @@ test("a workspace cloned from its own published head still resolves the target b
     } as unknown as RunnerConfig;
     const claim = workspaceClaim({
       task: { id: "task-target-refspec" },
-      repo: { remoteUrl: remote, defaultBranch: target, dependencyProvisioning: "NONE" },
+      repo: { remoteUrl: remote, defaultBranch: target },
       run: { id: "run-target-refspec", runNumber: 2, targetBranch: target, branch },
     });
 
-    const workspace = await provisionWorkspace(config, claim);
+    const workspace = await provisionWorkspace(config, claim, NO_DEPENDENCIES);
     assert.equal(git(workspace.path, "rev-parse", `origin/${target}`), targetSha);
     assert.deepEqual(
       git(workspace.path, "config", "--get-all", "remote.origin.fetch").split("\n"),
@@ -281,7 +297,7 @@ test("provisioning trusts an already-published intended head after its database 
     } as unknown as RunnerConfig;
     const claim = workspaceClaim({
       task: { id: "task-1" },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NONE" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
         id: "run-2",
         runNumber: 2,
@@ -292,7 +308,7 @@ test("provisioning trusts an already-published intended head after its database 
       },
     });
 
-    const workspace = await provisionWorkspace(config, claim);
+    const workspace = await provisionWorkspace(config, claim, NO_DEPENDENCIES);
     assert.equal(workspace.branch, "agentos/chain/demo-deadbeef");
     assert.equal(workspace.baseSha, publishedSha);
     assert.equal(await readFile(join(workspace.path, "tree.txt"), "utf8"), "published\n");
@@ -328,7 +344,7 @@ test("provisioning commits the server-prepared direct specification before the a
     const specificationPath = `.chain/${branch}/spec.md`;
     const claim = workspaceClaim({
       task: { id: "task-specification" },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NONE" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
         id: "run-specification",
         runNumber: 1,
@@ -342,7 +358,7 @@ test("provisioning commits the server-prepared direct specification before the a
       },
     });
 
-    const workspace = await provisionWorkspace(config, claim);
+    const workspace = await provisionWorkspace(config, claim, NO_DEPENDENCIES);
     assert.equal(await readFile(join(workspace.path, specificationPath), "utf8"), "authoritative brief");
     assert.equal(git(workspace.path, "status", "--porcelain"), "");
     assert.equal(workspace.baseSha, git(workspace.path, "rev-parse", "HEAD"));
@@ -378,7 +394,7 @@ test("prepared specification refuses a repository symlink that would escape the 
     const branch = "feature/platform-spec";
     const claim = workspaceClaim({
       task: { id: "task-specification-symlink" },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NONE" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: { id: "run-specification-symlink", runNumber: 1, targetBranch: "main", branch },
       specificationMaterialization: {
         kind: "direct-implementation",
@@ -387,7 +403,7 @@ test("prepared specification refuses a repository symlink that would escape the 
       },
     });
 
-    await assert.rejects(provisionWorkspace(config, claim), /Prepared specification parent .* is a symlink/u);
+    await assert.rejects(provisionWorkspace(config, claim, NO_DEPENDENCIES), /Prepared specification parent .* is a symlink/u);
     await assert.rejects(readFile(join(escaped, branch, "spec.md")), /ENOENT/u);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -425,13 +441,13 @@ test("a resolver-confirmed newer salvage base outranks an existing declared head
     } as unknown as RunnerConfig;
     const claim = workspaceClaim({
       task: { id: "task-1" },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NONE" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
         id: "run-3", runNumber: 3, targetBranch: salvage,
         targetBranchPublished: true, branch: declared,
       },
     });
-    const workspace = await provisionWorkspace(config, claim);
+    const workspace = await provisionWorkspace(config, claim, NO_DEPENDENCIES);
     assert.equal(workspace.branch, declared);
     assert.equal(workspace.baseSha, salvageSha);
     assert.equal(await readFile(join(workspace.path, "tree.txt"), "utf8"), "newer salvage\n");
@@ -477,7 +493,7 @@ test("a pinned workspace fetches only the recorded commit and never creates the 
     } as unknown as RunnerConfig;
     const claim = workspaceClaim({
       task: { id: "task-blind" },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NONE" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: {
         id: "run-blind",
         runNumber: 1,
@@ -489,7 +505,7 @@ test("a pinned workspace fetches only the recorded commit and never creates the 
       },
     });
 
-    const workspace = await provisionWorkspace(config, claim);
+    const workspace = await provisionWorkspace(config, claim, NO_DEPENDENCIES);
     assert.equal(workspace.baseSha, pinnedBaseSha);
     assert.equal(git(workspace.path, "branch", "--show-current"), "");
     assert.equal(git(workspace.path, "for-each-ref", "--format=%(refname)"), "");
@@ -524,7 +540,6 @@ test("the mirror fetch retries two transient failures and succeeds on the third 
       repo: {
         remoteUrl: "https://github.com/acme/app.git",
         defaultBranch: "main",
-        dependencyProvisioning: "NONE",
       },
       run: { id: "run-retry", runNumber: 1, targetBranch: "main", branch: "main" },
     });
@@ -540,7 +555,7 @@ test("the mirror fetch retries two transient failures and succeeds on the third 
       if (executable === "git" && args[0] === "rev-parse") return "base-sha";
       return "";
     };
-    const workspace = await provisionWorkspace(config, claim, {
+    const workspace = await provisionWorkspace(config, claim, NO_DEPENDENCIES, {
       execute: fake,
       retryOptions: { wait: async () => undefined },
     });
@@ -582,7 +597,6 @@ test("the mirror's remote fetch carries a per-command ceiling while local git co
       repo: {
         remoteUrl: "https://github.com/acme/app.git",
         defaultBranch: "main",
-        dependencyProvisioning: "NONE",
       },
       run: { id: "run-timeout", runNumber: 1, targetBranch: "main", branch: "agentos/task-timeout/run-1" },
     });
@@ -594,7 +608,7 @@ test("the mirror's remote fetch carries a per-command ceiling while local git co
       if (args[0] === "rev-parse") return "base-sha";
       return "";
     });
-    await provisionWorkspace(config, claim, {
+    await provisionWorkspace(config, claim, NO_DEPENDENCIES, {
       execute: fake,
       retryOptions: { wait: async () => undefined },
     });
@@ -638,7 +652,6 @@ test("the pinned range is fetched out of the mirror, and only the mirror's own f
       repo: {
         remoteUrl: "https://github.com/acme/app.git",
         defaultBranch: "main",
-        dependencyProvisioning: "NONE",
       },
       run: {
         id: "run-pinned-timeout",
@@ -656,7 +669,7 @@ test("the pinned range is fetched out of the mirror, and only the mirror's own f
       if (args[0] === "rev-parse") return "pinned-sha";
       return "";
     });
-    await provisionWorkspace(config, claim, {
+    await provisionWorkspace(config, claim, NO_DEPENDENCIES, {
       execute: fake,
       retryOptions: { wait: async () => undefined },
     });
@@ -778,11 +791,11 @@ test("a run-as workspace is provisioned by the launched account and cannot be en
     } as unknown as RunnerConfig;
     const claim = workspaceClaim({
       task: { id: "task-prefix" },
-      repo: { remoteUrl: remote, defaultBranch: "main", dependencyProvisioning: "NONE" },
+      repo: { remoteUrl: remote, defaultBranch: "main" },
       run: { id: "run-prefix", runNumber: 1, targetBranch: "main", branch: "main" },
     });
 
-    const workspace = await provisionWorkspace(config, claim);
+    const workspace = await provisionWorkspace(config, claim, NO_DEPENDENCIES);
 
     // Traverse but not list. It cannot be 0700: node chdirs into `cwd` as the
     // daemon's uid before exec, so the CLI's own spawn would fail with EACCES

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -11,6 +11,7 @@ import type { SessionConfigOptions } from "./adapters/session-config.js";
 import { defaultSessionConfigBaselineRoot, type RunnerConfig, type RunnerKind } from "./config.js";
 import { runtimeToolPaths } from "./runtime-tools.js";
 import { materializeWorkspaceDependencies, type DependencyCacheOptions } from "./dependency-cache.js";
+import type { DependencyProvisioningDecision } from "./dependency-provisioning.js";
 import { platformCommitArgs, runCommand, type CommandOptions } from "./exec.js";
 import {
   configureWorkspaceGit, resolveRunnerGitIdentity, type GitProvenanceClaim,
@@ -105,7 +106,7 @@ export type WorkspaceCommandExecutor = (
 
 export type WorkspaceProvisionClaim = GitProvenanceClaim & Pick<ClaimedTask, "specificationMaterialization"> & {
   task: GitProvenanceClaim["task"] & Pick<ClaimedTask["task"], "id">;
-  repo: Pick<ClaimedTask["repo"], "remoteUrl" | "defaultBranch" | "dependencyProvisioning">;
+  repo: Pick<ClaimedTask["repo"], "remoteUrl" | "defaultBranch">;
   run: GitProvenanceClaim["run"] & Pick<
     ClaimedTask["run"],
     | "runNumber"
@@ -444,6 +445,7 @@ export const provisionSessionConfig = async (
 export const provisionWorkspace = async (
   config: RunnerConfig,
   claim: WorkspaceProvisionClaim,
+  provisioning: DependencyProvisioningDecision,
   dependencies: ProvisionWorkspaceDependencies = {},
 ): Promise<Workspace> => {
   const execute = dependencies.execute ?? command;
@@ -590,18 +592,10 @@ export const provisionWorkspace = async (
       execute,
       env,
     );
-    // A canonical review step explicitly opts out of dependencies. Every
-    // other admitted path, including a null template step, remains governed
-    // by the repository policy supplied by the control plane.
-    if (claim.task.templateStep?.provisionDependencies !== false) {
-      await materializeWorkspaceDependencies(
-        config,
-        workspace,
-        claim.repo.dependencyProvisioning,
-        env,
-        { execute },
-        dependencyCacheOptions,
-      );
+    // The decision was made when the claim was admitted; provisioning does not
+    // re-read the template step or the repository policy.
+    if (provisioning.provision) {
+      await materializeWorkspaceDependencies(config, workspace, env, { execute }, dependencyCacheOptions);
     }
     return materialized;
   } catch (error: unknown) {


### PR DESCRIPTION
## What changed

One question — does this Run install dependencies, and what does a provisioning
failure mean — was answered in four places with four representations:
`runner.ts` validated the claim shape twice, `provisionWorkspace` re-read
`claim.task.templateStep?.provisionDependencies` as a gate,
`materializeWorkspaceDependencies` re-read `dependencyProvisioning === "NONE"`
as a short-circuit, and the runner's failure path reached back into the
dependency cache's error taxonomy (`instanceof
DependencyProvisioningManifestMissingError`).

`packages/runner/src/dependency-provisioning.ts` is now the module that answers
it, once, when the claim is admitted:

- `decideDependencyProvisioning(claim)` returns either a refusal (one of the
  two protocol conditions, unchanged in wording) or the decision. The two
  claim-shape validations in `runner.ts` are deleted in favour of it.
- `provisionWorkspace` takes the decision as an argument and gates the
  materializer on it. `WorkspaceProvisionClaim["repo"]` no longer carries
  `dependencyProvisioning`, so provisioning cannot re-derive the answer.
- `materializeWorkspaceDependencies` installs under the NPM_CI policy and
  nothing else: the policy parameter, the `NONE` short-circuit and the
  `not-applicable` result status are gone.
- `classifyDependencyProvisioningFailure(error)` carries the failure class a
  provisioning failure means, and returns `null` when the adapter's own
  classification applies. `runner.ts` no longer imports anything from
  `dependency-cache.ts`; the value it produces is one input to the failure
  envelope a1 landed.

Leverage: a caller states the decision it was given instead of re-deriving it
from two claim fields. Locality: the next change to the provisioning question
edits one module, not four sites across three files plus their tests.

## Evidence

Run in the worktree after the final commit (`06d890dc`, which merges
`origin/main` at `aac993cb`), with `export RUNNER_WORKSPACE_ROOT=$(mktemp -d)`
first:

- `npm run lint` — exit 0. `Checked 729 files in 4s. No fixes applied.`, eslint
  silent.
- `npm run typecheck` — exit 0, all workspaces.
- `npm run test -w @anneal/runner` — exit 0. `tests 504 / pass 502 / fail 0 /
  skipped 2` (the two skips are the pre-existing root-only run-as cases).

Merge gate: `MERGE GATE: PASS 06d890dc5f4d785e8a9c70510606113ebd0861b9`.

Not run: `test:db`. `packages/api/src/chain-branch.dbtest.ts` changed (it
imports `provisionWorkspace` dynamically and its signature moved); it is
typechecked here and is merge gate evidence.

New tests:

- `dependency-provisioning.test.ts` — a 13-row table over the template-step
  flag by the repository policy, covering both refusals, the precedence of a
  malformed step over a malformed policy, the precedence of the step's opt-out
  over the policy for the skip evidence, and provisioning under a null step;
  plus the manifest-missing classification and the null it returns for every
  other error.
- `runner.test.ts` keeps one end-to-end proof per refusal — that it reaches the
  control plane before any workspace, npm invocation, adapter preflight or
  provider launch — and its two fixture mutators become table rows above. Four
  heavyweight tests become two.
- Fixtures that only carried `dependencyProvisioning` to satisfy the
  provisioning path lose it: `workspace.test.ts` (8), `repo-mirror.test.ts`,
  `dependency-cache.test.ts` (2). The `NONE` test in `dependency-cache.test.ts`
  is deleted with the code path it covered; `workspace.test.ts`'s review-step
  test is what now proves a skipped decision touches neither npm nor the cache.

## Decisions taken

**The brief expected six test files to lose the `dependencyProvisioning`
fixture literal; only three can.** `adapters.test.ts`, `git-provenance.test.ts`,
`provision-failure.test.ts`, `run-output.test.ts` and `runner.test.ts` annotate
their fixtures as `ClaimedTask`, and `ClaimRepo.dependencyProvisioning` is a
required field of the claim wire contract in `packages/db/src/claim-contract.ts`
— the control plane really does send it, and the decision really does read it.
Removing it there would mean weakening the contract, which would be the wrong
change and is outside this fence. The literal disappears exactly where the type
stopped demanding it: the `WorkspaceProvisionClaim`-typed fixtures. Reported
here rather than forced.

**The decision carries no policy field.** `DependencyProvisioning` has two
members and one of them means "do not provision", so a `provision: true`
decision is NPM_CI and nothing else; `materializeWorkspaceDependencies` reads
no policy. Adding a policy field no caller reads would recreate the unread
positional argument this candidate exists to remove.

**A NONE-policy repository now records durable skip evidence.** The decision's
false branch carries the evidence line, and `runner.ts` writes it for either
reason. Previously only the template-step opt-out produced a session note,
while a NONE repository produced a progress event that goes nowhere durable.
Emitting one line for one decision is the shape; the template-step opt-out is
checked first, so the existing message and its assertion are unchanged.

## Fence widened

- `packages/api/src/chain-branch.dbtest.ts` — it dynamically imports
  `provisionWorkspace` under a locally declared signature, which had to gain
  the decision argument. `QUEUE.md` assigns this file to no lane.

## Reported but unfixed

- **The fallback gate worker `agentos-gate` has no `jq`.** The first dispatch of
  this branch landed there and failed two pre-existing tests in
  `dependency-cache.test.ts` (`dependency-cache audit payloads retain stable
  event names and fields`, `locked byte-budget enforcement deletes multiple
  oldest entries and preserves exact-budget state`). Both build a tally with
  `execFileSync("/bin/sh", ["-c", "jq -r .event | sort | uniq -c"])`; with `jq`
  absent the pipeline still exits 0 and returns an empty string, so the
  assertion fails on the tally rather than on the missing tool. Nothing in this
  change touches those assertions, and the same head passed on
  `ci-desktop-worker`, which has `jq`. Two follow-ups, neither in this fence:
  install `jq` on the fallback worker, and make the tally fail loudly when its
  tool is absent (`dependency-cache.test.ts` is r2's file).
- `packages/runner/src/dependency-cache.ts` still threads `(config, ..., env,
  execute)` positionally through nine internal functions and hard-imports fs,
  `Date.now()` and `flock`. That is candidates R2 and R3, not this lane.
- `DependencyCacheResult.condition` is now only ever set alongside `status:
  "installed"` for a cache-input miss. Narrowing that type to a union is inside
  r2's fence (`dependency-cache.ts` proper), so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkdrWeWXGQBmzbBHccx8ef
