### PR TITLE
refactor(web): state run liveness once for every card that reads a run

### DIFF
--- a/apps/web/src/components/chain-aggregate-card.tsx
+++ b/apps/web/src/components/chain-aggregate-card.tsx
@@ -108,13 +108,13 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
         {holdPill ?? (state === "running" ? null : <Pill tone={STATE_TONE[state]}>{t(`tasks.aggregate.state.${state}`)}</Pill>)}
       </span>,
       ...(aggregate.frontier.latestRun === null ? [] : [
-        <RunLine run={aggregate.frontier.latestRun} mergeOutcome={aggregate.frontier.mergeOutcome} showElapsed showModel />,
+        <RunLine run={aggregate.frontier.latestRun} mergeOutcome={aggregate.frontier.mergeOutcome} elapsed="line" showModel />,
       ]),
       ...(activeRepair?.latestRun === null || activeRepair?.latestRun === undefined ? [] : [
         <span data-chain-repair="" className="contents">
           <span>{activeRepair.repairKind}</span>
           <span aria-hidden="true"> · </span>
-          <RunLine run={activeRepair.latestRun} showElapsed showModel />
+          <RunLine run={activeRepair.latestRun} elapsed="line" showModel />
         </span>,
       ]),
       ...(controlAction?.kind === "activate" ? [

--- a/apps/web/src/components/run-line.tsx
+++ b/apps/web/src/components/run-line.tsx
@@ -5,8 +5,8 @@ import { splitModel } from "@anneal/db/model-routing";
 import { duration } from "../lib/format";
 import { useT } from "../lib/i18n";
 import { mergeBadge } from "../lib/merge-outcome";
-import { isActiveRunStatus } from "../lib/board";
-import type { BoardLatestRun, MergeOutcome, RunStatus } from "../lib/types";
+import { type RunLivenessSubject, runLiveness } from "../lib/board";
+import type { CodexServiceTier, MergeOutcome, RunStatus } from "../lib/types";
 import { cn } from "../lib/utils";
 import { Badge } from "./ui/badge";
 
@@ -48,42 +48,50 @@ const dotTone = (status: RunStatus, mergeOutcome?: MergeOutcome | null | undefin
  *  say it twice. The detail page keeps the full identifier. */
 const cardModelName = (model: string): string => model.slice(model.lastIndexOf("/") + 1);
 
+/** Everything the line reads off a run. Both projections satisfy it, so the
+ *  detail page hands over its `Run` and the board its `BoardLatestRun`. */
+export type RunLineSubject = RunLivenessSubject & {
+  runNumber: number;
+  model: string;
+  codexServiceTier: CodexServiceTier;
+};
+
+/** Which element draws the run's elapsed clock. `caller` is the task card,
+ *  whose footer owns a ticking clock of its own. Stated rather than defaulted,
+ *  because the answer is never "nobody": the line drops the RUNNING word on the
+ *  strength of a clock showing somewhere. */
+export type ElapsedOwner = "line" | "caller";
+
 /** The sole board rendering of a Run: number, dot tone, status word, and merge override. */
 export const RunLine = ({
   run,
   mergeOutcome,
-  showElapsed = false,
+  elapsed: elapsedOwner,
   showModel = false,
-  suppressRunningStatus = false,
 }: {
-  run: BoardLatestRun;
+  run: RunLineSubject;
   mergeOutcome?: MergeOutcome | null | undefined;
-  showElapsed?: boolean;
+  elapsed: ElapsedOwner;
   /** Aggregate cards put the claimed model beside the run; task cards retain
    * their dedicated model row and leave this off. */
   showModel?: boolean;
-  /** Task cards render a live RUNNING duration in their footer. */
-  suppressRunningStatus?: boolean;
 }): ReactNode => {
   const t = useT();
+  const liveness = runLiveness(run);
   const presentation = runPresentation(run.status, mergeOutcome);
-  const elapsed = showElapsed && isActiveRunStatus(run.status) && run.startedAt !== null
-    ? duration(run.startedAt, null)
+  const elapsed = elapsedOwner === "line" && liveness.elapsedSince !== null
+    ? duration(liveness.elapsedSince, null)
     : null;
   const model = showModel ? splitModel(run.model) : null;
   const badge = mergeBadge(mergeOutcome);
-  const hideStatus = run.status === "RUNNING"
-    && badge === null
-    && (elapsed !== null || suppressRunningStatus);
+  const hideStatus = liveness.statusSuppressed && badge === null;
   const runDetailParts = [
     ...(model === null ? [] : [
       cardModelName(model.model),
       ...(model.effort === null ? [] : [model.effort]),
       ...(run.codexServiceTier === "FAST" ? ["fast"] : []),
     ]),
-    // The dot already says a run is live, so a RUNNING row spends its width on
-    // the elapsed time rather than on the word. Every other status still names
-    // itself: nothing else on the row distinguishes queued from waiting inbox.
+    // `statusSuppressed` owns why RUNNING is the one word a clock replaces.
     ...(hideStatus ? [] : [t(presentation.key)]),
     ...(elapsed === null ? [] : [elapsed]),
   ];

--- a/apps/web/src/components/task-card.tsx
+++ b/apps/web/src/components/task-card.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, memo, useEffect, useState } from "react";
 
 import { chainPositionMarker } from "../lib/chain";
 import { duration, money, timeAgo, usageCostAmount, usageCostLabel } from "../lib/format";
-import { chainBinding, chainBindingLabel, retryable, scheduleLabel, statusLabel } from "../lib/board";
+import { chainBinding, chainBindingLabel, retryable, runLiveness, scheduleLabel, statusLabel } from "../lib/board";
 import { type Translate, useT } from "../lib/i18n";
 import type { BoardTask, TaskStatus } from "../lib/types";
 import { cn } from "../lib/utils";
@@ -78,7 +78,8 @@ export const cardTime = (task: BoardTask, now = Date.now()): string => {
   if (!run) return timeAgo(task.updatedAt);
   // A live run says so with the run line's amber dot; the footer is left with
   // the one thing the dot cannot say, which is how long it has been running.
-  if (run.status === "RUNNING" && run.startedAt !== null) return duration(run.startedAt, null, now);
+  const { elapsedSince } = runLiveness(run);
+  if (elapsedSince !== null) return duration(elapsedSince, null, now);
   if (run.startedAt !== null && run.endedAt !== null) {
     return `${duration(run.startedAt, run.endedAt)} · ${timeAgo(task.updatedAt)}`;
   }
@@ -121,6 +122,9 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
   const hasScheduleRow = schedule !== null || task.approvalGate || task.source === "CRON" || task.source === "WEBHOOK";
   const model = cardModel(task);
   const modelLine = model === null ? null : cardModelFast(task, model);
+  // The footer owns this card's clock, so the run line never renders one and
+  // never repeats the RUNNING word beside it.
+  const elapsedSince = task.latestRun === null ? null : runLiveness(task.latestRun).elapsedSince;
   const taskCostLabel = usageCostLabel(task.taskCost);
   const hasTokenFallback = task.taskCost !== null && task.taskCost.costUsd === null;
   // The task's own total where there is one, and the newest run's spend where
@@ -173,11 +177,9 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
           <span>{chainPositionMarker(task.chainProgress)}</span>
         </span>,
     ]),
-    ...(task.latestRun === null ? [] : [<RunLine
-      run={task.latestRun}
-      mergeOutcome={task.mergeOutcome}
-      suppressRunningStatus={task.latestRun.status === "RUNNING" && task.latestRun.startedAt !== null}
-    />]),
+    ...(task.latestRun === null ? [] : [
+      <RunLine run={task.latestRun} mergeOutcome={task.mergeOutcome} elapsed="caller" />,
+    ]),
     ...(modelLine === null ? [] : [<span className="min-w-0 [overflow-wrap:anywhere]" aria-label={t("tasks.card.model", { model: modelLine })}>
       {modelLine}
     </span>]),
@@ -199,9 +201,7 @@ const TaskCardBody = ({ task, actions, draggable = false }: CardProps): ReactNod
       <span className="flex-1" />
       <span className="whitespace-nowrap">
         {costAmount === null ? null : `${costAmount} · `}
-        {task.latestRun?.status === "RUNNING" && task.latestRun.startedAt !== null
-          ? <RunningCardTime task={task} />
-          : cardTime(task)}
+        {elapsedSince === null ? cardTime(task) : <RunningCardTime task={task} />}
       </span>
   </>;
   const after = hasTokenFallback ? (

--- a/apps/web/src/lib/board.ts
+++ b/apps/web/src/lib/board.ts
@@ -262,14 +262,54 @@ export const orderColumn = <T extends BoardTask | BoardEntry>(tasks: readonly T[
   ));
 };
 
-/* -------------------------------------------------------------- the actions */
+/* ------------------------------------------------------------- run liveness */
 
-export const ACTIVE_RUN_STATUSES = [
+/** The statuses under which the control plane still owns a Run. The same five
+ *  the server fences on (`packages/api/src/run-fence.ts`), suspended Inbox work
+ *  included; everything else is terminal. */
+const ACTIVE_RUN_STATUSES = [
   "QUEUED", "CLAIMED", "PROVISIONING", "RUNNING", "WAITING_INBOX",
 ] as const satisfies readonly RunStatus[];
 
-export const isActiveRunStatus = (status: RunStatus): boolean =>
+const isActiveRunStatus = (status: RunStatus): boolean =>
   ACTIVE_RUN_STATUSES.includes(status as (typeof ACTIVE_RUN_STATUSES)[number]);
+
+/** The run fields the rule reads. Both projections carry them, so a caller
+ *  hands over whichever it holds: the board's `BoardLatestRun` or the detail
+ *  page's `Run`. */
+export type RunLivenessSubject = { status: RunStatus; startedAt: string | null };
+
+/** Everything a card says about a run's liveness. */
+export type RunLiveness = {
+  /** The control plane still owns this run. Cancellation is offered on it, and
+   *  a retry is not. */
+  live: boolean;
+  /** The instant an elapsed clock counts from, or null where no clock runs. A
+   *  run that has not started has nothing to count from, and a terminal run's
+   *  `startedAt` belongs to a duration that already ended. */
+  elapsedSince: string | null;
+  /** RUNNING is the one status word a clock replaces: the amber dot already
+   *  says the run is live and the elapsed time says more than the word. Every
+   *  other status still names itself, because nothing else on a card
+   *  distinguishes queued from waiting inbox. */
+  statusSuppressed: boolean;
+};
+
+/**
+ * The single answer to "is this run live, and whose clock shows".
+ *
+ * Stated once because the board card, the aggregate card and the detail page
+ * all ask it: a CLAIMED run with a `startedAt` used to take an elapsed clock
+ * from the aggregate card's run line and a `timeAgo` from the task card's
+ * footer, which are two answers to one question about one run.
+ */
+export const runLiveness = (run: RunLivenessSubject): RunLiveness => {
+  const live = isActiveRunStatus(run.status);
+  const elapsedSince = live && run.startedAt !== null ? run.startedAt : null;
+  return { live, elapsedSince, statusSuppressed: run.status === "RUNNING" && elapsedSince !== null };
+};
+
+/* -------------------------------------------------------------- the actions */
 
 /**
  * A retry only lands once the last run is terminal; the API rejects the rest.

--- a/apps/web/src/pages/TaskDetail.tsx
+++ b/apps/web/src/pages/TaskDetail.tsx
@@ -19,7 +19,7 @@ import {
   STAT_PILL, STAT_PILLS, TABLE_NAME, TABLE_SUB, TABLE_TIGHT,
   Card, EmptyState, ErrorNotice, KeyValue, Markdown, MarkdownClamp, Page, Pill, RunPill, TaskPill, Toggle,
 } from "../components/ui";
-import { isActiveRunStatus, retryable } from "../lib/board";
+import { retryable, runLiveness } from "../lib/board";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Select } from "../components/ui/select";
@@ -69,16 +69,12 @@ export const NowBlock = ({ run }: { run: Run }): ReactNode => {
   const [expanded, setExpanded] = useState(false);
   const message = run.session?.latestAgentMessage ?? null;
   const body = message?.body ?? t("taskDetail.now.noMessage");
-  // Task-detail Runs carry cost on their nested Session, while RunLine's
-  // shared board projection keeps it at the top level. The line only needs the
-  // common run fields, so provide the projection's unavailable cost as null.
-  const runLine = { ...run, costUsd: run.session?.costUsd ?? null };
 
   return (
     <div data-task-now="">
       <Card title={t("taskDetail.now.title")}>
         <div className="grid gap-[12px]">
-          <RunLine run={runLine} mergeOutcome={run.mergeOutcome} showElapsed showModel />
+          <RunLine run={run} mergeOutcome={run.mergeOutcome} elapsed="line" showModel />
           <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-[10px]">
             {message === null ? (
               <span className="min-w-0 [overflow-wrap:anywhere] text-secondary-foreground">{body}</span>
@@ -407,7 +403,7 @@ const TaskDetailResource = ({ taskId }: { taskId: string }): ReactNode => {
   // `app.ts` orders runs `runNumber desc`, so the newest run is the head.
   const newest = runs[0];
   const newestIsActive = task.executionOwner === "agent" && newest !== undefined
-    && isActiveRunStatus(newest.status);
+    && runLiveness(newest).live;
   const newestIsCancelling = newestIsActive && newest.cancelRequestedAt !== null && newest.cancelAcknowledgedAt === null;
   const newestBranch = newest?.branch ?? newest?.targetBranch ?? null;
   const newestBranchUrl = branchUrl(task.repo?.remoteUrl, newestBranch);

--- a/apps/web/src/tests/board.test.tsx
+++ b/apps/web/src/tests/board.test.tsx
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  ACTIVE_RUN_STATUSES, chainBinding, chainBindingLabel, chainParked, clampScroll, columnStep, countByStatus, defaultTab, edgeState,
-  focusAfterMove, isActiveRunStatus, orderColumn, parseStatus, retryable, sameEdges, scheduleLabel, storedScroll,
+  chainBinding, chainBindingLabel, chainParked, clampScroll, columnStep, countByStatus, defaultTab, edgeState,
+  focusAfterMove, orderColumn, parseStatus, retryable, runLiveness, sameEdges, scheduleLabel, storedScroll,
 } from "../lib/board";
-import type { BoardTask, ChainProgress } from "../lib/types";
+import type { BoardTask, ChainProgress, RunStatus } from "../lib/types";
 
 const task = (overrides: Partial<BoardTask> = {}): BoardTask => ({
   id: "t1", name: "Ship the thing", displayName: overrides.name ?? "Ship the thing", status: "TODO", moveTargets: [], failureReason: null,
@@ -172,11 +172,38 @@ test("a retry waits for the last run to be terminal", () => {
   assert.equal(retryable(task({ status: "REVIEW" }), { status: "SUCCEEDED" }), true);
 });
 
-test("the active Run statuses include suspended Inbox work and exclude every terminal status", () => {
-  assert.deepEqual(ACTIVE_RUN_STATUSES, ["QUEUED", "CLAIMED", "PROVISIONING", "RUNNING", "WAITING_INBOX"]);
-  for (const status of ACTIVE_RUN_STATUSES) assert.equal(isActiveRunStatus(status), true, status);
-  for (const status of ["SUCCEEDED", "FAILED", "TIMED_OUT", "CANCELLED", "LOST"] as const) {
-    assert.equal(isActiveRunStatus(status), false, status);
+/* ------------------------------------------------------------- run liveness */
+
+const STARTED = "2026-08-16T00:00:00.000Z";
+
+test("one liveness rule answers the clock, the live state and the suppressed status word", () => {
+  // Every Run status, started and not, with the answer stated rather than
+  // recomputed. Suspended Inbox work is live; every terminal status is not, and
+  // a terminal run's `startedAt` belongs to a duration that already ended.
+  const rows: Array<{
+    status: RunStatus; startedAt: string | null;
+    live: boolean; elapsedSince: string | null; statusSuppressed: boolean;
+  }> = [
+    { status: "QUEUED", startedAt: null, live: true, elapsedSince: null, statusSuppressed: false },
+    { status: "QUEUED", startedAt: STARTED, live: true, elapsedSince: STARTED, statusSuppressed: false },
+    { status: "CLAIMED", startedAt: null, live: true, elapsedSince: null, statusSuppressed: false },
+    // The divergence this rule exists to close: a CLAIMED run with a start took
+    // an elapsed clock from one card and a `timeAgo` from another.
+    { status: "CLAIMED", startedAt: STARTED, live: true, elapsedSince: STARTED, statusSuppressed: false },
+    { status: "PROVISIONING", startedAt: null, live: true, elapsedSince: null, statusSuppressed: false },
+    { status: "PROVISIONING", startedAt: STARTED, live: true, elapsedSince: STARTED, statusSuppressed: false },
+    { status: "RUNNING", startedAt: null, live: true, elapsedSince: null, statusSuppressed: false },
+    { status: "RUNNING", startedAt: STARTED, live: true, elapsedSince: STARTED, statusSuppressed: true },
+    { status: "WAITING_INBOX", startedAt: null, live: true, elapsedSince: null, statusSuppressed: false },
+    { status: "WAITING_INBOX", startedAt: STARTED, live: true, elapsedSince: STARTED, statusSuppressed: false },
+    { status: "SUCCEEDED", startedAt: STARTED, live: false, elapsedSince: null, statusSuppressed: false },
+    { status: "FAILED", startedAt: STARTED, live: false, elapsedSince: null, statusSuppressed: false },
+    { status: "TIMED_OUT", startedAt: STARTED, live: false, elapsedSince: null, statusSuppressed: false },
+    { status: "CANCELLED", startedAt: STARTED, live: false, elapsedSince: null, statusSuppressed: false },
+    { status: "LOST", startedAt: STARTED, live: false, elapsedSince: null, statusSuppressed: false },
+  ];
+  for (const { status, startedAt, ...expected } of rows) {
+    assert.deepEqual(runLiveness({ status, startedAt }), expected, `${status} startedAt=${startedAt}`);
   }
 });
 

--- a/apps/web/src/tests/run-line.test.tsx
+++ b/apps/web/src/tests/run-line.test.tsx
@@ -26,7 +26,7 @@ test("the aggregate run line renders its full details without an ellipsis or a n
     <LocaleProvider initialLocale="en">
       <RunLine
         run={run({ model: "claude-opus-5-with-a-very-long-identifier:high", status: "WAITING_INBOX" })}
-        showElapsed
+        elapsed="line"
         showModel
       />
     </LocaleProvider>,
@@ -69,7 +69,7 @@ test("an active run reads as a duration alone, and the model drops its provider 
   // model name does not: both were the same fact printed twice.
   const line = parse(renderToStaticMarkup(
     <LocaleProvider initialLocale="en">
-      <RunLine run={run({ model: "openai-codex/gpt-5.6-luna:max" })} showElapsed showModel />
+      <RunLine run={run({ model: "openai-codex/gpt-5.6-luna:max" })} elapsed="line" showModel />
     </LocaleProvider>,
   ));
   const text = visibleText(line);
@@ -80,15 +80,25 @@ test("an active run reads as a duration alone, and the model drops its provider 
 
 test("a task-card run line keeps its text and gains no ellipsis", () => {
   const line = parse(renderToStaticMarkup(
-    <LocaleProvider initialLocale="en"><RunLine run={run({ status: "SUCCEEDED" })} /></LocaleProvider>,
+    <LocaleProvider initialLocale="en"><RunLine run={run({ status: "SUCCEEDED" })} elapsed="caller" /></LocaleProvider>,
   ));
   assert.equal(visibleText(line), "run 7 · succeeded");
   assert.doesNotMatch(line.innerHTML, /text-ellipsis/u);
 });
 
+test("a caller-owned clock leaves the line with neither the duration nor the word", () => {
+  // The task card's footer counts this run up; the line would otherwise print
+  // the same fact twice, once as a word and once as a second clock.
+  const line = parse(renderToStaticMarkup(
+    <LocaleProvider initialLocale="en"><RunLine run={run()} elapsed="caller" /></LocaleProvider>,
+  ));
+  assert.equal(visibleText(line), "run 7");
+  assert.doesNotMatch(visibleText(line), /running|\d+m/u);
+});
+
 test("the zh run line wraps under the same rules", () => {
   const line = parse(renderToStaticMarkup(
-    <LocaleProvider initialLocale="zh"><RunLine run={run()} showElapsed showModel /></LocaleProvider>,
+    <LocaleProvider initialLocale="zh"><RunLine run={run()} elapsed="line" showModel /></LocaleProvider>,
   ));
   assert.match(visibleText(line), /claude-opus-5 · high/u);
   const details = line.querySelector("[data-run-line-details]");

--- a/apps/web/src/tests/task-detail.test.tsx
+++ b/apps/web/src/tests/task-detail.test.tsx
@@ -25,7 +25,7 @@ test("the Runs section is rendered before the Chain section", () => {
 });
 
 test("active Runs expose cancellation and an outstanding intent renders Cancelling", () => {
-  assert.match(source, /isActiveRunStatus\(newest\.status\)/u);
+  assert.match(source, /runLiveness\(newest\)\.live/u);
   assert.match(source, /newest\.cancelRequestedAt !== null/u);
   assert.match(source, /newest\.cancelAcknowledgedAt === null/u);
   assert.match(source, /taskDetail\.cancel\.cancelling/u);

--- a/apps/web/src/tests/tasks-board.test.tsx
+++ b/apps/web/src/tests/tasks-board.test.tsx
@@ -442,6 +442,10 @@ test("running, ended, and absent runs render only durations their timestamps pro
   Date.now = () => new Date("2026-08-16T00:12:00.000Z").getTime();
   try {
     assert.equal(cardTime(task({ latestRun: { id: "r1", runNumber: 1, status: "RUNNING", model: "claude-opus-5:medium", codexServiceTier: "DEFAULT", costUsd: null, startedAt: "2026-08-16T00:00:00.000Z", endedAt: null, pullRequestUrl: null } })), "12m 0s");
+    // Every live status the run line already gives an elapsed clock to gets the
+    // same clock here: the footer used to answer `timeAgo` for a CLAIMED run
+    // that the aggregate card was counting up.
+    assert.equal(cardTime(task({ updatedAt: "2026-08-15T21:12:00.000Z", latestRun: { id: "r1", runNumber: 1, status: "CLAIMED", model: "claude-opus-5:medium", codexServiceTier: "DEFAULT", costUsd: null, startedAt: "2026-08-16T00:00:00.000Z", endedAt: null, pullRequestUrl: null } })), "12m 0s");
     assert.equal(cardTime(task({ updatedAt: "2026-08-15T21:12:00.000Z", latestRun: { id: "r1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5:medium", codexServiceTier: "DEFAULT", costUsd: null, startedAt: "2026-08-16T00:00:00.000Z", endedAt: "2026-08-16T00:08:00.000Z", pullRequestUrl: null } })), "8m 0s · 3h ago");
     assert.equal(cardTime(task({ updatedAt: "2026-08-15T21:12:00.000Z" })), "3h ago");
     assert.equal(cardTime(task({ updatedAt: "2026-08-15T21:12:00.000Z", latestRun: { id: "r1", runNumber: 1, status: "SUCCEEDED", model: "claude-opus-5:medium", codexServiceTier: "DEFAULT", costUsd: null, startedAt: null, endedAt: null, pullRequestUrl: null } })), "3h ago");


### PR DESCRIPTION
Lane b3 of Anneal deepening program 16 (2026-09-02). Findings: `FINDINGS-B-board-contract.md`, Candidate B3.

## What changed

One module now answers "is this run live, and whose clock shows".

`runLiveness` in `apps/web/src/lib/board.ts` takes the run fields both projections carry — `status` and `startedAt`, which is all `RunLivenessSubject` asks for — and returns the three facts a card needs: whether the control plane still owns the run, the instant an elapsed clock counts from, and whether the RUNNING word is one a clock replaces. Its interface is those three facts; `ACTIVE_RUN_STATUSES` and `isActiveRunStatus` became private to the module, so there is exactly one exported way to ask.

Before this, the rule was stated four times and two of the statements disagreed. `run-line.tsx` read `isActiveRunStatus(run.status) && run.startedAt !== null` (five statuses); `task-card.tsx` read `run.status === "RUNNING" && run.startedAt !== null` three times over. A CLAIMED run carrying a `startedAt` therefore took an elapsed clock from the aggregate card's run line and a `timeAgo` from the task card's footer — two answers to one question about one run. The five-status definition wins, for the reason the brief gives: it is the server's own `activeRunStatuses` fence (`packages/api/src/run-fence.ts`), and it degrades correctly on its own — a run with no `startedAt` has nothing to count from, so QUEUED, CLAIMED and PROVISIONING normally yield no clock without the rule having to name them.

`RunLine` now declares `RunLineSubject`, which is exactly what the line reads. Both projections satisfy it structurally, so `TaskDetail.tsx`'s inline adapter (`{ ...run, costUsd: run.session?.costUsd ?? null }`) is gone: it existed only to satisfy `BoardLatestRun`, and the line never read `costUsd` at all.

`RunLine`'s `showElapsed` / `suppressRunningStatus` pair collapsed into one required `elapsed: "line" | "caller"`, naming the element that draws the clock. That removes an illegal combination from the interface and, more to the point, removes the last caller-side restatement of the rule: `task-card.tsx` used to compute `suppressRunningStatus={status === "RUNNING" && startedAt !== null}` and now passes `elapsed="caller"` unconditionally.

## Evidence

Head `a578086af1318aac6f9529fc12d812d904759df9`, which is the merge of `origin/main` `aac993cb` into the lane commit `455af6d7`.

- `npm run lint` (root, after the final commit): `Checked 733 files in 13s. No fixes applied.`, then `eslint .` clean. Exit 0.
- `npm run typecheck` (root): every workspace, exit 0.
- `npm run test -w @anneal/web`: `tests 611 / pass 607 / fail 0 / skipped 4`. The 4 skips predate this branch.
- `test:db` not run: no local PostgreSQL, and this change touches no database code.
- No `docs/` file and no HTTP route changed, so `test:snapshot-scan` and `docs/operator-api.md` do not apply.

Anchors re-verified on the base before editing: `run-line.tsx` had moved to `:70` and `:75-77`, `task-card.tsx` to `:81`, `:179`, `:202`, `TaskDetail.tsx` to `:72-75` and `:410`, `board.ts` to `:267-272`. All still present as the findings describe.

New and changed coverage:

- `apps/web/src/tests/board.test.tsx`: one table test over all ten Run statuses, started and not, with the expected `{live, elapsedSince, statusSuppressed}` triple stated rather than recomputed. It subsumes the retired `ACTIVE_RUN_STATUSES` deepEqual test, which pinned the same five statuses through a now-private symbol, and pins the CLAIMED-with-a-start row the finding is about.
- `apps/web/src/tests/tasks-board.test.tsx`: one row added to the `cardTime` table for a CLAIMED run with a start, which used to answer `timeAgo` while the aggregate card counted the same run up.
- `apps/web/src/tests/run-line.test.tsx`: one test for `elapsed="caller"` — the line renders neither the duration nor the word, because the task card's footer owns that clock.
- `apps/web/src/tests/task-detail.test.tsx`: the source assertion pinning cancellation to the liveness rule follows the rename.

## Decisions taken

**The brief's instruction to shrink existing run-row assertions to presence is not delivered, and I recommend against it.** The brief asks for `task-detail-navigation.test.tsx`, `tasks-board.test.tsx` and `chain-aggregate-board.test.tsx` to drop their run-row label assertions on the grounds that the new table covers the label logic. On the evidence, it does not: those assertions cover composition the table cannot reach — model splitting and the `openai-codex/` prefix drop, the FAST marker appearing exactly once, the merge-outcome badge overriding the status word, and both locales rendering the same suppression. None of them broke under this change, because the change is behaviour-preserving everywhere except the CLAIMED case. Deleting green, non-duplicative assertions would have cost coverage for nothing, so I kept them and added the table alongside.

**`ACTIVE_RUN_STATUSES` and `isActiveRunStatus` are now private.** Leaving a second exported liveness predicate beside `runLiveness` is what let the two statements diverge in the first place. The set is still pinned, through `runLiveness` over all ten statuses.

**`elapsed` is required, with no `"none"`.** Every call site either draws the clock or delegates it to a footer that does; a third state would have been generality for a caller that does not exist.

## Fence widened

- `apps/web/src/components/chain-aggregate-card.tsx` (lane b2, `merged`): two `showElapsed` props follow the rename to `elapsed="line"`. Required by making the prop required.
- `apps/web/src/tests/tasks-board.test.tsx` (lane b2, `merged`): one added `cardTime` row.
- `apps/web/src/tests/board.test.tsx`, `apps/web/src/tests/run-line.test.tsx`, `apps/web/src/tests/task-detail.test.tsx` (no lane): tests whose assertions this change necessarily breaks, which `00-COMMON.md` places inside the fence.

`apps/web/src/tests/chain-aggregate-board.test.tsx` was left untouched: nothing in it broke and nothing in it needed adding.

## Reported but unfixed

- `apps/web/src/lib/board.ts` keeps a second copy of the five active Run statuses; `packages/db` exports the same list, which `packages/api` imports as `ACTIVE_RUN_STATUSES`. The web copy could read the shared one instead, which would make the two provably identical rather than identical by comment. That needs `packages/db/package.json`'s export map, which belongs to lane b1, so it stays out of this change.
- `apps/web/src/components/task-card.tsx:96`: `RunningCardTime`'s effect depends on `task.latestRun?.startedAt` alone, so a run whose status leaves the live set without its `startedAt` changing keeps its interval alive until the card re-renders for another reason. Out of this lane's scope; the interval is harmless but pointless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R81rg1s5ydQJPFYNHbifow
