### PR TITLE
refactor(db): make the canonical sync report a returned value

### DIFF
--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -18,6 +18,15 @@ import {
   SPEC_REVALIDATOR_AGENT_NAME,
 } from "../src/canonical-step-adoption.js";
 import {
+  canonicalSyncSummary,
+  canonicalSyncSummaryLine,
+  emptyCanonicalSyncCounters,
+  recordRolePromptUpdate,
+  recordStepPromptUpdate,
+  type CanonicalSyncCounters,
+  type CanonicalSyncProjectOutcome,
+} from "../src/canonical-sync-report.js";
+import {
   applyCanonicalInstallation,
   planCanonicalInstallation,
   type CanonicalInstallationAction,
@@ -39,134 +48,13 @@ const runtimeConfigRefusal = (agent: { model: string; runnerPreference: RunnerPr
   return `Model ${agent.model} requires ${expected}, but this Agent stores ${agent.runnerPreference}`;
 };
 
-type PreservedTaskAssignments = { archived: number; nonTodo: number; started: number; output: number };
-type ProjectCounters = {
-  templates: number;
-  createdCanonicalTemplates: number;
-  createdAgents: number;
-  createdAgentRepoGrants: number;
-  adoptedAssignees: number;
-  adoptedStepBases: number;
-  adoptedPriorOutputDeclarations: number;
-  adoptedDependencyProvisioning: number;
-  renamedSteps: number;
-  migratedTasks: number;
-  adoptedAgentDefaults: number;
-  runtimeDriftNotices: number;
-  updated: number;
-  preservedTaskAssignments: PreservedTaskAssignments;
-  updatedSteps: Record<string, Record<number, number>>;
-  updatedRoles: Record<string, number>;
-};
-
 type ProjectRow = { id: string; slug: string };
-
-const mutationCounterNames = [
-  "createdCanonicalTemplates",
-  "createdAgents",
-  "createdAgentRepoGrants",
-  "adoptedAssignees",
-  "adoptedStepBases",
-  "adoptedPriorOutputDeclarations",
-  "adoptedDependencyProvisioning",
-  "renamedSteps",
-  "migratedTasks",
-  "adoptedAgentDefaults",
-  "runtimeDriftNotices",
-] as const;
 
 const sortedProjectRows = (rows: readonly ProjectRow[]): ProjectRow[] => [...rows].sort((left, right) => (
   left.slug < right.slug ? -1 : left.slug > right.slug ? 1 : 0
 ));
 
-const emptyProjectCounters = (
-  templateSources: ReadonlyMap<CanonicalTemplateName, readonly TemplateStepSource[]>,
-  roleNames: readonly string[],
-): ProjectCounters => ({
-  templates: 0,
-  createdCanonicalTemplates: 0,
-  createdAgents: 0,
-  createdAgentRepoGrants: 0,
-  adoptedAssignees: 0,
-  adoptedStepBases: 0,
-  adoptedPriorOutputDeclarations: 0,
-  adoptedDependencyProvisioning: 0,
-  renamedSteps: 0,
-  migratedTasks: 0,
-  adoptedAgentDefaults: 0,
-  runtimeDriftNotices: 0,
-  updated: 0,
-  preservedTaskAssignments: { archived: 0, nonTodo: 0, started: 0, output: 0 },
-  updatedSteps: Object.fromEntries([...templateSources].map(([name, steps]) => [
-    name,
-    Object.fromEntries(steps.map((step) => [step.stepIndex, 0])),
-  ])),
-  updatedRoles: Object.fromEntries(roleNames.map((name) => [name, 0])),
-});
-
-const finalizeUpdated = (counters: ProjectCounters): void => {
-  const scalar = mutationCounterNames.reduce((sum, name) => sum + counters[name], 0);
-  const steps = Object.values(counters.updatedSteps)
-    .flatMap((byStep) => Object.values(byStep))
-    .reduce((sum, count) => sum + count, 0);
-  const roles = Object.values(counters.updatedRoles).reduce((sum, count) => sum + count, 0);
-  counters.updated = scalar + steps + roles;
-};
-
 const projectError = (project: ProjectRow, message: string): Error => new Error(`Project ${project.slug}: ${message}`);
-
-const increment = <K extends keyof ProjectCounters>(
-  countersByProject: Map<string, ProjectCounters>,
-  projectId: string,
-  field: K,
-  amount = 1,
-): void => {
-  const counters = countersByProject.get(projectId);
-  if (!counters) throw new Error(`Project ${projectId} was not found`);
-  const value = counters[field];
-  if (typeof value !== "number") throw new Error(`Project ${projectId} counter ${String(field)} is not scalar`);
-  (counters[field] as number) = value + amount;
-};
-
-const addPreserved = (
-  countersByProject: Map<string, ProjectCounters>,
-  projectId: string,
-  field: keyof PreservedTaskAssignments,
-): void => {
-  const counters = countersByProject.get(projectId);
-  if (!counters) throw new Error(`Project ${projectId} was not found`);
-  counters.preservedTaskAssignments[field] += 1;
-};
-
-const addStepUpdate = (
-  countersByProject: Map<string, ProjectCounters>,
-  projectId: string,
-  templateName: string,
-  stepIndex: number,
-  amount: number,
-): void => {
-  const counters = countersByProject.get(projectId);
-  if (!counters) throw new Error(`Project ${projectId} was not found`);
-  const byStep = counters.updatedSteps[templateName];
-  if (!byStep || byStep[stepIndex] === undefined) {
-    throw new Error(`Project ${projectId} has no counter for ${templateName} step ${stepIndex}`);
-  }
-  byStep[stepIndex] += amount;
-};
-
-const addRoleUpdate = (
-  countersByProject: Map<string, ProjectCounters>,
-  projectId: string,
-  roleName: string,
-  amount: number,
-): void => {
-  const counters = countersByProject.get(projectId);
-  if (!counters) throw new Error(`Project ${projectId} was not found`);
-  if (counters.updatedRoles[roleName] === undefined) {
-    throw new Error(`Project ${projectId} has no counter for Agent ${roleName}`);
-  }
-  counters.updatedRoles[roleName] += amount;
-};
 
 const transitionStepInclude = {
   assigneeAgent: { select: { name: true } },
@@ -304,7 +192,7 @@ const migrateSpecialCanonicalAgents = async (
   canonicalProject: ProjectRow,
   sources: AgentSources,
   rolesByName: ReadonlyMap<string, RoleSource>,
-  countersByProject: Map<string, ProjectCounters>,
+  counters: CanonicalSyncCounters,
 ): Promise<void> => {
   const regressionRole = rolesByName.get(REGRESSION_VERIFIER_AGENT_NAME);
   if (!regressionRole) throw projectError(canonicalProject, `Canonical role ${REGRESSION_VERIFIER_AGENT_NAME} was not found`);
@@ -316,8 +204,8 @@ const migrateSpecialCanonicalAgents = async (
     REGRESSION_AGENT_SOURCE,
     null,
   );
-  if (regression.created) increment(countersByProject, canonicalProject.id, "createdAgents");
-  if (regression.grants > 0) increment(countersByProject, canonicalProject.id, "createdAgentRepoGrants", regression.grants);
+  if (regression.created) counters.createdAgents += 1;
+  if (regression.grants > 0) counters.createdAgentRepoGrants += regression.grants;
 
   const revalidatorRole = rolesByName.get(SPEC_REVALIDATOR_AGENT_NAME);
   if (!revalidatorRole) throw projectError(canonicalProject, `Canonical role ${SPEC_REVALIDATOR_AGENT_NAME} was not found`);
@@ -329,8 +217,8 @@ const migrateSpecialCanonicalAgents = async (
     SPEC_REVALIDATOR_AGENT_SOURCE,
     RepoPermission.GIT_READ,
   );
-  if (revalidator.created) increment(countersByProject, canonicalProject.id, "createdAgents");
-  if (revalidator.grants > 0) increment(countersByProject, canonicalProject.id, "createdAgentRepoGrants", revalidator.grants);
+  if (revalidator.created) counters.createdAgents += 1;
+  if (revalidator.grants > 0) counters.createdAgentRepoGrants += revalidator.grants;
 };
 
 const installMissingAgents = async (
@@ -339,7 +227,7 @@ const installMissingAgents = async (
   sources: AgentSources,
   rolesByName: ReadonlyMap<string, RoleSource>,
   roleNames: readonly string[],
-  countersByProject: Map<string, ProjectCounters>,
+  counters: CanonicalSyncCounters,
 ): Promise<void> => {
   const existing = await tx.agent.findMany({
     where: { projectId: target.id, archivedAt: null, name: { in: [...roleNames] } },
@@ -368,7 +256,7 @@ const installMissingAgents = async (
       archivedAt: null,
     } });
     createdNames.add(name);
-    increment(countersByProject, target.id, "createdAgents");
+    counters.createdAgents += 1;
   }
 
   if (createdNames.size === 0) return;
@@ -402,7 +290,7 @@ const synchronizeAgents = async (
   sources: AgentSources,
   rolesByName: ReadonlyMap<string, RoleSource>,
   roleNames: readonly string[],
-  countersByProject: Map<string, ProjectCounters>,
+  counters: CanonicalSyncCounters,
   runtimeConfigAdoptions: Array<{
     name: string;
     from: { model: string; runnerPreference: RunnerPreference };
@@ -467,7 +355,7 @@ const synchronizeAgents = async (
       if (adopted.count !== 1) {
         throw projectError(project, `Agent ${agent.name} (${agent.id}) changed while its canonical runtime configuration was being adopted`);
       }
-      increment(countersByProject, project.id, "adoptedAgentDefaults");
+      counters.adoptedAgentDefaults += 1;
       runtimeConfigAdoptions.push({
         name: agent.name,
         from: { model: agent.model, runnerPreference: agent.runnerPreference },
@@ -511,7 +399,7 @@ const synchronizeAgents = async (
           ].join("\n"),
           ...(thread ? { threadId: thread.id } : {}),
         } });
-        increment(countersByProject, project.id, "runtimeDriftNotices");
+        counters.runtimeDriftNotices += 1;
       }
     } else if (!adoptsCanonicalDefaults && agent.runtimeConfigDriftNoticeFingerprint !== null) {
       await tx.agent.updateMany({
@@ -537,7 +425,7 @@ const synchronizeAgents = async (
       },
       data: { foundationalPrompt: sources.foundationalPrompt, rolePrompt: role.rolePrompt },
     });
-    if (promptUpdate.count > 0) addRoleUpdate(countersByProject, project.id, role.name, promptUpdate.count);
+    if (promptUpdate.count > 0) recordRolePromptUpdate(counters, role.name, promptUpdate.count);
   }
 };
 
@@ -547,7 +435,7 @@ const syncCanonicalTemplates = async (
   tx: Prisma.TransactionClient,
   project: ProjectRow,
   templateSources: ReadonlyMap<CanonicalTemplateName, readonly TemplateStepSource[]>,
-  countersByProject: Map<string, ProjectCounters>,
+  counters: CanonicalSyncCounters,
 ): Promise<RegressionStep[]> => {
   const regressionSteps: RegressionStep[] = [];
   for (const [templateName, steps] of templateSources) {
@@ -556,7 +444,7 @@ const syncCanonicalTemplates = async (
       select: { id: true, projectId: true },
     });
     for (const template of templates) {
-      increment(countersByProject, project.id, "templates");
+      counters.templates += 1;
       const persistedSteps = await tx.taskTemplateStep.findMany({
         where: { taskTemplateId: template.id },
         select: {
@@ -628,7 +516,7 @@ const syncCanonicalTemplates = async (
           } else {
             await tx.taskTemplateStep.update({ where: { id: persisted.id }, data: adoption.write.data });
           }
-          increment(countersByProject, project.id, adoption.counter);
+          counters[adoption.counter] += 1;
         }
         if (step.agentName === REGRESSION_VERIFIER_AGENT_NAME) {
           regressionSteps.push({
@@ -646,7 +534,7 @@ const syncCanonicalTemplates = async (
         }
         if (persisted.prompt !== step.prompt) {
           await tx.taskTemplateStep.update({ where: { id: persisted.id }, data: { prompt: step.prompt } });
-          addStepUpdate(countersByProject, project.id, templateName, step.stepIndex, 1);
+          recordStepPromptUpdate(counters, templateName, step.stepIndex, 1);
         }
       }
     }
@@ -658,7 +546,7 @@ const migrateRegressionTasks = async (
   tx: Prisma.TransactionClient,
   project: ProjectRow,
   regressionSteps: readonly RegressionStep[],
-  countersByProject: Map<string, ProjectCounters>,
+  counters: CanonicalSyncCounters,
 ): Promise<void> => {
   for (const step of regressionSteps) {
     const target = await tx.agent.findFirst({
@@ -687,19 +575,19 @@ const migrateRegressionTasks = async (
     });
     for (const task of tasks) {
       if (task.archivedAt) {
-        addPreserved(countersByProject, project.id, "archived");
+        counters.preservedTaskAssignments.archived += 1;
         continue;
       }
       if (task.status !== TaskStatus.TODO) {
-        addPreserved(countersByProject, project.id, "nonTodo");
+        counters.preservedTaskAssignments.nonTodo += 1;
         continue;
       }
       if (task._count.runs > 0 || task._count.sessions > 0) {
-        addPreserved(countersByProject, project.id, "started");
+        counters.preservedTaskAssignments.started += 1;
         continue;
       }
       if (task.stepOutput) {
-        addPreserved(countersByProject, project.id, "output");
+        counters.preservedTaskAssignments.output += 1;
         continue;
       }
       const adopted = await tx.task.updateMany({
@@ -728,35 +616,9 @@ const migrateRegressionTasks = async (
           toAgentId: target.id,
         },
       } });
-      increment(countersByProject, project.id, "migratedTasks");
+      counters.migratedTasks += 1;
     }
   }
-};
-
-const sumCounters = (
-  projectRows: readonly ProjectRow[],
-  countersByProject: Map<string, ProjectCounters>,
-  templateSources: ReadonlyMap<CanonicalTemplateName, readonly TemplateStepSource[]>,
-  roleNames: readonly string[],
-): ProjectCounters => {
-  const total = emptyProjectCounters(templateSources, roleNames);
-  for (const project of projectRows) {
-    const counters = countersByProject.get(project.id);
-    if (!counters) continue;
-    total.templates += counters.templates;
-    for (const name of mutationCounterNames) total[name] += counters[name];
-    for (const field of Object.keys(total.preservedTaskAssignments) as (keyof PreservedTaskAssignments)[]) {
-      total.preservedTaskAssignments[field] += counters.preservedTaskAssignments[field];
-    }
-    for (const [templateName, byStep] of Object.entries(counters.updatedSteps)) {
-      for (const [stepIndex, count] of Object.entries(byStep)) {
-        total.updatedSteps[templateName]![Number(stepIndex)]! += count;
-      }
-    }
-    for (const [roleName, count] of Object.entries(counters.updatedRoles)) total.updatedRoles[roleName]! += count;
-  }
-  finalizeUpdated(total);
-  return total;
 };
 
 export const main = async (
@@ -769,6 +631,7 @@ export const main = async (
   const [templateSources, sources] = await Promise.all([loadAllTemplateStepSources(), loadAgentSources()]);
   const rolesByName = new Map(sources.roles.map((role) => [role.name, role]));
   const roleNames = [...rolesByName.keys()];
+  const reportKeys = { templateSteps: templateSources, roleNames };
 
   const prisma = database ?? new PrismaClient();
   const ownsPrisma = database === undefined;
@@ -786,13 +649,12 @@ export const main = async (
       canonicalProject,
       ...projectRows.filter(({ id }) => id !== canonicalProject.id),
     ];
-    const countersByProject = new Map<string, ProjectCounters>();
+    const outcomes: CanonicalSyncProjectOutcome[] = [];
     const runtimeConfigAdoptions: Array<{
       name: string;
       from: { model: string; runnerPreference: RunnerPreference };
       to: { model: string; runnerPreference: RunnerPreference };
     }> = [];
-    const refusals = new Map<string, string>();
 
     for (const project of orderedProjects) {
       try {
@@ -810,8 +672,7 @@ export const main = async (
             if (!present) throw projectError(project, "Project was not found");
           }
 
-          const projectCounters = emptyProjectCounters(templateSources, roleNames);
-          const transactionCounters = new Map([[project.id, projectCounters]]);
+          const projectCounters = emptyCanonicalSyncCounters(reportKeys);
           const transactionAdoptions: typeof runtimeConfigAdoptions = [];
           const installationRows = await readCanonicalInstallationRows(tx, project.id, templateSources);
           const installationPlan = planCanonicalInstallation(
@@ -823,12 +684,12 @@ export const main = async (
           if (plannedRefusal) throw projectError(project, plannedRefusal.reason);
           for (const action of installationPlan) {
             if (action.kind === "create" || action.kind === "rollover") {
-              increment(transactionCounters, action.projectId, "createdCanonicalTemplates");
+              projectCounters.createdCanonicalTemplates += 1;
             }
           }
 
           if (project.id === canonicalProject.id) {
-            await migrateSpecialCanonicalAgents(tx, canonicalProject, sources, rolesByName, transactionCounters);
+            await migrateSpecialCanonicalAgents(tx, canonicalProject, sources, rolesByName, projectCounters);
           }
           await synchronizeAgents(
             tx,
@@ -837,40 +698,39 @@ export const main = async (
             sources,
             rolesByName,
             roleNames,
-            transactionCounters,
+            projectCounters,
             transactionAdoptions,
           );
 
           await applyCanonicalInstallation(tx, installationPlan, templateSources, {
             projectLabel: () => project.slug,
           });
-          const regressionSteps = await syncCanonicalTemplates(tx, project, templateSources, transactionCounters);
-          await migrateRegressionTasks(tx, project, regressionSteps, transactionCounters);
+          const regressionSteps = await syncCanonicalTemplates(tx, project, templateSources, projectCounters);
+          await migrateRegressionTasks(tx, project, regressionSteps, projectCounters);
 
           if (fullInstallTarget) {
-            await installMissingAgents(tx, fullInstallTarget, sources, rolesByName, roleNames, transactionCounters);
+            await installMissingAgents(tx, fullInstallTarget, sources, rolesByName, roleNames, projectCounters);
             const postSyncRows = await readCanonicalInstallationRows(tx, project.id, templateSources);
             const fullInstallationPlan = planCanonicalInstallation(postSyncRows, templateSources, [project.id]);
             for (const action of fullInstallationPlan) {
               if (action.kind === "create" || action.kind === "rollover") {
-                increment(transactionCounters, action.projectId, "createdCanonicalTemplates");
+                projectCounters.createdCanonicalTemplates += 1;
               }
             }
             await applyCanonicalInstallation(tx, fullInstallationPlan, templateSources, {
               projectLabel: () => project.slug,
             });
           }
-          finalizeUpdated(projectCounters);
           return { counters: projectCounters, runtimeConfigAdoptions: transactionAdoptions };
         }, { timeout: 120_000 });
-        countersByProject.set(project.id, result.counters);
+        outcomes.push({ kind: "synced", slug: project.slug, counters: result.counters });
         runtimeConfigAdoptions.push(...result.runtimeConfigAdoptions);
       } catch (error) {
         if (project.id === canonicalProject.id || project.id === installFullProjectId) throw error;
         const message = error instanceof Error ? error.message : String(error);
         const prefix = `Project ${project.slug}: `;
         const reason = message.startsWith(prefix) ? message.slice(prefix.length) : message;
-        refusals.set(project.id, reason.replace(/\s+/gu, " ").trim());
+        outcomes.push({ kind: "refused", slug: project.slug, reason: reason.replace(/\s+/gu, " ").trim() });
       }
     }
 
@@ -881,21 +741,12 @@ export const main = async (
         + `to model=${adoption.to.model}, runnerPreference=${adoption.to.runnerPreference}`,
       );
     }
-    for (const project of orderedProjects) {
-      const refusal = refusals.get(project.id);
-      if (refusal !== undefined) console.log(`REFUSED ${project.slug}: ${refusal}`);
-      else console.log(`SYNCED ${project.slug}: ${JSON.stringify(countersByProject.get(project.id)!)}`);
+    const summary = canonicalSyncSummary(outcomes, reportKeys);
+    for (const outcome of outcomes) {
+      if (outcome.kind === "refused") console.log(`REFUSED ${outcome.slug}: ${outcome.reason}`);
+      else console.log(`SYNCED ${outcome.slug}: ${JSON.stringify(summary.projects[outcome.slug])}`);
     }
-    const projects = Object.fromEntries(projectRows.flatMap((project) => {
-      const counters = countersByProject.get(project.id);
-      return counters ? [[project.slug, counters]] : [];
-    }));
-    const refused = Object.fromEntries(projectRows.flatMap((project) => {
-      const reason = refusals.get(project.id);
-      return reason === undefined ? [] : [[project.slug, reason]];
-    }));
-    const totals = sumCounters(projectRows, countersByProject, templateSources, roleNames);
-    console.log(JSON.stringify({ projects, refused, totals }));
+    console.log(canonicalSyncSummaryLine(summary));
   } finally {
     if (ownsPrisma) await prisma.$disconnect();
   }

--- a/packages/db/src/canonical-prompt-sync-multi-project.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync-multi-project.dbtest.ts
@@ -24,6 +24,12 @@ import {
 
 import { loadAgentSources, type AgentSources, type RoleSource } from "./agent-sources.js";
 import {
+  emptyCanonicalSyncCounters,
+  parseCanonicalSyncSummary,
+  type CanonicalSyncCounters,
+  type CanonicalSyncSummary,
+} from "./canonical-sync-report.js";
+import {
   LEGACY_ALL_PRIOR_OUTPUTS,
   loadAllTemplateStepSources,
   type CanonicalTemplateName,
@@ -69,24 +75,6 @@ const rootNpmCommand = (args: string[]) => {
 };
 
 type FixtureProject = { id: string; slug: string; environmentId: string };
-type ProjectCounters = {
-  templates: number;
-  createdCanonicalTemplates: number;
-  createdAgents: number;
-  createdAgentRepoGrants: number;
-  adoptedAssignees: number;
-  adoptedStepBases: number;
-  adoptedPriorOutputDeclarations: number;
-  adoptedDependencyProvisioning: number;
-  renamedSteps: number;
-  migratedTasks: number;
-  adoptedAgentDefaults: number;
-  runtimeDriftNotices: number;
-  updated: number;
-  preservedTaskAssignments: { archived: number; nonTodo: number; started: number; output: number };
-  updatedSteps: Record<string, Record<string, number>>;
-  updatedRoles: Record<string, number>;
-};
 
 let prisma: PrismaClient;
 let sources: AgentSources;
@@ -97,47 +85,14 @@ let canonicalProject: FixtureProject;
 const canonicalTemplateNames = (): string[] => [...templateSources.keys()];
 const canonicalRoleNames = (): string[] => sources.roles.map(({ name }) => name);
 
-const zeroSteps = (): Record<string, Record<string, number>> => Object.fromEntries(
-  [...templateSources.entries()].map(([name, steps]) => [
-    name,
-    Object.fromEntries(steps.map(({ stepIndex }) => [String(stepIndex), 0])),
-  ]),
-);
-
-const zeroRoles = (): Record<string, number> => Object.fromEntries(
-  sources.roles.map(({ name }) => [name, 0]),
-);
-
-const zeroCounters = (): ProjectCounters => ({
-  templates: 0,
-  createdCanonicalTemplates: 0,
-  createdAgents: 0,
-  createdAgentRepoGrants: 0,
-  adoptedAssignees: 0,
-  adoptedStepBases: 0,
-  adoptedPriorOutputDeclarations: 0,
-  adoptedDependencyProvisioning: 0,
-  renamedSteps: 0,
-  migratedTasks: 0,
-  adoptedAgentDefaults: 0,
-  runtimeDriftNotices: 0,
-  updated: 0,
-  preservedTaskAssignments: { archived: 0, nonTodo: 0, started: 0, output: 0 },
-  updatedSteps: zeroSteps(),
-  updatedRoles: zeroRoles(),
+const zeroCounters = (): CanonicalSyncCounters => emptyCanonicalSyncCounters({
+  templateSteps: templateSources,
+  roleNames: canonicalRoleNames(),
 });
 
-type SyncSummary = {
-  projects: Record<string, ProjectCounters>;
-  refused: Record<string, string>;
-  totals: ProjectCounters;
-};
+const zeroSteps = (): Record<string, Record<string, number>> => zeroCounters().updatedSteps;
 
-const summaryFrom = (output: string): SyncSummary => {
-  const line = output.trim().split("\n").at(-1);
-  assert.ok(line, `sync did not print a summary: ${output}`);
-  return JSON.parse(line) as SyncSummary;
-};
+const zeroRoles = (): Record<string, number> => zeroCounters().updatedRoles;
 
 const createProject = async (slug: string, withEnvironment = true): Promise<FixtureProject> => {
   const project = await prisma.project.create({ data: { name: `A2 ${slug}`, slug } });
@@ -267,7 +222,7 @@ const deleteProject = async (projectId: string): Promise<void> => {
   await prisma.project.delete({ where: { id: projectId } });
 };
 
-const assertSummaryShape = (summary: SyncSummary): void => {
+const assertSummaryShape = (summary: CanonicalSyncSummary): void => {
   const expectedCounters = Object.keys(zeroCounters()).sort();
   for (const counter of [...Object.values(summary.projects), summary.totals]) {
     assert.deepEqual(Object.keys(counter).sort(), expectedCounters);
@@ -427,7 +382,7 @@ test("ordinary sync covers active canonical Agents in every Project and preserve
   assert.equal(await prisma.agent.count({ where: { projectId: project.id, name: "implementation-plan-executioner" } }), 0);
   assert.equal(await prisma.agent.count({ where: { projectId: project.id, name: "regression-verifier" } }), 0);
   assert.equal(await prisma.agent.count({ where: { projectId: project.id, name: "spec-revalidator" } }), 0);
-  const summary = summaryFrom(synced.output);
+  const summary = parseCanonicalSyncSummary(synced.output);
   assertSummaryShape(summary);
   assert.equal(summary.projects[project.slug]!.adoptedAgentDefaults, 1);
   assert.equal(summary.projects[project.slug]!.runtimeDriftNotices, 1);
@@ -494,7 +449,7 @@ test("foreign structural drift refuses only that Project and still syncs canonic
     }),
     { foundationalPrompt: sources.foundationalPrompt, rolePrompt: role("default").rolePrompt },
   );
-  const summary = summaryFrom(refused.output);
+  const summary = parseCanonicalSyncSummary(refused.output);
   assert.equal(Object.hasOwn(summary.projects, refusedProject.slug), false);
   assert.match(summary.refused[refusedProject.slug]!, /Agent default/u);
   assert.ok(summary.projects[canonicalProject.slug]);
@@ -661,7 +616,7 @@ test("partial template rows synchronize across Projects, leave missing rows vali
   assert.equal((await prisma.taskTemplateStep.findUniqueOrThrow({ where: { id: directStep7.id } })).name, "Merge authorization");
   assert.equal((await prisma.task.findUniqueOrThrow({ where: { id: task.id } })).assigneeAgentId, transitionAgents.get("regression-verifier"));
   assert.equal(await prisma.taskActivity.count({ where: { taskId: task.id, body: { contains: "Canonical routing reassigned" } } }), 1);
-  const summary = summaryFrom(synced.output);
+  const summary = parseCanonicalSyncSummary(synced.output);
   assertSummaryShape(summary);
   assert.equal(summary.projects[partial.slug]!.templates, 1);
   assert.equal(summary.projects[empty.slug]!.templates, 0);
@@ -801,7 +756,7 @@ test("full installation fills only the addressed Project's missing inventory and
   assert.equal(await prisma.filesystemGrant.count({ where: { agent: { projectId: project.id } } }), filesystemGrantCountBefore);
   assert.equal(await prisma.agentSkill.count({ where: { agent: { projectId: project.id } } }), skillGrantCountBefore);
   assert.equal(await prisma.agentMCPConnection.count({ where: { agent: { projectId: project.id } } }), mcpGrantCountBefore);
-  const installedSummary = summaryFrom(installed.output);
+  const installedSummary = parseCanonicalSyncSummary(installed.output);
   assertSummaryShape(installedSummary);
   assert.equal(installedSummary.projects[project.slug]!.createdAgents, canonicalRoleNames().length - initialNames.length);
   assert.equal(installedSummary.projects[project.slug]!.createdCanonicalTemplates, 2);
@@ -809,7 +764,7 @@ test("full installation fills only the addressed Project's missing inventory and
 
   const second = command(["tsx", "prisma/sync-canonical-prompts.ts", "--install-full", project.id]);
   assert.equal(second.status, 0, second.output);
-  const secondSummary = summaryFrom(second.output);
+  const secondSummary = parseCanonicalSyncSummary(second.output);
   assertSummaryShape(secondSummary);
   assert.deepEqual(secondSummary.projects[project.slug], {
     ...zeroCounters(),
@@ -1060,9 +1015,9 @@ test("summary reports every Project, nested canonical keys, lexical slugs, and f
 
   const synced = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
   assert.equal(synced.status, 0, synced.output);
-  const summary = summaryFrom(synced.output);
+  const summary = parseCanonicalSyncSummary(synced.output);
   assertSummaryShape(summary);
-  const activeCounters: ProjectCounters = {
+  const activeCounters: CanonicalSyncCounters = {
     ...zeroCounters(),
     templates: 2,
     adoptedAgentDefaults: 1,
@@ -1075,8 +1030,8 @@ test("summary reports every Project, nested canonical keys, lexical slugs, and f
     },
     updatedRoles: { ...zeroRoles(), "senior-dev": 1 },
   };
-  const canonicalCounters: ProjectCounters = { ...zeroCounters(), templates: canonicalTemplateNames().length };
-  const totals: ProjectCounters = {
+  const canonicalCounters: CanonicalSyncCounters = { ...zeroCounters(), templates: canonicalTemplateNames().length };
+  const totals: CanonicalSyncCounters = {
     ...activeCounters,
     templates: activeCounters.templates + canonicalCounters.templates,
   };

--- a/packages/db/src/canonical-sync-report.test.ts
+++ b/packages/db/src/canonical-sync-report.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canonicalSyncSummary,
+  canonicalSyncSummaryLine,
+  emptyCanonicalSyncCounters,
+  parseCanonicalSyncSummary,
+  recordRolePromptUpdate,
+  recordStepPromptUpdate,
+  type CanonicalSyncCounters,
+  type CanonicalSyncReportKeys,
+} from "./canonical-sync-report.js";
+
+const keys: CanonicalSyncReportKeys = {
+  templateSteps: new Map([
+    ["direct", [{ stepIndex: 0 }, { stepIndex: 1 }]],
+    ["compound", [{ stepIndex: 0 }]],
+  ]),
+  roleNames: ["senior-dev", "reviewer"],
+};
+
+const empty = (): CanonicalSyncCounters => emptyCanonicalSyncCounters(keys);
+
+test("an empty report names every canonical step and role at zero", () => {
+  assert.deepEqual(empty(), {
+    templates: 0,
+    createdCanonicalTemplates: 0,
+    createdAgents: 0,
+    createdAgentRepoGrants: 0,
+    adoptedAssignees: 0,
+    adoptedStepBases: 0,
+    adoptedPriorOutputDeclarations: 0,
+    adoptedDependencyProvisioning: 0,
+    renamedSteps: 0,
+    migratedTasks: 0,
+    adoptedAgentDefaults: 0,
+    runtimeDriftNotices: 0,
+    updated: 0,
+    preservedTaskAssignments: { archived: 0, nonTodo: 0, started: 0, output: 0 },
+    updatedSteps: { direct: { "0": 0, "1": 0 }, compound: { "0": 0 } },
+    updatedRoles: { "senior-dev": 0, reviewer: 0 },
+  });
+});
+
+test("a report counter that no canonical source declares is refused", () => {
+  assert.throws(() => recordStepPromptUpdate(empty(), "direct", 7, 1), /no counter for direct step 7/u);
+  assert.throws(() => recordStepPromptUpdate(empty(), "absent", 0, 1), /no counter for absent step 0/u);
+  assert.throws(() => recordRolePromptUpdate(empty(), "absent", 1), /no counter for Agent absent/u);
+});
+
+test("updated sums every write and excludes the templates inspected", () => {
+  const counters = empty();
+  counters.templates = 4;
+  counters.createdAgents = 2;
+  counters.migratedTasks = 1;
+  counters.preservedTaskAssignments.archived = 3;
+  recordStepPromptUpdate(counters, "direct", 1, 5);
+  recordRolePromptUpdate(counters, "reviewer", 6);
+
+  const summary = canonicalSyncSummary([{ kind: "synced", slug: "one", counters }], keys);
+  assert.equal(summary.projects["one"]?.updated, 14);
+  assert.equal(summary.projects["one"]?.templates, 4);
+  assert.equal(summary.totals.updated, 14);
+});
+
+test("totals accumulate every counter across Projects", () => {
+  const first = empty();
+  first.templates = 2;
+  first.adoptedAssignees = 1;
+  first.preservedTaskAssignments.started = 1;
+  recordStepPromptUpdate(first, "direct", 0, 1);
+  recordRolePromptUpdate(first, "senior-dev", 1);
+
+  const second = empty();
+  second.templates = 3;
+  second.adoptedAssignees = 4;
+  second.preservedTaskAssignments.started = 2;
+  recordStepPromptUpdate(second, "direct", 0, 2);
+  recordStepPromptUpdate(second, "compound", 0, 1);
+  recordRolePromptUpdate(second, "senior-dev", 3);
+
+  const summary = canonicalSyncSummary([
+    { kind: "synced", slug: "first", counters: first },
+    { kind: "synced", slug: "second", counters: second },
+  ], keys);
+
+  assert.equal(summary.totals.templates, 5);
+  assert.equal(summary.totals.adoptedAssignees, 5);
+  assert.equal(summary.totals.preservedTaskAssignments.started, 3);
+  assert.deepEqual(summary.totals.updatedSteps, { direct: { "0": 3, "1": 0 }, compound: { "0": 1 } });
+  assert.deepEqual(summary.totals.updatedRoles, { "senior-dev": 4, reviewer: 0 });
+  assert.equal(summary.totals.updated, 13);
+});
+
+test("summing leaves each Project's own counters alone", () => {
+  const counters = empty();
+  counters.adoptedAssignees = 1;
+  recordStepPromptUpdate(counters, "direct", 0, 1);
+  const summary = canonicalSyncSummary([{ kind: "synced", slug: "one", counters }], keys);
+
+  assert.equal(counters.updated, 0);
+  assert.equal(summary.projects["one"]?.updated, 2);
+  assert.equal(summary.totals.updatedSteps["direct"]?.["0"], 1);
+  assert.equal(counters.updatedSteps["direct"]?.["0"], 1);
+});
+
+test("a refused Project reports its reason and no counters", () => {
+  const summary = canonicalSyncSummary([
+    { kind: "refused", slug: "broken", reason: "Agent default drifted" },
+    { kind: "synced", slug: "healthy", counters: empty() },
+  ], keys);
+
+  assert.deepEqual(Object.keys(summary.projects), ["healthy"]);
+  assert.deepEqual(summary.refused, { broken: "Agent default drifted" });
+  assert.deepEqual(summary.totals, { ...empty(), updated: 0 });
+});
+
+test("Projects are reported by slug, not in the order they were synced", () => {
+  const summary = canonicalSyncSummary([
+    { kind: "synced", slug: "zulu", counters: empty() },
+    { kind: "refused", slug: "mike", reason: "no" },
+    { kind: "synced", slug: "alpha", counters: empty() },
+  ], keys);
+
+  assert.deepEqual(Object.keys(summary.projects), ["alpha", "zulu"]);
+  assert.deepEqual(Object.keys(summary.refused), ["mike"]);
+});
+
+test("two outcomes for one Project are refused rather than silently collapsed", () => {
+  assert.throws(() => canonicalSyncSummary([
+    { kind: "synced", slug: "one", counters: empty() },
+    { kind: "refused", slug: "one", reason: "no" },
+  ], keys), /Project one reported two sync outcomes/u);
+});
+
+test("the printed summary survives a round trip through stdout", () => {
+  const counters = empty();
+  counters.templates = 1;
+  recordRolePromptUpdate(counters, "reviewer", 2);
+  const summary = canonicalSyncSummary([
+    { kind: "synced", slug: "one", counters },
+    { kind: "refused", slug: "two", reason: "Agent default drifted" },
+  ], keys);
+
+  const stdout = [
+    "SYNCED one: {}",
+    "REFUSED two: Agent default drifted",
+    canonicalSyncSummaryLine(summary),
+    "",
+  ].join("\n");
+  assert.deepEqual(parseCanonicalSyncSummary(stdout), summary);
+});
+
+test("output that carries no summary is refused rather than read as empty", () => {
+  assert.throws(() => parseCanonicalSyncSummary("   \n  "), /printed no output/u);
+  assert.throws(() => parseCanonicalSyncSummary("SYNCED one: {}"), /not JSON/u);
+  assert.throws(() => parseCanonicalSyncSummary("[1,2]"), /not an object/u);
+  assert.throws(() => parseCanonicalSyncSummary('{"projects":{},"refused":{}}'), /has no totals/u);
+});

--- a/packages/db/src/canonical-sync-report.ts
+++ b/packages/db/src/canonical-sync-report.ts
@@ -1,0 +1,221 @@
+/**
+ * The canonical prompt sync report.
+ *
+ * `prisma/sync-canonical-prompts.ts` walks every Project in one transaction
+ * each and prints what it changed. That print is a real interface: the
+ * multi-project acceptance test reads the JSON line back and asserts on it,
+ * and an operator reads it to decide whether a deployment mutated anything.
+ * It used to exist only as a `console.log` of an object literal, so the shape,
+ * the arithmetic that fills it, and the parse that reads it were three
+ * independent restatements of the same contract; three of the four most recent
+ * fixes to the sync script were report bugs rather than sync bugs.
+ *
+ * This module owns all three. The sync script accumulates one
+ * `CanonicalSyncCounters` per Project inside its transaction, hands the
+ * outcomes to `canonicalSyncSummary`, and prints `canonicalSyncSummaryLine`;
+ * the test calls `parseCanonicalSyncSummary`. `updated` is derived here and
+ * nowhere else, so a caller cannot report an unfinalised total.
+ */
+
+/**
+ * The skeleton a report is seeded from: every canonical template's step
+ * indexes, and every canonical Agent name. The report needs nothing else about
+ * a step or a role, so it does not depend on the source loader's types.
+ */
+export type CanonicalSyncReportKeys = {
+  templateSteps: ReadonlyMap<string, readonly { stepIndex: number }[]>;
+  roleNames: readonly string[];
+};
+
+/** Unstarted regression Tasks the sync deliberately did not reassign. */
+export type PreservedTaskAssignmentCounters = {
+  archived: number;
+  nonTodo: number;
+  started: number;
+  output: number;
+};
+
+const PRESERVED_TASK_ASSIGNMENT_FIELDS = ["archived", "nonTodo", "started", "output"] as const;
+
+/**
+ * Every counter that records a write. `templates` counts what was inspected
+ * rather than what changed, and `updated` is their sum, so neither is here.
+ * `CanonicalAdoptionCounter` in `canonical-step-adoption.ts` names a subset of
+ * these; `counters[adoption.counter] += 1` is what keeps the two in step.
+ */
+const CANONICAL_SYNC_MUTATION_COUNTERS = [
+  "createdCanonicalTemplates",
+  "createdAgents",
+  "createdAgentRepoGrants",
+  "adoptedAssignees",
+  "adoptedStepBases",
+  "adoptedPriorOutputDeclarations",
+  "adoptedDependencyProvisioning",
+  "renamedSteps",
+  "migratedTasks",
+  "adoptedAgentDefaults",
+  "runtimeDriftNotices",
+] as const;
+
+export type CanonicalSyncMutationCounter = typeof CANONICAL_SYNC_MUTATION_COUNTERS[number];
+
+/**
+ * One Project's sync outcome. `updatedSteps` and `updatedRoles` are keyed by
+ * template name then step index, and by Agent name; both key sets are seeded
+ * from the canonical sources so a report always names every step and role,
+ * including the ones that did not change.
+ */
+export type CanonicalSyncCounters = Record<CanonicalSyncMutationCounter, number> & {
+  templates: number;
+  updated: number;
+  preservedTaskAssignments: PreservedTaskAssignmentCounters;
+  updatedSteps: Record<string, Record<string, number>>;
+  updatedRoles: Record<string, number>;
+};
+
+export type CanonicalSyncProjectOutcome =
+  | { kind: "synced"; slug: string; counters: CanonicalSyncCounters }
+  | { kind: "refused"; slug: string; reason: string };
+
+export type CanonicalSyncSummary = {
+  projects: Record<string, CanonicalSyncCounters>;
+  refused: Record<string, string>;
+  totals: CanonicalSyncCounters;
+};
+
+export const emptyCanonicalSyncCounters = (
+  keys: CanonicalSyncReportKeys,
+): CanonicalSyncCounters => ({
+  templates: 0,
+  createdCanonicalTemplates: 0,
+  createdAgents: 0,
+  createdAgentRepoGrants: 0,
+  adoptedAssignees: 0,
+  adoptedStepBases: 0,
+  adoptedPriorOutputDeclarations: 0,
+  adoptedDependencyProvisioning: 0,
+  renamedSteps: 0,
+  migratedTasks: 0,
+  adoptedAgentDefaults: 0,
+  runtimeDriftNotices: 0,
+  updated: 0,
+  preservedTaskAssignments: { archived: 0, nonTodo: 0, started: 0, output: 0 },
+  updatedSteps: Object.fromEntries([...keys.templateSteps].map(([name, steps]) => [
+    name,
+    Object.fromEntries(steps.map((step) => [String(step.stepIndex), 0])),
+  ])),
+  updatedRoles: Object.fromEntries(keys.roleNames.map((name) => [name, 0])),
+});
+
+/** Count prompt rewrites on one canonical template step. */
+export const recordStepPromptUpdate = (
+  counters: CanonicalSyncCounters,
+  templateName: string,
+  stepIndex: number,
+  amount: number,
+): void => {
+  const key = String(stepIndex);
+  const byStep = counters.updatedSteps[templateName];
+  const current = byStep?.[key];
+  if (byStep === undefined || current === undefined) {
+    throw new Error(`Canonical sync report has no counter for ${templateName} step ${stepIndex}`);
+  }
+  byStep[key] = current + amount;
+};
+
+/** Count prompt rewrites on one canonical Agent. */
+export const recordRolePromptUpdate = (
+  counters: CanonicalSyncCounters,
+  roleName: string,
+  amount: number,
+): void => {
+  const current = counters.updatedRoles[roleName];
+  if (current === undefined) {
+    throw new Error(`Canonical sync report has no counter for Agent ${roleName}`);
+  }
+  counters.updatedRoles[roleName] = current + amount;
+};
+
+const withUpdatedTotal = (counters: CanonicalSyncCounters): CanonicalSyncCounters => {
+  const scalar = CANONICAL_SYNC_MUTATION_COUNTERS.reduce((sum, name) => sum + counters[name], 0);
+  const steps = Object.values(counters.updatedSteps)
+    .flatMap((byStep) => Object.values(byStep))
+    .reduce((sum, count) => sum + count, 0);
+  const roles = Object.values(counters.updatedRoles).reduce((sum, count) => sum + count, 0);
+  return { ...counters, updated: scalar + steps + roles };
+};
+
+const sumCounters = (
+  keys: CanonicalSyncReportKeys,
+  perProject: readonly CanonicalSyncCounters[],
+): CanonicalSyncCounters => {
+  const total = emptyCanonicalSyncCounters(keys);
+  for (const counters of perProject) {
+    total.templates += counters.templates;
+    for (const name of CANONICAL_SYNC_MUTATION_COUNTERS) total[name] += counters[name];
+    for (const field of PRESERVED_TASK_ASSIGNMENT_FIELDS) {
+      total.preservedTaskAssignments[field] += counters.preservedTaskAssignments[field];
+    }
+    for (const [templateName, byStep] of Object.entries(counters.updatedSteps)) {
+      for (const [stepIndex, count] of Object.entries(byStep)) {
+        recordStepPromptUpdate(total, templateName, Number(stepIndex), count);
+      }
+    }
+    for (const [roleName, count] of Object.entries(counters.updatedRoles)) {
+      recordRolePromptUpdate(total, roleName, count);
+    }
+  }
+  return total;
+};
+
+/**
+ * Build the report from the outcomes the fan-out loop accumulated. Projects are
+ * ordered by slug rather than by the order they were synced, so the report does
+ * not depend on the canonical Project being walked first.
+ */
+export const canonicalSyncSummary = (
+  outcomes: readonly CanonicalSyncProjectOutcome[],
+  keys: CanonicalSyncReportKeys,
+): CanonicalSyncSummary => {
+  const slugs = new Set<string>();
+  for (const outcome of outcomes) {
+    if (slugs.has(outcome.slug)) throw new Error(`Project ${outcome.slug} reported two sync outcomes`);
+    slugs.add(outcome.slug);
+  }
+  const ordered = [...outcomes].sort((left, right) => (
+    left.slug < right.slug ? -1 : left.slug > right.slug ? 1 : 0
+  ));
+  const synced = ordered.filter((outcome): outcome is Extract<CanonicalSyncProjectOutcome, { kind: "synced" }> => (
+    outcome.kind === "synced"
+  ));
+  return {
+    projects: Object.fromEntries(synced.map((outcome) => [outcome.slug, withUpdatedTotal(outcome.counters)])),
+    refused: Object.fromEntries(ordered.flatMap((outcome) => (
+      outcome.kind === "refused" ? [[outcome.slug, outcome.reason]] : []
+    ))),
+    totals: withUpdatedTotal(sumCounters(keys, synced.map((outcome) => outcome.counters))),
+  };
+};
+
+/** The one line the sync script prints last, and the only machine-read output. */
+export const canonicalSyncSummaryLine = (summary: CanonicalSyncSummary): string => JSON.stringify(summary);
+
+const isRecord = (value: unknown): value is Record<string, unknown> => (
+  typeof value === "object" && value !== null && !Array.isArray(value)
+);
+
+export const parseCanonicalSyncSummary = (output: string): CanonicalSyncSummary => {
+  const line = output.trim().split("\n").at(-1);
+  if (!line) throw new Error("Canonical sync printed no output to read a summary from");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    throw new Error(`Canonical sync summary line is not JSON: ${line}`);
+  }
+  if (!isRecord(parsed)) throw new Error(`Canonical sync summary line is not an object: ${line}`);
+  for (const field of ["projects", "refused", "totals"] as const) {
+    if (!isRecord(parsed[field])) throw new Error(`Canonical sync summary has no ${field}: ${line}`);
+  }
+  return parsed as unknown as CanonicalSyncSummary;
+};


### PR DESCRIPTION
## What changed

The canonical prompt sync report is now a module with an interface instead of a
`console.log` of an object literal.

`packages/db/src/canonical-sync-report.ts` declares the reported shape
(`CanonicalSyncCounters`, `CanonicalSyncSummary`), the arithmetic that fills it,
the line that prints it (`canonicalSyncSummaryLine`) and the parse that reads it
back (`parseCanonicalSyncSummary`). Previously those four were three independent
restatements: the sync script declared `ProjectCounters` and `sumCounters`, the
multi-project dbtest re-declared the same type and did
`output.trim().split("\n").at(-1)` in its own `summaryFrom`, and `updated` was
filled by a `finalizeUpdated` that mutated its argument.

Inside the sync script, one Project's outcome is now a returned value.
`Map<projectId, Counters>` is gone from every helper signature, as is the
`new Map([[project.id, projectCounters]])` that `main` built purely to satisfy
them; each helper takes the one `CanonicalSyncCounters` its transaction owns.
The fan-out loop accumulates `CanonicalSyncProjectOutcome` values (`synced` with
counters, or `refused` with a reason) and the report is built once at the end
from the accumulated value. The `increment` / `addPreserved` helpers, which
existed only to look a Project up in that map and re-check that the counter was
a scalar, are deleted: with the map gone the writes are direct and typed. The
two helpers that do carry an invariant — a prompt update must name a step or a
role the canonical sources declare — survive as `recordStepPromptUpdate` and
`recordRolePromptUpdate` in the report module, which owns that key skeleton.

Depth: `updated` is derived inside `canonicalSyncSummary` and nowhere else, so a
caller cannot hand out a half-finalised total; and `canonicalSyncSummary` orders
Projects by slug, so the report no longer depends on the canonical Project being
walked first. The report module's only input is
`{ templateSteps, roleNames }` — step indexes and Agent names — so it does not
depend on the source-loader types at all.

Net -198 lines across the two existing files.

Printed output is unchanged: the runtime-config adoption lines, then
`REFUSED <slug>: ...` / `SYNCED <slug>: {...}` in walk order, then the same
`{projects, refused, totals}` JSON object as the last line.

## Evidence

Commands run in the worktree after the final commit, with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh `mktemp -d`:

- `npm run lint` — pass (`Checked 731 files in 7s`, then eslint clean).
- `npm run typecheck` — pass, all workspaces.
- `npm run typecheck:cli -w @anneal/db` — pass (this is what covers
  `prisma/sync-canonical-prompts.ts`).
- `npm run test -w @anneal/db` — 367 pass, 0 fail. Confirmed the new file is in
  that run by grepping its test names out of the output.
- `npm run test:auto-deploy` — 111 pass, 0 fail. Run even though the deploy
  script is unchanged, because it owns the consumer of the sync stdout.
- `packages/db/src/canonical-sync-report.test.ts` — 10 new tests, all passing:
  the empty report names every step and role; an undeclared counter is refused;
  `updated` sums every write and excludes `templates`; totals accumulate scalars,
  preserved assignments, steps and roles; summing does not mutate a Project's own
  counters; a refused Project contributes a reason and no counters; Projects are
  reported by slug rather than walk order; two outcomes for one slug are refused
  rather than silently collapsed; the printed line survives a round trip through
  stdout; and empty, non-JSON, non-object and field-missing output are each
  refused rather than read as an empty report.

Not run: `npm run test:db -w @anneal/db`. There is no local PostgreSQL; the
multi-project dbtest is merge gate evidence. It is written and typechecked here
(`tsc -p tsconfig.json` covers `src/**`, dbtests included).

## Decisions taken

**The brief's premise about the deploy script is wrong on the evidence, so
`scripts/deploy/quiet-window-deploy.mjs` is untouched.** The brief says the
deploy script re-declares `ProjectCounters` and parses the last stdout line, and
asks for the printed JSON to stay byte-compatible with what it consumes.
Re-verified on this base: `quiet-window-deploy.mjs` consumes only
`canonicalSyncRefusedLines(stdout)` at `:162`, which filters lines starting with
`REFUSED `. It never reads the JSON summary and never names a counter. It is a
`.mjs` file, so it could not import a TypeScript type in any case. Those REFUSED
lines are byte-identical after this change, so the consumer needs no edit — and
editing it to import something it does not use would have been the wrong shape.
The only summary consumer in the repository is the multi-project dbtest, which
now imports the shape and the parser.

**Two types (a tally without `updated`, a report with it) were considered and
rejected.** Deriving `updated` only inside `canonicalSyncSummary` closes the
"someone forgot to finalise" hole by construction, because the summary is the
only way counters reach a reader. A second type would have bought nothing and
doubled the vocabulary.

**The module and its test are named after the module, not after the script.**
The brief names the test `packages/db/src/sync-canonical-prompts.test.ts`. The
thing under test is `canonical-sync-report.ts`, and a test named for a different
file costs locality, so it is `canonical-sync-report.test.ts` next to it. Both
files are new and belong to no lane.

**`CanonicalAdoptionCounter` in `canonical-step-adoption.ts` (lane t1) is left
alone.** It names a subset of the report's mutation counters, and the two are now
kept in step by the type checker: `counters[adoption.counter] += 1` fails to
compile if t1 ever names a counter the report does not declare. Re-listing the
union to enforce that structurally would have added a restatement, not removed
one.

**One vacuous guard was dropped rather than reproduced.** `increment(...,
action.projectId, ...)` threw if the installation action named a Project other
than the one being synced. `planCanonicalInstallation` is called with rows read
for exactly that Project and with `[project.id]` as its install targets, so
`action.projectId` is always the current Project; the guard could not fire.
Verified against `canonical-template-installation.ts:87-126`.

## Fence widened

Two new files inside `packages/db/src/`, both belonging to no lane in
`QUEUE.md`:

- `packages/db/src/canonical-sync-report.ts` — the shared shape the brief asked
  to be declared once in `packages/db/src/`.
- `packages/db/src/canonical-sync-report.test.ts` — its unit tests, standing in
  for the brief's `packages/db/src/sync-canonical-prompts.test.ts`.

No file owned by another lane was edited. `packages/db/package.json` was not
touched: both callers import by relative path, so no `exports` entry is needed,
and that file belongs to lane b1.

## Reported but unfixed

- `packages/db/prisma/sync-canonical-prompts.ts` still passes `templateSources`
  and `roleNames` separately to `syncCanonicalTemplates` and friends alongside
  the counters, and `sortedProjectRows` re-sorts rows that Prisma already
  returned `orderBy: { slug: "asc" }`. Both are inside this lane's fence but
  outside the brief, which is scoped to the report.
- `packages/db/src/canonical-prompt-sync-multi-project.dbtest.ts` keeps
  `zeroSteps()` and `zeroRoles()` as thin readers of `zeroCounters()`. They have
  one and two call sites respectively and could be inlined; left as they are to
  keep this diff to the report contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd4dWkbWYeazixzUPVawzZ
