### PR TITLE
refactor(runner): give the delivery receipt one writer

### DIFF
--- a/packages/runner/assets/pi-agentos-extension.ts
+++ b/packages/runner/assets/pi-agentos-extension.ts
@@ -9,7 +9,9 @@
  *  Loaded by pi's own loader, not compiled by the runner's tsc — keep it
  *  dependency-free and self-contained. SessionToolContract is inlined here at
  *  build time; session-tool-contract.test.ts checks the inlined adapter against
- *  the canonical definitions and request shapes. */
+ *  the canonical definitions and request shapes. The delivery receipt writer is
+ *  not inlined by hand: scripts/generate-pi-extension.mjs copies it verbatim
+ *  from src/task-output-receipt.ts into the marked region below. */
 
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
@@ -296,19 +298,40 @@ const call = async (request: ToolRequest): Promise<unknown> => {
 
 const said = (text: string): ToolResult => ({ content: [{ type: "text", text }], details: {} });
 
-const writeTaskOutputReceipt = async (kind: string, commitSha: string): Promise<void> => {
-  const session = credentials();
-  const path = join(session.workspacePath, ".agentos", "task-output-receipt.json");
+/** Copied verbatim from packages/runner/src/task-output-receipt.ts by
+ *  scripts/generate-pi-extension.mjs. Edit that module, not this region;
+ *  scripts/generate-pi-extension.test.mjs fails when the two drift. */
+// AGENT-WRITER-BEGIN
+export type TaskOutputReceipt = {
+  runId: string;
+  kind: string;
+  commitSha: string;
+};
+
+export const taskOutputReceiptPath = (workspacePath: string): string =>
+  join(workspacePath, ".agentos", "task-output-receipt.json");
+
+/**
+ * Record the delivered output identity only after the session output request
+ * has succeeded. The runner includes this Agent-writable receipt in recovery
+ * audit evidence; the server-returned output identity alone authorizes recovery.
+ */
+export const writeTaskOutputReceipt = async (
+  workspacePath: string,
+  output: TaskOutputReceipt,
+): Promise<void> => {
+  const path = taskOutputReceiptPath(workspacePath);
   const temporary = `${path}.${process.pid}.${randomUUID()}`;
   await mkdir(dirname(path), { recursive: true, mode: 0o700 });
   try {
-    await writeFile(temporary, `${JSON.stringify({ runId: session.runId, kind, commitSha })}\n`, { mode: 0o600 });
+    await writeFile(temporary, `${JSON.stringify(output)}\n`, { mode: 0o600 });
     await rename(temporary, path);
   } catch (error: unknown) {
     await rm(temporary, { force: true }).catch(() => undefined);
     throw error;
   }
 };
+// AGENT-WRITER-END
 
 const invokeTool = async (name: ToolName, params: Record<string, unknown>): Promise<ToolResult> => {
   const request = requestFor(name, params);
@@ -322,9 +345,11 @@ const invokeTool = async (name: ToolName, params: Record<string, unknown>): Prom
     const body = params.body as string;
     const kind = params.kind as string;
     const commitSha = taskOutputCommitSha as string;
-    await writeTaskOutputReceipt(kind, commitSha).catch((error: unknown) => {
-      console.error(`Unable to write task output receipt: ${error instanceof Error ? error.message : String(error)}`);
-    });
+    const session = credentials();
+    await writeTaskOutputReceipt(session.workspacePath, { runId: session.runId, kind, commitSha })
+      .catch((error: unknown) => {
+        console.error(`Unable to write task output receipt: ${error instanceof Error ? error.message : String(error)}`);
+      });
     const predecessorOutputs = (result as { predecessorOutputs?: unknown } | null)?.predecessorOutputs;
     return said([
       `Output persisted as '${kind}' (${body.length} characters).`,

--- a/packages/runner/scripts/generate-pi-extension.mjs
+++ b/packages/runner/scripts/generate-pi-extension.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * pi loads `assets/pi-agentos-extension.ts` with its own loader, so the asset
+ * cannot import runner code: `src` is absent from a release and `dist` is
+ * absent from a checkout. The delivery receipt writer therefore has one source
+ * — the region below in `task-output-receipt.ts` — copied verbatim into the
+ * asset by this script. `generate-pi-extension.test.mjs` fails when the copy
+ * in git drifts from that source, so the checked-in asset is always the
+ * generated one and the build needs no generation step.
+ */
+const BEGIN = "// AGENT-WRITER-BEGIN";
+const END = "// AGENT-WRITER-END";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+export const RECEIPT_MODULE = resolve(packageRoot, "src/task-output-receipt.ts");
+export const PI_EXTENSION = resolve(packageRoot, "assets/pi-agentos-extension.ts");
+
+const region = (source, label) => {
+  const begin = source.indexOf(BEGIN);
+  const end = source.indexOf(END);
+  if (begin === -1 || end === -1 || end < begin) {
+    throw new Error(`generate-pi-extension: ${label} has no ${BEGIN}/${END} region`);
+  }
+  return { before: source.slice(0, begin + BEGIN.length), body: source.slice(begin + BEGIN.length, end), after: source.slice(end) };
+};
+
+/** The asset text this repository should have, given the current module. */
+export const generatedPiExtension = () => {
+  const writer = region(readFileSync(RECEIPT_MODULE, "utf8"), "src/task-output-receipt.ts").body;
+  const asset = region(readFileSync(PI_EXTENSION, "utf8"), "assets/pi-agentos-extension.ts");
+  return `${asset.before}${writer}${asset.after}`;
+};
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  writeFileSync(PI_EXTENSION, generatedPiExtension());
+}

--- a/packages/runner/scripts/generate-pi-extension.test.mjs
+++ b/packages/runner/scripts/generate-pi-extension.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { generatedPiExtension, PI_EXTENSION, RECEIPT_MODULE } from "./generate-pi-extension.mjs";
+
+test("the pi extension in git is the one generated from the receipt module", () => {
+  assert.equal(
+    readFileSync(PI_EXTENSION, "utf8"),
+    generatedPiExtension(),
+    "run `node packages/runner/scripts/generate-pi-extension.mjs`",
+  );
+});
+
+test("the generated region carries the whole writer and the asset defines it nowhere else", () => {
+  const generated = generatedPiExtension();
+  const module = readFileSync(RECEIPT_MODULE, "utf8");
+  for (const symbol of ["taskOutputReceiptPath", "writeTaskOutputReceipt"]) {
+    const definition = `export const ${symbol} =`;
+    assert.ok(module.includes(definition), `${symbol} must be defined in the receipt module`);
+    assert.equal(
+      generated.split(definition).length - 1,
+      1,
+      `${symbol} must be defined exactly once in the pi extension`,
+    );
+  }
+});

--- a/packages/runner/src/mcp-server.test.ts
+++ b/packages/runner/src/mcp-server.test.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { handleRequest, invokeTool, readCredentials, TOOLS, type SessionCredentials } from "./mcp-server.js";
-import { taskOutputReceiptPath } from "./task-output-receipt.js";
+import { parseTaskOutputReceipt, taskOutputReceiptPath } from "./task-output-receipt.js";
 
 type Received = { method: string; url: string; authorization: string | undefined; body: string };
 
@@ -127,7 +127,7 @@ test("tools carry the session token and fencing token to the session endpoints",
     assert.ok(received.every((hit) => JSON.parse(hit.body).fencingToken === "1:run-1:token"));
     const commitSha = String(JSON.parse(received[0]!.body).commitSha);
     assert.match(commitSha, /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u);
-    assert.deepEqual(JSON.parse(await readFile(taskOutputReceiptPath(credentials.workspacePath), "utf8")), {
+    assert.deepEqual(parseTaskOutputReceipt(await readFile(taskOutputReceiptPath(credentials.workspacePath), "utf8")), {
       runId: "run-1",
       kind: "spec",
       commitSha,

--- a/packages/runner/src/session-tool-contract.test.ts
+++ b/packages/runner/src/session-tool-contract.test.ts
@@ -17,7 +17,7 @@ import {
   type SessionToolName,
   type SessionToolRequest,
 } from "./session-tool-contract.js";
-import { taskOutputReceiptPath } from "./task-output-receipt.js";
+import { parseTaskOutputReceipt, taskOutputReceiptPath } from "./task-output-receipt.js";
 
 const piExtension = fileURLToPath(new URL("../assets/pi-agentos-extension.ts", import.meta.url));
 
@@ -192,7 +192,7 @@ test("the dependency-free PI adapter inlines the canonical definitions and reque
       ...(name === "task_output" ? { commitSha } : {}),
       ...(name === "inbox_ask" ? { requestIdPrefix: `pi:${runId}` } : {}),
     }))));
-    assert.deepEqual(JSON.parse(readFileSync(taskOutputReceiptPath(workspace), "utf8")), {
+    assert.deepEqual(parseTaskOutputReceipt(readFileSync(taskOutputReceiptPath(workspace), "utf8")), {
       runId,
       kind: "result",
       commitSha,

--- a/packages/runner/src/task-output-receipt.ts
+++ b/packages/runner/src/task-output-receipt.ts
@@ -8,6 +8,7 @@ import { workspaceEnvironment, type Workspace } from "./workspace.js";
 
 const MAX_RECEIPT_BYTES = 8 * 1024;
 
+// AGENT-WRITER-BEGIN
 export type TaskOutputReceipt = {
   runId: string;
   kind: string;
@@ -16,19 +17,6 @@ export type TaskOutputReceipt = {
 
 export const taskOutputReceiptPath = (workspacePath: string): string =>
   join(workspacePath, ".agentos", "task-output-receipt.json");
-
-const receipt = (value: unknown): TaskOutputReceipt => {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("Task output receipt is not an object");
-  }
-  const candidate = value as Record<string, unknown>;
-  if (typeof candidate.runId !== "string"
-    || typeof candidate.kind !== "string"
-    || typeof candidate.commitSha !== "string") {
-    throw new Error("Task output receipt is missing runId, kind, or commitSha");
-  }
-  return { runId: candidate.runId, kind: candidate.kind, commitSha: candidate.commitSha };
-};
 
 /**
  * Record the delivered output identity only after the session output request
@@ -49,6 +37,26 @@ export const writeTaskOutputReceipt = async (
     await rm(temporary, { force: true }).catch(() => undefined);
     throw error;
   }
+};
+// AGENT-WRITER-END
+
+export const parseTaskOutputReceipt = (raw: string): TaskOutputReceipt => {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (error: unknown) {
+    throw new Error(`Task output receipt is not JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Task output receipt is not an object");
+  }
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.runId !== "string"
+    || typeof candidate.kind !== "string"
+    || typeof candidate.commitSha !== "string") {
+    throw new Error("Task output receipt is missing runId, kind, or commitSha");
+  }
+  return { runId: candidate.runId, kind: candidate.kind, commitSha: candidate.commitSha };
 };
 
 const readReceiptFile = async (config: RunnerConfig, workspace: Workspace): Promise<string | null> => {
@@ -96,5 +104,5 @@ export const readTaskOutputReceipt = async (
 ): Promise<TaskOutputReceipt | null> => {
   const raw = await readReceiptFile(config, workspace);
   if (raw === null) return null;
-  return receipt(JSON.parse(raw));
+  return parseTaskOutputReceipt(raw);
 };


### PR DESCRIPTION
## What changed

`writeTaskOutputReceipt` had two implementations of the same behaviour: the module
`packages/runner/src/task-output-receipt.ts`, imported by the MCP server, and a
hand-copied one inside `packages/runner/assets/pi-agentos-extension.ts` that
re-derived the path, the atomic write, the modes, and the record shape from the
session environment. `5a9ae4ba`, `9064a104` and `dd3e02eb` each had to edit both.

The extension cannot import the module at runtime. pi loads the asset with its own
loader, and the asset resolves against nothing the runner compiles: a release ships
`packages/runner/assets` and `dist` but not `src`
(`scripts/deploy/release-artifacts.mjs`, `DEPLOY_RELEASE_EXTRA_ARTIFACT_PATHS`),
while a checkout has `src` and no `dist` — the contract test loads the asset through
tsx with nothing built. So the writer keeps one source and the asset carries a
generated copy of it:

- The module marks the agent-writable region (`AGENT-WRITER-BEGIN` / `-END`):
  `TaskOutputReceipt`, `taskOutputReceiptPath`, `writeTaskOutputReceipt`. Nothing in
  that region imports runner code; the reader below it still does.
- `packages/runner/scripts/generate-pi-extension.mjs` copies that region verbatim
  into the asset's matching region.
- `packages/runner/scripts/generate-pi-extension.test.mjs` fails when the file in git
  differs from what the generator would produce, and when either symbol is defined
  more than once in the asset. Nothing generates at build time, so a release is
  byte-identical to what is committed.

The extension's call site is now the same call the MCP server makes:
`writeTaskOutputReceipt(session.workspacePath, { runId, kind, commitSha })`.

The receipt's shape knowledge also had two homes: a private parser in the module and
a hand-written JSON literal in each of the two transport tests. It is now
`parseTaskOutputReceipt`, used by the runner-side reader and by both tests, so each
test asserts the receipt through the module rather than re-encoding the file format.

`runner.ts` is unchanged: the reader stays audit evidence inside
`POST_DELIVERY_DISCONNECT_ACCEPTED` and is not re-promoted into the verdict path.

## Evidence

Anchors re-verified on base `aac993cb`: the hand-copied writer was still at
`assets/pi-agentos-extension.ts:299-311`, the module writer at
`src/task-output-receipt.ts:38-52`, the MCP call at `src/mcp-server.ts:136`, the
duplicated assertions at `mcp-server.test.ts:130` and
`session-tool-contract.test.ts:195`, and the audit-only read at `runner.ts:715`.

Run in this worktree after the final commit, with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh `mktemp -d`:

- `npm run lint` — exit 0. biome checked 735 files, no fixes; eslint clean.
- `npm run typecheck` — exit 0.
- `npm run test -w @anneal/runner` — exit 0: `tests 493 / pass 491 / fail 0 / skipped 2`.
  The two skips are the pre-existing root-only cases. This includes the two new
  `scripts/generate-pi-extension.test.mjs` cases and the receipt assertions in
  `mcp-server.test.ts` and `session-tool-contract.test.ts`.

Merge gate, dispatched for this exact head:

- Attempt 1 on the fallback worker `agentos-gate`: `MERGE GATE: FAIL`, one failing
  test, `scripts/merge-lease.test.mjs:36` "merge lease acquire restamps acquiredAt on
  every attempt while it queues" — the fixture repository rejected its own lease-ref
  push ("cannot update a remote ref that points at a non-commit object") while a merge
  train held slots on the same worker. Nothing in this change goes near
  `scripts/merge-lease*`; re-dispatched unmodified.
- Attempt 2 on `ci-desktop-worker`:
  `MERGE GATE: PASS 8dc76d29b6eb30f51fbb9292c5780169c947dffa`.

`test:db` was not run: there is no local PostgreSQL and this change touches no
`*.dbtest.ts`. No file under `docs/` changed, so `test:snapshot-scan` does not apply.
No HTTP route was added or renamed.

## Decisions taken

The brief allowed a runtime import if the asset could reach runner code, and
generation otherwise. The asset cannot: `RUNNER_PI_EXTENSION_PATH ?? join(packageRoot,
"assets", "pi-agentos-extension.ts")` in `adapters/pi.ts` loads it straight from the
package, never from agent scratch, and neither `src` nor `dist` is present in both a
release and a checkout. Generation it is.

The generator is not wired into `npm run build`. Wiring it there would let a stale
committed asset be silently corrected during a release, so the release would differ
from git. Instead the checked-in asset is the generated artifact and the test is the
guard, which is also one less build step to keep working.

The generated region keeps its `export` keywords, so the copy is byte-identical to the
module region and the test is a plain string comparison. The extra named exports on
the asset are inert: pi calls its default export.

`credentials()` moved out of the receipt writer to the call site, which is outside the
`.catch` that tolerates a failed receipt write. It cannot throw there — `call(request)`
ran first and would have thrown on the same missing environment — and a credentials
failure should surface rather than be logged as a receipt-write failure.

## Fence widened

`packages/runner/scripts/generate-pi-extension.mjs` and
`packages/runner/scripts/generate-pi-extension.test.mjs` are new files in a directory
`QUEUE.md` assigns to no lane, taken under rule 1. They sit next to the existing
`build-runtime-tools.mjs` / `build-runtime-tools.test.mjs` pair, are already inside
`public-snapshot.json`'s `packages/runner/scripts/*.mjs` glob, and are picked up by the
runner package's existing `scripts/*.test.mjs` test glob.

## Reported but unfixed

- `assets/pi-agentos-extension.ts` header still says "SessionToolContract is inlined
  here at build time". Nothing inlines it at build time; the adapter is hand-written
  and `session-tool-contract.test.ts` checks it behaviourally against the canonical
  definitions. The same generator could own that region too, which would delete
  roughly 130 lines of hand-copied tool definitions from the asset. Out of this
  brief's scope.
- `run-output.test.ts:370` writes a receipt with a shell `printf` inside the sandboxed
  fixture. That is a deliberate stand-in for an agent and not a fourth writer, but it
  hard-codes the path and the record shape; it belongs to lane a1/a2's file and was
  left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9Sr1Pf9K1dRPMjThNn5Qi
