### PR TITLE
refactor(api,runner,db): decide a Run's output evidence once

### DIFF
--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -1738,20 +1738,32 @@ The two revalidation routes below are session-only capabilities; they are
 listed here so their authorization boundary is explicit even though operators
 cannot call them directly. A `spec-revalidator` session on a bound direct chain
 is the only caller accepted.
-The machine-only `/session/runs/:runId/status` projection used by PR-workflow
-delivery is run-bound and is not an operator read route. For the current
-canonical template, it carries persisted output bodies only for the current
-`implementation` or `fixed-implementation` Run at its chain index. Each entry
-contains the Task id, chain index, output kind, body, and commit SHA, and is
-accepted only when its `projectId` and `chainId` match the claimed Run.
-Malformed, foreign-chain, or missing required evidence is rejected rather than
-silently omitted or guessed. The implementation delivery receives only its
-current `implementation` entry; the final delivery receives exactly
-`implementation`, `sol-findings`, `blind-findings`, and `fixed-implementation`,
-in chain order. This projection does not widen prompt `priorOutputs`, expose
-sibling evidence to a blind review, or derive text from provider output,
-activity prose, or repository contents. Its source is persisted task output
-and its authentication is the claimed session/run identity.
+The machine-only `/session/runs/:runId/status` projection is run-bound and is
+not an operator read route. Its `task.outputEvidence` is the server's decided
+answer about this Run's deliverables, and the runner reads it rather than
+re-deciding anything. It has two parts.
+
+`outputEvidence.satisfaction` names whether the deliverable this Run's Step
+requires exists: `delivered` (this Run persisted it; carries the output `kind`
+and `commitSha`), `not-required`, `satisfied-by-prior-run` (an immutable
+findings artifact an earlier Run authored, which this Run may not replace), or
+`absent` (with the required `outputKind` and whether asking the agent again can
+still produce it).
+
+`outputEvidence.prHandoff` names the canonical PR handoff this delivery may
+publish: `not-a-pr-delivery`, `complete` with the ordered `outputs`, or
+`incomplete` with the reason it was refused. Each entry contains the Task id,
+chain index, output kind, body, and commit SHA, and is accepted only when its
+`projectId` and `chainId` match the claimed Run. The implementation delivery
+receives only its current `implementation` entry; the final delivery receives
+exactly `implementation`, `sol-findings`, `blind-findings`, and
+`fixed-implementation`, in chain order. Malformed, foreign-chain, out-of-order
+or missing evidence makes the handoff `incomplete` rather than being silently
+omitted or guessed, and delivery fails instead of publishing. This projection
+does not widen prompt `priorOutputs`, expose sibling evidence to a blind
+review, or derive text from provider output, activity prose, or repository
+contents. Its source is persisted task output and its authentication is the
+claimed session/run identity.
 The machine-only `POST /runner/runs/:runId/complete` completion payload and
 `POST /runner/runs/:runId/cancel/acknowledge` cancellation acknowledgement
 accept the optional `worktreeContainmentViolations` array: absolute worktree

--- a/packages/api/src/routes/session.test.ts
+++ b/packages/api/src/routes/session.test.ts
@@ -61,24 +61,23 @@ test("session output authorization cannot introduce a second fence instant", asy
   ).in === activeRunStatuses));
 });
 
-test("GET /session/runs/:runId/status projects task output identity or null", async () => {
+test("GET /session/runs/:runId/status projects the decided output evidence", async () => {
   await withTokens(async () => {
     const commitSha = "a".repeat(40);
     const outputCases = [
       {
         stepOutput: { runId: "run-1", kind: "implementation", commitSha },
-        expected: { runId: "run-1", kind: "implementation", commitSha },
-        persisted: true,
+        expected: { case: "delivered", output: { kind: "implementation", commitSha } },
       },
-      { stepOutput: null, expected: null, persisted: false },
+      { stepOutput: null, expected: { case: "not-required" } },
       {
+        // A Step that requires no deliverable never claims an earlier Run's.
         stepOutput: { runId: "run-prior", kind: "implementation", commitSha },
-        expected: null,
-        persisted: false,
+        expected: { case: "not-required" },
       },
     ] as const;
 
-    for (const { stepOutput, expected, persisted } of outputCases) {
+    for (const { stepOutput, expected } of outputCases) {
       const database = {
         run: {
           findFirst: async () => ({ id: "run-1", leaseGeneration: 1 }),
@@ -118,11 +117,7 @@ test("GET /session/runs/:runId/status projects task output identity or null", as
           status: string;
           approvalGate: boolean;
           chainIndex: number;
-          output: unknown;
-          outputRequired: boolean;
-          outputRemediationAllowed: boolean;
-          outputSatisfiedByPriorRun: boolean;
-          outputPersisted: boolean;
+          outputEvidence: unknown;
         };
       };
       assert.equal(body.run.id, "run-1");
@@ -132,11 +127,10 @@ test("GET /session/runs/:runId/status projects task output identity or null", as
       assert.equal(body.task.status, "DOING");
       assert.equal(body.task.approvalGate, false);
       assert.equal(body.task.chainIndex, 0);
-      assert.deepEqual(body.task.output, expected);
-      assert.equal(body.task.outputRequired, false);
-      assert.equal(body.task.outputRemediationAllowed, true);
-      assert.equal(body.task.outputSatisfiedByPriorRun, false);
-      assert.equal(body.task.outputPersisted, persisted);
+      assert.deepEqual(body.task.outputEvidence, {
+        satisfaction: expected,
+        prHandoff: { case: "not-a-pr-delivery" },
+      });
     }
   });
 });
@@ -213,15 +207,18 @@ test("PR workflow status projects same-chain canonical output bodies through the
     });
     assert.equal(response.status, 200);
     const body = await response.json() as {
-      task: { prWorkflowOutputs?: unknown };
+      task: { outputEvidence: { prHandoff: unknown } };
     };
-    assert.deepEqual(body.task.prWorkflowOutputs, outputs.map(({ id, chainIndex, stepOutput }) => ({
-      taskId: id,
-      chainIndex,
-      kind: stepOutput.kind,
-      body: stepOutput.body,
-      commitSha: stepOutput.commitSha,
-    })));
+    assert.deepEqual(body.task.outputEvidence.prHandoff, {
+      case: "complete",
+      outputs: outputs.map(({ id, chainIndex, stepOutput }) => ({
+        taskId: id,
+        chainIndex,
+        kind: stepOutput.kind,
+        body: stepOutput.body,
+        commitSha: stepOutput.commitSha,
+      })),
+    });
     const where = (calls[0] as { where: Record<string, unknown> }).where;
     assert.equal(where.projectId, "project-1");
     assert.equal(where.chainId, "chain-1");
@@ -283,14 +280,17 @@ test("PR implementation status projects only the current Run's implementation ev
       headers: { Authorization: "Bearer agos_session_current" },
     });
     assert.equal(response.status, 200);
-    const body = await response.json() as { task: { prWorkflowOutputs: unknown } };
-    assert.deepEqual(body.task.prWorkflowOutputs, [{
-      taskId: current.id,
-      chainIndex: 1,
-      kind: "implementation",
-      body: "implementation body",
-      commitSha: "a".repeat(40),
-    }]);
+    const body = await response.json() as { task: { outputEvidence: { prHandoff: unknown } } };
+    assert.deepEqual(body.task.outputEvidence.prHandoff, {
+      case: "complete",
+      outputs: [{
+        taskId: current.id,
+        chainIndex: 1,
+        kind: "implementation",
+        body: "implementation body",
+        commitSha: "a".repeat(40),
+      }],
+    });
     const where = (query as { where: Record<string, unknown> }).where;
     assert.equal(where.projectId, "project-current");
     assert.equal(where.chainId, "chain-current");
@@ -299,7 +299,7 @@ test("PR implementation status projects only the current Run's implementation ev
   });
 });
 
-test("PR workflow status omits nullable output rows so required evidence is refused downstream", async () => {
+test("PR workflow status refuses a nullable commit identity instead of shortening the handoff", async () => {
   await withTokens(async () => {
     const database = {
       run: {
@@ -325,8 +325,12 @@ test("PR workflow status omits nullable output rows so required evidence is refu
       headers: { Authorization: "Bearer agos_session_current" },
     });
     assert.equal(response.status, 200);
-    const body = await response.json() as { task: { prWorkflowOutputs: unknown } };
-    assert.deepEqual(body.task.prWorkflowOutputs, []);
+    const body = await response.json() as { task: { outputEvidence: { prHandoff: { case: string; reason: string } } } };
+    assert.equal(body.task.outputEvidence.prHandoff.case, "incomplete");
+    assert.match(
+      body.task.outputEvidence.prHandoff.reason,
+      /requires exactly 4 output entries, not 1/u,
+    );
   });
 });
 
@@ -369,8 +373,8 @@ test("non-PR session status does not expose the PR evidence projection", async (
       headers: { Authorization: "Bearer agos_session_current" },
     });
     assert.equal(response.status, 200);
-    const body = await response.json() as { task: Record<string, unknown> };
-    assert.equal("prWorkflowOutputs" in body.task, false);
+    const body = await response.json() as { task: { outputEvidence: { prHandoff: unknown } } };
+    assert.deepEqual(body.task.outputEvidence.prHandoff, { case: "not-a-pr-delivery" });
     assert.equal(queried, false);
   });
 });

--- a/packages/api/src/routes/session.ts
+++ b/packages/api/src/routes/session.ts
@@ -10,6 +10,7 @@ import {
   runOwnsMergeOutcome,
   selectAuthorization,
   taskIsIntegratorStep,
+  isRegressionVerificationOutputKind,
   decidePrHandoff,
   decideRunOutputSatisfaction,
   PR_HANDOFF_KINDS,
@@ -300,6 +301,7 @@ export function registerSessionRoutes(app: RouteApp, deps: RouteDeps): () => voi
         {
           outputKind: run.task ? requiredOutputKind(run.task.templateStep) : null,
           immutableOncePersisted: outputIsImmutableOncePersisted(run.task?.templateStep),
+          remediable: !isRegressionVerificationOutputKind(run.task?.templateStep?.outputKind),
         },
         run.task?.stepOutput ?? null,
       ),

--- a/packages/api/src/routes/session.ts
+++ b/packages/api/src/routes/session.ts
@@ -10,7 +10,12 @@ import {
   runOwnsMergeOutcome,
   selectAuthorization,
   taskIsIntegratorStep,
-  isRegressionVerificationOutputKind,
+  decidePrHandoff,
+  decideRunOutputSatisfaction,
+  PR_HANDOFF_KINDS,
+  type PrHandoff,
+  type PrHandoffStage,
+  type RunOutputEvidence,
   type CandidateActivity,
   type CardRow,
   type DecisionRow,
@@ -62,46 +67,36 @@ import {
 
 const SESSION_READ_LIMIT = 5 * 1024 * 1024;
 const SESSION_BASE64_BODY_LIMIT = 34 * 1024 * 1024;
-const PR_WORKFLOW_OUTPUT_KINDS = [
-  "implementation",
-  "sol-findings",
-  "blind-findings",
-  "fixed-implementation",
-] as const;
-const PR_DELIVERY_OUTPUT_KINDS = ["implementation", "fixed-implementation"] as const;
-
-type PrWorkflowOutputProjection = {
-  taskId: string;
-  chainIndex: number;
-  kind: string;
-  body: string;
-  commitSha: string;
-};
-
-const isPrDeliveryStep = (task: {
+/**
+ * Which canonical PR delivery this Task is, or null when it is not one. The
+ * chain predicates are part of the answer rather than a later trust decision:
+ * a Step without a positive chain index has no handoff to assemble.
+ */
+const prDeliveryStage = (task: {
   chainId: string | null;
   chainIndex: number | null;
   templateStep: { outputKind: string; taskTemplate: { name: string } } | null;
-}): boolean => typeof task.chainId === "string"
-  && task.chainId.trim().length > 0
-  && task.chainIndex !== null
-  && Number.isInteger(task.chainIndex)
-  && task.chainIndex > 0
-  && task.templateStep?.taskTemplate?.name === PR_TEMPLATE_NAME
-  && PR_DELIVERY_OUTPUT_KINDS.includes(task.templateStep.outputKind as (typeof PR_DELIVERY_OUTPUT_KINDS)[number]);
+}): PrHandoffStage | null => {
+  if (typeof task.chainId !== "string" || task.chainId.trim().length === 0) return null;
+  if (task.chainIndex === null || !Number.isInteger(task.chainIndex) || task.chainIndex <= 0) return null;
+  if (task.templateStep?.taskTemplate?.name !== PR_TEMPLATE_NAME) return null;
+  if (task.templateStep.outputKind === "implementation") return "implementation";
+  return task.templateStep.outputKind === "fixed-implementation" ? "final" : null;
+};
 
 /**
- * Project only the persisted canonical PR handoff bodies that the current
- * delivery Run is allowed to consume. The project/chain predicates are part
- * of the query rather than a post-query trust decision: a session can never
- * receive a body from a same-index task in another Project or Chain.
+ * Decide the canonical PR handoff this delivery Run may publish. The
+ * project/chain predicates are part of the query rather than a post-query
+ * trust decision: a session can never receive a body from a same-index task in
+ * another Project or Chain.
  *
  * The implementation Run sees only its own output (there are no earlier PR
  * outputs at its index); the final Run sees all four canonical outputs that
- * exist through its chain index. Missing rows remain absent so delivery can
- * fail loudly instead of treating an unavailable body as a success.
+ * exist through its chain index. Rows that are absent or unusable stay in the
+ * candidate list as themselves, so `decidePrHandoff` refuses with the reason
+ * rather than silently shortening the handoff.
  */
-const prWorkflowOutputsFor = async (
+const prHandoffFor = async (
   db: PrismaClient,
   runId: string,
   task: {
@@ -111,24 +106,23 @@ const prWorkflowOutputsFor = async (
     chainIndex: number | null;
     templateStep: { outputKind: string; taskTemplate: { name: string } } | null;
   },
-): Promise<PrWorkflowOutputProjection[] | undefined> => {
-  if (!isPrDeliveryStep(task)) return undefined;
+): Promise<PrHandoff> => {
+  const stage = prDeliveryStage(task);
+  if (stage === null) return decidePrHandoff(null, []);
 
   const rows = await db.task.findMany({
     where: {
       projectId: task.projectId,
       chainId: task.chainId,
-      chainIndex: task.templateStep?.outputKind === "implementation"
-        ? task.chainIndex!
-        : { lte: task.chainIndex! },
+      chainIndex: stage === "implementation" ? task.chainIndex! : { lte: task.chainIndex! },
       templateStep: {
-        outputKind: { in: [...PR_WORKFLOW_OUTPUT_KINDS] },
+        outputKind: { in: [...PR_HANDOFF_KINDS] },
         taskTemplate: { name: PR_TEMPLATE_NAME },
       },
-      stepOutput: task.templateStep?.outputKind === "implementation"
+      stepOutput: stage === "implementation"
         ? { is: { runId, kind: "implementation" } }
         : { isNot: null },
-      ...(task.templateStep?.outputKind === "implementation" ? {} : {
+      ...(stage === "implementation" ? {} : {
         OR: [
           { id: { not: task.id } },
           { id: task.id, stepOutput: { is: { runId } } },
@@ -139,23 +133,20 @@ const prWorkflowOutputsFor = async (
     select: {
       id: true,
       chainIndex: true,
-      templateStep: { select: { outputKind: true } },
       stepOutput: { select: { kind: true, body: true, commitSha: true } },
     },
   });
 
-  return rows.flatMap((row) => (
-    row.chainIndex === null || row.stepOutput === null || row.templateStep === null
-      || typeof row.stepOutput.commitSha !== "string"
-      ? []
-      : [{
-        taskId: row.id,
-        chainIndex: row.chainIndex,
-        kind: row.stepOutput.kind,
-        body: row.stepOutput.body,
-        commitSha: row.stepOutput.commitSha,
-      }]
-  ));
+  return decidePrHandoff(
+    { taskId: task.id, chainIndex: task.chainIndex!, stage },
+    rows.map((row) => ({
+      taskId: row.id,
+      chainIndex: row.chainIndex,
+      kind: row.stepOutput?.kind ?? "",
+      body: row.stepOutput?.body ?? "",
+      commitSha: row.stepOutput?.commitSha ?? null,
+    })),
+  );
 };
 const sessionWriteInput = z.object({
   path: z.string(),
@@ -303,23 +294,17 @@ export function registerSessionRoutes(app: RouteApp, deps: RouteDeps): () => voi
     if (boundImplementationTask && "message" in boundImplementationTask) {
       return refusalJson(context, boundImplementationTask);
     }
-    const taskOutput = run.task?.stepOutput;
-    const outputPersisted = taskOutput?.runId === run.id;
-    const outputSatisfiedByPriorRun = Boolean(
-      run.task && taskOutput
-      && !outputPersisted
-      && outputIsImmutableOncePersisted(run.task.templateStep),
-    );
-    const output = outputPersisted && taskOutput
-      ? {
-        runId: taskOutput.runId,
-        kind: taskOutput.kind,
-        commitSha: taskOutput.commitSha,
-      }
-      : null;
-    const prWorkflowOutputs = run.task
-      ? await prWorkflowOutputsFor(db, run.id, run.task)
-      : undefined;
+    const outputEvidence: RunOutputEvidence = {
+      satisfaction: decideRunOutputSatisfaction(
+        run.id,
+        {
+          outputKind: run.task ? requiredOutputKind(run.task.templateStep) : null,
+          immutableOncePersisted: outputIsImmutableOncePersisted(run.task?.templateStep),
+        },
+        run.task?.stepOutput ?? null,
+      ),
+      prHandoff: run.task ? await prHandoffFor(db, run.id, run.task) : decidePrHandoff(null, []),
+    };
     return context.json({
       run: {
         id: run.id,
@@ -340,16 +325,10 @@ export function registerSessionRoutes(app: RouteApp, deps: RouteDeps): () => voi
         chainIndex: run.task.chainIndex,
         stepName: run.task.templateStep?.name ?? null,
         outputKind: run.task.templateStep?.outputKind ?? null,
-        output,
-        outputRequired: requiredOutputKind(run.task.templateStep) !== null,
-        outputRemediationAllowed:
-          !isRegressionVerificationOutputKind(run.task.templateStep?.outputKind)
-          && !(run.task.stepOutput && outputIsImmutableOncePersisted(run.task.templateStep)),
-        outputSatisfiedByPriorRun,
-        // A retry must not mistake an earlier Run's artifact for its own. This
-        // is the same run-scoped fact completion validates before it advances.
-        outputPersisted,
-        ...(prWorkflowOutputs === undefined ? {} : { prWorkflowOutputs }),
+        // The one decided answer completion reads too, so a retry cannot
+        // mistake an earlier Run's artifact for its own and delivery cannot
+        // re-judge a handoff this route already refused.
+        outputEvidence,
         ...(boundImplementationTask ? { boundImplementationTask } : {}),
       } : null,
     });

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -7,6 +7,7 @@ import {
   canonicalStepOrdinals,
   canonicalTemplateIdentity,
   CleanupStatus,
+  decideRunOutputSatisfaction,
   executionModeFor,
   FailureClass,
   failurePhases,
@@ -380,9 +381,19 @@ export const completionEvidenceRefusal = (
       requirement.headSha,
     );
   }
-  return persistedOutput?.runId !== run.id
-    && !(persistedOutput && outputIsImmutableOncePersisted(run.task?.templateStep))
-    ? `missing ${requirement.outputKind} task output for current Run ${run.id}`
+  // The same decision the session status route hands the runner, read here so
+  // completion and the Run that asked cannot disagree about whether the
+  // deliverable exists.
+  const satisfaction = decideRunOutputSatisfaction(
+    run.id,
+    {
+      outputKind: requirement.outputKind,
+      immutableOncePersisted: outputIsImmutableOncePersisted(run.task?.templateStep),
+    },
+    persistedOutput,
+  );
+  return satisfaction.case === "absent"
+    ? `missing ${satisfaction.outputKind} task output for current Run ${run.id}`
     : null;
 };
 

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -389,6 +389,7 @@ export const completionEvidenceRefusal = (
     {
       outputKind: requirement.outputKind,
       immutableOncePersisted: outputIsImmutableOncePersisted(run.task?.templateStep),
+      remediable: !isRegressionVerificationOutputKind(run.task?.templateStep?.outputKind),
     },
     persistedOutput,
   );

--- a/packages/api/src/run-output.dbtest.ts
+++ b/packages/api/src/run-output.dbtest.ts
@@ -790,9 +790,11 @@ test("Regression v2 status reserves remediation for the mechanical Runner path",
 
   assert.equal(status.status, 200, JSON.stringify(status.body));
   assert.equal(status.body.task.outputKind, "regression-verification-v2");
-  assert.equal(status.body.task.outputRequired, true);
-  assert.equal(status.body.task.outputRemediationAllowed, false);
-  assert.equal(status.body.task.outputPersisted, false);
+  assert.deepEqual(status.body.task.outputEvidence.satisfaction, {
+    case: "absent",
+    outputKind: "regression-verification-v2",
+    remediable: false,
+  });
 });
 
 test("a run that authored nothing is re-queued even when a prior run's output is on the task", async () => {
@@ -821,10 +823,11 @@ test("a run that authored nothing is re-queued even when a prior run's output is
   const claimed = await claimRun(secondRunId, "prior-output-runner-2");
   const status = await call("GET", `/session/runs/${secondRunId}/status`, claimed.sessionToken);
   assert.equal(status.status, 200, JSON.stringify(status.body));
-  assert.equal(status.body.task.outputRequired, true);
-  assert.equal(status.body.task.outputRemediationAllowed, true);
-  assert.equal(status.body.task.outputSatisfiedByPriorRun, false);
-  assert.equal(status.body.task.outputPersisted, false, "the prior Run's output is not this Run's deliverable");
+  assert.deepEqual(
+    status.body.task.outputEvidence.satisfaction,
+    { case: "absent", outputKind: "implementation", remediable: true },
+    "the prior Run's replaceable output is not this Run's deliverable",
+  );
 
   const completed = await call(
     "POST", `/runner/runs/${secondRunId}/complete`, RUNNER,
@@ -870,10 +873,10 @@ test("an immutable prior Run output disables remediation and explicitly satisfie
   const status = await call("GET", `/session/runs/${secondRunId}/status`, second.sessionToken);
 
   assert.equal(status.status, 200, JSON.stringify(status.body));
-  assert.equal(status.body.task.outputRequired, true);
-  assert.equal(status.body.task.outputRemediationAllowed, false);
-  assert.equal(status.body.task.outputSatisfiedByPriorRun, true);
-  assert.equal(status.body.task.outputPersisted, false);
+  assert.deepEqual(status.body.task.outputEvidence.satisfaction, {
+    case: "satisfied-by-prior-run",
+    outputKind: "sol-findings",
+  });
 
   const completed = await call(
     "POST", `/runner/runs/${secondRunId}/complete`, RUNNER,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -112,6 +112,7 @@ export * from "./cost.js";
 export * from "./task-source.js";
 export * from "./failure-envelope.js";
 export * from "./run-outcome.js";
+export * from "./run-output-evidence.js";
 export * from "./provider-terminal.js";
 export * from "./agent-sources.js";
 export * from "./agent-contract.js";

--- a/packages/db/src/run-output-evidence.test.ts
+++ b/packages/db/src/run-output-evidence.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decidePrHandoff,
+  decideRunOutputSatisfaction,
+  parseRunOutputEvidence,
+  type PrHandoffCandidate,
+  type PersistedTaskOutput,
+  type RunOutputRequirement,
+  type RunOutputSatisfaction,
+} from "./run-output-evidence.js";
+
+const required: RunOutputRequirement = { outputKind: "implementation", immutableOncePersisted: false };
+const findings: RunOutputRequirement = { outputKind: "sol-findings", immutableOncePersisted: true };
+const mechanical: RunOutputRequirement = { outputKind: "regression-verification-v2", immutableOncePersisted: false };
+const optional: RunOutputRequirement = { outputKind: null, immutableOncePersisted: false };
+
+const persisted = (runId: string | null, kind = "implementation"): PersistedTaskOutput => ({
+  runId,
+  kind,
+  commitSha: "a".repeat(40),
+});
+
+for (const [name, requirement, output, expected] of [
+  [
+    "this Run's own output is the deliverable",
+    required,
+    persisted("run-1"),
+    { case: "delivered", output: { kind: "implementation", commitSha: "a".repeat(40) } },
+  ],
+  [
+    "a Step that requires nothing and wrote nothing needs nothing",
+    optional,
+    null,
+    { case: "not-required" },
+  ],
+  [
+    "an output this Run wrote counts even where the Step requires none",
+    optional,
+    persisted("run-1", "result"),
+    { case: "delivered", output: { kind: "result", commitSha: "a".repeat(40) } },
+  ],
+  [
+    "an immutable findings artifact from an earlier Run leaves nothing to author",
+    findings,
+    persisted("run-0", "sol-findings"),
+    { case: "satisfied-by-prior-run", outputKind: "sol-findings" },
+  ],
+  [
+    "a replaceable output from an earlier Run is not this Run's deliverable",
+    required,
+    persisted("run-0"),
+    { case: "absent", outputKind: "implementation", remediable: true },
+  ],
+  [
+    "an unowned output row is not this Run's deliverable",
+    required,
+    persisted(null),
+    { case: "absent", outputKind: "implementation", remediable: true },
+  ],
+  [
+    "a required deliverable nobody wrote is remediable",
+    required,
+    null,
+    { case: "absent", outputKind: "implementation", remediable: true },
+  ],
+  [
+    "a mechanical verdict cannot be re-asked from the agent",
+    mechanical,
+    null,
+    { case: "absent", outputKind: "regression-verification-v2", remediable: false },
+  ],
+] as Array<[string, RunOutputRequirement, PersistedTaskOutput | null, RunOutputSatisfaction]>) {
+  test(`run output satisfaction: ${name}`, () => {
+    assert.deepEqual(decideRunOutputSatisfaction("run-1", requirement, output), expected);
+  });
+}
+
+const candidate = (overrides: Partial<PrHandoffCandidate> & { kind: string; chainIndex: number }): PrHandoffCandidate => ({
+  taskId: `task-${overrides.kind}`,
+  body: JSON.stringify({ schemaVersion: 1 }),
+  commitSha: String(overrides.chainIndex).repeat(40),
+  ...overrides,
+});
+
+const finalCandidates = (): PrHandoffCandidate[] => [
+  candidate({ kind: "implementation", chainIndex: 1 }),
+  candidate({ kind: "sol-findings", chainIndex: 2 }),
+  candidate({ kind: "blind-findings", chainIndex: 3 }),
+  candidate({ kind: "fixed-implementation", chainIndex: 4 }),
+];
+
+const finalDelivery = { taskId: "task-fixed-implementation", chainIndex: 4, stage: "final" } as const;
+
+test("a Step that is not a canonical PR delivery carries no handoff", () => {
+  assert.deepEqual(decidePrHandoff(null, []), { case: "not-a-pr-delivery" });
+});
+
+test("the implementation delivery carries its own output alone", () => {
+  const handoff = decidePrHandoff(
+    { taskId: "task-implementation", chainIndex: 1, stage: "implementation" },
+    [candidate({ kind: "implementation", chainIndex: 1 })],
+  );
+  assert.equal(handoff.case, "complete");
+  assert.deepEqual(handoff.case === "complete" ? handoff.outputs.map(({ kind }) => kind) : [], ["implementation"]);
+});
+
+test("the final delivery carries all four canonical outputs in chain order", () => {
+  const handoff = decidePrHandoff(finalDelivery, finalCandidates());
+  assert.equal(handoff.case, "complete");
+  assert.deepEqual(
+    handoff.case === "complete" ? handoff.outputs.map(({ chainIndex }) => chainIndex) : [],
+    [1, 2, 3, 4],
+  );
+});
+
+test("a SHA-256 commit identity is a canonical output identity", () => {
+  const candidates = finalCandidates();
+  candidates[3]!.commitSha = "d".repeat(64);
+  assert.equal(decidePrHandoff(finalDelivery, candidates).case, "complete");
+});
+
+for (const [name, mutate, reason] of [
+  ["a short handoff", (rows: PrHandoffCandidate[]) => rows.splice(2, 1), /requires exactly 4 output entries, not 3/u],
+  ["an out-of-order kind", (rows: PrHandoffCandidate[]) => { rows.reverse(); }, /missing or out of order at implementation/u],
+  ["an absent commit identity", (rows: PrHandoffCandidate[]) => { rows[0]!.commitSha = null; }, /malformed implementation canonical output evidence/u],
+  ["a commit identity that is not a SHA", (rows: PrHandoffCandidate[]) => { rows[1]!.commitSha = "not-a-sha"; }, /malformed sol-findings canonical output evidence/u],
+  ["an empty body", (rows: PrHandoffCandidate[]) => { rows[2]!.body = "  "; }, /malformed blind-findings canonical output evidence/u],
+  ["a non-positive chain index", (rows: PrHandoffCandidate[]) => { rows[0]!.chainIndex = 0; }, /malformed implementation canonical output evidence/u],
+  ["a repeated chain index", (rows: PrHandoffCandidate[]) => { rows[1]!.chainIndex = 1; }, /not ordered by chain index/u],
+  ["a repeated Task", (rows: PrHandoffCandidate[]) => { rows[1]!.taskId = rows[0]!.taskId; }, /repeats a Task/u],
+  ["a current entry from another Task", (rows: PrHandoffCandidate[]) => { rows[3]!.taskId = "task-elsewhere"; }, /belongs to another Task/u],
+  ["a current entry at another chain index", (rows: PrHandoffCandidate[]) => { rows[3]!.chainIndex = 9; }, /not for the current chain index/u],
+] as Array<[string, (rows: PrHandoffCandidate[]) => void, RegExp]>) {
+  test(`the final delivery refuses ${name}`, () => {
+    const candidates = finalCandidates();
+    mutate(candidates);
+    const handoff = decidePrHandoff(finalDelivery, candidates);
+    assert.equal(handoff.case, "incomplete");
+    assert.match(handoff.case === "incomplete" ? handoff.reason : "", reason);
+  });
+}
+
+test("the decided answer survives the wire unchanged", () => {
+  const evidence = {
+    satisfaction: decideRunOutputSatisfaction("run-1", required, persisted("run-1")),
+    prHandoff: decidePrHandoff(finalDelivery, finalCandidates()),
+  };
+  assert.deepEqual(parseRunOutputEvidence(JSON.parse(JSON.stringify(evidence))), evidence);
+});
+
+for (const malformed of [
+  undefined,
+  null,
+  { satisfaction: { case: "delivered" }, prHandoff: { case: "not-a-pr-delivery" } },
+  { satisfaction: { case: "absent", outputKind: "implementation" }, prHandoff: { case: "not-a-pr-delivery" } },
+  { satisfaction: { case: "not-required" } },
+  {
+    satisfaction: { case: "not-required" },
+    prHandoff: { case: "complete", outputs: [{ taskId: "t", chainIndex: 1, kind: "implementation", body: "{}", commitSha: "zz" }] },
+  },
+]) {
+  test(`the wire parse refuses ${JSON.stringify(malformed) ?? "undefined"}`, () => {
+    assert.throws(() => parseRunOutputEvidence(malformed));
+  });
+}

--- a/packages/db/src/run-output-evidence.test.ts
+++ b/packages/db/src/run-output-evidence.test.ts
@@ -11,10 +11,10 @@ import {
   type RunOutputSatisfaction,
 } from "./run-output-evidence.js";
 
-const required: RunOutputRequirement = { outputKind: "implementation", immutableOncePersisted: false };
-const findings: RunOutputRequirement = { outputKind: "sol-findings", immutableOncePersisted: true };
-const mechanical: RunOutputRequirement = { outputKind: "regression-verification-v2", immutableOncePersisted: false };
-const optional: RunOutputRequirement = { outputKind: null, immutableOncePersisted: false };
+const required: RunOutputRequirement = { outputKind: "implementation", immutableOncePersisted: false, remediable: true };
+const findings: RunOutputRequirement = { outputKind: "sol-findings", immutableOncePersisted: true, remediable: true };
+const mechanical: RunOutputRequirement = { outputKind: "regression-verification-v2", immutableOncePersisted: false, remediable: false };
+const optional: RunOutputRequirement = { outputKind: null, immutableOncePersisted: false, remediable: true };
 
 const persisted = (runId: string | null, kind = "implementation"): PersistedTaskOutput => ({
   runId,

--- a/packages/db/src/run-output-evidence.ts
+++ b/packages/db/src/run-output-evidence.ts
@@ -1,0 +1,232 @@
+import { z } from "zod";
+
+import { isRegressionVerificationOutputKind } from "./merge-tail.js";
+
+/**
+ * Whether the deliverable a Run's Step requires exists, decided once.
+ *
+ * Before this, the sentence "a valid, current-Run output exists" was projected
+ * as four booleans plus the raw output row and re-judged by everyone who read
+ * it: the session status route emitted `outputRequired`,
+ * `outputRemediationAllowed`, `outputSatisfiedByPriorRun` and
+ * `outputPersisted`; the runner re-derived the same combinations at four
+ * separate reads of that route; `completeRun` re-derived it a fifth time from
+ * its own query of the same row. The canonical PR handoff array was validated
+ * three times independently -- ordering and uniqueness in the runner's wire
+ * parse, ordering and Task identity again in `deliverWorkspace`, and scoping in
+ * the route's query.
+ *
+ * The cases below are what those booleans were spelling, and each one names a
+ * situation an operator can act on. Combinations that could not occur stop
+ * being representable: remediation is a property of an absent deliverable, not
+ * a free-standing flag, and a deliverable satisfied by an immutable earlier Run
+ * is neither present for this Run nor remediable by it.
+ */
+export type RunOutputSatisfaction =
+  /**
+   * This Run persisted the Task's output row. `output` is the server-side
+   * identity of what it wrote; only the runner can compare it with local HEAD.
+   */
+  | { case: "delivered"; output: PersistedRunOutput }
+  /** The Step declares no deliverable its own agent must author. */
+  | { case: "not-required" }
+  /**
+   * An earlier Run persisted the immutable findings artifact this Step
+   * requires. A findings artifact is the review it records, so this Run has
+   * nothing left to author and may not replace it.
+   */
+  | { case: "satisfied-by-prior-run"; outputKind: string }
+  /**
+   * The required deliverable is not there. `remediable` is whether asking the
+   * agent again can produce it: a mechanical verdict cannot be re-asked, so a
+   * Regression Step's absent handoff is terminal rather than remediable.
+   */
+  | { case: "absent"; outputKind: string; remediable: boolean };
+
+export type PersistedRunOutput = {
+  kind: string;
+  commitSha: string | null;
+};
+
+/** What a Step's own agent must author, and whether it may ever be replaced. */
+export type RunOutputRequirement = {
+  /** The output kind the agent must author, or null when completion may synthesize one. */
+  outputKind: string | null;
+  /** A findings artifact is immutable once persisted, whoever authored it. */
+  immutableOncePersisted: boolean;
+};
+
+/** The persisted Task output row, as the control plane holds it. */
+export type PersistedTaskOutput = {
+  runId: string | null;
+  kind: string;
+  commitSha: string | null;
+};
+
+export const decideRunOutputSatisfaction = (
+  runId: string,
+  requirement: RunOutputRequirement,
+  persisted: PersistedTaskOutput | null,
+): RunOutputSatisfaction => {
+  if (persisted && persisted.runId === runId) {
+    return { case: "delivered", output: { kind: persisted.kind, commitSha: persisted.commitSha } };
+  }
+  const { outputKind } = requirement;
+  if (outputKind === null) return { case: "not-required" };
+  if (persisted && requirement.immutableOncePersisted) {
+    return { case: "satisfied-by-prior-run", outputKind };
+  }
+  return { case: "absent", outputKind, remediable: !isRegressionVerificationOutputKind(outputKind) };
+};
+
+/** The canonical PR workflow's four output kinds, in the order a chain authors them. */
+export const PR_HANDOFF_KINDS = [
+  "implementation",
+  "sol-findings",
+  "blind-findings",
+  "fixed-implementation",
+] as const;
+
+export type PrHandoffKind = (typeof PR_HANDOFF_KINDS)[number];
+
+/**
+ * Which canonical PR delivery a Run is: the implementation Run publishes the
+ * pull request from its own output alone, the fix Run updates it from all four.
+ */
+export type PrHandoffStage = "implementation" | "final";
+
+const PR_HANDOFF_SEQUENCE: Record<PrHandoffStage, readonly PrHandoffKind[]> = {
+  implementation: ["implementation"],
+  final: PR_HANDOFF_KINDS,
+};
+
+export type PrHandoffOutput = {
+  taskId: string;
+  chainIndex: number;
+  kind: PrHandoffKind;
+  body: string;
+  commitSha: string;
+};
+
+/** Whether this Run's delivery may publish a canonical pull request, decided once. */
+export type PrHandoff =
+  /** This Run's Step is not a canonical PR delivery and carries no handoff. */
+  | { case: "not-a-pr-delivery" }
+  /**
+   * Exactly the ordered handoff the stage requires, every entry well formed,
+   * one Task per chain index, and the last entry bound to this delivery.
+   * Delivery still parses the bodies: their schemas and their agreement with
+   * each other and with local HEAD are a different fact.
+   */
+  | { case: "complete"; outputs: readonly PrHandoffOutput[] }
+  /** The handoff cannot be assembled, so delivery must fail rather than publish. */
+  | { case: "incomplete"; reason: string };
+
+/** Canonical repositories may use SHA-1 (40 hex) or SHA-256 (64 hex). */
+const CANONICAL_COMMIT_SHA = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u;
+
+/** A persisted PR-workflow output row as the route's scoped query projects it. */
+export type PrHandoffCandidate = {
+  taskId: string;
+  chainIndex: number | null;
+  kind: string;
+  body: string;
+  commitSha: string | null;
+};
+
+export const decidePrHandoff = (
+  delivery: { taskId: string; chainIndex: number; stage: PrHandoffStage } | null,
+  candidates: readonly PrHandoffCandidate[],
+): PrHandoff => {
+  if (!delivery) return { case: "not-a-pr-delivery" };
+  const expected = PR_HANDOFF_SEQUENCE[delivery.stage];
+  if (candidates.length !== expected.length) {
+    return {
+      case: "incomplete",
+      reason: `canonical PR handoff requires exactly ${expected.length} output entr${expected.length === 1 ? "y" : "ies"}, not ${candidates.length}`,
+    };
+  }
+  const outputs: PrHandoffOutput[] = [];
+  for (const [index, kind] of expected.entries()) {
+    const candidate = candidates[index]!;
+    if (candidate.kind !== kind) {
+      return { case: "incomplete", reason: `canonical PR handoff evidence is missing or out of order at ${kind}` };
+    }
+    if (candidate.taskId.trim().length === 0
+      || candidate.chainIndex === null
+      || !Number.isInteger(candidate.chainIndex)
+      || candidate.chainIndex <= 0
+      || candidate.body.trim().length === 0
+      || candidate.commitSha === null
+      || !CANONICAL_COMMIT_SHA.test(candidate.commitSha)) {
+      return { case: "incomplete", reason: `malformed ${kind} canonical output evidence` };
+    }
+    const previous = outputs[index - 1];
+    if (previous && candidate.chainIndex <= previous.chainIndex) {
+      return { case: "incomplete", reason: "canonical PR handoff evidence is not ordered by chain index" };
+    }
+    if (outputs.some((output) => output.taskId === candidate.taskId)) {
+      return { case: "incomplete", reason: "canonical PR handoff evidence repeats a Task" };
+    }
+    outputs.push({
+      taskId: candidate.taskId,
+      chainIndex: candidate.chainIndex,
+      kind,
+      body: candidate.body,
+      commitSha: candidate.commitSha,
+    });
+  }
+  const current = outputs.at(-1)!;
+  if (current.taskId !== delivery.taskId) {
+    return { case: "incomplete", reason: `${current.kind} canonical output evidence belongs to another Task` };
+  }
+  if (current.chainIndex !== delivery.chainIndex) {
+    return { case: "incomplete", reason: `${current.kind} canonical output evidence is not for the current chain index` };
+  }
+  return { case: "complete", outputs };
+};
+
+/** Everything the session status route decides about this Run's deliverables. */
+export type RunOutputEvidence = {
+  satisfaction: RunOutputSatisfaction;
+  prHandoff: PrHandoff;
+};
+
+const satisfactionSchema: z.ZodType<RunOutputSatisfaction> = z.discriminatedUnion("case", [
+  z.object({
+    case: z.literal("delivered"),
+    output: z.object({ kind: z.string().min(1), commitSha: z.string().nullable() }),
+  }),
+  z.object({ case: z.literal("not-required") }),
+  z.object({ case: z.literal("satisfied-by-prior-run"), outputKind: z.string().min(1) }),
+  z.object({ case: z.literal("absent"), outputKind: z.string().min(1), remediable: z.boolean() }),
+]);
+
+const prHandoffSchema: z.ZodType<PrHandoff> = z.discriminatedUnion("case", [
+  z.object({ case: z.literal("not-a-pr-delivery") }),
+  z.object({
+    case: z.literal("complete"),
+    outputs: z.array(z.object({
+      taskId: z.string().min(1),
+      chainIndex: z.number().int().positive(),
+      kind: z.enum(PR_HANDOFF_KINDS),
+      body: z.string().min(1),
+      commitSha: z.string().regex(CANONICAL_COMMIT_SHA),
+    })).min(1),
+  }),
+  z.object({ case: z.literal("incomplete"), reason: z.string().min(1) }),
+]);
+
+const runOutputEvidenceSchema: z.ZodType<RunOutputEvidence> = z.object({
+  satisfaction: satisfactionSchema,
+  prHandoff: prHandoffSchema,
+});
+
+/**
+ * Read the decided answer off the wire. The runner is on the untrusted side of
+ * this seam and must reject a payload that is not one, but it no longer
+ * re-derives any of the rules the decision applied: this rejects a shape, not a
+ * verdict. Throws a `ZodError` on anything else.
+ */
+export const parseRunOutputEvidence = (value: unknown): RunOutputEvidence =>
+  runOutputEvidenceSchema.parse(value);

--- a/packages/db/src/run-output-evidence.ts
+++ b/packages/db/src/run-output-evidence.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-import { isRegressionVerificationOutputKind } from "./merge-tail.js";
-
 /**
  * Whether the deliverable a Run's Step requires exists, decided once.
  *
@@ -48,12 +46,14 @@ export type PersistedRunOutput = {
   commitSha: string | null;
 };
 
-/** What a Step's own agent must author, and whether it may ever be replaced. */
+/** A Step's output contract: what its own agent must author, and on what terms. */
 export type RunOutputRequirement = {
   /** The output kind the agent must author, or null when completion may synthesize one. */
   outputKind: string | null;
   /** A findings artifact is immutable once persisted, whoever authored it. */
   immutableOncePersisted: boolean;
+  /** Whether the agent can be asked again for it. A mechanical verdict cannot. */
+  remediable: boolean;
 };
 
 /** The persisted Task output row, as the control plane holds it. */
@@ -76,7 +76,7 @@ export const decideRunOutputSatisfaction = (
   if (persisted && requirement.immutableOncePersisted) {
     return { case: "satisfied-by-prior-run", outputKind };
   }
-  return { case: "absent", outputKind, remediable: !isRegressionVerificationOutputKind(outputKind) };
+  return { case: "absent", outputKind, remediable: requirement.remediable };
 };
 
 /** The canonical PR workflow's four output kinds, in the order a chain authors them. */

--- a/packages/runner/src/api.ts
+++ b/packages/runner/src/api.ts
@@ -1,11 +1,11 @@
 import { statfs } from "node:fs/promises";
 
-import type { CleanupStatus, RunOutcome } from "@anneal/db";
+import { parseRunOutputEvidence, type CleanupStatus, type RunOutcome, type RunOutputEvidence } from "@anneal/db";
 import type { ClaimContract } from "@anneal/db/claim-contract";
 
 import type { RunnerConfig, RunnerKind } from "./config.js";
 
-export type { CleanupStatus, FailureClass } from "@anneal/db";
+export type { CleanupStatus, FailureClass, PrHandoffOutput, RunOutputEvidence } from "@anneal/db";
 /** The only repository dependency-provisioning policies understood by a runner. */
 export const DEPENDENCY_PROVISIONING_VALUES = ["NONE", "NPM_CI"] as const;
 export type DependencyProvisioning = (typeof DEPENDENCY_PROVISIONING_VALUES)[number];
@@ -196,29 +196,6 @@ const acknowledgeCancellation = async (
   });
 };
 
-export type SessionTaskOutputStatus = {
-  outputKind: string | null;
-  outputRequired: boolean;
-  outputRemediationAllowed: boolean;
-  outputSatisfiedByPriorRun: boolean;
-  outputPersisted: boolean;
-  output: {
-    runId: string;
-    kind: string;
-    commitSha: string | null;
-  } | null;
-  /** Persisted canonical PR handoff bodies projected by the session route. */
-  prWorkflowOutputs?: SessionPrWorkflowOutput[];
-};
-
-export type SessionPrWorkflowOutput = {
-  taskId: string;
-  chainIndex: number;
-  kind: "implementation" | "sol-findings" | "blind-findings" | "fixed-implementation";
-  body: string;
-  commitSha: string;
-};
-
 export type SessionTaskOutput = {
   kind: string;
   body: string;
@@ -241,91 +218,30 @@ const persistSessionTaskOutput = async (
   });
 };
 
-/** Read the output fact through the Run's session principal. Completion is too
- * late for recovery: by then the provider process and workspace are gone. */
-const readSessionTaskOutputStatus = async (
+/** Read the decided output evidence through the Run's session principal.
+ * Completion is too late for recovery: by then the provider process and
+ * workspace are gone. The runner judges nothing here -- the control plane
+ * already decided satisfaction and the canonical PR handoff -- so this only
+ * refuses a payload that is not the decided answer. */
+const readSessionRunOutputEvidence = async (
   config: RunnerConfig,
   claim: RunSessionClaim,
-): Promise<SessionTaskOutputStatus | null> => {
+): Promise<RunOutputEvidence | null> => {
   const response = await request(config, `/session/runs/${claim.run.id}/status`, {
     method: "GET",
     headers: { Authorization: `Bearer ${claim.sessionToken}` },
   });
-  const payload = await response.json() as {
-    task?: {
-      outputKind?: unknown;
-      outputRequired?: unknown;
-      outputRemediationAllowed?: unknown;
-      outputSatisfiedByPriorRun?: unknown;
-      outputPersisted?: unknown;
-      output?: unknown;
-      prWorkflowOutputs?: unknown;
-    } | null;
-  };
-  const output = payload.task?.output;
-  const prWorkflowOutputs = payload.task?.prWorkflowOutputs;
-  const validOutput = output === null || (
-    typeof output === "object"
-    && !Array.isArray(output)
-    && typeof (output as Record<string, unknown>).runId === "string"
-    && typeof (output as Record<string, unknown>).kind === "string"
-    && (typeof (output as Record<string, unknown>).commitSha === "string"
-      || (output as Record<string, unknown>).commitSha === null)
-  );
-  // Canonical repositories may use SHA-1 (40 hex) or SHA-256 (64 hex).
-  const isCanonicalCommitSha = (value: unknown): value is string => (
-    typeof value === "string" && /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(value)
-  );
-  const validPrWorkflowOutputs = prWorkflowOutputs === undefined || (
-    Array.isArray(prWorkflowOutputs)
-    && prWorkflowOutputs.every((entry: unknown, index: number, entries: unknown[]) => {
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false;
-      const value = entry as Record<string, unknown>;
-      const previous = entries[index - 1];
-      const previousIndex = previous && typeof previous === "object" && !Array.isArray(previous)
-        ? (previous as Record<string, unknown>).chainIndex
-        : undefined;
-      return typeof value.taskId === "string"
-        && value.taskId.trim().length > 0
-        && Number.isInteger(value.chainIndex)
-        && (value.chainIndex as number) > 0
-        && typeof value.body === "string"
-        && value.body.trim().length > 0
-        && isCanonicalCommitSha(value.commitSha)
-        && (value.kind === "implementation"
-          || value.kind === "sol-findings"
-          || value.kind === "blind-findings"
-          || value.kind === "fixed-implementation")
-        && (index === 0 || (Number.isInteger(previousIndex)
-          && (value.chainIndex as number) > (previousIndex as number)))
-        && entries.findIndex((candidate) => candidate
-          && typeof candidate === "object"
-          && !Array.isArray(candidate)
-          && (candidate as Record<string, unknown>).taskId === value.taskId) === index;
-    })
-  );
-  if (payload.task === null) return null;
-  if (!payload.task
-    || (typeof payload.task.outputKind !== "string" && payload.task.outputKind !== null)
-    || typeof payload.task.outputRequired !== "boolean"
-    || typeof payload.task.outputRemediationAllowed !== "boolean"
-    || typeof payload.task.outputSatisfiedByPriorRun !== "boolean"
-    || typeof payload.task.outputPersisted !== "boolean"
-    || !validOutput
-    || !validPrWorkflowOutputs) {
-    throw new Error(`Anneal API returned an invalid task output status for Run ${claim.run.id}`);
+  const payload = await response.json() as { task?: { outputEvidence?: unknown } | null };
+  if (!payload.task) return null;
+  try {
+    return parseRunOutputEvidence(payload.task.outputEvidence);
+  } catch (error: unknown) {
+    throw new Error(
+      `Anneal API returned an invalid task output status for Run ${claim.run.id}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   }
-  return {
-    outputKind: payload.task.outputKind,
-    outputRequired: payload.task.outputRequired,
-    outputRemediationAllowed: payload.task.outputRemediationAllowed,
-    outputSatisfiedByPriorRun: payload.task.outputSatisfiedByPriorRun,
-    outputPersisted: payload.task.outputPersisted,
-    output: output as SessionTaskOutputStatus["output"],
-    ...(prWorkflowOutputs === undefined ? {} : {
-      prWorkflowOutputs: prWorkflowOutputs as SessionPrWorkflowOutput[],
-    }),
-  };
 };
 
 /** Durably acknowledge the exact ref immediately after git accepts the push.
@@ -584,8 +500,8 @@ export interface RunSession {
   emit(events: SessionEventPayload[], providerConversationId?: string | null): Promise<void>;
   /** Persist a mechanically-authored deliverable under the Run's session principal. */
   publishOutput(output: SessionTaskOutput): Promise<void>;
-  /** Read the output fact under the Run's session principal. */
-  outputStatus(): Promise<SessionTaskOutputStatus | null>;
+  /** Read the decided output evidence under the Run's session principal. */
+  outputStatus(): Promise<RunOutputEvidence | null>;
   /** Durably acknowledge the exact ref immediately after git accepts the push. */
   publishBranch(pushedBranch: string): Promise<void>;
   /** Record cleanup that carries no authority over the Run's outcome. */
@@ -640,7 +556,7 @@ export const openRunSession = (config: RunnerConfig, claim: RunSessionClaim): Ru
   note: (body, metadata) => appendActivity(config, claim, body, metadata),
   emit: (events, providerConversationId) => appendEvents(config, claim, events, providerConversationId),
   publishOutput: (output) => persistSessionTaskOutput(config, claim, output),
-  outputStatus: () => readSessionTaskOutputStatus(config, claim),
+  outputStatus: () => readSessionRunOutputEvidence(config, claim),
   publishBranch: (pushedBranch) => recordPublishedBranch(config, claim, pushedBranch),
   recordCleanup: (cleanup) => recordLeaseIndependentCleanup(config, claim, cleanup),
   acknowledgeCancellation: (cancellation, workspace, containment) =>

--- a/packages/runner/src/control-plane.test.ts
+++ b/packages/runner/src/control-plane.test.ts
@@ -53,120 +53,61 @@ test("startup retries only transport failures and control-plane server errors", 
   assert.equal(retriableStartupError(new ControlPlaneError(409, "refused")), false);
 });
 
-test("session status validates and normalizes the nested PR workflow evidence projection", async () => {
+const answerWith = (task: unknown): (() => void) => {
   const originalFetch = globalThis.fetch;
-  const output = {
-    taskId: "task-implementation",
-    chainIndex: 1,
-    kind: "implementation",
-    body: JSON.stringify({ schemaVersion: 1 }),
-    commitSha: "a".repeat(40),
-  } as const;
-  globalThis.fetch = async () => new Response(JSON.stringify({
-    task: {
-      outputKind: "implementation",
-      outputRequired: true,
-      outputRemediationAllowed: true,
-      outputSatisfiedByPriorRun: false,
-      outputPersisted: true,
-      output: { runId: "run-1", kind: "implementation", commitSha: output.commitSha },
-      prWorkflowOutputs: [output],
-    },
-  }), { status: 200, headers: { "Content-Type": "application/json" } });
-  try {
-    const status = await session().outputStatus();
-    assert.deepEqual(status?.prWorkflowOutputs, [output]);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
+  globalThis.fetch = async () => new Response(JSON.stringify({ task }), {
+    status: 200, headers: { "Content-Type": "application/json" },
+  });
+  return () => { globalThis.fetch = originalFetch; };
+};
 
-test("session status rejects malformed PR workflow evidence entries", async () => {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => new Response(JSON.stringify({
-    task: {
-      outputKind: "fixed-implementation",
-      outputRequired: true,
-      outputRemediationAllowed: true,
-      outputSatisfiedByPriorRun: false,
-      outputPersisted: true,
-      output: null,
-      prWorkflowOutputs: [{
-        taskId: "task-fixed",
-        chainIndex: "4",
-        kind: "fixed-implementation",
-        body: "{}",
-        commitSha: "b".repeat(40),
-      }],
-    },
-  }), { status: 200, headers: { "Content-Type": "application/json" } });
-  try {
-    await assert.rejects(
-      session().outputStatus(),
-      /invalid task output status/u,
-    );
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-test("session status accepts the exact ordered final PR evidence set including SHA-256", async () => {
-  const originalFetch = globalThis.fetch;
-  const kinds = ["implementation", "sol-findings", "blind-findings", "fixed-implementation"] as const;
-  const outputs = kinds.map((kind, index) => ({
-    taskId: `task-${kind}`,
-    chainIndex: index + 1,
-    kind,
-    body: JSON.stringify({ schemaVersion: 1, kind }),
-    commitSha: index === 3 ? "d".repeat(64) : String(index + 1).repeat(40),
-  }));
-  globalThis.fetch = async () => new Response(JSON.stringify({
-    task: {
-      outputKind: "fixed-implementation",
-      outputRequired: true,
-      outputRemediationAllowed: true,
-      outputSatisfiedByPriorRun: false,
-      outputPersisted: true,
-      output: { runId: "run-1", kind: "fixed-implementation", commitSha: outputs[3]!.commitSha },
-      prWorkflowOutputs: outputs,
-    },
-  }), { status: 200, headers: { "Content-Type": "application/json" } });
-  try {
-    const status = await session().outputStatus();
-    assert.deepEqual(status?.prWorkflowOutputs, outputs);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
-});
-
-for (const malformed of [
-  { name: "nullable commit", mutate: (outputs: any[]) => { outputs[0].commitSha = null; } },
-  { name: "duplicate Task identity", mutate: (outputs: any[]) => { outputs[1].taskId = outputs[0].taskId; } },
-  { name: "out-of-order chain index", mutate: (outputs: any[]) => { outputs[1].chainIndex = 1; } },
-] as const) {
-  test(`session status rejects ${malformed.name} in final PR evidence`, async () => {
-    const originalFetch = globalThis.fetch;
-    const outputs = ["implementation", "sol-findings", "blind-findings", "fixed-implementation"].map((kind, index) => ({
+test("session status reads the decided output evidence without re-deciding it", async () => {
+  const outputs = ["implementation", "sol-findings", "blind-findings", "fixed-implementation"]
+    .map((kind, index) => ({
       taskId: `task-${kind}`,
       chainIndex: index + 1,
       kind,
-      body: "{}",
-      commitSha: String(index + 1).repeat(40),
+      body: JSON.stringify({ schemaVersion: 1, kind }),
+      commitSha: index === 3 ? "d".repeat(64) : String(index + 1).repeat(40),
     }));
-    malformed.mutate(outputs);
-    globalThis.fetch = async () => new Response(JSON.stringify({
-      task: {
-        outputKind: "fixed-implementation", outputRequired: true, outputRemediationAllowed: true,
-        outputSatisfiedByPriorRun: false, outputPersisted: true, output: null, prWorkflowOutputs: outputs,
+  const evidence = {
+    satisfaction: { case: "delivered", output: { kind: "fixed-implementation", commitSha: outputs[3]!.commitSha } },
+    prHandoff: { case: "complete", outputs },
+  };
+  const restore = answerWith({ outputEvidence: evidence });
+  try {
+    assert.deepEqual(await session().outputStatus(), evidence);
+  } finally {
+    restore();
+  }
+});
+
+test("a Run without a task has no output evidence to read", async () => {
+  const restore = answerWith(null);
+  try {
+    assert.equal(await session().outputStatus(), null);
+  } finally {
+    restore();
+  }
+});
+
+test("session status refuses a payload that is not the decided answer", async () => {
+  for (const outputEvidence of [
+    undefined,
+    { satisfaction: { case: "delivered" }, prHandoff: { case: "not-a-pr-delivery" } },
+    {
+      satisfaction: { case: "not-required" },
+      prHandoff: {
+        case: "complete",
+        outputs: [{ taskId: "t", chainIndex: 1, kind: "implementation", body: "{}", commitSha: "not-a-sha" }],
       },
-    }), { status: 200, headers: { "Content-Type": "application/json" } });
+    },
+  ]) {
+    const restore = answerWith({ outputEvidence });
     try {
-      await assert.rejects(
-        session().outputStatus(),
-        /invalid task output status/u,
-      );
+      await assert.rejects(session().outputStatus(), /invalid task output status/u);
     } finally {
-      globalThis.fetch = originalFetch;
+      restore();
     }
-  });
-}
+  }
+});

--- a/packages/runner/src/delivery.test.ts
+++ b/packages/runner/src/delivery.test.ts
@@ -11,7 +11,7 @@ import type { ExitEvidence } from "./adapters.js";
 import type { RunnerConfig } from "./config.js";
 import {
   deliverWorkspace, pullRequestTitle, salvageWorkspace,
-  type CommandExecutor, type DeliveryClaim, type PrWorkflowOutput,
+  type CommandExecutor, type DeliveryClaim,
 } from "./delivery.js";
 import { completionEnvelope } from "./envelope.js";
 import { CommandTimeoutError, KILL_OVERHEAD_MS } from "./exec.js";
@@ -451,24 +451,34 @@ test("canonical PR final delivery fails for a non-GitHub remote after publishing
   assert.equal(result.pushedBranch, workspace.branch);
 });
 
-test("canonical PR malformed evidence is refused before git or gh", async () => {
-  const calls: string[] = [];
-  const malformed: PrWorkflowOutput[] = [...canonicalFinalOutputs()];
-  malformed[3] = { ...malformed[3]!, commitSha: null };
-  const result = await deliverWorkspace(
-    config,
-    canonicalClaim("fixed-implementation", "task-fixed", 4),
-    { ...workspace, baseSha: canonicalImplementationSha },
-    {
-      command: async (executable, args) => { calls.push(`${executable} ${args.join(" ")}`); return ""; },
-      headSha: canonicalFixedSha,
-      prWorkflowOutputs: malformed,
-    },
-  );
-  assert.equal(result.pushStatus, "FAILED");
-  assert.equal(result.failure?.operation, "canonical PR output validation");
-  assert.deepEqual(calls, []);
-});
+// The shape, order and Task binding of the handoff are the control plane's
+// decision (`decidePrHandoff`); what delivery still refuses on its own is a
+// canonical PR delivery reached without one, or with a body that does not
+// satisfy its kind's schema.
+for (const missing of [
+  { name: "no handoff at all", outputs: undefined },
+  { name: "a handoff missing its final artifact", outputs: canonicalFinalOutputs().slice(0, 3) },
+  { name: "a body that violates its canonical schema", outputs: canonicalFinalOutputs().map((output, index) => (
+    index === 3 ? { ...output, body: JSON.stringify({ schemaVersion: 1 }) } : output
+  )) },
+] as const) {
+  test(`canonical PR final delivery with ${missing.name} is refused before git or gh`, async () => {
+    const calls: string[] = [];
+    const result = await deliverWorkspace(
+      config,
+      canonicalClaim("fixed-implementation", "task-fixed", 4),
+      { ...workspace, baseSha: canonicalImplementationSha },
+      {
+        command: async (executable, args) => { calls.push(`${executable} ${args.join(" ")}`); return ""; },
+        headSha: canonicalFixedSha,
+        ...(missing.outputs ? { prWorkflowOutputs: missing.outputs } : {}),
+      },
+    );
+    assert.equal(result.pushStatus, "FAILED");
+    assert.equal(result.failure?.operation, "canonical PR output validation");
+    assert.deepEqual(calls, []);
+  });
+}
 
 test("canonical PR final output and completion head mismatches are refused before publication", async () => {
   for (const candidate of [

--- a/packages/runner/src/delivery.ts
+++ b/packages/runner/src/delivery.ts
@@ -1,5 +1,5 @@
 import { confirmedWrite, isDeterministicRefusal, isLostResponse } from "@anneal/github-client";
-import { canonicalOutputSchema, PR_TEMPLATE_NAME } from "@anneal/db";
+import { canonicalOutputSchema, PR_TEMPLATE_NAME, type PrHandoffKind, type PrHandoffOutput } from "@anneal/db";
 
 import type { ClaimedTask, FailureClass } from "./api.js";
 import type { RunnerConfig } from "./config.js";
@@ -70,23 +70,14 @@ export type DeliveryClaim = {
   run: Partial<Pick<ClaimedTask["run"], "opensPullRequest" | "pullRequestBase" | "requiresCommit">>;
 };
 
-/** Server-projected, run-bound evidence for the canonical PR handover. */
-export type PrWorkflowOutput = {
-  taskId: string;
-  chainIndex: number;
-  kind: string;
-  body: string;
-  commitSha: string | null;
-};
-
 export type DeliverWorkspaceDependencies = {
   command?: CommandExecutor;
   /** HEAD already captured by the runner before delivery. Direct callers may
    *  omit it and let delivery resolve the commit itself. */
   headSha?: string;
   recordPublication?: (branch: string) => Promise<void>;
-  /** Persisted canonical PR outputs projected by the session status route. */
-  prWorkflowOutputs?: readonly PrWorkflowOutput[];
+  /** The canonical PR handoff the session status route already decided complete. */
+  prWorkflowOutputs?: readonly PrHandoffOutput[];
   retryOptions?: RetryOptions;
 };
 
@@ -211,13 +202,6 @@ const PR_IMPLEMENTATION_KIND = "implementation";
 const PR_SOL_FINDINGS_KIND = "sol-findings";
 const PR_BLIND_FINDINGS_KIND = "blind-findings";
 const PR_FIXED_IMPLEMENTATION_KIND = "fixed-implementation";
-const PR_INITIAL_OUTPUT_KINDS = [PR_IMPLEMENTATION_KIND] as const;
-const PR_FINAL_OUTPUT_KINDS = [
-  PR_IMPLEMENTATION_KIND,
-  PR_SOL_FINDINGS_KIND,
-  PR_BLIND_FINDINGS_KIND,
-  PR_FIXED_IMPLEMENTATION_KIND,
-] as const;
 
 type PrImplementationArtifact = {
   headSha: string;
@@ -289,25 +273,17 @@ const taskGoal = (claim: DeliveryClaim): string => {
   return description.slice(briefStart, briefEnd).split(/\r?\n/u)[0] ?? "";
 };
 
-const isWellFormedPrOutput = (output: PrWorkflowOutput | undefined): output is PrWorkflowOutput & { commitSha: string } => (
-  output !== undefined
-  && typeof output.taskId === "string"
-  && output.taskId.trim().length > 0
-  && Number.isInteger(output.chainIndex)
-  && output.chainIndex > 0
-  && typeof output.body === "string"
-  && typeof output.commitSha === "string"
-);
-
+/**
+ * Read one canonical artifact out of the decided handoff. Its shape, order and
+ * Task binding were decided by the control plane; what is checked here is the
+ * body: valid JSON that satisfies the kind's canonical schema.
+ */
 const parsePrOutput = <T>(
-  output: PrWorkflowOutput | undefined,
-  expectedKind: string,
+  output: PrHandoffOutput | undefined,
+  expectedKind: PrHandoffKind,
 ): T => {
   if (!output || output.kind !== expectedKind) {
     throw new Error(`missing required ${expectedKind} canonical output evidence`);
-  }
-  if (!isWellFormedPrOutput(output)) {
-    throw new Error(`malformed ${expectedKind} canonical output evidence`);
   }
   let value: unknown;
   try {
@@ -324,13 +300,13 @@ const parsePrOutput = <T>(
 
 const validatePrReviewHandoff = (
   implementation: PrImplementationArtifact,
-  implementationOutput: PrWorkflowOutput,
+  implementationOutput: PrHandoffOutput,
   sol: PrReviewArtifact,
-  solOutput: PrWorkflowOutput,
+  solOutput: PrHandoffOutput,
   blind: PrReviewArtifact,
-  blindOutput: PrWorkflowOutput,
+  blindOutput: PrHandoffOutput,
   fixed: PrFixedArtifact,
-  fixedOutput: PrWorkflowOutput,
+  fixedOutput: PrHandoffOutput,
 ): void => {
   if (implementationOutput.commitSha !== implementation.headSha
     || solOutput.commitSha !== sol.headSha
@@ -365,47 +341,6 @@ const validatePrReviewHandoff = (
     || adoptedIds.some((id) => !closedIds.includes(id))) {
     throw new Error("fixed-implementation closedFindings do not match adopted review fixes");
   }
-};
-
-const requiredPrOutputs = (
-  claim: DeliveryClaim,
-  outputs: readonly PrWorkflowOutput[] | undefined,
-  final: boolean,
-): readonly PrWorkflowOutput[] => {
-  const expectedKinds = final ? PR_FINAL_OUTPUT_KINDS : PR_INITIAL_OUTPUT_KINDS;
-  if (!Array.isArray(outputs) || outputs.length !== expectedKinds.length) {
-    throw new Error(`canonical PR workflow requires exactly ${expectedKinds.length} output evidence entr${expectedKinds.length === 1 ? "y" : "ies"}`);
-  }
-  for (const [index, expectedKind] of expectedKinds.entries()) {
-    const output = outputs[index];
-    if (!output || output.kind !== expectedKind) {
-      throw new Error(`canonical PR workflow output evidence is missing or out of order at ${expectedKind}`);
-    }
-    if (!isWellFormedPrOutput(output)) {
-      throw new Error(`malformed ${expectedKind} canonical output evidence`);
-    }
-    if (index > 0 && output.chainIndex <= outputs[index - 1]!.chainIndex) {
-      throw new Error("canonical PR workflow output evidence is not ordered by chain index");
-    }
-  }
-  const current = outputs.at(-1)!;
-  if (final && current.taskId !== claim.task.id) {
-    throw new Error("fixed-implementation canonical output evidence belongs to another Task");
-  }
-  if (!final && outputs[0]!.taskId !== claim.task.id) {
-    throw new Error("implementation canonical output evidence belongs to another Task");
-  }
-  if (claim.task.chainId === undefined || claim.task.chainId === null || claim.task.chainId.trim().length === 0) {
-    throw new Error("canonical PR workflow requires a non-null chain identity");
-  }
-  if (claim.task.chainIndex === undefined || claim.task.chainIndex === null
-    || !Number.isInteger(claim.task.chainIndex) || claim.task.chainIndex <= 0) {
-    throw new Error("canonical PR workflow requires a non-null chain index");
-  }
-  if (current.chainIndex !== claim.task.chainIndex) {
-    throw new Error(`${current.kind} canonical output evidence is not for the current chain index`);
-  }
-  return outputs;
 };
 
 const markdownTests = (testsRun: readonly string[]): string => testsRun.length > 0
@@ -529,7 +464,7 @@ export const deliverWorkspace = async (
   const canonicalFinal = isCanonicalPrFinal(claim);
   const canonicalPr = canonicalImplementation || canonicalFinal;
   let canonicalBody: string | undefined;
-  let canonicalOutputs: readonly PrWorkflowOutput[] | undefined;
+  const canonicalOutputs = dependencies.prWorkflowOutputs;
   let implementationArtifact: PrImplementationArtifact | undefined;
   let solArtifact: PrReviewArtifact | undefined;
   let blindArtifact: PrReviewArtifact | undefined;
@@ -540,21 +475,20 @@ export const deliverWorkspace = async (
   // malformed output cannot turn into an ordinary branch push.
   if (canonicalPr) {
     try {
-      canonicalOutputs = requiredPrOutputs(claim, dependencies.prWorkflowOutputs, canonicalFinal);
-      implementationArtifact = parsePrOutput<PrImplementationArtifact>(canonicalOutputs[0], PR_IMPLEMENTATION_KIND);
+      implementationArtifact = parsePrOutput<PrImplementationArtifact>(canonicalOutputs?.[0], PR_IMPLEMENTATION_KIND);
       if (canonicalFinal) {
-        solArtifact = parsePrOutput<PrReviewArtifact>(canonicalOutputs[1], PR_SOL_FINDINGS_KIND);
-        blindArtifact = parsePrOutput<PrReviewArtifact>(canonicalOutputs[2], PR_BLIND_FINDINGS_KIND);
-        fixedArtifact = parsePrOutput<PrFixedArtifact>(canonicalOutputs[3], PR_FIXED_IMPLEMENTATION_KIND);
+        solArtifact = parsePrOutput<PrReviewArtifact>(canonicalOutputs?.[1], PR_SOL_FINDINGS_KIND);
+        blindArtifact = parsePrOutput<PrReviewArtifact>(canonicalOutputs?.[2], PR_BLIND_FINDINGS_KIND);
+        fixedArtifact = parsePrOutput<PrFixedArtifact>(canonicalOutputs?.[3], PR_FIXED_IMPLEMENTATION_KIND);
         validatePrReviewHandoff(
           implementationArtifact,
-          canonicalOutputs[0]!,
+          canonicalOutputs![0]!,
           solArtifact,
-          canonicalOutputs[1]!,
+          canonicalOutputs![1]!,
           blindArtifact,
-          canonicalOutputs[2]!,
+          canonicalOutputs![2]!,
           fixedArtifact,
-          canonicalOutputs[3]!,
+          canonicalOutputs![3]!,
         );
         canonicalBody = finalPullRequestBody(claim, implementationArtifact, solArtifact, blindArtifact, fixedArtifact);
       } else {

--- a/packages/runner/src/run-output.test.ts
+++ b/packages/runner/src/run-output.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { PR_TEMPLATE_NAME } from "@anneal/db";
+import { PR_TEMPLATE_NAME, type RunOutputEvidence, type RunOutputSatisfaction } from "@anneal/db";
 
 import { ControlPlaneError, type ClaimedTask } from "./api.js";
 import { adapters, type ExitEvidence, type RuntimeHandle } from "./adapters.js";
@@ -313,34 +313,25 @@ const regressionExplicitTerminalFailureAgent = regressionAgent([
   "exit 0",
 ]);
 
-const outputStatus = (overrides: Partial<{
-  outputKind: string | null;
-  outputRequired: boolean;
-  outputRemediationAllowed: boolean;
-  outputSatisfiedByPriorRun: boolean;
-  outputPersisted: boolean;
-  output: { runId: string; kind: string; commitSha: string | null } | null;
-}> = {}) => ({
-  task: {
-    outputKind: "implementation",
-    outputRequired: true,
-    outputRemediationAllowed: true,
-    outputSatisfiedByPriorRun: false,
-    outputPersisted: false,
-    output: null,
-    ...overrides,
-  },
+/** The decided answer the session status route hands a Run, as a fixture. */
+const outputEvidence = (satisfaction: RunOutputSatisfaction): RunOutputEvidence => ({
+  satisfaction,
+  prHandoff: { case: "not-a-pr-delivery" },
 });
 
-const matchingResultOutputStatus = (root: string) => outputStatus({
-  outputKind: "result",
-  outputPersisted: true,
+const absentImplementation = (remediable = true): RunOutputEvidence => outputEvidence({
+  case: "absent",
+  outputKind: "implementation",
+  remediable,
+});
+
+const deliveredResult = (root: string): RunOutputEvidence => outputEvidence({
+  case: "delivered",
   output: {
-    runId: "run-114",
     kind: "result",
     commitSha: git(join(root, "workspaces", "run-114"), "rev-parse", "HEAD"),
   },
-}).task;
+});
 
 /**
  * The succeeding stub again, with one addition: it drops a sentinel file on its
@@ -428,26 +419,23 @@ const explicitTerminalFailureFixtures = [
   },
 ] as const;
 
+/**
+ * Ownership is the control plane's decision -- a `delivered` answer is this
+ * Run's own output by construction -- so what is left for the runner to refuse
+ * is what only it can see: the kind its recovery accepts, and the commit the
+ * workspace actually ends on.
+ */
 const rejectedServerIdentityFixtures = [
-  {
-    name: "a different Run",
-    output: (root: string) => ({
-      runId: "run-other",
-      kind: "result",
-      commitSha: git(join(root, "workspaces", "run-114"), "rev-parse", "HEAD"),
-    }),
-  },
   {
     name: "a non-result kind",
     output: (root: string) => ({
-      runId: "run-114",
       kind: "implementation",
       commitSha: git(join(root, "workspaces", "run-114"), "rev-parse", "HEAD"),
     }),
   },
   {
-    name: "a non-40-hex commit SHA",
-    output: () => ({ runId: "run-114", kind: "result", commitSha: "not-a-commit-sha" }),
+    name: "a commit that is not the workspace head",
+    output: () => ({ kind: "result", commitSha: "not-a-commit-sha" }),
   },
 ] as const;
 
@@ -647,10 +635,11 @@ test("Regression v2 never resumes the model to remediate an absent mechanical ha
     await writeFile(agentBinary, remediatingAgent(remediationPrompt));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus({
+      outputStatus: async () => outputEvidence({
+        case: "absent",
         outputKind: REGRESSION_OUTPUT_KIND,
-        outputRemediationAllowed: true,
-      }).task,
+        remediable: false,
+      }),
     });
 
     await executeClaim(
@@ -686,7 +675,9 @@ test("a successful run remediates its missing required output in the same provid
     const controlPlane = createControlPlaneDouble({
       outputStatus: async () => {
         statusReads += 1;
-        return outputStatus({ outputPersisted: statusReads >= 2 }).task;
+        return statusReads >= 2
+          ? outputEvidence({ case: "delivered", output: { kind: "implementation", commitSha: null } })
+          : absentImplementation();
       },
     });
 
@@ -730,7 +721,10 @@ test("canonical PR evidence handoff failures are flushed before completion", asy
       // The regular required-output check succeeds. The canonical PR projection
       // is deliberately absent, which must fail closed and leave a durable
       // diagnostic event rather than silently proceeding with generic delivery.
-      outputStatus: async () => outputStatus({ outputPersisted: true }).task,
+      outputStatus: async () => outputEvidence({
+        case: "delivered",
+        output: { kind: "implementation", commitSha: null },
+      }),
     });
 
     await executeClaim(
@@ -760,10 +754,7 @@ test("canonical PR evidence handoff does not overwrite an earlier terminal failu
     await writeFile(agentBinary, succeedingAgent);
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus({
-        outputPersisted: false,
-        outputRemediationAllowed: false,
-      }).task,
+      outputStatus: async () => absentImplementation(false),
     });
 
     await executeClaim(
@@ -775,7 +766,7 @@ test("canonical PR evidence handoff does not overwrite an earlier terminal failu
     const completion = controlPlane.completions.at(-1);
     assert.ok(completion);
     assert.equal(completion.outcome.case, "required-output-unsatisfied");
-    assert.match(failureReasonOf(completion.outcome), /Task output remediation unavailable/u);
+    assert.match(failureReasonOf(completion.outcome), /finished without a current-Run mechanical output handoff/u);
     assert.doesNotMatch(failureReasonOf(completion.outcome), /Canonical PR workflow evidence handoff failed/u);
     assert.ok(controlPlane.eventBatches.flat().some(({ type }) => type === "PR_WORKFLOW_EVIDENCE_HANDOFF_FAILED"));
   } finally {
@@ -792,10 +783,10 @@ test("an immutable output satisfied by a prior Run skips remediation", async () 
     await writeFile(agentBinary, remediatingAgent(remediationPrompt));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus({
-          outputRemediationAllowed: false,
-          outputSatisfiedByPriorRun: true,
-      }).task,
+      outputStatus: async () => outputEvidence({
+        case: "satisfied-by-prior-run",
+        outputKind: "implementation",
+      }),
     });
 
     await executeClaim(config(join(root, "workspaces"), agentBinary), requiredOutputClaim(remote), {
@@ -818,7 +809,7 @@ test("missing output with no provider conversation reports remediation unavailab
     await writeFile(agentBinary, succeedingAgent);
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus().task,
+      outputStatus: async () => absentImplementation(),
     });
 
     await executeClaim(config(join(root, "workspaces"), agentBinary), requiredOutputClaim(remote), {
@@ -882,7 +873,7 @@ test("remediation that still leaves output missing fails with provider evidence"
     await writeFile(agentBinary, remediatingAgent(remediationPrompt, [], remediationResult));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus().task,
+      outputStatus: async () => absentImplementation(),
     });
 
     await executeClaim(config(join(root, "workspaces"), agentBinary), requiredOutputClaim(remote), {
@@ -935,7 +926,7 @@ test("cancellation during remediation drains the resumed handle before ACK", asy
     let acknowledgementCount = 0;
     const configured = { ...config(join(root, "workspaces"), agentBinary), heartbeatIntervalMs: 10 };
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus().task,
+      outputStatus: async () => absentImplementation(),
       heartbeat: async () => {
         if (!resumeReturning || cancellationSent) return { held: true };
         cancellationSent = true;
@@ -980,7 +971,9 @@ test("remediation cannot change workspace HEAD or publish its changes", async ()
     const controlPlane = createControlPlaneDouble({
       outputStatus: async () => {
         statusReads += 1;
-        return outputStatus({ outputPersisted: statusReads >= 2 }).task;
+        return statusReads >= 2
+          ? outputEvidence({ case: "delivered", output: { kind: "implementation", commitSha: null } })
+          : absentImplementation();
       },
     });
 
@@ -1014,7 +1007,7 @@ test("the original Run budget continues through remediation", async () => {
     await writeFile(agentBinary, remediatingAgent(remediationPrompt));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus().task,
+      outputStatus: async () => absentImplementation(),
     });
     let initialHandle: RuntimeHandle | null = null;
     let remediationHandle: RuntimeHandle | null = null;
@@ -1150,7 +1143,7 @@ for (const fixture of explicitTerminalFailureFixtures) {
       await writeFile(agentBinary, streamLostAfterDeliveryAgent("matching"));
       await chmod(agentBinary, 0o755);
       const controlPlane = createControlPlaneDouble({
-        outputStatus: async () => matchingResultOutputStatus(root),
+        outputStatus: async () => deliveredResult(root),
       });
 
       await executeClaim(config(join(root, "workspaces"), agentBinary), resultOutputClaim(remote), {
@@ -1184,7 +1177,7 @@ test("a missing terminal event with matching server output succeeds without a lo
     await writeFile(agentBinary, streamLostAfterDeliveryAgent("missing"));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => matchingResultOutputStatus(root),
+      outputStatus: async () => deliveredResult(root),
     });
     const promotedClaim = resultOutputClaim(remote);
     promotedClaim.run.branch = "configured-delivery";
@@ -1231,7 +1224,7 @@ test("transport-noise stderr does not suppress post-delivery disconnect promotio
     ));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => matchingResultOutputStatus(root),
+      outputStatus: async () => deliveredResult(root),
     });
     const promotedClaim = resultOutputClaim(remote);
     promotedClaim.run.branch = "configured-delivery";
@@ -1271,7 +1264,7 @@ test("a run-as reader includes an otherwise protected receipt in recovery audit"
     ].join("\n"));
     await chmod(launcher, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => matchingResultOutputStatus(root),
+      outputStatus: async () => deliveredResult(root),
     });
     const promotedClaim = resultOutputClaim(remote);
     promotedClaim.run.branch = "configured-delivery";
@@ -1320,15 +1313,12 @@ test("the real task_output MCP receipt promotes a delivered disconnect", async (
     const controlPlane = createControlPlaneDouble({
       outputStatus: async () => {
         const delivered = receivedOutputs.at(-1);
-        return outputStatus({
-          outputKind: "result",
-          outputPersisted: Boolean(delivered),
-          output: delivered ? {
-            runId: "run-114",
-            kind: String(delivered.kind),
-            commitSha: String(delivered.commitSha),
-          } : null,
-        }).task;
+        return outputEvidence(delivered
+          ? {
+            case: "delivered",
+            output: { kind: String(delivered.kind), commitSha: String(delivered.commitSha) },
+          }
+          : { case: "not-required" });
       },
     });
     const promotedClaim = resultOutputClaim(remote);
@@ -1360,7 +1350,7 @@ test("exit code 0 with no persisted output stays FAILED", async () => {
     await writeFile(agentBinary, streamLostAfterDeliveryAgent("matching"));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus({ outputKind: "result", outputPersisted: false }).task,
+      outputStatus: async () => outputEvidence({ case: "not-required" }),
     });
 
     await executeClaim(config(join(root, "workspaces"), agentBinary), resultOutputClaim(remote), {
@@ -1376,32 +1366,6 @@ test("exit code 0 with no persisted output stays FAILED", async () => {
   }
 });
 
-test("persisted output with no server-side identity stays FAILED even with a matching local receipt", async () => {
-  const root = await mkdtemp(join(tmpdir(), "runner-output-disconnect-no-receipt-"));
-  try {
-    const remote = await seedRemote(root);
-    const agentBinary = join(root, "agent.sh");
-    await writeFile(agentBinary, streamLostAfterDeliveryAgent("matching"));
-    await chmod(agentBinary, 0o755);
-    const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus({ outputKind: "result", outputPersisted: true, output: null }).task,
-    });
-
-    await executeClaim(config(join(root, "workspaces"), agentBinary), resultOutputClaim(remote), {
-      controlPlane: controlPlane.controlPlane,
-    });
-
-    const completion = controlPlane.completions.at(-1);
-    assert.equal(completion?.outcome.case, "provider-failure");
-    assert.equal(envelopeOf(completion?.outcome).runnerClass, "PROTOCOL_ERROR");
-    const reported = controlPlane.eventBatches.flat()
-      .find(({ type }) => type === "POST_DELIVERY_DISCONNECT_CHECK_FAILED");
-    assert.match(String(reported?.payload.message), /no server-side identity/u);
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
-});
-
 for (const fixture of rejectedServerIdentityFixtures) {
   test(`server output identity for ${fixture.name} rejects recovery`, async () => {
     const root = await mkdtemp(join(tmpdir(), "runner-output-disconnect-server-identity-"));
@@ -1411,11 +1375,7 @@ for (const fixture of rejectedServerIdentityFixtures) {
       await writeFile(agentBinary, streamLostAfterDeliveryAgent("matching"));
       await chmod(agentBinary, 0o755);
       const controlPlane = createControlPlaneDouble({
-        outputStatus: async () => outputStatus({
-          outputKind: "result",
-          outputPersisted: true,
-          output: fixture.output(root),
-        }).task,
+        outputStatus: async () => outputEvidence({ case: "delivered", output: fixture.output(root) }),
       });
 
       await executeClaim(config(join(root, "workspaces"), agentBinary), resultOutputClaim(remote), {
@@ -1428,11 +1388,6 @@ for (const fixture of rejectedServerIdentityFixtures) {
       assert.equal(
         controlPlane.eventBatches.flat().some(({ type }) => type === "POST_DELIVERY_DISCONNECT_ACCEPTED"),
         false,
-      );
-      assert.equal(
-        controlPlane.eventBatches.flat()
-          .filter(({ type }) => type === "POST_DELIVERY_DISCONNECT_CHECK_FAILED").length,
-        1,
       );
       assert.equal(
         controlPlane.activities.some(({ body }) => body.includes("provider disconnect after delivery was tolerated")),
@@ -1452,7 +1407,7 @@ test("a tolerance-activity failure does not demote a qualified promotion", async
     await writeFile(agentBinary, streamLostAfterDeliveryAgent("matching"));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => matchingResultOutputStatus(root),
+      outputStatus: async () => deliveredResult(root),
       note: async (body) => {
         if (body.includes("provider disconnect after delivery was tolerated")) throw new Error("activity unavailable");
       },
@@ -1489,7 +1444,7 @@ test("a failed delivery never claims that its provider disconnect was tolerated"
     );
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => matchingResultOutputStatus(root),
+      outputStatus: async () => deliveredResult(root),
     });
 
     await executeClaim(config(join(root, "workspaces"), agentBinary), resultOutputClaim(remote), {
@@ -1542,11 +1497,10 @@ test("rewritten local receipt cannot override a mismatched server commit SHA", a
     await writeFile(agentBinary, streamLostAfterDeliveryAgent("mismatched"));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus({
-        outputKind: "result",
-        outputPersisted: true,
-        output: { runId: "run-114", kind: "result", commitSha: "a".repeat(40) },
-      }).task,
+      outputStatus: async () => outputEvidence({
+        case: "delivered",
+        output: { kind: "result", commitSha: "a".repeat(40) },
+      }),
     });
 
     await executeClaim(config(join(root, "workspaces"), agentBinary), resultOutputClaim(remote), {
@@ -1570,7 +1524,7 @@ test("nonzero exit with persisted output stays FAILED", async () => {
     await writeFile(agentBinary, streamLostAfterDeliveryAgent("matching", 1));
     await chmod(agentBinary, 0o755);
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus({ outputKind: "result", outputPersisted: true }).task,
+      outputStatus: async () => deliveredResult(root),
     });
 
     await executeClaim(config(join(root, "workspaces"), agentBinary), resultOutputClaim(remote), {
@@ -1602,7 +1556,7 @@ test("timeout terminationReason with persisted output stays FAILED", async () =>
       },
     };
     const controlPlane = createControlPlaneDouble({
-      outputStatus: async () => outputStatus({ outputKind: "result", outputPersisted: true }).task,
+      outputStatus: async () => deliveredResult(root),
     });
 
     await executeClaim(config(join(root, "workspaces"), agentBinary), resultOutputClaim(remote), {

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -7,7 +7,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 
-import type { RunOutcome } from "@anneal/db";
+import type { RunOutcome, RunOutputEvidence } from "@anneal/db";
 
 import { adapters, buildPrompt, type CliAdapter } from "./adapters.js";
 import type { ClaimedTask, ControlPlane } from "./api.js";
@@ -126,13 +126,9 @@ const mechanicalClaim: ClaimedTask = {
 };
 
 /** The output status of a step whose agent persisted what it declared. */
-const persistedResultOutput = {
-  outputKind: "result",
-  outputRequired: true,
-  outputRemediationAllowed: true,
-  outputSatisfiedByPriorRun: false,
-  outputPersisted: true,
-  output: null,
+const persistedResultOutput: RunOutputEvidence = {
+  satisfaction: { case: "delivered", output: { kind: "result", commitSha: null } },
+  prHandoff: { case: "not-a-pr-delivery" },
 };
 
 /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3,9 +3,10 @@ import { createHash } from "node:crypto";
 import {
   agentExecutionSucceeded,
   PR_TEMPLATE_NAME,
-  REGRESSION_VERIFICATION_OUTPUT_KIND,
   type BudgetGate,
+  type PrHandoffOutput,
   type RunOutcome,
+  type RunOutputEvidence,
 } from "@anneal/db";
 
 import {
@@ -34,7 +35,6 @@ import {
   type RunSession,
   type SessionEventPayload,
   type SessionTaskOutput,
-  type SessionTaskOutputStatus,
 } from "./api.js";
 import {
   probeSupportedCliAvailability,
@@ -43,7 +43,7 @@ import {
 } from "./availability.js";
 import { evaluateBudget } from "./budget.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
-import { deliverWorkspace, type PrWorkflowOutput } from "./delivery.js";
+import { deliverWorkspace } from "./delivery.js";
 import { disposeWorkspace, type WorkspaceDisposal } from "./dispose-workspace.js";
 import {
   buildFailureEnvelope,
@@ -102,7 +102,7 @@ const missingOutputRemediationInput = (outputKind: string): string => [
   `Anneal detected that this Run finished its work but did not persist its required '${outputKind}' task output.`,
   "Do not redo the task, edit files, commit, push, open a PR, or run delivery steps.",
   `Using the work and evidence already produced in this conversation, call task_output with kind '${outputKind}' and a body that satisfies the task's exact output contract and current HEAD binding.`,
-  "If the write is rejected, correct the body and retry. Then call task_status and finish only after it reports outputPersisted: true for this Run.",
+  "If the write is rejected, correct the body and retry. Then call task_status and finish only after its outputEvidence reports satisfaction case 'delivered' for this Run.",
 ].join("\n");
 
 const sameWorkspaceSnapshot = (left: WorkspaceSnapshot, right: WorkspaceSnapshot): boolean =>
@@ -530,14 +530,14 @@ export const executeClaim = async (
       && runLease.held
       && terminalFailureReason === null) {
       const declaredOutputKind = claim.task.templateStep.outputKind;
-      let outputStatus: SessionTaskOutputStatus | null = null;
+      let outputEvidence: RunOutputEvidence | null = null;
       let statusFailure: string | null = null;
       try {
-        outputStatus = await session.outputStatus();
+        outputEvidence = await session.outputStatus();
       } catch (error: unknown) {
         statusFailure = errorMessage(error);
       }
-      if (outputStatus === null) {
+      if (outputEvidence === null) {
         statusFailure ??= "Anneal API returned no task output status";
       }
       if (statusFailure !== null) {
@@ -549,11 +549,20 @@ export const executeClaim = async (
         taskOutputStatusCheckFailed = true;
         terminalFailureReason = `Task output status could not be established for a step declaring output kind '${declaredOutputKind}' for Run ${claim.run.id}: ${statusFailure}`;
       }
-      if (outputStatus?.outputRequired && !outputStatus.outputPersisted) {
-        const outputKind = outputStatus.outputKind;
+      const satisfaction = outputEvidence?.satisfaction;
+      if (satisfaction?.case === "satisfied-by-prior-run") {
+        sink({
+          source: "RUNNER",
+          type: "TASK_OUTPUT_REMEDIATION_SKIPPED",
+          payload: { outputKind: satisfaction.outputKind, reason: "immutable-output-satisfied-by-prior-run" },
+        });
+      } else if (satisfaction?.case === "absent") {
+        const { outputKind } = satisfaction;
         const providerConversationId = completedHandle.providerConversationId;
-        if (claim.task.templateStep.outputKind === REGRESSION_VERIFICATION_OUTPUT_KIND) {
-          terminalFailureReason = `Regression verification finished without a current-Run mechanical output handoff for Run ${claim.run.id}`;
+        if (!satisfaction.remediable) {
+          // Only a mechanical verdict is undeliverable by asking again, and
+          // the control plane says so; the runner does not re-test the kind.
+          terminalFailureReason = `A step declaring output kind '${outputKind}' finished without a current-Run mechanical output handoff for Run ${claim.run.id}`;
           sink({
             source: "RUNNER",
             type: "TASK_OUTPUT_REMEDIATION_UNAVAILABLE",
@@ -564,16 +573,7 @@ export const executeClaim = async (
               reason: regressionHandoffPersisted ? "mechanical-output-not-visible" : "mechanical-handoff-absent",
             },
           });
-        } else if (outputStatus.outputSatisfiedByPriorRun) {
-          sink({
-            source: "RUNNER",
-            type: "TASK_OUTPUT_REMEDIATION_SKIPPED",
-            payload: { outputKind, reason: "immutable-output-satisfied-by-prior-run" },
-          });
-        } else if (outputStatus.outputRemediationAllowed
-          && outputKind
-          && providerConversationId
-          && runLease.held) {
+        } else if (providerConversationId && runLease.held) {
           const beforeRemediation = await captureWorkspaceSnapshot(config, workspace);
           // Snapshotting is asynchronous. Cancellation may have been ACKed
           // against the already-closed first launch while it ran, so no second
@@ -598,9 +598,8 @@ export const executeClaim = async (
               let statusCheckError: string | null = null;
               if (!workspaceChanged) {
                 try {
-                  const remediatedStatus = await session.outputStatus();
-                  remediated = remediatedStatus?.outputPersisted === true
-                    || remediatedStatus?.outputSatisfiedByPriorRun === true;
+                  const recheck = (await session.outputStatus())?.satisfaction.case;
+                  remediated = recheck === "delivered" || recheck === "satisfied-by-prior-run";
                 } catch (error: unknown) {
                   statusCheckError = errorMessage(error);
                   sink({
@@ -638,16 +637,14 @@ export const executeClaim = async (
           }
         } else {
           terminalFailureReason = `Task output remediation unavailable for Run ${claim.run.id}: ${
-            !outputStatus.outputRemediationAllowed ? "remediation is not allowed"
-              : !outputKind ? "output kind is unavailable"
-                : "provider conversation id is unavailable"
+            providerConversationId ? "the Run no longer holds its lease" : "provider conversation id is unavailable"
           }`;
           sink({
             source: "RUNNER",
             type: "TASK_OUTPUT_REMEDIATION_UNAVAILABLE",
             payload: {
               outputKind,
-              outputRemediationAllowed: outputStatus.outputRemediationAllowed,
+              outputRemediationAllowed: true,
               providerConversationIdAvailable: providerConversationId !== null,
             },
           });
@@ -689,21 +686,18 @@ export const executeClaim = async (
       && runLease.held;
     if (disconnectCandidate) {
       try {
-        const outputStatus = await session.outputStatus();
+        const satisfaction = (await session.outputStatus())?.satisfaction;
         const expectedKind = "result";
-        if (outputStatus?.outputPersisted !== true) {
+        // The server-returned output identity alone authorizes recovery, and
+        // "this Run delivered it" is the control plane's decision, not a
+        // predicate to re-run here. What remains is the one fact only this
+        // process knows: the commit the workspace actually ends on.
+        if (satisfaction?.case !== "delivered") {
           throw new Error(`No persisted ${expectedKind} output exists for this Run`);
         }
-        const output = outputStatus.output;
-        if (!output) throw new Error(`Persisted ${expectedKind} output has no server-side identity`);
-        if (output.runId !== claim.run.id) {
-          throw new Error(`Persisted ${expectedKind} output belongs to Run ${output.runId}`);
-        }
+        const { output } = satisfaction;
         if (output.kind !== expectedKind) {
           throw new Error(`Persisted output kind ${output.kind} is not ${expectedKind}`);
-        }
-        if (typeof output.commitSha !== "string" || !/^[0-9a-f]{40}$/u.test(output.commitSha)) {
-          throw new Error(`Persisted ${expectedKind} output has an invalid commit SHA`);
         }
         if (output.commitSha !== capturedHeadSha) {
           throw new Error(`Persisted ${expectedKind} output does not match captured workspace HEAD`);
@@ -737,19 +731,19 @@ export const executeClaim = async (
         });
       }
     }
-    let prWorkflowOutputs: readonly PrWorkflowOutput[] | undefined;
+    let prWorkflowOutputs: readonly PrHandoffOutput[] | undefined;
     const templateStep = claim.task.templateStep;
     const canonicalPrDelivery = templateStep?.taskTemplate.name === PR_TEMPLATE_NAME
       && (templateStep.outputKind === "implementation" || templateStep.outputKind === "fixed-implementation");
     if (canonicalPrDelivery && runLease.held) {
       try {
-        const status = await session.outputStatus() as (
-          SessionTaskOutputStatus & { prWorkflowOutputs?: readonly PrWorkflowOutput[] }
-        ) | null;
-        if (!status || !Array.isArray(status.prWorkflowOutputs)) {
-          throw new Error("session status omitted canonical PR workflow output evidence");
+        const handoff = (await session.outputStatus())?.prHandoff;
+        if (handoff?.case !== "complete") {
+          throw new Error(handoff?.case === "incomplete"
+            ? handoff.reason
+            : "session status omitted canonical PR workflow output evidence");
         }
-        prWorkflowOutputs = status.prWorkflowOutputs;
+        prWorkflowOutputs = handoff.outputs;
       } catch (error: unknown) {
         if (terminalFailureReason === null) {
           terminalFailureReason = `Canonical PR workflow evidence handoff failed for Run ${claim.run.id}: ${errorMessage(error)}`;

--- a/packages/runner/src/test-control-plane.ts
+++ b/packages/runner/src/test-control-plane.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import type { FailureEnvelope, RunOutcome } from "@anneal/db";
+import { parseRunOutputEvidence, type FailureEnvelope, type RunOutcome } from "@anneal/db";
 
 import {
   ControlPlaneError,
@@ -17,7 +17,6 @@ import {
   type RunStartSnapshot,
   type SessionEventPayload,
   type SessionTaskOutput,
-  type SessionTaskOutputStatus,
 } from "./api.js";
 import type { RunnerConfig, RunnerKind } from "./config.js";
 
@@ -243,11 +242,11 @@ export const createRoutedControlPlaneDouble = (
           }, "PUT");
         },
         outputStatus: async () => {
-          const payload = await request<{ task: SessionTaskOutputStatus | null }>(
+          const payload = await request<{ task: { outputEvidence: unknown } | null }>(
             `/session/runs/${claim.run.id}/status`,
             {},
           );
-          return payload.task;
+          return payload.task ? parseRunOutputEvidence(payload.task.outputEvidence) : null;
         },
         publishBranch: async (pushedBranch) => {
           await request(`/runner/runs/${claim.run.id}/publication`, { ...fenced, pushedBranch });

--- a/scripts/operator-api-docs.test.mjs
+++ b/scripts/operator-api-docs.test.mjs
@@ -271,24 +271,30 @@ test("the canonical PR workflow documents its clean-tree and five-section handov
   assert.match(text, /exactly these\s+five sections, in order[\s\S]*no provider-generated or activity-log prose/u);
 });
 
-test("the handbook documents the machine-only, run-bound PR evidence projection", () => {
-  const marker = "The machine-only `/session/runs/:runId/status` projection used by PR-workflow";
+test("the handbook documents the machine-only, run-bound decided output evidence", () => {
+  const marker = "The machine-only `/session/runs/:runId/status` projection is run-bound";
   const start = handbook.indexOf(marker);
-  assert.notEqual(start, -1, "operator handbook must document the PR evidence projection");
+  assert.notEqual(start, -1, "operator handbook must document the decided output evidence");
   const end = handbook.indexOf("\nThe machine-only `POST /runner/runs/:runId/complete`", start + marker.length);
   const text = handbook.slice(start, end === -1 ? handbook.length : end);
 
-  assert.match(text, /run-bound and is not an operator read route/u);
-  assert.match(text, /persisted output bodies only for the current[\s\S]*`implementation` or `fixed-implementation`/u);
+  assert.match(text, /not an operator read route/u);
+  assert.match(text, /the runner reads it rather than\s+re-deciding anything/u);
+  for (const satisfaction of ["delivered", "not-required", "satisfied-by-prior-run", "absent"]) {
+    assert.match(text, new RegExp(`\`${satisfaction}\``, "u"));
+  }
+  for (const handoff of ["not-a-pr-delivery", "complete", "incomplete"]) {
+    assert.match(text, new RegExp(`\`${handoff}\``, "u"));
+  }
   for (const field of ["Task id", "chain index", "output kind", "body", "commit SHA", "projectId", "chainId"]) {
     assert.match(text, new RegExp(field.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&"), "u"));
   }
-  assert.match(text, /implementation\s+delivery receives only its\s+current `implementation` entry/u);
-  assert.match(text, /final\s+delivery receives exactly\s+`implementation`, `sol-findings`,\s+`blind-findings`, and `fixed-implementation`,\s+in chain order/u);
-  assert.match(text, /does not widen prompt `priorOutputs`, expose\s+sibling evidence to a blind\s+review/u);
-  assert.match(text, /derive text from provider output,\s+activity prose, or repository\s+contents/u);
+  assert.match(text, /implementation delivery\s+receives only its current `implementation` entry/u);
+  assert.match(text, /final delivery receives\s+exactly `implementation`, `sol-findings`, `blind-findings`, and\s+`fixed-implementation`, in chain order/u);
+  assert.match(text, /does not widen prompt `priorOutputs`, expose sibling evidence to a blind\s+review/u);
+  assert.match(text, /derive text from provider output, activity prose, or repository\s+contents/u);
   assert.match(text, /source is persisted task output[\s\S]*claimed session\/run identity/u);
-  assert.match(text, /Malformed, foreign-chain, or missing required evidence is rejected rather than\s+silently omitted or guessed/u);
+  assert.match(text, /out-of-order\s+or missing evidence makes the handoff `incomplete` rather than being silently\s+omitted or guessed, and delivery fails instead of publishing/u);
 });
 
 test("the template step replace route documents its contract, refusals, warnings, and example", () => {


### PR DESCRIPTION
## What changed

One module in `@anneal/db` now decides, for a Run, whether the deliverable its
Step requires exists, and whether its canonical PR handoff may publish. Both
`completeRun` and the session status route read it; the runner receives the
decided answer over the wire and parses a shape, not a verdict.

`packages/db/src/run-output-evidence.ts` is the module. Its interface is two
named values:

- `RunOutputSatisfaction`: `delivered` (this Run persisted the output; carries
  the output's kind and commit identity), `not-required`,
  `satisfied-by-prior-run` (an immutable findings artifact an earlier Run
  authored), `absent` (with the required kind and whether asking the agent
  again can still produce it). Combinations that could not occur stop being
  representable: remediation is a property of an absent deliverable, not a
  free-standing flag, and a deliverable satisfied by an immutable earlier Run
  is neither present for this Run nor remediable by it.
- `PrHandoff`: `not-a-pr-delivery`, `complete` with the ordered outputs, or
  `incomplete` with the reason. Ordering by chain index, one Task per entry,
  well-formedness, and binding to the current delivery are decided here, once.

Leverage and locality: the four booleans plus the raw output row that the
status route used to emit are gone, and with them the recombination each
consumer performed.

Deleted in the same change:

- `readSessionTaskOutputStatus`'s 85-line hand validation in
  `packages/runner/src/api.ts`, including its re-implementation of chain-index
  ordering and taskId uniqueness. It is now `parseRunOutputEvidence`, which
  refuses a payload that is not the decided answer and re-derives nothing.
- `requiredPrOutputs` and `isWellFormedPrOutput` in
  `packages/runner/src/delivery.ts`, the third copy of the same array rules.
  What delivery still owns is the artifact bodies (`parsePrOutput`,
  `validatePrReviewHandoff`) and the comparison against local HEAD, which is
  the one fact only the runner knows.
- The runner's re-test of the Regression verification output kind: the control
  plane says whether an absent deliverable is remediable, and the runner obeys.
- The redundant output-ownership and commit-format checks in disconnect
  recovery. A `delivered` answer is this Run's own output by construction, so
  what remains is the kind recovery accepts and the commit the workspace
  actually ends on.

The comment at the status route ("This is the same run-scoped fact completion
validates before it advances") is now true by construction: both call
`decideRunOutputSatisfaction`.

The route's path did not change; its response shape did. `task.outputEvidence`
replaces `output`, `outputRequired`, `outputRemediationAllowed`,
`outputSatisfiedByPriorRun`, `outputPersisted` and `prWorkflowOutputs`.
`docs/operator-api.md` is updated in this change, and the remediation prompt
the runner gives an agent names the new field.

## Evidence

Run in the worktree after the final commit (`941dda04`), with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh temporary directory:

- `npm run lint` — exit 0 (biome: 735 files, no fixes; eslint clean).
- `npm run typecheck` — exit 0.
- `npm run test -w @anneal/db` — exit 0, 388 tests, 388 pass, 0 fail.
- `npm run test -w @anneal/api` — exit 0, 823 tests, 822 pass, 0 fail, 1 skipped.
- `npm run test -w @anneal/runner` — exit 0, 488 tests, 486 pass, 0 fail,
  2 skipped (both pre-existing: one needs root, one needs a distinct uid).
- `npm run test:snapshot-scan` — exit 0, 21 tests, 21 pass (docs/ changed).
- `npm run test:operator-api-docs` — exit 0, 13 tests, 13 pass.

`test:db` was not run: there is no local PostgreSQL. `run-output.dbtest.ts` was
updated and typechecks; the merge gate runs it.

Base `f77dfabfd5a26f6ca756ba2798d5902adec44cf7`; `origin/main` moved to
`aac993cb` during the work and was merged into the branch (`45908769`), not
rebased.

## Decisions taken

**Where the module lives.** `packages/db/src/run-output-evidence.ts`, following
a1's precedent for `run-outcome.ts`: the decided answer crosses the runner/api
seam, so its type and its wire parse must have exactly one home. The db package
is already a runner dependency.

**Remediability is an input, not an import.** The module first derived "can the
agent be asked again" from `isRegressionVerificationOutputKind`. That coupled a
type both sides of the seam load to merge-tail machinery, and the defense list
test (`merge-tail.test.ts`) correctly refused it. Remediability is a property of
the Step's output contract alongside its kind and its immutability, so
`RunOutputRequirement` carries all three and the caller derives them from the
template step. The module stays about output satisfaction alone, and the
defense list was not widened.

**One authority for remediability, not two.** The runner used to accept the
route's `outputRemediationAllowed` and then separately refuse to resume a
Regression step by re-testing the output kind. Only the control plane decides
now. The runner's terminal reason for that case names the output kind instead
of hardcoding "Regression verification", because the branch is keyed on the
decided answer rather than on a kind the runner re-tested.

**Unusable rows stay in the handoff instead of being filtered out.** The route's
projection used to drop a row whose commit identity was null, leaving a short
array for delivery to refuse with a count error. The candidates now go to
`decidePrHandoff` as themselves and it refuses with the reason
(`malformed <kind> canonical output evidence`). Same fail-loud, an accurate
reason, no silent shortening.

**Two tests lost their premise and were removed rather than adapted.** "persisted
output with no server-side identity" and the "a different Run" server-identity
fixture in `run-output.test.ts` describe payloads the decided answer cannot
produce: `delivered` always carries an output, and it is always this Run's. The
rules they were guarding are now table-driven unit tests in
`run-output-evidence.test.ts` (ownership, immutability, ordering, uniqueness,
binding, commit format), and the runner keeps a wire-shape rejection test in
`control-plane.test.ts`. The `POST_DELIVERY_DISCONNECT_CHECK_FAILED` count
assertion is gone; those tests assert the outcome and the absence of tolerance
instead.

## Fence widened

Files edited outside lane a2's owned paths in `QUEUE.md`. Every one belongs to
a lane that is `merged` (a1, whose PR #417 is in this branch's base) or to no
lane at all.

- `packages/db/src/run-output-evidence.ts`, `packages/db/src/run-output-evidence.test.ts`
  (new, no lane) and `packages/db/src/index.ts` (one export line, no lane).
- `packages/runner/src/runner.ts` — the four endpoint reads the brief names.
  a1's shape is untouched: the reads feed a1's `RunOutcome` cases exactly as
  before. The merge train then hit a conflict here against live `main`: lane
  r1 (now `merged`, and the owner of this file) added the
  `dependency-provisioning` imports on the same import line this branch
  shortened when `PrWorkflowOutput` moved to the decided PR handoff in
  `@anneal/db`. `origin/main` `80f9acc9` was merged into the branch (not
  rebased) and the conflict resolved keeping both intents: r1's imports stay,
  the retired type stays gone. Verification was re-run in full after that
  merge commit and the gate re-dispatched for the new head.
- `packages/runner/src/runner.test.ts`, `packages/runner/src/control-plane.test.ts`,
  `packages/runner/src/delivery.test.ts`, `packages/runner/src/test-control-plane.ts`
  — test files and the in-memory control-plane double whose fixtures pin the old
  payload shape.
- `docs/operator-api.md` and `scripts/operator-api-docs.test.mjs` — the route's
  response shape changed, and `CLAUDE.md` requires the handbook to change with
  it. The handbook test pinned the old prose verbatim.

`packages/api/src/canonical-task-output.ts` is inside the fence but needed no
change: `requiredOutputKind` and `outputIsImmutableOncePersisted` are exactly
the two Step facts the new requirement input wants.

## Reported but unfixed

- `packages/runner/src/mcp-server.ts` returns the whole status payload to the
  agent as JSON for `task_status`, so an agent now reads `outputEvidence`
  rather than `outputPersisted`. The runner's remediation prompt was updated to
  name the new field, but `mcp-server.ts` itself belongs to lane a3
  (`pending`), so no shaping of that tool's reply was attempted here.
- `packages/runner/assets/pi-agentos-extension.ts` proxies `GET /status`
  without interpreting it, so it needed no change; it is also a3's.
- The `TASK_OUTPUT_REMEDIATION_UNAVAILABLE` event still carries an
  `outputRemediationAllowed` field that is now constant within each of its two
  emit sites. It distinguishes the two, so it was left alone rather than
  reshaped inside another lane's event vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Yswh33reARuAZRQ6ofLMG

