### PR TITLE
refactor(runner): give the dependency cache entry store its own interface

### DIFF
--- a/packages/runner/src/dependency-cache-store.test.ts
+++ b/packages/runner/src/dependency-cache-store.test.ts
@@ -1,0 +1,451 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  chmod, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, utimes, writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  DEPENDENCY_CACHE_BYTE_BUDGET, accountDependencyCacheEntryBytes, describeTargetTrees, openCacheEntryStore,
+  selectDependencyCacheEvictions,
+  type CacheEntryExpectation, type CacheEntryInput, type CacheEntryStore, type CacheStoreEvent,
+  type DependencyCacheToolchain,
+} from "./dependency-cache-store.js";
+
+// The store's whole point is that keys, entries, bytes and usage are reachable
+// from a bare temporary directory: nothing below builds an npm workspace, runs
+// a command, or constructs a RunnerConfig.
+
+const TOOLCHAIN: DependencyCacheToolchain = {
+  node: "v24.0.0",
+  npm: "11.0.0",
+  operatingSystem: "darwin",
+  architecture: "arm64",
+};
+
+const INPUTS: CacheEntryInput[] = [
+  { path: "package.json", sha256: "a".repeat(64) },
+  { path: "packages/db/prisma/schema.prisma", absent: true },
+];
+
+const TARGET_PATHS = ["node_modules", "packages/db/node_modules"];
+
+const key = (index: number): string => index.toString(16).padStart(64, "0");
+
+const expectation = (entryKey: string): CacheEntryExpectation =>
+  ({ key: entryKey, toolchain: TOOLCHAIN, inputs: INPUTS, targetPaths: TARGET_PATHS });
+
+const makeImmutable = async (path: string): Promise<void> => {
+  const info = await lstat(path);
+  if (info.isSymbolicLink()) return;
+  if (info.isDirectory()) for (const child of await readdir(path)) await makeImmutable(join(path, child));
+  await chmod(path, info.isDirectory() ? 0o555 : 0o444 | (info.mode & 0o111));
+};
+
+const makeWritable = async (path: string): Promise<void> => {
+  const info = await lstat(path);
+  if (info.isSymbolicLink()) return;
+  await chmod(path, info.mode | 0o700);
+  if (info.isDirectory()) for (const child of await readdir(path)) await makeWritable(join(path, child));
+};
+
+const cleanupRoot = async (root: string): Promise<void> => {
+  await makeWritable(root).catch(() => undefined);
+  await rm(root, { recursive: true, force: true });
+};
+
+const openStore = (root: string): Promise<CacheEntryStore> =>
+  openCacheEntryStore(join(root, "cache"), join(root, "sources"));
+
+/** A plain directory holding the two target trees a publication snapshots. */
+const sourceTree = async (root: string, name: string, content: string): Promise<string> => {
+  const source = join(root, "sources", name);
+  await mkdir(join(source, "node_modules/package-a"), { recursive: true });
+  await mkdir(join(source, "packages/db/node_modules/package-b"), { recursive: true });
+  await writeFile(join(source, "node_modules/package-a/index.js"), content);
+  await writeFile(join(source, "packages/db/node_modules/package-b/index.js"), content);
+  return source;
+};
+
+const publish = async (
+  store: CacheEntryStore,
+  root: string,
+  entryKey: string,
+  content = `content for ${entryKey.slice(56)}\n`,
+  decorate: (source: string) => Promise<void> = async () => undefined,
+): Promise<CacheEntryExpectation> => {
+  const source = await sourceTree(root, entryKey.slice(56), content);
+  await decorate(source);
+  const targets = await describeTargetTrees(source, TARGET_PATHS);
+  const expected = expectation(entryKey);
+  assert.equal(await store.publishEntry(expected, targets, source), "published");
+  await store.recordUse(entryKey);
+  return expected;
+};
+
+const usageMarker = (store: CacheEntryStore, entryKey: string): string => join(store.root, "usage", entryKey);
+
+/** An independent allocated-size walk, so accounting is checked against a second reading. */
+const accountedBytes = async (path: string): Promise<bigint> => {
+  const info = await lstat(path);
+  if (info.isDirectory()) {
+    let total = BigInt(info.blocks) * 512n;
+    for (const child of await readdir(path)) total += await accountedBytes(join(path, child));
+    return total;
+  }
+  return BigInt(info.blocks) * 512n;
+};
+
+const orderUsage = async (store: CacheEntryStore, keys: string[]): Promise<void> => {
+  for (const [index, entryKey] of keys.entries()) {
+    const when = new Date(1_000 * (index + 1));
+    await utimes(usageMarker(store, entryKey), when, when);
+  }
+};
+
+test("a cache root refuses a layout it cannot own", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-layout-"));
+  try {
+    const realRoot = await realpath(root);
+    await assert.rejects(
+      openCacheEntryStore(join(root, "cache"), join(realRoot, "cache/entries")),
+      /overlaps/u,
+      "a root that contains the trees it caches cannot be immutable",
+    );
+    await mkdir(join(root, "elsewhere"));
+    await symlink(join(root, "elsewhere"), join(root, "linked-cache"));
+    await assert.rejects(openCacheEntryStore(join(root, "linked-cache"), join(root, "sources")), /symlink/u);
+
+    const store = await openStore(root);
+    assert.deepEqual((await readdir(store.root)).sort(), ["entries", "usage"]);
+    assert.equal((await lstat(join(store.root, "usage"))).mode & 0o777, 0o700);
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("a published entry is immutable, reads back, and refuses a different expectation", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-publish-"));
+  try {
+    const store = await openStore(root);
+    assert.equal(await store.hasEntry(key(1)), false);
+    const expected = await publish(store, root, key(1), "published tree\n");
+    assert.equal(await store.hasEntry(key(1)), true);
+
+    const entry = store.entryPath(key(1));
+    assert.equal((await lstat(entry)).mode & 0o222, 0, "a published entry carries no writable bit");
+    assert.equal(
+      await readFile(join(store.targetSourcePath(key(1), "node_modules"), "package-a/index.js"), "utf8"),
+      "published tree\n",
+    );
+
+    const document = await store.readEntry(expected);
+    assert.equal(document.key, key(1));
+    assert.deepEqual(document.targets.map(({ path }) => path), TARGET_PATHS);
+    assert.equal(document.targets.every(({ present }) => present), true);
+
+    const second = await sourceTree(root, "second", "published tree\n");
+    assert.equal(
+      await store.publishEntry(expected, await describeTargetTrees(second, TARGET_PATHS), second),
+      "converged",
+      "a second publication of the same key converges on the entry already there",
+    );
+
+    await assert.rejects(
+      store.readEntry({ ...expected, toolchain: { ...TOOLCHAIN, node: "v22.0.0" } }),
+      /toolchain-mismatch/u,
+    );
+    await assert.rejects(store.readEntry(expectation(key(2))), /entry-not-directory/u);
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("usage markers are written per key and refused when they are not plain files", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-usage-"));
+  try {
+    const store = await openStore(root);
+    await store.validateUseMarker(key(1));
+
+    await store.recordUse(key(1));
+    const marker = usageMarker(store, key(1));
+    assert.equal((await lstat(marker)).isFile(), true);
+    const first = await readFile(marker, "utf8");
+    assert.match(first, /^\d{4}-\d{2}-\d{2}T/u);
+    await utimes(marker, new Date(1_000), new Date(1_000));
+    await store.recordUse(key(1));
+    assert.ok((await lstat(marker)).mtimeMs > 1_000, "recording use refreshes the marker");
+    await store.validateUseMarker(key(1));
+
+    await rm(marker);
+    await mkdir(join(root, "marker-target"));
+    await symlink(join(root, "marker-target"), marker);
+    await assert.rejects(store.validateUseMarker(key(1)), /unsafe-usage-marker/u);
+    await rm(marker);
+    await mkdir(marker);
+    await assert.rejects(store.validateUseMarker(key(1)), /unsafe-usage-marker/u);
+
+    await assert.rejects(store.recordUse("not-a-cache-key"), /usage key is invalid/u);
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("byte-budget eviction takes the least recently used keys and never the protected one", () => {
+  const gibibyte = 1024 ** 3;
+  const belowBudget = Array.from({ length: 40 }, (_, index) => ({
+    key: key(index), bytes: 256 * 1024 ** 2, usedMs: index + 1,
+  }));
+  assert.equal(
+    belowBudget.reduce((total, entry) => total + entry.bytes, 0) < DEPENDENCY_CACHE_BYTE_BUDGET,
+    true,
+    "the synthetic population is below the fixed budget",
+  );
+  assert.deepEqual(
+    selectDependencyCacheEvictions(belowBudget, key(39), DEPENDENCY_CACHE_BYTE_BUDGET),
+    [],
+    "entry count does not trigger retention",
+  );
+
+  const entries = [
+    { key: key(100), bytes: 4 * gibibyte, usedMs: 1 },
+    { key: key(101), bytes: 7 * gibibyte, usedMs: 2 },
+    { key: key(102), bytes: 6 * gibibyte, usedMs: 3 },
+    { key: key(103), bytes: 5 * gibibyte, usedMs: 4 },
+  ];
+  const victims = selectDependencyCacheEvictions(entries, key(103), DEPENDENCY_CACHE_BYTE_BUDGET);
+  assert.deepEqual(victims, [key(100), key(101)], "multiple oldest entries are evicted in one pass");
+  assert.ok(entries.filter(({ key: candidate }) => !victims.includes(candidate))
+    .reduce((total, entry) => total + entry.bytes, 0) <= DEPENDENCY_CACHE_BYTE_BUDGET);
+
+  const exact = [
+    { key: key(110), bytes: 8 * gibibyte, usedMs: 1 },
+    { key: key(111), bytes: 8 * gibibyte, usedMs: 2 },
+  ];
+  assert.deepEqual(
+    selectDependencyCacheEvictions(exact, key(111), DEPENDENCY_CACHE_BYTE_BUDGET),
+    [],
+    "exactly the budget is retained",
+  );
+
+  const refreshable = [
+    { key: key(120), bytes: 6 * gibibyte, usedMs: 1 },
+    { key: key(121), bytes: 7 * gibibyte, usedMs: 2 },
+    { key: key(122), bytes: 5 * gibibyte, usedMs: 3 },
+  ];
+  assert.deepEqual(selectDependencyCacheEvictions(refreshable, key(122), DEPENDENCY_CACHE_BYTE_BUDGET), [key(120)]);
+  refreshable[0]!.usedMs = 10;
+  assert.deepEqual(
+    selectDependencyCacheEvictions(refreshable, key(122), DEPENDENCY_CACHE_BYTE_BUDGET),
+    [key(121)],
+    "refreshing the oldest usage marker changes the victim",
+  );
+
+  assert.throws(
+    () => selectDependencyCacheEvictions(
+      [{ key: key(130), bytes: DEPENDENCY_CACHE_BYTE_BUDGET + 1, usedMs: 1 }], key(130), DEPENDENCY_CACHE_BYTE_BUDGET,
+    ),
+    /protected-entry-exceeds-byte-budget/u,
+    "a protected entry larger than the budget is a named refusal",
+  );
+});
+
+test("locked byte-budget enforcement deletes multiple oldest entries and preserves exact-budget state", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-budget-"));
+  try {
+    const store = await openStore(root);
+    const keys = [key(1), key(2), key(3)];
+    for (const entryKey of keys) await publish(store, root, entryKey);
+    await orderUsage(store, keys);
+    const sizes = await Promise.all(keys.map((entryKey) => accountDependencyCacheEntryBytes(store.entryPath(entryKey))));
+    const exactBudget = Number(sizes.reduce((total, size) => total + size, 0n));
+
+    const exactEvents: CacheStoreEvent[] = [];
+    await store.enforceByteBudget(key(3), undefined, (event) => exactEvents.push(event), exactBudget);
+    assert.deepEqual(exactEvents, [], "exact budget emits no eviction");
+
+    const events: CacheStoreEvent[] = [];
+    await store.enforceByteBudget(key(3), undefined, (event) => events.push(event), Number(sizes[2]));
+    assert.deepEqual(events, [key(1), key(2)].map((evicted) => ({
+      event: "eviction", key: evicted.slice(0, 16), condition: "byte-budget",
+    })));
+    await assert.rejects(lstat(store.entryPath(key(1))), /ENOENT/u);
+    await assert.rejects(lstat(store.entryPath(key(2))), /ENOENT/u);
+    await assert.rejects(lstat(usageMarker(store, key(1))), /ENOENT/u);
+    await assert.rejects(lstat(usageMarker(store, key(2))), /ENOENT/u);
+    assert.equal((await lstat(store.entryPath(key(3)))).isDirectory(), true);
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("an oversized protected publication is rolled back and rejected with audit evidence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-rollback-"));
+  try {
+    const store = await openStore(root);
+    await publish(store, root, key(1));
+    const bytes = await accountDependencyCacheEntryBytes(store.entryPath(key(1)));
+    const events: CacheStoreEvent[] = [];
+
+    await assert.rejects(
+      store.enforceByteBudget(key(1), key(1), (event) => events.push(event), Number(bytes - 1n)),
+      (error: unknown) => error instanceof Error
+        && error.name === "DependencyCacheBudgetError"
+        && /protected-entry-exceeds-byte-budget/u.test(error.message),
+    );
+
+    await assert.rejects(lstat(store.entryPath(key(1))), /ENOENT/u, "the rolled-back entry is gone");
+    await assert.rejects(lstat(usageMarker(store, key(1))), /ENOENT/u, "its usage marker goes with it");
+    assert.deepEqual(events, [
+      { event: "eviction", key: key(1).slice(0, 16), condition: "byte-budget" },
+      { event: "integrity-refusal", key: key(1).slice(0, 16), condition: "protected-entry-exceeds-byte-budget" },
+    ]);
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("an entry that cannot be safely evicted rejects the byte-budget invariant", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-eviction-failure-"));
+  const entriesRoot = join(root, "cache/entries");
+  try {
+    const store = await openStore(root);
+    await publish(store, root, key(1));
+    await publish(store, root, key(2));
+    await orderUsage(store, [key(1), key(2)]);
+    const currentBytes = await accountDependencyCacheEntryBytes(store.entryPath(key(2)));
+    await chmod(entriesRoot, 0o555);
+    const events: CacheStoreEvent[] = [];
+
+    await assert.rejects(
+      store.enforceByteBudget(key(2), undefined, (event) => events.push(event), Number(currentBytes)),
+      (error: unknown) => error instanceof Error
+        && error.name === "DependencyCacheBudgetError"
+        && /eviction-failed/u.test(error.message),
+    );
+    assert.ok(events.some(({ event, key: evicted, condition }) =>
+      event === "integrity-refusal" && evicted === key(1).slice(0, 16) && condition?.startsWith("eviction-failed")));
+    assert.equal(events.some(({ event }) => event === "eviction"), false);
+  } finally {
+    await chmod(entriesRoot, 0o711).catch(() => undefined);
+    await cleanupRoot(root);
+  }
+});
+
+test("an unrelated corrupt entry refuses the pass and preserves a valid new publication", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-unrelated-"));
+  try {
+    const store = await openStore(root);
+    await publish(store, root, key(1));
+    await publish(store, root, key(2));
+    await makeWritable(store.entryPath(key(1)));
+    await writeFile(join(store.entryPath(key(1)), "metadata.json"), "malformed\n");
+    const events: CacheStoreEvent[] = [];
+
+    await assert.rejects(
+      store.enforceByteBudget(key(2), key(2), (event) => events.push(event)),
+      /metadata-unreadable/u,
+    );
+
+    assert.equal((await lstat(store.entryPath(key(2)))).isDirectory(), true);
+    assert.equal((await lstat(usageMarker(store, key(2)))).isFile(), true);
+    assert.equal(events.some(({ event }) => event === "eviction"), false);
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("orphan publication stages are reaped and unrecognised usage files are left alone", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-orphan-"));
+  try {
+    const store = await openStore(root);
+    await publish(store, root, key(1));
+    const staging = join(store.root, "entries/.stage-0123456789abcdef-orphaned");
+    await mkdir(staging);
+    await writeFile(join(staging, "partial-snapshot"), "interrupted publication\n");
+    const stray = join(store.root, "usage/stray-operator-file");
+    await writeFile(stray, "not a cache usage marker\n");
+
+    await store.enforceByteBudget(key(1), undefined, () => undefined);
+
+    await assert.rejects(lstat(staging), /ENOENT/u, "an orphaned stage is reaped under the exclusive lock");
+    assert.equal((await lstat(stray)).isFile(), true, "unrecognised usage files are ignored, not mutated");
+    assert.equal((await lstat(store.entryPath(key(1)))).isDirectory(), true);
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("exclusive byte-budget enforcement waits for an existing shared lock owner", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-lock-"));
+  try {
+    const store = await openStore(root);
+    await publish(store, root, key(1));
+    let enterShared!: () => void;
+    const sharedEntered = new Promise<void>((resolve) => { enterShared = resolve; });
+    let releaseShared!: () => void;
+    const sharedHeld = new Promise<void>((resolve) => { releaseShared = resolve; });
+
+    const shared = store.withSharedLock(async () => {
+      enterShared();
+      await sharedHeld;
+    });
+    await sharedEntered;
+    let settled = false;
+    const enforcement = store.enforceByteBudget(key(1), undefined, () => undefined)
+      .finally(() => { settled = true; });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(settled, false, "blocking exclusive retention must wait instead of skipping enforcement");
+
+    releaseShared();
+    await Promise.all([shared, enforcement]);
+    assert.equal((await lstat(store.entryPath(key(1)))).isDirectory(), true);
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("allocated-byte accounting includes metadata, trees, and safe symlink inodes without following links", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-accounting-"));
+  try {
+    const store = await openStore(root);
+    await publish(store, root, key(1), "accounted tree\n", async (source) => {
+      await symlink("index.js", join(source, "node_modules/package-a/safe-link.js"));
+    });
+    const entry = store.entryPath(key(1));
+
+    const expected = await accountedBytes(entry);
+    assert.equal(await accountDependencyCacheEntryBytes(entry), expected, "the walk counts every lstat inode");
+    assert.ok(await accountedBytes(join(entry, "metadata.json")) > 0n, "metadata contributes to accounted bytes");
+    assert.ok(await accountedBytes(join(entry, "trees")) > 0n, "complete trees contribute to accounted bytes");
+    const link = join(store.targetSourcePath(key(1), "node_modules"), "package-a/safe-link.js");
+    const linkInfo = await lstat(link);
+    assert.equal(linkInfo.isSymbolicLink(), true);
+    assert.equal(expected >= BigInt(linkInfo.blocks) * 512n, true, "the symlink inode is counted");
+  } finally {
+    await cleanupRoot(root);
+  }
+});
+
+test("allocated-byte accounting rejects special files instead of treating them as cache misses", async () => {
+  const root = await mkdtemp(join(tmpdir(), "runner-cache-store-special-"));
+  try {
+    const store = await openStore(root);
+    await publish(store, root, key(1));
+    const entry = store.entryPath(key(1));
+    await makeWritable(entry);
+    execFileSync("mkfifo", [join(store.targetSourcePath(key(1), "node_modules"), "package-a/special")]);
+    await makeImmutable(entry);
+
+    await assert.rejects(accountDependencyCacheEntryBytes(entry), /special-file/u);
+    await assert.rejects(
+      store.enforceByteBudget(key(1), undefined, () => undefined),
+      /special-file/u,
+      "retention refuses rather than sizing a population it cannot walk",
+    );
+  } finally {
+    await cleanupRoot(root);
+  }
+});

--- a/packages/runner/src/dependency-cache-store.ts
+++ b/packages/runner/src/dependency-cache-store.ts
@@ -1,0 +1,857 @@
+/**
+ * The on-disk store of published dependency trees.
+ *
+ * Its vocabulary is keys, entries, bytes and usage. It knows nothing about npm,
+ * run workspaces, RunnerConfig or command execution: an entry is an immutable
+ * directory of target trees named by a 64-hex key, an entry records when it was
+ * last used, and the population of entries is held under a byte budget.
+ *
+ * Everything here is reachable from a bare temporary directory, which is what
+ * makes lock, usage, accounting, eviction and rollback testable on their own.
+ */
+
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import {
+  chmod, cp, lstat, mkdir, mkdtemp, open, readFile, readdir, readlink, realpath, rename, rm, writeFile,
+} from "node:fs/promises";
+import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path";
+
+import { flock } from "fs-ext";
+
+export const CACHE_ENTRY_FORMAT = "agentos-runner-dependency-cache-v2";
+const METADATA_FILE = "metadata.json";
+const TREE_DIRECTORY = "trees";
+const ENTRIES_DIRECTORY = "entries";
+const USAGE_DIRECTORY = "usage";
+const LOCK_FILE = "lock";
+const MAX_METADATA_BYTES = 128 * 1024 * 1024;
+const CACHE_KEY = /^[a-f0-9]{64}$/u;
+
+export const DEPENDENCY_CACHE_BYTE_BUDGET = 16 * 1024 ** 3;
+
+// Target confinement is lexical: a target path is relative and free of "..",
+// so whether a recorded symlink escapes depends on the target's depth and the
+// link's own "..", never on where the tree will actually be restored. Entry
+// validation therefore applies the rule against this nominal root and does not
+// need a run workspace at all.
+const NOMINAL_RESTORE_ROOT = "/dependency-cache-restore-root";
+
+export class DependencyCacheIntegrityError extends Error {
+  constructor(readonly condition: string) {
+    super(`Dependency cache integrity refusal: ${condition}`);
+    this.name = "DependencyCacheIntegrityError";
+  }
+}
+
+export class DependencyCacheBudgetError extends Error {
+  constructor(readonly condition: string) {
+    super(`Dependency cache byte budget refusal: ${condition}`);
+    this.name = "DependencyCacheBudgetError";
+  }
+}
+
+export type DependencyCacheToolchain = {
+  node: string;
+  npm: string;
+  operatingSystem: string;
+  architecture: string;
+};
+
+export type CacheEntryInput = { path: string; sha256: string } | { path: string; absent: true };
+
+export type CacheEntryTreeNode =
+  | { path: string; kind: "directory"; mode: number }
+  | { path: string; kind: "file"; mode: number; sha256: string }
+  | { path: string; kind: "symlink"; target: string };
+
+export type CacheEntryTarget = { path: string; present: boolean; tree: CacheEntryTreeNode[] };
+
+export type CacheEntryDocument = {
+  format: typeof CACHE_ENTRY_FORMAT;
+  key: string;
+  toolchain: DependencyCacheToolchain;
+  inputs: CacheEntryInput[];
+  targets: CacheEntryTarget[];
+};
+
+/** Everything an entry must match to be usable, minus the trees themselves. */
+export type CacheEntryExpectation = {
+  key: string;
+  toolchain: DependencyCacheToolchain;
+  inputs: CacheEntryInput[];
+  targetPaths: string[];
+};
+
+export type CacheEntryPublication = "published" | "converged" | "refused";
+
+export type CacheStoreEvent = {
+  event: "integrity-refusal" | "eviction";
+  key?: string;
+  condition?: string;
+};
+
+export type CacheStoreReport = (event: CacheStoreEvent) => void;
+
+export type DependencyCacheRetentionSize = { key: string; bytes: number; usedMs: number };
+
+/**
+ * The least-recently-used keys whose removal brings the population inside the
+ * budget. `currentKey` is never a victim; if it alone exceeds the budget the
+ * population cannot be made to fit and this refuses.
+ */
+export const selectDependencyCacheEvictions = (
+  entries: readonly DependencyCacheRetentionSize[],
+  currentKey?: string,
+  budget = DEPENDENCY_CACHE_BYTE_BUDGET,
+): string[] => {
+  if (!Number.isFinite(budget) || budget < 0) throw new Error("Dependency cache byte budget is invalid");
+  for (const entry of entries) {
+    if (!Number.isFinite(entry.bytes) || entry.bytes < 0) throw new Error("Dependency cache entry size is invalid");
+    if (!Number.isFinite(entry.usedMs)) throw new Error("Dependency cache usage time is invalid");
+  }
+  const protectedEntry = currentKey === undefined ? undefined : entries.find(({ key }) => key === currentKey);
+  if (protectedEntry !== undefined && protectedEntry.bytes > budget) {
+    throw new DependencyCacheBudgetError("protected-entry-exceeds-byte-budget");
+  }
+  let total = entries.reduce((sum, entry) => sum + entry.bytes, 0);
+  const victims: string[] = [];
+  const ordered = [...entries].sort((left, right) => left.usedMs - right.usedMs || left.key.localeCompare(right.key));
+  for (const entry of ordered) {
+    if (total <= budget) break;
+    if (entry.key === currentKey) continue;
+    total -= entry.bytes;
+    victims.push(entry.key);
+  }
+  return victims;
+};
+
+const insideOrEqual = (root: string, candidate: string): boolean =>
+  candidate === root || candidate.startsWith(`${root}${sep}`);
+
+const sha256 = (content: string | Buffer): string => createHash("sha256").update(content).digest("hex");
+
+const sameJson = (left: unknown, right: unknown): boolean => JSON.stringify(left) === JSON.stringify(right);
+
+const errorCode = (error: unknown): string | undefined => (error as NodeJS.ErrnoException).code;
+
+const pathKind = async (path: string): Promise<"missing" | "directory" | "file" | "symlink" | "other"> => {
+  try {
+    const info = await lstat(path);
+    if (info.isSymbolicLink()) return "symlink";
+    if (info.isDirectory()) return "directory";
+    if (info.isFile()) return "file";
+    return "other";
+  } catch (error: unknown) {
+    if (errorCode(error) === "ENOENT") return "missing";
+    throw error;
+  }
+};
+
+/**
+ * The store holds npm dependency trees, so a target is a `node_modules`
+ * directory somewhere at or below `root`. This is the one place that rule and
+ * the confinement rule are written.
+ */
+export const assertCacheTargetPath = (root: string, target: string): string => {
+  if (target !== "node_modules" && !target.endsWith("/node_modules")) {
+    throw new Error(`Invalid dependency target: ${target}`);
+  }
+  const absolute = resolve(root, target);
+  if (!insideOrEqual(root, absolute)) throw new Error(`Dependency target escaped the run workspace: ${target}`);
+  return absolute;
+};
+
+const treeManifest = async (
+  treeRoot: string,
+  root: string,
+  mappedRoot: string,
+  requireImmutable: boolean,
+): Promise<CacheEntryTreeNode[]> => {
+  const manifest: CacheEntryTreeNode[] = [];
+  const visit = async (path: string): Promise<void> => {
+    const info = await lstat(path);
+    const mapped = resolve(mappedRoot, relative(treeRoot, path));
+    if (!insideOrEqual(root, mapped)) throw new DependencyCacheIntegrityError("tree-path-escape");
+    const manifestPath = relative(treeRoot, path).split(sep).join("/") || ".";
+    if (info.isSymbolicLink()) {
+      const link = await readlink(path);
+      if (isAbsolute(link) || !insideOrEqual(root, resolve(dirname(mapped), link))) {
+        throw new DependencyCacheIntegrityError("symlink-escape");
+      }
+      manifest.push({ path: manifestPath, kind: "symlink", target: link });
+      return;
+    }
+    if (requireImmutable && (info.mode & 0o222) !== 0) {
+      throw new DependencyCacheIntegrityError("writable-entry");
+    }
+    if (info.isDirectory()) {
+      if (requireImmutable && (info.mode & 0o005) !== 0o005) {
+        throw new DependencyCacheIntegrityError("entry-not-readable");
+      }
+      manifest.push({ path: manifestPath, kind: "directory", mode: info.mode & 0o111 });
+      for (const child of (await readdir(path)).sort()) await visit(join(path, child));
+      return;
+    }
+    if (!info.isFile()) throw new DependencyCacheIntegrityError("special-file");
+    if (requireImmutable && (info.mode & 0o004) === 0) throw new DependencyCacheIntegrityError("entry-not-readable");
+    manifest.push({ path: manifestPath, kind: "file", mode: info.mode & 0o111, sha256: sha256(await readFile(path)) });
+  };
+  await visit(treeRoot);
+  return manifest;
+};
+
+/**
+ * Describe the target trees living under `root` right now. This is what a
+ * caller publishes, and what it compares a restored workspace against.
+ */
+export const describeTargetTrees = async (root: string, targets: string[]): Promise<CacheEntryTarget[]> => {
+  const manifest: CacheEntryTarget[] = [];
+  for (const target of targets) {
+    const absolute = assertCacheTargetPath(root, target);
+    const kind = await pathKind(absolute);
+    if (kind === "symlink") throw new Error(`Dependency target is a symlink: ${target}`);
+    if (kind !== "missing" && kind !== "directory") throw new Error(`Dependency target is not a directory: ${target}`);
+    const tree = kind === "directory" ? await treeManifest(absolute, root, absolute, false) : [];
+    manifest.push({ path: target, present: kind === "directory", tree });
+  }
+  return manifest;
+};
+
+const documentShape = (value: unknown): value is CacheEntryDocument => {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const metadata = value as Partial<CacheEntryDocument>;
+  if (metadata.format !== CACHE_ENTRY_FORMAT || typeof metadata.key !== "string") return false;
+  if (metadata.toolchain === null || typeof metadata.toolchain !== "object" || Array.isArray(metadata.toolchain)) return false;
+  const toolchain = metadata.toolchain as Partial<DependencyCacheToolchain>;
+  if (!sameJson(Object.keys(toolchain).sort(), ["architecture", "node", "npm", "operatingSystem"])) return false;
+  if (![toolchain.node, toolchain.npm, toolchain.operatingSystem, toolchain.architecture]
+    .every((coordinate) => typeof coordinate === "string" && coordinate.length > 0)) return false;
+  if (!Array.isArray(metadata.inputs) || !Array.isArray(metadata.targets) || metadata.targets.length === 0) return false;
+  return metadata.inputs.every((input) => {
+    if (input === null || typeof input !== "object" || typeof (input as CacheEntryInput).path !== "string") return false;
+    const fields = Object.keys(input).sort();
+    return (sameJson(fields, ["path", "sha256"]) && /^[a-f0-9]{64}$/u.test(String((input as { sha256?: unknown }).sha256)))
+      || (sameJson(fields, ["absent", "path"]) && (input as { absent?: unknown }).absent === true);
+  })
+    && metadata.targets.every((target) => target !== null && typeof target === "object"
+      && typeof (target as CacheEntryTarget).path === "string"
+      && typeof (target as CacheEntryTarget).present === "boolean"
+      && Array.isArray((target as CacheEntryTarget).tree)
+      && sameJson(Object.keys(target).sort(), ["path", "present", "tree"])
+      && (target as CacheEntryTarget).tree.every((entry) => {
+        if (entry === null || typeof entry !== "object" || typeof entry.path !== "string" || typeof entry.kind !== "string") return false;
+        if (entry.kind === "directory") {
+          return Number.isInteger(entry.mode) && entry.mode >= 0 && entry.mode <= 0o111
+            && sameJson(Object.keys(entry).sort(), ["kind", "mode", "path"]);
+        }
+        if (entry.kind === "file") {
+          return Number.isInteger(entry.mode) && entry.mode >= 0 && entry.mode <= 0o111
+            && /^[a-f0-9]{64}$/u.test(entry.sha256)
+            && sameJson(Object.keys(entry).sort(), ["kind", "mode", "path", "sha256"]);
+        }
+        return entry.kind === "symlink" && typeof entry.target === "string"
+          && sameJson(Object.keys(entry).sort(), ["kind", "path", "target"]);
+      }));
+};
+
+const readDocument = async (entry: string): Promise<CacheEntryDocument> => {
+  const path = join(entry, METADATA_FILE);
+  const info = await lstat(path).catch((error: unknown) => {
+    if (errorCode(error) === "ENOENT") throw new DependencyCacheIntegrityError("metadata-missing");
+    throw error;
+  });
+  if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_METADATA_BYTES) {
+    throw new DependencyCacheIntegrityError("metadata-malformed");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(path, "utf8"));
+  } catch (error: unknown) {
+    throw new DependencyCacheIntegrityError(`metadata-unreadable:${errorCode(error) ?? "invalid-json"}`);
+  }
+  if (!documentShape(parsed)) throw new DependencyCacheIntegrityError("metadata-malformed");
+  return parsed;
+};
+
+const validateTreeLayout = async (trees: string, targets: CacheEntryTarget[]): Promise<void> => {
+  const present = new Set(targets.filter(({ present }) => present).map(({ path }) => path));
+  const prefixes = new Set<string>();
+  for (const target of present) {
+    let parent = posix.dirname(target);
+    while (parent !== ".") {
+      prefixes.add(parent);
+      parent = posix.dirname(parent);
+    }
+  }
+  const walk = async (directory: string, relativeDirectory = ""): Promise<void> => {
+    if (((await lstat(directory)).mode & 0o222) !== 0) throw new DependencyCacheIntegrityError("writable-entry");
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = relativeDirectory === "" ? entry.name : `${relativeDirectory}/${entry.name}`;
+      if (present.has(path)) continue;
+      if (!prefixes.has(path) || !entry.isDirectory() || entry.isSymbolicLink()) {
+        throw new DependencyCacheIntegrityError("unexpected-tree-content");
+      }
+      await walk(join(directory, entry.name), path);
+    }
+  };
+  await walk(trees);
+};
+
+const validateImmutableEntryContents = async (entry: string, document: CacheEntryDocument): Promise<void> => {
+  const trees = join(entry, TREE_DIRECTORY);
+  if (await pathKind(trees) !== "directory") throw new DependencyCacheIntegrityError("tree-root-missing");
+  const entryNames = (await readdir(entry)).sort();
+  if (!sameJson(entryNames, [METADATA_FILE, TREE_DIRECTORY].sort())) {
+    throw new DependencyCacheIntegrityError("unexpected-entry-content");
+  }
+  await validateTreeLayout(trees, document.targets);
+  for (const target of document.targets) {
+    const cached = resolve(trees, target.path);
+    if (!insideOrEqual(trees, cached)) throw new DependencyCacheIntegrityError("target-path-escape");
+    const kind = await pathKind(cached);
+    if (target.present && kind !== "directory") throw new DependencyCacheIntegrityError("target-tree-missing");
+    if (!target.present && kind !== "missing") throw new DependencyCacheIntegrityError("unexpected-target-tree");
+    if (target.present) {
+      const actualTree = await treeManifest(
+        cached, NOMINAL_RESTORE_ROOT, assertCacheTargetPath(NOMINAL_RESTORE_ROOT, target.path), true,
+      );
+      if (!sameJson(actualTree, target.tree)) throw new DependencyCacheIntegrityError("tree-manifest-mismatch");
+    } else if (target.tree.length !== 0) {
+      throw new DependencyCacheIntegrityError("target-manifest-mismatch");
+    }
+  }
+  await treeManifest(join(entry, METADATA_FILE), NOMINAL_RESTORE_ROOT, NOMINAL_RESTORE_ROOT, true);
+  const entryInfo = await lstat(entry);
+  const treesInfo = await lstat(trees);
+  if ((entryInfo.mode & 0o222) !== 0 || (treesInfo.mode & 0o222) !== 0) {
+    throw new DependencyCacheIntegrityError("writable-entry");
+  }
+};
+
+const validateEntry = async (entry: string, expected: CacheEntryExpectation): Promise<CacheEntryDocument> => {
+  if (await pathKind(entry) !== "directory") throw new DependencyCacheIntegrityError("entry-not-directory");
+  const document = await readDocument(entry);
+  if (document.key !== expected.key) throw new DependencyCacheIntegrityError("key-mismatch");
+  if (!sameJson(document.toolchain, expected.toolchain)) throw new DependencyCacheIntegrityError("toolchain-mismatch");
+  if (!sameJson(document.inputs, expected.inputs)) throw new DependencyCacheIntegrityError("input-manifest-mismatch");
+  if (!sameJson(document.targets.map(({ path }) => path), expected.targetPaths)) {
+    throw new DependencyCacheIntegrityError("target-manifest-mismatch");
+  }
+  await validateImmutableEntryContents(entry, document);
+  return document;
+};
+
+const makeImmutable = async (path: string): Promise<void> => {
+  const info = await lstat(path);
+  if (info.isSymbolicLink()) return;
+  if (info.isDirectory()) for (const child of await readdir(path)) await makeImmutable(join(path, child));
+  await chmod(path, info.isDirectory() ? 0o555 : 0o444 | (info.mode & 0o111));
+};
+
+const makeWritable = async (path: string): Promise<void> => {
+  const kind = await pathKind(path);
+  if (kind === "missing" || kind === "symlink") return;
+  const info = await lstat(path);
+  await chmod(path, info.mode | 0o700);
+  if (kind === "directory") for (const child of await readdir(path)) await makeWritable(join(path, child));
+};
+
+const allocatedBytes = (info: { blocks: number }): bigint => {
+  if (!Number.isSafeInteger(info.blocks) || info.blocks < 0) {
+    throw new DependencyCacheIntegrityError("invalid-allocated-size");
+  }
+  return BigInt(info.blocks) * 512n;
+};
+
+// Cache entries are immutable after publication. Walk them without following
+// symlinks so accounting cannot escape the entry root. A symlink is itself an
+// inode and therefore contributes its own allocated blocks. Its lexical target
+// must remain below the entry root; validateEntry additionally checks the
+// target against the tree layout before a selected entry is restored.
+const accountCacheEntry = async (entry: string): Promise<bigint> => {
+  const root = resolve(entry);
+  const rootInfo = await lstat(root).catch((error: unknown) => {
+    if (errorCode(error) === "ENOENT") throw new DependencyCacheIntegrityError("entry-not-directory");
+    throw error;
+  });
+  if (rootInfo.isSymbolicLink() || !rootInfo.isDirectory()) {
+    throw new DependencyCacheIntegrityError(rootInfo.isSymbolicLink() ? "unsafe-retention-entry" : "entry-not-directory");
+  }
+  const visitedInodes = new Set<string>();
+  const visit = async (path: string): Promise<bigint> => {
+    let info;
+    try {
+      info = await lstat(path);
+    } catch (error: unknown) {
+      if (errorCode(error) === "ENOENT") throw new DependencyCacheIntegrityError("entry-disappeared");
+      throw error;
+    }
+    const inode = `${String(info.dev)}:${String(info.ino)}`;
+    if (info.ino !== 0 && visitedInodes.has(inode)) return 0n;
+    if (info.ino !== 0) visitedInodes.add(inode);
+    const ownBytes = allocatedBytes(info);
+    if (info.isSymbolicLink()) {
+      const target = await readlink(path);
+      if (isAbsolute(target) || !insideOrEqual(root, resolve(dirname(path), target))) {
+        throw new DependencyCacheIntegrityError("symlink-escape");
+      }
+      return ownBytes;
+    }
+    if (info.isFile()) return ownBytes;
+    if (!info.isDirectory()) throw new DependencyCacheIntegrityError("special-file");
+    let total = ownBytes;
+    for (const child of await readdir(path)) {
+      const childPath = join(path, child);
+      if (!insideOrEqual(root, childPath)) throw new DependencyCacheIntegrityError("entry-path-escape");
+      total += await visit(childPath);
+    }
+    return total;
+  };
+  return visit(root);
+};
+
+/** Allocated bytes an entry directory occupies, symlink inodes included. */
+export const accountDependencyCacheEntryBytes = async (entry: string): Promise<bigint> => {
+  let bytes: bigint;
+  try {
+    bytes = await accountCacheEntry(entry);
+  } catch (error: unknown) {
+    if (error instanceof DependencyCacheIntegrityError) throw error;
+    throw new DependencyCacheIntegrityError(`size-walk-failed:${errorCode(error) ?? "unknown"}`);
+  }
+  return bytes;
+};
+
+const flockAsync = (fd: number, operation: "sh" | "ex" | "un"): Promise<void> => new Promise((accept, reject) => {
+  flock(fd, operation, (error) => error ? reject(error) : accept());
+});
+
+type RetentionEntry = { key: string; path: string; usedMs: number; bytes: bigint };
+
+const totalRetentionBytes = (entries: RetentionEntry[]): bigint =>
+  entries.reduce((total, entry) => total + entry.bytes, 0n);
+
+const asRetentionIntegrityError = (error: unknown): DependencyCacheIntegrityError =>
+  error instanceof DependencyCacheIntegrityError
+    ? error
+    : new DependencyCacheIntegrityError(`retention-walk-failed:${errorCode(error) ?? "unknown"}`);
+
+const snapshotTarget = async (source: string, destination: string): Promise<void> => {
+  await mkdir(dirname(destination), { recursive: true });
+  await cp(source, destination, {
+    recursive: true,
+    preserveTimestamps: true,
+    verbatimSymlinks: true,
+    mode: constants.COPYFILE_FICLONE,
+  });
+};
+
+/**
+ * A cache root, opened.
+ *
+ * Every operation is named by a key. Publication and restore run under the
+ * shared lock; byte-budget enforcement takes the exclusive one, so it always
+ * sees a settled population.
+ */
+export type CacheEntryStore = {
+  /** The resolved root. Entries, usage markers and the lock live under it. */
+  readonly root: string;
+  entryPath: (key: string) => string;
+  /** Where a published target tree lives inside its entry. */
+  targetSourcePath: (key: string, targetPath: string) => string;
+  hasEntry: (key: string) => Promise<boolean>;
+  /** Run `work` while no exclusive owner (byte-budget enforcement) can run. */
+  withSharedLock: <T>(work: () => Promise<T>) => Promise<T>;
+  /** Refuse a usage marker that is not a plain file before it is trusted. */
+  validateUseMarker: (key: string) => Promise<void>;
+  recordUse: (key: string) => Promise<void>;
+  /** Validate the entry under `expected.key` against `expected` and return it. */
+  readEntry: (expected: CacheEntryExpectation) => Promise<CacheEntryDocument>;
+  /** Snapshot `targets` out of `source` into a new immutable entry. */
+  publishEntry: (
+    expected: CacheEntryExpectation, targets: CacheEntryTarget[], source: string,
+  ) => Promise<CacheEntryPublication>;
+  /**
+   * Hold the population at or below `budget` bytes, evicting least-recently-used
+   * entries. `currentKey` is never evicted; `newlyPublishedKey`, if the budget
+   * cannot be met, is rolled back so a refused pass leaves nothing behind.
+   */
+  enforceByteBudget: (
+    currentKey: string | undefined,
+    newlyPublishedKey: string | undefined,
+    report: CacheStoreReport,
+    budget?: number,
+  ) => Promise<void>;
+};
+
+/**
+ * Create the cache root layout and return the store bound to it.
+ *
+ * `disjointFrom` is a resolved real path the root may neither contain nor live
+ * inside: a cache that overlaps the trees it caches cannot be immutable. The
+ * comparison is lexical, so an unresolved path would not be recognised.
+ */
+export const openCacheEntryStore = async (configuredRoot: string, disjointFrom: string): Promise<CacheEntryStore> => {
+  const requestedRoot = resolve(configuredRoot);
+  await mkdir(requestedRoot, { recursive: true, mode: 0o711 });
+  if ((await lstat(requestedRoot)).isSymbolicLink()) throw new Error("Dependency cache root is a symlink");
+  const root = await realpath(requestedRoot);
+  if (insideOrEqual(root, disjointFrom) || insideOrEqual(disjointFrom, root)) {
+    throw new Error("Dependency cache root overlaps the run workspace");
+  }
+  await chmod(root, 0o711);
+  const entriesRoot = join(root, ENTRIES_DIRECTORY);
+  await mkdir(entriesRoot, { recursive: true, mode: 0o711 });
+  if ((await lstat(entriesRoot)).isSymbolicLink()) throw new Error("Dependency cache entries root is a symlink");
+  await chmod(entriesRoot, 0o711);
+  const usageRoot = join(root, USAGE_DIRECTORY);
+  await mkdir(usageRoot, { recursive: true, mode: 0o700 });
+  if ((await lstat(usageRoot)).isSymbolicLink()) throw new Error("Dependency cache usage root is a symlink");
+  await chmod(usageRoot, 0o700);
+
+  const entryPath = (key: string): string => {
+    const entry = resolve(entriesRoot, key);
+    if (!insideOrEqual(root, entry)) throw new Error("Dependency cache entry escaped its root");
+    return entry;
+  };
+
+  const openLock = async () => {
+    const path = join(root, LOCK_FILE);
+    const handle = await open(path, constants.O_CREAT | constants.O_RDWR | constants.O_NOFOLLOW, 0o600);
+    const info = await handle.stat();
+    if (!info.isFile()) {
+      await handle.close();
+      throw new Error("Dependency cache lock is not a file");
+    }
+    return handle;
+  };
+
+  const withSharedLock = async <T>(work: () => Promise<T>): Promise<T> => {
+    const handle = await openLock();
+    try {
+      await flockAsync(handle.fd, "sh");
+      try {
+        return await work();
+      } finally {
+        await flockAsync(handle.fd, "un");
+      }
+    } finally {
+      await handle.close();
+    }
+  };
+
+  const recordUse = async (key: string): Promise<void> => {
+    if (!CACHE_KEY.test(key)) throw new Error("Dependency cache usage key is invalid");
+    const marker = join(usageRoot, key);
+    const handle = await open(
+      marker,
+      constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC | constants.O_NOFOLLOW,
+      0o600,
+    ).catch((error: unknown) => {
+      throw new DependencyCacheIntegrityError(`usage-marker-unwritable:${errorCode(error) ?? "unknown"}`);
+    });
+    try {
+      await handle.writeFile(`${new Date().toISOString()}\n`);
+    } finally {
+      await handle.close();
+    }
+  };
+
+  const validateUseMarker = async (key: string): Promise<void> => {
+    const marker = join(usageRoot, key);
+    const info = await lstat(marker).catch((error: unknown) => {
+      if (errorCode(error) === "ENOENT") return null;
+      throw new DependencyCacheIntegrityError(`usage-marker-unreadable:${errorCode(error) ?? "unknown"}`);
+    });
+    if (info?.isSymbolicLink() || (info !== null && !info.isFile())) {
+      throw new DependencyCacheIntegrityError("unsafe-usage-marker");
+    }
+  };
+
+  const publishEntry = async (
+    expected: CacheEntryExpectation, targets: CacheEntryTarget[], source: string,
+  ): Promise<CacheEntryPublication> => {
+    if (!sameJson(targets.map(({ path }) => path), expected.targetPaths)) {
+      throw new Error("Published dependency targets do not match the expected target paths");
+    }
+    const entry = entryPath(expected.key);
+    if (await pathKind(entry) !== "missing") {
+      try {
+        await validateEntry(entry, expected);
+        return "converged";
+      } catch (error: unknown) {
+        if (error instanceof DependencyCacheIntegrityError) return "refused";
+        throw error;
+      }
+    }
+    const document: CacheEntryDocument = {
+      format: CACHE_ENTRY_FORMAT,
+      key: expected.key,
+      toolchain: expected.toolchain,
+      inputs: expected.inputs,
+      targets,
+    };
+    const staging = await mkdtemp(join(entriesRoot, `.stage-${expected.key.slice(0, 16)}-`));
+    if (!insideOrEqual(root, await realpath(staging))) throw new Error("Dependency cache staging escaped its root");
+    try {
+      await mkdir(join(staging, TREE_DIRECTORY));
+      for (const target of document.targets) {
+        if (target.present) {
+          await snapshotTarget(
+            assertCacheTargetPath(source, target.path), resolve(staging, TREE_DIRECTORY, target.path),
+          );
+        }
+      }
+      await writeFile(join(staging, METADATA_FILE), `${JSON.stringify(document)}\n`, { mode: 0o400 });
+      await makeImmutable(staging);
+      await validateEntry(staging, expected);
+      try {
+        await rename(staging, entry);
+        return "published";
+      } catch (error: unknown) {
+        // Darwin reports EACCES rather than EEXIST when the winning directory is
+        // already immutable. The destination's independently verified state,
+        // not the platform-specific errno, decides whether this was a safe race.
+        if (await pathKind(entry) === "missing") throw error;
+        try {
+          await validateEntry(entry, expected);
+          return "converged";
+        } catch (validationError: unknown) {
+          if (validationError instanceof DependencyCacheIntegrityError) return "refused";
+          throw validationError;
+        }
+      }
+    } finally {
+      if (await pathKind(staging) !== "missing") {
+        await makeWritable(staging).catch(() => undefined);
+        await rm(staging, { recursive: true, force: true });
+      }
+    }
+  };
+
+  const reportIntegrityRefusal = (
+    report: CacheStoreReport,
+    key: string | undefined,
+    condition: string,
+  ): DependencyCacheIntegrityError => {
+    report({ event: "integrity-refusal", ...(key ? { key: key.slice(0, 16) } : {}), condition });
+    return new DependencyCacheIntegrityError(condition);
+  };
+
+  const inspectRetentionEntry = async (key: string, path: string): Promise<void> => {
+    const document = await readDocument(path);
+    if (document.key !== key) throw new DependencyCacheIntegrityError("key-mismatch");
+    await validateImmutableEntryContents(path, document);
+  };
+
+  const retentionEntries = async (report: CacheStoreReport): Promise<RetentionEntry[]> => {
+    if (await pathKind(entriesRoot) !== "directory") {
+      throw reportIntegrityRefusal(report, undefined, "entries-root-missing");
+    }
+    if (await pathKind(usageRoot) !== "directory") {
+      throw reportIntegrityRefusal(report, undefined, "usage-root-missing");
+    }
+    const markerKinds = new Map<string, Awaited<ReturnType<typeof lstat>> | null>();
+    for (const name of await readdir(usageRoot)) {
+      // Only key-shaped names are cache usage markers. Ignore unrelated files
+      // rather than letting them deny all materializations on the shared host.
+      if (!CACHE_KEY.test(name)) continue;
+      const marker = join(usageRoot, name);
+      const markerInfo = await lstat(marker).catch((error: unknown) => {
+        if (errorCode(error) === "ENOENT") return null;
+        throw error;
+      });
+      if (markerInfo?.isSymbolicLink() || (markerInfo !== null && !markerInfo.isFile())) {
+        throw reportIntegrityRefusal(report, name, "unsafe-usage-marker");
+      }
+      markerKinds.set(name, markerInfo);
+    }
+    const entries: RetentionEntry[] = [];
+    for (const name of await readdir(entriesRoot)) {
+      if (!CACHE_KEY.test(name)) {
+        // publishEntry creates stages under this directory while holding a
+        // shared lock. Once the exclusive retention lock is held, a remaining
+        // stage is necessarily orphaned and may be reaped safely. Other non-key
+        // names are not immutable cache entries and are ignored.
+        if (name.startsWith(".stage-")) {
+          const staging = join(entriesRoot, name);
+          await makeWritable(staging).catch(() => undefined);
+          await rm(staging, { recursive: true, force: true }).catch(() => undefined);
+        }
+        continue;
+      }
+      const path = join(entriesRoot, name);
+      const info = await lstat(path).catch((error: unknown) => {
+        if (errorCode(error) === "ENOENT") return null;
+        throw error;
+      });
+      if (info === null) throw reportIntegrityRefusal(report, name, "retention-entry-disappeared");
+      if (info.isSymbolicLink() || !info.isDirectory()) {
+        throw reportIntegrityRefusal(report, name, "unsafe-retention-entry");
+      }
+      let bytes: bigint;
+      try {
+        await inspectRetentionEntry(name, path);
+        bytes = await accountCacheEntry(path);
+      } catch (error: unknown) {
+        throw reportIntegrityRefusal(report, name, asRetentionIntegrityError(error).condition);
+      }
+      const markerInfo = markerKinds.get(name) ?? null;
+      const usedMs = Number(markerInfo?.mtimeMs ?? info.mtimeMs);
+      if (!Number.isFinite(usedMs)) throw reportIntegrityRefusal(report, name, "invalid-usage-marker-time");
+      entries.push({ key: name, path, usedMs, bytes });
+    }
+    return entries;
+  };
+
+  const removeRetentionEntry = async (entry: RetentionEntry): Promise<void> => {
+    try {
+      await makeWritable(entry.path);
+      await rm(entry.path, { recursive: true, force: true });
+      if (await pathKind(entry.path) !== "missing") throw new Error("cache entry remained after deletion");
+      await rm(join(usageRoot, entry.key), { force: true });
+      if (await pathKind(join(usageRoot, entry.key)) !== "missing") {
+        throw new Error("cache usage marker remained after deletion");
+      }
+    } catch (error: unknown) {
+      throw new DependencyCacheBudgetError(`eviction-failed:${errorCode(error) ?? "unknown"}`);
+    }
+  };
+
+  const rollbackPublishedEntry = async (key: string, report: CacheStoreReport): Promise<void> => {
+    const entry: RetentionEntry = { key, path: entryPath(key), usedMs: 0, bytes: 0n };
+    const existed = await pathKind(entry.path) !== "missing";
+    try {
+      await removeRetentionEntry(entry);
+    } catch (error: unknown) {
+      const condition = error instanceof DependencyCacheBudgetError
+        ? `publication-rollback-failed:${error.condition}`
+        : "publication-rollback-failed";
+      report({ event: "integrity-refusal", key: key.slice(0, 16), condition });
+      throw new DependencyCacheBudgetError(condition);
+    }
+    if (existed) report({ event: "eviction", key: key.slice(0, 16), condition: "byte-budget" });
+  };
+
+  const enforceByteBudget = async (
+    currentKey: string | undefined,
+    newlyPublishedKey: string | undefined,
+    report: CacheStoreReport,
+    budget = DEPENDENCY_CACHE_BYTE_BUDGET,
+  ): Promise<void> => {
+    if (!Number.isSafeInteger(budget) || budget < 0) {
+      throw new DependencyCacheBudgetError("invalid-byte-budget");
+    }
+    const budgetBytes = BigInt(budget);
+    const handle = await openLock();
+    let locked = false;
+    try {
+      // This is deliberately blocking. Shared restore and publication owners
+      // must finish before this snapshot can be sized or entries removed.
+      await flockAsync(handle.fd, "ex");
+      locked = true;
+      try {
+        let entries: RetentionEntry[];
+        try {
+          entries = await retentionEntries(report);
+        } catch (error: unknown) {
+          const integrityError = asRetentionIntegrityError(error);
+          if (!(error instanceof DependencyCacheIntegrityError)) {
+            report({ event: "integrity-refusal", condition: integrityError.condition });
+          }
+          throw integrityError;
+        }
+        const protectedKey = currentKey && CACHE_KEY.test(currentKey) ? currentKey : undefined;
+        let total = totalRetentionBytes(entries);
+        if (total > budgetBytes) {
+          let victimKeys: string[];
+          try {
+            victimKeys = selectDependencyCacheEvictions(
+              entries.map(({ key, bytes, usedMs }) => {
+                const numericBytes = Number(bytes);
+                if (!Number.isSafeInteger(numericBytes)) throw new DependencyCacheIntegrityError("allocated-size-overflow");
+                return { key, bytes: numericBytes, usedMs };
+              }),
+              protectedKey,
+              budget,
+            );
+          } catch (error: unknown) {
+            if (error instanceof DependencyCacheBudgetError
+              && newlyPublishedKey
+              && CACHE_KEY.test(newlyPublishedKey)) {
+              await rollbackPublishedEntry(newlyPublishedKey, report);
+            }
+            const condition = error instanceof DependencyCacheBudgetError
+              ? error.condition
+              : asRetentionIntegrityError(error).condition;
+            report({
+              event: "integrity-refusal",
+              ...(protectedKey ? { key: protectedKey.slice(0, 16) } : {}),
+              condition,
+            });
+            throw error instanceof DependencyCacheBudgetError ? error : new DependencyCacheIntegrityError(condition);
+          }
+          const entriesByKey = new Map(entries.map((entry) => [entry.key, entry] as const));
+          for (const victimKey of victimKeys) {
+            const victim = entriesByKey.get(victimKey);
+            if (victim === undefined) throw new DependencyCacheBudgetError("byte-budget-invariant-unmet");
+            try {
+              await removeRetentionEntry(victim);
+            } catch (error: unknown) {
+              const condition = error instanceof DependencyCacheBudgetError ? error.condition : "eviction-failed";
+              report({ event: "integrity-refusal", key: victim.key.slice(0, 16), condition });
+              if (newlyPublishedKey && newlyPublishedKey !== victim.key && CACHE_KEY.test(newlyPublishedKey)) {
+                await rollbackPublishedEntry(newlyPublishedKey, report);
+              }
+              throw error instanceof DependencyCacheBudgetError ? error : new DependencyCacheBudgetError(condition);
+            }
+            total -= victim.bytes;
+            report({ event: "eviction", key: victim.key.slice(0, 16), condition: "byte-budget" });
+          }
+        }
+
+        // The exclusive lock has covered the initial walk and every deletion,
+        // so this tracked total is the authoritative final invariant without a
+        // second full manifest parse and inode walk.
+        if (total <= budgetBytes) return;
+
+        const protectedEntry = protectedKey === undefined
+          ? undefined
+          : entries.find((entry) => entry.key === protectedKey);
+        const condition = protectedEntry !== undefined && protectedEntry.bytes > budgetBytes
+          ? "protected-entry-exceeds-byte-budget"
+          : "byte-budget-invariant-unmet";
+        if (newlyPublishedKey && CACHE_KEY.test(newlyPublishedKey)) {
+          await rollbackPublishedEntry(newlyPublishedKey, report);
+        }
+        report({
+          event: "integrity-refusal",
+          ...(protectedKey ? { key: protectedKey.slice(0, 16) } : {}),
+          condition,
+        });
+        throw new DependencyCacheBudgetError(condition);
+      } finally {
+        await flockAsync(handle.fd, "un");
+        locked = false;
+      }
+    } finally {
+      if (locked) await flockAsync(handle.fd, "un").catch(() => undefined);
+      await handle.close();
+    }
+  };
+
+  return {
+    root,
+    entryPath,
+    targetSourcePath: (key: string, targetPath: string) =>
+      assertCacheTargetPath(join(entryPath(key), TREE_DIRECTORY), targetPath),
+    hasEntry: async (key: string): Promise<boolean> => await pathKind(entryPath(key)) !== "missing",
+    withSharedLock,
+    validateUseMarker,
+    recordUse,
+    readEntry: (expected: CacheEntryExpectation) => validateEntry(entryPath(expected.key), expected),
+    publishEntry,
+    enforceByteBudget,
+  };
+};

--- a/packages/runner/src/dependency-cache.test.ts
+++ b/packages/runner/src/dependency-cache.test.ts
@@ -11,12 +11,14 @@ import test from "node:test";
 import { flock } from "fs-ext";
 
 import type { RunnerConfig } from "./config.js";
-import * as dependencyCacheModule from "./dependency-cache.js";
+import {
+  accountDependencyCacheEntryBytes, openCacheEntryStore, type DependencyCacheToolchain,
+} from "./dependency-cache-store.js";
 import {
   DEPENDENCY_PROVISIONING_MANIFEST_MISSING, DependencyCacheInputMissError,
   DependencyProvisioningManifestMissingError, deriveDependencyCacheKey,
   materializeWorkspaceDependencies,
-  type DependencyCacheProgress, type DependencyCacheToolchain, type DependencyCommandExecutor,
+  type DependencyCacheProgress, type DependencyCommandExecutor,
 } from "./dependency-cache.js";
 import { CommandTimeoutError, runCommand } from "./exec.js";
 import { provisionWorkspace, workspaceEnvironment, type WorkspaceProvisionClaim } from "./workspace.js";
@@ -162,44 +164,10 @@ const cleanupRoot = async (root: string): Promise<void> => {
   await rm(root, { recursive: true, force: true });
 };
 
-const BYTE_BUDGET = 16 * 1024 ** 3;
-
-// Retention decisions are intentionally exercised through the production
-// selector with synthetic accounted sizes. The implementation exports this
-// narrow test seam so these cases do not need to allocate a 16 GiB fixture.
-type SyntheticRetentionEntry = { key: string; bytes: number; usedMs: number };
-type DependencyCacheTestApi = {
-  selectDependencyCacheEvictions: (
-    entries: SyntheticRetentionEntry[], currentKey?: string, budgetBytes?: number,
-  ) => string[];
-  accountDependencyCacheEntryBytes: (entry: string) => Promise<bigint>;
-  enforceDependencyCacheByteBudget: (
-    cacheRoot: string,
-    currentKey: string | undefined,
-    newlyPublishedKey: string | undefined,
-    report: (event: DependencyCacheProgress) => void,
-    budgetBytes?: number,
-  ) => Promise<void>;
-};
-const dependencyCacheTestApi = dependencyCacheModule as unknown as DependencyCacheTestApi;
-
-const assertDependencyCacheTestApi = (): void => {
-  assert.equal(typeof dependencyCacheTestApi.selectDependencyCacheEvictions, "function");
-  assert.equal(typeof dependencyCacheTestApi.accountDependencyCacheEntryBytes, "function");
-  assert.equal(typeof dependencyCacheTestApi.enforceDependencyCacheByteBudget, "function");
-};
-
-const syntheticKey = (index: number): string => index.toString(16).padStart(64, "0");
-
-const accountedBytes = async (path: string): Promise<bigint> => {
-  const info = await lstat(path);
-  if (info.isDirectory()) {
-    let total = BigInt(info.blocks) * 512n;
-    for (const child of await readdir(path)) total += await accountedBytes(join(path, child));
-    return total;
-  }
-  return BigInt(info.blocks) * 512n;
-};
+// Retention itself is proven against the store on a bare temporary directory
+// (dependency-cache-store.test.ts). What is left here is the interaction these
+// tests exist for: enforcement must wait behind a materialization's shared lock.
+const cacheStore = (root: string) => openCacheEntryStore(join(root, "cache"), join(root, "no-workspace-here"));
 
 const publishFixtureVersions = async (root: string, versions: string[]) => {
   const configured = config(root);
@@ -918,32 +886,6 @@ test("orphan publication stages and non-key usage files do not brick retention",
   }
 });
 
-test("unrelated retention corruption preserves a valid new publication without a budget eviction audit", async () => {
-  assertDependencyCacheTestApi();
-  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-publication-integrity-"));
-  try {
-    const { published } = await publishFixtureVersions(root, ["2.0.4", "2.0.5"]);
-    const [unrelated, publishedEntry] = published;
-    assert.ok(unrelated && publishedEntry);
-    await makeWritable(entryPath(root, unrelated.key));
-    await writeFile(join(entryPath(root, unrelated.key), "metadata.json"), "malformed\n");
-    const events: DependencyCacheProgress[] = [];
-
-    await assert.rejects(
-      dependencyCacheTestApi.enforceDependencyCacheByteBudget(
-        join(root, "cache"), publishedEntry.key, publishedEntry.key, (event) => events.push(event),
-      ),
-      /metadata-unreadable/u,
-    );
-
-    assert.equal((await lstat(entryPath(root, publishedEntry.key))).isDirectory(), true);
-    assert.equal((await lstat(join(root, "cache/usage", publishedEntry.key))).isFile(), true);
-    assert.equal(events.some(({ event }) => event === "eviction"), false);
-  } finally {
-    await cleanupRoot(root);
-  }
-});
-
 test("an unsafe usage marker refuses retention instead of allowing an over-budget snapshot", async () => {
   const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-marker-corruption-"));
   try {
@@ -1134,201 +1076,7 @@ test("concurrent publishers converge on one valid immutable entry", async () => 
   }
 });
 
-test("byte-budget retention keeps a large below-budget population and evicts oldest bytes", () => {
-  assertDependencyCacheTestApi();
-  const gibibyte = 1024 ** 3;
-  const belowBudget = Array.from({ length: 40 }, (_, index) => ({
-    key: syntheticKey(index), bytes: 256 * 1024 ** 2, usedMs: index + 1,
-  }));
-  assert.equal(
-    belowBudget.reduce((total, entry) => total + entry.bytes, 0) < BYTE_BUDGET,
-    true,
-    "the synthetic population is below the fixed budget",
-  );
-  assert.deepEqual(
-    dependencyCacheTestApi.selectDependencyCacheEvictions(belowBudget, syntheticKey(39), BYTE_BUDGET),
-    [],
-    "entry count does not trigger retention",
-  );
-
-  const entries: SyntheticRetentionEntry[] = [
-    { key: syntheticKey(100), bytes: 4 * gibibyte, usedMs: 1 },
-    { key: syntheticKey(101), bytes: 7 * gibibyte, usedMs: 2 },
-    { key: syntheticKey(102), bytes: 6 * gibibyte, usedMs: 3 },
-    { key: syntheticKey(103), bytes: 5 * gibibyte, usedMs: 4 },
-  ];
-  const victims = dependencyCacheTestApi.selectDependencyCacheEvictions(entries, syntheticKey(103), BYTE_BUDGET);
-  assert.deepEqual(victims, [syntheticKey(100), syntheticKey(101)], "multiple oldest entries are evicted in one pass");
-  assert.ok(entries.filter(({ key }) => !victims.includes(key)).reduce((total, entry) => total + entry.bytes, 0) <= BYTE_BUDGET);
-
-  const exact = [
-    { key: syntheticKey(110), bytes: 8 * gibibyte, usedMs: 1 },
-    { key: syntheticKey(111), bytes: 8 * gibibyte, usedMs: 2 },
-  ];
-  assert.deepEqual(
-    dependencyCacheTestApi.selectDependencyCacheEvictions(exact, syntheticKey(111), BYTE_BUDGET),
-    [],
-    "exactly the budget is retained",
-  );
-
-  const refreshable: SyntheticRetentionEntry[] = [
-    { key: syntheticKey(120), bytes: 6 * gibibyte, usedMs: 1 },
-    { key: syntheticKey(121), bytes: 7 * gibibyte, usedMs: 2 },
-    { key: syntheticKey(122), bytes: 5 * gibibyte, usedMs: 3 },
-  ];
-  assert.deepEqual(
-    dependencyCacheTestApi.selectDependencyCacheEvictions(refreshable, syntheticKey(122), BYTE_BUDGET),
-    [syntheticKey(120)],
-  );
-  refreshable[0]!.usedMs = 10;
-  assert.deepEqual(
-    dependencyCacheTestApi.selectDependencyCacheEvictions(refreshable, syntheticKey(122), BYTE_BUDGET),
-    [syntheticKey(121)],
-    "refreshing the oldest usage marker changes the victim",
-  );
-
-  assert.throws(
-    () => dependencyCacheTestApi.selectDependencyCacheEvictions(
-      [{ key: syntheticKey(130), bytes: BYTE_BUDGET + 1, usedMs: 1 }], syntheticKey(130), BYTE_BUDGET,
-    ),
-    /(?:byte.?budget|oversized|over.?budget)/iu,
-    "a protected entry larger than the budget is a named refusal",
-  );
-});
-
-test("locked byte-budget enforcement deletes multiple oldest entries and preserves exact-budget state", async () => {
-  assertDependencyCacheTestApi();
-  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-byte-enforcement-"));
-  try {
-    const { published } = await publishFixtureVersions(root, ["3.0.0", "3.0.1", "3.0.2"]);
-    const cacheRoot = join(root, "cache");
-    const [oldest, middle, current] = published;
-    assert.ok(oldest && middle && current);
-    await Promise.all([
-      utimes(join(cacheRoot, "usage", oldest.key), new Date(1_000), new Date(1_000)),
-      utimes(join(cacheRoot, "usage", middle.key), new Date(2_000), new Date(2_000)),
-      utimes(join(cacheRoot, "usage", current.key), new Date(3_000), new Date(3_000)),
-    ]);
-    const sizes = await Promise.all(published.map(({ key }) =>
-      dependencyCacheTestApi.accountDependencyCacheEntryBytes(entryPath(root, key))));
-    const exactBudget = Number(sizes.reduce((total, size) => total + size, 0n));
-    const exactEvents: DependencyCacheProgress[] = [];
-    await dependencyCacheTestApi.enforceDependencyCacheByteBudget(
-      cacheRoot, current.key, undefined, (event) => exactEvents.push(event), exactBudget,
-    );
-    assert.equal(exactEvents.some(({ event }) => event === "eviction"), false, "exact budget emits no eviction");
-
-    const events: DependencyCacheProgress[] = [];
-    await dependencyCacheTestApi.enforceDependencyCacheByteBudget(
-      cacheRoot, current.key, undefined, (event) => events.push(event), Number(sizes[2]),
-    );
-    assert.deepEqual(events, [oldest, middle].map(({ key }) => ({
-      event: "eviction", key: key.slice(0, 16), condition: "byte-budget",
-    })));
-    await assert.rejects(lstat(entryPath(root, oldest.key)), /ENOENT/u);
-    await assert.rejects(lstat(entryPath(root, middle.key)), /ENOENT/u);
-    await assert.rejects(lstat(join(cacheRoot, "usage", oldest.key)), /ENOENT/u);
-    await assert.rejects(lstat(join(cacheRoot, "usage", middle.key)), /ENOENT/u);
-    assert.equal((await lstat(entryPath(root, current.key))).isDirectory(), true);
-    const serialized = events.map((event) => JSON.stringify({ audit: "dependency-cache", ...event })).join("\n");
-    const tally = execFileSync("/bin/sh", ["-c", "jq -r .event | sort | uniq -c"], {
-      encoding: "utf8", input: `${serialized}\n`,
-    });
-    assert.match(tally, /^\s*2 eviction\s*$/u);
-  } finally {
-    await cleanupRoot(root);
-  }
-});
-
-test("an oversized protected publication is rolled back and rejected with audit evidence", async () => {
-  assertDependencyCacheTestApi();
-  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-oversized-"));
-  try {
-    const { published: [current] } = await publishFixtureVersions(root, ["4.0.0"]);
-    assert.ok(current);
-    const cacheRoot = join(root, "cache");
-    const bytes = await dependencyCacheTestApi.accountDependencyCacheEntryBytes(entryPath(root, current.key));
-    const events: DependencyCacheProgress[] = [];
-    await assert.rejects(
-      dependencyCacheTestApi.enforceDependencyCacheByteBudget(
-        cacheRoot, current.key, current.key, (event) => events.push(event), Number(bytes - 1n),
-      ),
-      (error: unknown) => error instanceof Error
-        && error.name === "DependencyCacheBudgetError"
-        && /protected-entry-exceeds-byte-budget/u.test(error.message),
-    );
-    await assert.rejects(lstat(entryPath(root, current.key)), /ENOENT/u);
-    await assert.rejects(lstat(join(cacheRoot, "usage", current.key)), /ENOENT/u);
-    assert.ok(events.some(({ event, key, condition }) =>
-      event === "eviction" && key === current.key.slice(0, 16) && condition === "byte-budget"));
-    assert.ok(events.some(({ event }) => event === "integrity-refusal"));
-    assert.ok(!events.some(({ event }) => event === "publication"), "rolled-back publication is never reported successful");
-  } finally {
-    await cleanupRoot(root);
-  }
-});
-
-test("an entry that cannot be safely evicted rejects the byte-budget invariant", async () => {
-  assertDependencyCacheTestApi();
-  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-eviction-failure-"));
-  const entriesRoot = join(root, "cache/entries");
-  try {
-    const { published } = await publishFixtureVersions(root, ["5.0.0", "5.0.1"]);
-    const [oldest, current] = published;
-    assert.ok(oldest && current);
-    await Promise.all([
-      utimes(join(root, "cache/usage", oldest.key), new Date(1_000), new Date(1_000)),
-      utimes(join(root, "cache/usage", current.key), new Date(2_000), new Date(2_000)),
-    ]);
-    const currentBytes = await dependencyCacheTestApi.accountDependencyCacheEntryBytes(entryPath(root, current.key));
-    await chmod(entriesRoot, 0o555);
-    const events: DependencyCacheProgress[] = [];
-    await assert.rejects(
-      dependencyCacheTestApi.enforceDependencyCacheByteBudget(
-        join(root, "cache"), current.key, undefined, (event) => events.push(event), Number(currentBytes),
-      ),
-      (error: unknown) => error instanceof Error
-        && error.name === "DependencyCacheBudgetError"
-        && /eviction-failed/u.test(error.message),
-    );
-    assert.ok(events.some(({ event, key, condition }) =>
-      event === "integrity-refusal" && key === oldest.key.slice(0, 16) && condition?.startsWith("eviction-failed")));
-    assert.equal(events.some(({ event }) => event === "eviction"), false);
-  } finally {
-    await chmod(entriesRoot, 0o711).catch(() => undefined);
-    await cleanupRoot(root);
-  }
-});
-
-test("exclusive byte-budget enforcement waits for an existing shared cache owner", async () => {
-  assertDependencyCacheTestApi();
-  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-retention-lock-"));
-  try {
-    const { published: [current] } = await publishFixtureVersions(root, ["6.0.0"]);
-    assert.ok(current);
-    const cacheRoot = join(root, "cache");
-    const shared = await lockCache(join(cacheRoot, "lock"), "sh");
-    try {
-      let settled = false;
-      const enforcement = dependencyCacheTestApi.enforceDependencyCacheByteBudget(
-        cacheRoot, current.key, undefined, () => undefined,
-      ).finally(() => { settled = true; });
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      assert.equal(settled, false, "blocking exclusive retention must wait instead of skipping enforcement");
-      await shared.close();
-      await enforcement;
-    } catch (error: unknown) {
-      await shared.close().catch(() => undefined);
-      throw error;
-    }
-    assert.equal((await lstat(entryPath(root, current.key))).isDirectory(), true);
-  } finally {
-    await cleanupRoot(root);
-  }
-});
-
 test("over-budget enforcement waits for an active restore and evicts only the safe LRU entry", async () => {
-  assertDependencyCacheTestApi();
   const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-active-restore-"));
   try {
     const { configured, published } = await publishFixtureVersions(root, ["6.1.0", "6.1.1"]);
@@ -1339,7 +1087,7 @@ test("over-budget enforcement waits for an active restore and evicts only the sa
       utimes(join(cacheRoot, "usage", oldest.key), new Date(1_000), new Date(1_000)),
       utimes(join(cacheRoot, "usage", active.key), new Date(2_000), new Date(2_000)),
     ]);
-    const activeBytes = await dependencyCacheTestApi.accountDependencyCacheEntryBytes(entryPath(root, active.key));
+    const activeBytes = await accountDependencyCacheEntryBytes(entryPath(root, active.key));
     let restoreArrived!: () => void;
     const restoreStarted = new Promise<void>((resolve) => { restoreArrived = resolve; });
     let releaseRestore!: () => void;
@@ -1361,8 +1109,8 @@ test("over-budget enforcement waits for an active restore and evicts only the sa
     await restoreStarted;
     const events: DependencyCacheProgress[] = [];
     let enforcementSettled = false;
-    const enforcement = dependencyCacheTestApi.enforceDependencyCacheByteBudget(
-      cacheRoot, active.key, undefined, (event) => events.push(event), Number(activeBytes),
+    const enforcement = (await cacheStore(root)).enforceByteBudget(
+      active.key, undefined, (event) => events.push(event), Number(activeBytes),
     ).finally(() => { enforcementSettled = true; });
     await new Promise((resolve) => setTimeout(resolve, 50));
     assert.equal(enforcementSettled, false, "retention remains blocked throughout the restore's shared lock");
@@ -1381,14 +1129,13 @@ test("over-budget enforcement waits for an active restore and evicts only the sa
 });
 
 test("over-budget enforcement waits for concurrent publication convergence and preserves the published entry", async () => {
-  assertDependencyCacheTestApi();
   const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-active-publication-"));
   const sizingRoot = await mkdtemp(join(tmpdir(), "runner-dependency-cache-publication-size-"));
   try {
     const { configured, published: [oldest] } = await publishFixtureVersions(root, ["6.2.0"]);
     const { published: [sized] } = await publishFixtureVersions(sizingRoot, ["6.2.1"]);
     assert.ok(oldest && sized);
-    const budget = await dependencyCacheTestApi.accountDependencyCacheEntryBytes(entryPath(sizingRoot, sized.key));
+    const budget = await accountDependencyCacheEntryBytes(entryPath(sizingRoot, sized.key));
     const workspaces = [join(root, "workspace-publisher-a"), join(root, "workspace-publisher-b")];
     await Promise.all(workspaces.map(async (workspace) => {
       await createFixture(workspace);
@@ -1417,8 +1164,8 @@ test("over-budget enforcement waits for concurrent publication convergence and p
     await publishersStarted;
     const events: DependencyCacheProgress[] = [];
     let enforcementSettled = false;
-    const enforcement = dependencyCacheTestApi.enforceDependencyCacheByteBudget(
-      join(root, "cache"), publishedKey, undefined, (event) => events.push(event), Number(budget),
+    const enforcement = (await cacheStore(root)).enforceByteBudget(
+      publishedKey, undefined, (event) => events.push(event), Number(budget),
     ).finally(() => { enforcementSettled = true; });
     await new Promise((resolve) => setTimeout(resolve, 50));
     assert.equal(enforcementSettled, false, "retention remains blocked throughout both publishers' shared locks");
@@ -1438,69 +1185,7 @@ test("over-budget enforcement waits for concurrent publication convergence and p
   }
 });
 
-test("allocated-byte accounting includes metadata, trees, and safe symlink inodes without following links", async () => {
-  assertDependencyCacheTestApi();
-  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-size-walk-"));
-  try {
-    const workspace = join(root, "workspace");
-    await createFixture(workspace);
-    const fake = fakeInstallExecutor(async (cwd) => {
-      await mkdir(join(cwd, "node_modules/fake-package"), { recursive: true });
-      await mkdir(join(cwd, "packages/db/node_modules/nested-package"), { recursive: true });
-      await writeFile(join(cwd, "node_modules/fake-package/index.js"), "cached root\n");
-      await writeFile(join(cwd, "packages/db/node_modules/nested-package/index.js"), "cached nested\n");
-      await symlink("index.js", join(cwd, "node_modules/fake-package/safe-link.js"));
-    });
-    const configured = config(root);
-    const result = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
-      { toolchain: TOOLCHAIN, report: () => undefined },
-    );
-    assert.ok(result.key);
-    const entry = entryPath(root, result.key);
-    const expected = await accountedBytes(entry);
-    const actual = await dependencyCacheTestApi.accountDependencyCacheEntryBytes(entry);
-    assert.equal(actual, expected, "the production walk counts every lstat inode allocation");
-    assert.ok(await accountedBytes(join(entry, "metadata.json")) > 0n, "metadata contributes to accounted bytes");
-    assert.ok(await accountedBytes(join(entry, "trees")) > 0n, "complete trees contribute to accounted bytes");
-    const link = join(entry, "trees/node_modules/fake-package/safe-link.js");
-    const linkInfo = await lstat(link);
-    assert.equal(linkInfo.isSymbolicLink(), true);
-    assert.equal(actual >= BigInt(linkInfo.blocks) * 512n, true, "the symlink inode is counted");
-    assert.equal(await readFile(join(entry, "trees/node_modules/fake-package/index.js"), "utf8"), "cached root\n");
-  } finally {
-    await cleanupRoot(root);
-  }
-});
-
-test("allocated-byte accounting rejects special files instead of treating them as cache misses", async () => {
-  assertDependencyCacheTestApi();
-  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-size-special-"));
-  try {
-    const workspace = join(root, "workspace");
-    await createFixture(workspace);
-    const fake = fakeInstallExecutor();
-    const configured = config(root);
-    const result = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
-      { toolchain: TOOLCHAIN, report: () => undefined },
-    );
-    assert.ok(result.key);
-    const entry = entryPath(root, result.key);
-    await makeWritable(entry);
-    const special = join(entry, "trees/node_modules/fake-package/special");
-    await runCommand([], "mkfifo", [special], root, process.env);
-    await assert.rejects(
-      dependencyCacheTestApi.accountDependencyCacheEntryBytes(entry),
-      /(?:special|unsupported|malformed)/iu,
-    );
-  } finally {
-    await cleanupRoot(root);
-  }
-});
-
 test("a malformed unrelated size walk emits integrity refusal without invoking npm", async () => {
-  assertDependencyCacheTestApi();
   const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-retention-special-"));
   try {
     const { configured, fake, published } = await publishFixtureVersions(root, ["7.0.0", "7.0.1"]);

--- a/packages/runner/src/dependency-cache.ts
+++ b/packages/runner/src/dependency-cache.ts
@@ -1,56 +1,20 @@
 import { createHash } from "node:crypto";
-import { constants } from "node:fs";
-import {
-  chmod, cp, lstat, mkdir, mkdtemp, open, readFile, readdir, readlink, realpath, rename, rm, writeFile,
-} from "node:fs/promises";
+import { lstat, readFile, readdir, realpath } from "node:fs/promises";
 import { platform } from "node:os";
 import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path";
 
-import { flock } from "fs-ext";
-
 import type { RunnerConfig } from "./config.js";
+import {
+  CACHE_ENTRY_FORMAT, DependencyCacheIntegrityError, assertCacheTargetPath, describeTargetTrees, openCacheEntryStore,
+  type CacheEntryDocument, type CacheEntryExpectation, type CacheEntryInput, type CacheEntryStore,
+  type CacheEntryTarget, type DependencyCacheToolchain,
+} from "./dependency-cache-store.js";
 import type { CommandOptions } from "./exec.js";
 import {
   NPM_INSTALL_COMMAND_TIMEOUT_MS, NPM_INSTALL_OPERATION_BUDGET_MS, runWithNetworkRetry, type RetryOptions,
 } from "./network-retry.js";
 
-const CACHE_FORMAT = "agentos-runner-dependency-cache-v2";
-const METADATA_FILE = "metadata.json";
-const TREE_DIRECTORY = "trees";
-const MAX_METADATA_BYTES = 128 * 1024 * 1024;
 const NPM_PROBE_TIMEOUT_MS = 10_000;
-const CACHE_LOCK_FILE = "lock";
-const CACHE_USAGE_DIRECTORY = "usage";
-const CACHE_KEY = /^[a-f0-9]{64}$/u;
-export const DEPENDENCY_CACHE_BYTE_BUDGET = 16 * 1024 ** 3;
-
-export type DependencyCacheRetentionSize = { key: string; bytes: number; usedMs: number };
-
-export const selectDependencyCacheEvictions = (
-  entries: readonly DependencyCacheRetentionSize[],
-  currentKey?: string,
-  budget = DEPENDENCY_CACHE_BYTE_BUDGET,
-): string[] => {
-  if (!Number.isFinite(budget) || budget < 0) throw new Error("Dependency cache byte budget is invalid");
-  for (const entry of entries) {
-    if (!Number.isFinite(entry.bytes) || entry.bytes < 0) throw new Error("Dependency cache entry size is invalid");
-    if (!Number.isFinite(entry.usedMs)) throw new Error("Dependency cache usage time is invalid");
-  }
-  const protectedEntry = currentKey === undefined ? undefined : entries.find(({ key }) => key === currentKey);
-  if (protectedEntry !== undefined && protectedEntry.bytes > budget) {
-    throw new DependencyCacheBudgetError("protected-entry-exceeds-byte-budget");
-  }
-  let total = entries.reduce((sum, entry) => sum + entry.bytes, 0);
-  const victims: string[] = [];
-  const ordered = [...entries].sort((left, right) => left.usedMs - right.usedMs || left.key.localeCompare(right.key));
-  for (const entry of ordered) {
-    if (total <= budget) break;
-    if (entry.key === currentKey) continue;
-    total -= entry.bytes;
-    victims.push(entry.key);
-  }
-  return victims;
-};
 
 export type DependencyCommandExecutor = (
   config: RunnerConfig,
@@ -65,30 +29,8 @@ export type DependencyCacheDependencies = {
   execute: DependencyCommandExecutor;
 };
 
-export type DependencyCacheToolchain = {
-  node: string;
-  npm: string;
-  operatingSystem: string;
-  architecture: string;
-};
-
-type CacheInput = { path: string; sha256: string } | { path: string; absent: true };
-type TreeManifestEntry =
-  | { path: string; kind: "directory"; mode: number }
-  | { path: string; kind: "file"; mode: number; sha256: string }
-  | { path: string; kind: "symlink"; target: string };
-type TargetManifestEntry = { path: string; present: boolean; tree: TreeManifestEntry[] };
-
-type CacheMetadata = {
-  format: typeof CACHE_FORMAT;
-  key: string;
-  toolchain: DependencyCacheToolchain;
-  inputs: CacheInput[];
-  targets: TargetManifestEntry[];
-};
-
 type DependencyProject = {
-  inputs: CacheInput[];
+  inputs: CacheEntryInput[];
   targets: string[];
   nativeWorkspaces: string[];
   inputMissCondition?: string;
@@ -149,20 +91,6 @@ class DependencyInputMissSignal extends Error {
   }
 }
 
-export class DependencyCacheIntegrityError extends Error {
-  constructor(readonly condition: string) {
-    super(`Dependency cache integrity refusal: ${condition}`);
-    this.name = "DependencyCacheIntegrityError";
-  }
-}
-
-export class DependencyCacheBudgetError extends Error {
-  constructor(readonly condition: string) {
-    super(`Dependency cache byte budget refusal: ${condition}`);
-    this.name = "DependencyCacheBudgetError";
-  }
-}
-
 const insideOrEqual = (root: string, candidate: string): boolean =>
   candidate === root || candidate.startsWith(`${root}${sep}`);
 
@@ -200,7 +128,7 @@ const pathKind = async (path: string): Promise<"missing" | "directory" | "file" 
   }
 };
 
-const readInput = async (workspace: string, path: string, required: boolean): Promise<CacheInput> => {
+const readInput = async (workspace: string, path: string, required: boolean): Promise<CacheEntryInput> => {
   const absolute = resolve(workspace, path);
   if (!insideOrEqual(workspace, absolute)) throw new Error(`Ambiguous dependency input: ${path}`);
   const kind = await pathKind(absolute);
@@ -430,7 +358,7 @@ const inspectDependencyProject = async (workspacePath: string): Promise<Dependen
     if (!pkg.name) throw new Error(`Native workspace ${pkg.manifestPath} has no package name`);
     nativeWorkspaces.push(pkg.name);
   }
-  const inputs: CacheInput[] = [];
+  const inputs: CacheEntryInput[] = [];
   let inputMissCondition: string | undefined;
   for (const { path, required } of [
     ...requiredPaths.map((path) => ({ path, required: true })),
@@ -521,7 +449,7 @@ const effectiveNpmConfigInput = async (
   workspace: string,
   env: NodeJS.ProcessEnv,
   execute: DependencyCommandExecutor,
-): Promise<CacheInput> => {
+): Promise<CacheEntryInput> => {
   const raw = await execute(config, "npm", ["config", "ls", "--json"], workspace, env, { timeoutMs: NPM_PROBE_TIMEOUT_MS });
   const parsed = parseJsonObject(raw, "effective npm configuration");
   const filtered = canonicalValue(parsed);
@@ -531,7 +459,7 @@ const effectiveNpmConfigInput = async (
 export type DependencyCacheIdentity = {
   key: string;
   toolchain: DependencyCacheToolchain;
-  inputs: CacheInput[];
+  inputs: CacheEntryInput[];
   targets: string[];
   nativeWorkspaces: string[];
 };
@@ -556,17 +484,8 @@ export const deriveDependencyCacheKey = async (
   inputs.push(await effectiveNpmConfigInput(config, workspace, env, execute));
   inputs.sort((left, right) => left.path.localeCompare(right.path, "en"));
   const toolchain = options.toolchain ?? await currentToolchain(config, workspace, env, execute);
-  const key = sha256(`${JSON.stringify({ format: CACHE_FORMAT, toolchain: validatedToolchain(toolchain), inputs })}\n`);
+  const key = sha256(`${JSON.stringify({ format: CACHE_ENTRY_FORMAT, toolchain: validatedToolchain(toolchain), inputs })}\n`);
   return { key, toolchain, inputs, targets, nativeWorkspaces };
-};
-
-const assertTarget = (workspace: string, target: string): string => {
-  if (target !== "node_modules" && !target.endsWith("/node_modules")) {
-    throw new Error(`Invalid dependency target: ${target}`);
-  }
-  const absolute = resolve(workspace, target);
-  if (!insideOrEqual(workspace, absolute)) throw new Error(`Dependency target escaped the run workspace: ${target}`);
-  return absolute;
 };
 
 const clearTargets = async (
@@ -578,7 +497,7 @@ const clearTargets = async (
 ): Promise<void> => {
   const existing: Array<{ absolute: string; target: string }> = [];
   for (const target of targets) {
-    const absolute = assertTarget(workspace, target);
+    const absolute = assertCacheTargetPath(workspace, target);
     await ensureRealDirectory(workspace, posix.dirname(target), `Dependency target parent ${posix.dirname(target)}`);
     const kind = await pathKind(absolute);
     if (kind === "symlink") throw new Error(`Dependency target is a symlink: ${target}`);
@@ -591,689 +510,44 @@ const clearTargets = async (
   }
 };
 
-const treeManifest = async (
-  treeRoot: string,
-  workspace: string,
-  workspaceTarget: string,
-  requireImmutable: boolean,
-): Promise<TreeManifestEntry[]> => {
-  const manifest: TreeManifestEntry[] = [];
-  const visit = async (path: string): Promise<void> => {
-    const info = await lstat(path);
-    const mapped = resolve(workspaceTarget, relative(treeRoot, path));
-    if (!insideOrEqual(workspace, mapped)) throw new DependencyCacheIntegrityError("tree-path-escape");
-    const manifestPath = relative(treeRoot, path).split(sep).join("/") || ".";
-    if (info.isSymbolicLink()) {
-      const link = await readlink(path);
-      if (isAbsolute(link) || !insideOrEqual(workspace, resolve(dirname(mapped), link))) {
-        throw new DependencyCacheIntegrityError("symlink-escape");
-      }
-      manifest.push({ path: manifestPath, kind: "symlink", target: link });
-      return;
-    }
-    if (requireImmutable && (info.mode & 0o222) !== 0) {
-      throw new DependencyCacheIntegrityError("writable-entry");
-    }
-    if (info.isDirectory()) {
-      if (requireImmutable && (info.mode & 0o005) !== 0o005) {
-        throw new DependencyCacheIntegrityError("entry-not-readable");
-      }
-      manifest.push({ path: manifestPath, kind: "directory", mode: info.mode & 0o111 });
-      for (const child of (await readdir(path)).sort()) await visit(join(path, child));
-      return;
-    }
-    if (!info.isFile()) throw new DependencyCacheIntegrityError("special-file");
-    if (requireImmutable && (info.mode & 0o004) === 0) throw new DependencyCacheIntegrityError("entry-not-readable");
-    manifest.push({ path: manifestPath, kind: "file", mode: info.mode & 0o111, sha256: sha256(await readFile(path)) });
-  };
-  await visit(treeRoot);
-  return manifest;
-};
+const sameJson = (left: unknown, right: unknown): boolean => JSON.stringify(left) === JSON.stringify(right);
 
-const findTargetManifest = async (workspace: string, targets: string[]): Promise<TargetManifestEntry[]> => {
-  const manifest: TargetManifestEntry[] = [];
-  for (const target of targets) {
-    const absolute = assertTarget(workspace, target);
-    const kind = await pathKind(absolute);
-    if (kind === "symlink") throw new Error(`Dependency target is a symlink: ${target}`);
-    if (kind !== "missing" && kind !== "directory") throw new Error(`Dependency target is not a directory: ${target}`);
-    const tree = kind === "directory" ? await treeManifest(absolute, workspace, absolute, false) : [];
-    manifest.push({ path: target, present: kind === "directory", tree });
-  }
+// npm ci is the only producer of these trees, so the root target must exist
+// afterwards. An install that leaves it missing is a failed install, not an
+// entry worth publishing.
+const installedTargetTrees = async (workspace: string, targets: string[]): Promise<CacheEntryTarget[]> => {
+  const manifest = await describeTargetTrees(workspace, targets);
   if (!manifest[0]?.present || manifest[0].path !== "node_modules") {
     throw new Error("npm ci did not produce the root node_modules target");
   }
   return manifest;
 };
 
-const metadataShape = (value: unknown): value is CacheMetadata => {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const metadata = value as Partial<CacheMetadata>;
-  if (metadata.format !== CACHE_FORMAT || typeof metadata.key !== "string") return false;
-  if (metadata.toolchain === null || typeof metadata.toolchain !== "object" || Array.isArray(metadata.toolchain)) return false;
-  const toolchain = metadata.toolchain as Partial<DependencyCacheToolchain>;
-  if (!sameJson(Object.keys(toolchain).sort(), ["architecture", "node", "npm", "operatingSystem"])) return false;
-  if (![toolchain.node, toolchain.npm, toolchain.operatingSystem, toolchain.architecture]
-    .every((coordinate) => typeof coordinate === "string" && coordinate.length > 0)) return false;
-  if (!Array.isArray(metadata.inputs) || !Array.isArray(metadata.targets) || metadata.targets.length === 0) return false;
-  return metadata.inputs.every((input) => {
-    if (input === null || typeof input !== "object" || typeof (input as CacheInput).path !== "string") return false;
-    const fields = Object.keys(input).sort();
-    return (sameJson(fields, ["path", "sha256"]) && /^[a-f0-9]{64}$/u.test(String((input as { sha256?: unknown }).sha256)))
-      || (sameJson(fields, ["absent", "path"]) && (input as { absent?: unknown }).absent === true);
-  })
-    && metadata.targets.every((target) => target !== null && typeof target === "object"
-      && typeof (target as TargetManifestEntry).path === "string"
-      && typeof (target as TargetManifestEntry).present === "boolean"
-      && Array.isArray((target as TargetManifestEntry).tree)
-      && sameJson(Object.keys(target).sort(), ["path", "present", "tree"])
-      && (target as TargetManifestEntry).tree.every((entry) => {
-        if (entry === null || typeof entry !== "object" || typeof entry.path !== "string" || typeof entry.kind !== "string") return false;
-        if (entry.kind === "directory") {
-          return Number.isInteger(entry.mode) && entry.mode >= 0 && entry.mode <= 0o111
-            && sameJson(Object.keys(entry).sort(), ["kind", "mode", "path"]);
-        }
-        if (entry.kind === "file") {
-          return Number.isInteger(entry.mode) && entry.mode >= 0 && entry.mode <= 0o111
-            && /^[a-f0-9]{64}$/u.test(entry.sha256)
-            && sameJson(Object.keys(entry).sort(), ["kind", "mode", "path", "sha256"]);
-        }
-        return entry.kind === "symlink" && typeof entry.target === "string"
-          && sameJson(Object.keys(entry).sort(), ["kind", "path", "target"]);
-      }));
-};
-
-const readMetadata = async (entry: string): Promise<CacheMetadata> => {
-  const path = join(entry, METADATA_FILE);
-  const info = await lstat(path).catch((error: unknown) => {
-    if (errorCode(error) === "ENOENT") throw new DependencyCacheIntegrityError("metadata-missing");
-    throw error;
-  });
-  if (!info.isFile() || info.isSymbolicLink() || info.size > MAX_METADATA_BYTES) {
-    throw new DependencyCacheIntegrityError("metadata-malformed");
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(await readFile(path, "utf8"));
-  } catch (error: unknown) {
-    throw new DependencyCacheIntegrityError(`metadata-unreadable:${errorCode(error) ?? "invalid-json"}`);
-  }
-  if (!metadataShape(parsed)) throw new DependencyCacheIntegrityError("metadata-malformed");
-  return parsed;
-};
-
-const sameJson = (left: unknown, right: unknown): boolean => JSON.stringify(left) === JSON.stringify(right);
-
-const validateTreeLayout = async (trees: string, targets: TargetManifestEntry[]): Promise<void> => {
-  const present = new Set(targets.filter(({ present }) => present).map(({ path }) => path));
-  const prefixes = new Set<string>();
-  for (const target of present) {
-    let parent = posix.dirname(target);
-    while (parent !== ".") {
-      prefixes.add(parent);
-      parent = posix.dirname(parent);
-    }
-  }
-  const walk = async (directory: string, relativeDirectory = ""): Promise<void> => {
-    if (((await lstat(directory)).mode & 0o222) !== 0) throw new DependencyCacheIntegrityError("writable-entry");
-    for (const entry of await readdir(directory, { withFileTypes: true })) {
-      const path = relativeDirectory === "" ? entry.name : `${relativeDirectory}/${entry.name}`;
-      if (present.has(path)) continue;
-      if (!prefixes.has(path) || !entry.isDirectory() || entry.isSymbolicLink()) {
-        throw new DependencyCacheIntegrityError("unexpected-tree-content");
-      }
-      await walk(join(directory, entry.name), path);
-    }
-  };
-  await walk(trees);
-};
-
-const validateImmutableEntryContents = async (
-  entry: string,
-  metadata: CacheMetadata,
-  workspace: string,
-): Promise<void> => {
-  const trees = join(entry, TREE_DIRECTORY);
-  if (await pathKind(trees) !== "directory") throw new DependencyCacheIntegrityError("tree-root-missing");
-  const entryNames = (await readdir(entry)).sort();
-  if (!sameJson(entryNames, [METADATA_FILE, TREE_DIRECTORY].sort())) {
-    throw new DependencyCacheIntegrityError("unexpected-entry-content");
-  }
-  await validateTreeLayout(trees, metadata.targets);
-  for (const target of metadata.targets) {
-    const cached = resolve(trees, target.path);
-    if (!insideOrEqual(trees, cached)) throw new DependencyCacheIntegrityError("target-path-escape");
-    const kind = await pathKind(cached);
-    if (target.present && kind !== "directory") throw new DependencyCacheIntegrityError("target-tree-missing");
-    if (!target.present && kind !== "missing") throw new DependencyCacheIntegrityError("unexpected-target-tree");
-    if (target.present) {
-      const actualTree = await treeManifest(cached, workspace, assertTarget(workspace, target.path), true);
-      if (!sameJson(actualTree, target.tree)) throw new DependencyCacheIntegrityError("tree-manifest-mismatch");
-    } else if (target.tree.length !== 0) {
-      throw new DependencyCacheIntegrityError("target-manifest-mismatch");
-    }
-  }
-  await treeManifest(join(entry, METADATA_FILE), workspace, workspace, true);
-  const entryInfo = await lstat(entry);
-  const treesInfo = await lstat(trees);
-  if ((entryInfo.mode & 0o222) !== 0 || (treesInfo.mode & 0o222) !== 0) {
-    throw new DependencyCacheIntegrityError("writable-entry");
-  }
-};
-
-const validateEntry = async (
-  entry: string,
-  expected: Omit<CacheMetadata, "targets"> & { targetPaths: string[] },
-  workspace: string,
-): Promise<CacheMetadata> => {
-  if (await pathKind(entry) !== "directory") throw new DependencyCacheIntegrityError("entry-not-directory");
-  const metadata = await readMetadata(entry);
-  if (metadata.key !== expected.key) throw new DependencyCacheIntegrityError("key-mismatch");
-  if (!sameJson(metadata.toolchain, expected.toolchain)) throw new DependencyCacheIntegrityError("toolchain-mismatch");
-  if (!sameJson(metadata.inputs, expected.inputs)) throw new DependencyCacheIntegrityError("input-manifest-mismatch");
-  if (!sameJson(metadata.targets.map(({ path }) => path), expected.targetPaths)) {
-    throw new DependencyCacheIntegrityError("target-manifest-mismatch");
-  }
-  await validateImmutableEntryContents(entry, metadata, workspace);
-  return metadata;
-};
-
-const makeImmutable = async (path: string): Promise<void> => {
-  const info = await lstat(path);
-  if (info.isSymbolicLink()) return;
-  if (info.isDirectory()) for (const child of await readdir(path)) await makeImmutable(join(path, child));
-  await chmod(path, info.isDirectory() ? 0o555 : 0o444 | (info.mode & 0o111));
-};
-
-const makeWritable = async (path: string): Promise<void> => {
-  const kind = await pathKind(path);
-  if (kind === "missing" || kind === "symlink") return;
-  const info = await lstat(path);
-  await chmod(path, info.mode | 0o700);
-  if (kind === "directory") for (const child of await readdir(path)) await makeWritable(join(path, child));
-};
-
-const allocatedBytes = (info: { blocks: number }): bigint => {
-  if (!Number.isSafeInteger(info.blocks) || info.blocks < 0) {
-    throw new DependencyCacheIntegrityError("invalid-allocated-size");
-  }
-  return BigInt(info.blocks) * 512n;
-};
-
-// Cache entries are immutable after publication. Walk them without following
-// symlinks so accounting cannot escape the canonical cache root. A symlink is
-// itself an inode and therefore contributes its own allocated blocks. Its
-// lexical target must remain below the entry root; validateEntry additionally
-// checks the target against the workspace layout before a selected entry is
-// restored.
-const accountCacheEntry = async (entry: string): Promise<bigint> => {
-  const root = resolve(entry);
-  const rootInfo = await lstat(root).catch((error: unknown) => {
-    if (errorCode(error) === "ENOENT") throw new DependencyCacheIntegrityError("entry-not-directory");
-    throw error;
-  });
-  if (rootInfo.isSymbolicLink() || !rootInfo.isDirectory()) {
-    throw new DependencyCacheIntegrityError(rootInfo.isSymbolicLink() ? "unsafe-retention-entry" : "entry-not-directory");
-  }
-  const visitedInodes = new Set<string>();
-  const visit = async (path: string): Promise<bigint> => {
-    let info;
-    try {
-      info = await lstat(path);
-    } catch (error: unknown) {
-      if (errorCode(error) === "ENOENT") throw new DependencyCacheIntegrityError("entry-disappeared");
-      throw error;
-    }
-    const inode = `${String(info.dev)}:${String(info.ino)}`;
-    if (info.ino !== 0 && visitedInodes.has(inode)) return 0n;
-    if (info.ino !== 0) visitedInodes.add(inode);
-    const ownBytes = allocatedBytes(info);
-    if (info.isSymbolicLink()) {
-      const target = await readlink(path);
-      if (isAbsolute(target) || !insideOrEqual(root, resolve(dirname(path), target))) {
-        throw new DependencyCacheIntegrityError("symlink-escape");
-      }
-      return ownBytes;
-    }
-    if (info.isFile()) return ownBytes;
-    if (!info.isDirectory()) throw new DependencyCacheIntegrityError("special-file");
-    let total = ownBytes;
-    for (const child of await readdir(path)) {
-      const childPath = join(path, child);
-      if (!insideOrEqual(root, childPath)) throw new DependencyCacheIntegrityError("entry-path-escape");
-      total += await visit(childPath);
-    }
-    return total;
-  };
-  return visit(root);
-};
-
-export const accountDependencyCacheEntryBytes = async (entry: string): Promise<bigint> => {
-  let bytes: bigint;
-  try {
-    bytes = await accountCacheEntry(entry);
-  } catch (error: unknown) {
-    if (error instanceof DependencyCacheIntegrityError) throw error;
-    throw new DependencyCacheIntegrityError(`size-walk-failed:${errorCode(error) ?? "unknown"}`);
-  }
-  return bytes;
-};
-
-const ensureCacheRoot = async (configuredRoot: string, workspace: string): Promise<string> => {
-  const requestedRoot = resolve(configuredRoot);
-  await mkdir(requestedRoot, { recursive: true, mode: 0o711 });
-  if ((await lstat(requestedRoot)).isSymbolicLink()) throw new Error("Dependency cache root is a symlink");
-  const root = await realpath(requestedRoot);
-  if (insideOrEqual(root, workspace) || insideOrEqual(workspace, root)) {
-    throw new Error("Dependency cache root overlaps the run workspace");
-  }
-  await chmod(root, 0o711);
-  const entries = join(root, "entries");
-  await mkdir(entries, { recursive: true, mode: 0o711 });
-  if ((await lstat(entries)).isSymbolicLink()) throw new Error("Dependency cache entries root is a symlink");
-  await chmod(entries, 0o711);
-  const usage = join(root, CACHE_USAGE_DIRECTORY);
-  await mkdir(usage, { recursive: true, mode: 0o700 });
-  if ((await lstat(usage)).isSymbolicLink()) throw new Error("Dependency cache usage root is a symlink");
-  await chmod(usage, 0o700);
-  return root;
-};
-
-const flockAsync = (fd: number, operation: "sh" | "ex" | "un"): Promise<void> => new Promise((accept, reject) => {
-  flock(fd, operation, (error) => error ? reject(error) : accept());
-});
-
-const openCacheLock = async (cacheRoot: string) => {
-  const path = join(cacheRoot, CACHE_LOCK_FILE);
-  const handle = await open(path, constants.O_CREAT | constants.O_RDWR | constants.O_NOFOLLOW, 0o600);
-  const info = await handle.stat();
-  if (!info.isFile()) {
-    await handle.close();
-    throw new Error("Dependency cache lock is not a file");
-  }
-  return handle;
-};
-
-const withSharedCacheLock = async <T>(cacheRoot: string, work: () => Promise<T>): Promise<T> => {
-  const handle = await openCacheLock(cacheRoot);
-  try {
-    await flockAsync(handle.fd, "sh");
-    try {
-      return await work();
-    } finally {
-      await flockAsync(handle.fd, "un");
-    }
-  } finally {
-    await handle.close();
-  }
-};
-
-const recordCacheUse = async (cacheRoot: string, key: string): Promise<void> => {
-  if (!CACHE_KEY.test(key)) throw new Error("Dependency cache usage key is invalid");
-  const marker = join(cacheRoot, CACHE_USAGE_DIRECTORY, key);
-  const handle = await open(
-    marker,
-    constants.O_CREAT | constants.O_WRONLY | constants.O_TRUNC | constants.O_NOFOLLOW,
-    0o600,
-  ).catch((error: unknown) => {
-    throw new DependencyCacheIntegrityError(`usage-marker-unwritable:${errorCode(error) ?? "unknown"}`);
-  });
-  try {
-    await handle.writeFile(`${new Date().toISOString()}\n`);
-  } finally {
-    await handle.close();
-  }
-};
-
-const validateCacheUseMarker = async (cacheRoot: string, key: string): Promise<void> => {
-  const marker = join(cacheRoot, CACHE_USAGE_DIRECTORY, key);
-  const info = await lstat(marker).catch((error: unknown) => {
-    if (errorCode(error) === "ENOENT") return null;
-    throw new DependencyCacheIntegrityError(`usage-marker-unreadable:${errorCode(error) ?? "unknown"}`);
-  });
-  if (info?.isSymbolicLink() || (info !== null && !info.isFile())) {
-    throw new DependencyCacheIntegrityError("unsafe-usage-marker");
-  }
-};
-
-type RetentionEntry = { key: string; path: string; usedMs: number; bytes: bigint };
-
-const reportIntegrityRefusal = (
-  report: (progress: DependencyCacheProgress) => void,
-  key: string | undefined,
-  condition: string,
-): DependencyCacheIntegrityError => {
-  report({ event: "integrity-refusal", ...(key ? { key: key.slice(0, 16) } : {}), condition });
-  return new DependencyCacheIntegrityError(condition);
-};
-
-const inspectRetentionEntry = async (key: string, path: string): Promise<void> => {
-  const metadata = await readMetadata(path);
-  if (metadata.key !== key) throw new DependencyCacheIntegrityError("key-mismatch");
-  // Retention has no originating workspace, but the immutable manifest's
-  // relative targets can be mapped beneath a lexical workspace boundary. This
-  // applies the same target and symlink confinement as a selected restore.
-  await validateImmutableEntryContents(path, metadata, join(path, ".retention-workspace"));
-};
-
-const retentionEntries = async (
-  cacheRoot: string,
-  report: (progress: DependencyCacheProgress) => void,
-): Promise<RetentionEntry[]> => {
-  const entriesRoot = join(cacheRoot, "entries");
-  const usageRoot = join(cacheRoot, CACHE_USAGE_DIRECTORY);
-  if (await pathKind(entriesRoot) !== "directory") {
-    throw reportIntegrityRefusal(report, undefined, "entries-root-missing");
-  }
-  if (await pathKind(usageRoot) !== "directory") {
-    throw reportIntegrityRefusal(report, undefined, "usage-root-missing");
-  }
-  const markerKinds = new Map<string, Awaited<ReturnType<typeof lstat>> | null>();
-  for (const name of await readdir(usageRoot)) {
-    // Only key-shaped names are cache usage markers. Ignore unrelated files
-    // rather than letting them deny all materializations on the shared host.
-    if (!CACHE_KEY.test(name)) continue;
-    const marker = join(usageRoot, name);
-    const markerInfo = await lstat(marker).catch((error: unknown) => {
-      if (errorCode(error) === "ENOENT") return null;
-      throw error;
-    });
-    if (markerInfo?.isSymbolicLink() || (markerInfo !== null && !markerInfo.isFile())) {
-      throw reportIntegrityRefusal(report, name, "unsafe-usage-marker");
-    }
-    markerKinds.set(name, markerInfo);
-  }
-  const entries: RetentionEntry[] = [];
-  for (const name of await readdir(entriesRoot)) {
-    if (!CACHE_KEY.test(name)) {
-      // publishEntry creates stages under this directory while holding a
-      // shared lock. Once the exclusive retention lock is held, a remaining
-      // stage is necessarily orphaned and may be reaped safely. Other non-key
-      // names are not immutable cache entries and are ignored.
-      if (name.startsWith(".stage-")) {
-        const staging = join(entriesRoot, name);
-        await makeWritable(staging).catch(() => undefined);
-        await rm(staging, { recursive: true, force: true }).catch(() => undefined);
-      }
-      continue;
-    }
-    const path = join(entriesRoot, name);
-    const info = await lstat(path).catch((error: unknown) => {
-      if (errorCode(error) === "ENOENT") return null;
-      throw error;
-    });
-    if (info === null) throw reportIntegrityRefusal(report, name, "retention-entry-disappeared");
-    if (info.isSymbolicLink() || !info.isDirectory()) {
-      throw reportIntegrityRefusal(report, name, "unsafe-retention-entry");
-    }
-    let bytes: bigint;
-    try {
-      await inspectRetentionEntry(name, path);
-      bytes = await accountCacheEntry(path);
-    } catch (error: unknown) {
-      const integrityError = error instanceof DependencyCacheIntegrityError
-        ? error
-        : new DependencyCacheIntegrityError(`retention-walk-failed:${errorCode(error) ?? "unknown"}`);
-      throw reportIntegrityRefusal(report, name, integrityError.condition);
-    }
-    const markerInfo = markerKinds.get(name) ?? null;
-    const usedMs = Number(markerInfo?.mtimeMs ?? info.mtimeMs);
-    if (!Number.isFinite(usedMs)) throw reportIntegrityRefusal(report, name, "invalid-usage-marker-time");
-    entries.push({ key: name, path, usedMs, bytes });
-  }
-  return entries;
-};
-
-const totalRetentionBytes = (entries: RetentionEntry[]): bigint =>
-  entries.reduce((total, entry) => total + entry.bytes, 0n);
-
-const removeRetentionEntry = async (
-  entry: RetentionEntry,
-  usageRoot: string,
-): Promise<void> => {
-  try {
-    await makeWritable(entry.path);
-    await rm(entry.path, { recursive: true, force: true });
-    if (await pathKind(entry.path) !== "missing") throw new Error("cache entry remained after deletion");
-    await rm(join(usageRoot, entry.key), { force: true });
-    if (await pathKind(join(usageRoot, entry.key)) !== "missing") {
-      throw new Error("cache usage marker remained after deletion");
-    }
-  } catch (error: unknown) {
-    throw new DependencyCacheBudgetError(`eviction-failed:${errorCode(error) ?? "unknown"}`);
-  }
-};
-
-const rollbackPublishedEntry = async (
-  cacheRoot: string,
-  key: string,
-  report: (progress: DependencyCacheProgress) => void,
-): Promise<void> => {
-  const entry: RetentionEntry = {
-    key,
-    path: join(cacheRoot, "entries", key),
-    usedMs: 0,
-    bytes: 0n,
-  };
-  const existed = await pathKind(entry.path) !== "missing";
-  try {
-    await removeRetentionEntry(entry, join(cacheRoot, CACHE_USAGE_DIRECTORY));
-  } catch (error: unknown) {
-    const condition = error instanceof DependencyCacheBudgetError
-      ? `publication-rollback-failed:${error.condition}`
-      : "publication-rollback-failed";
-    report({ event: "integrity-refusal", key: key.slice(0, 16), condition });
-    throw new DependencyCacheBudgetError(condition);
-  }
-  if (existed) report({ event: "eviction", key: key.slice(0, 16), condition: "byte-budget" });
-};
-
-const asRetentionIntegrityError = (error: unknown): DependencyCacheIntegrityError =>
-  error instanceof DependencyCacheIntegrityError
-    ? error
-    : new DependencyCacheIntegrityError(`retention-walk-failed:${errorCode(error) ?? "unknown"}`);
-
-export const enforceDependencyCacheByteBudget = async (
-  cacheRoot: string,
-  currentKey: string | undefined,
-  newlyPublishedKey: string | undefined,
-  report: (progress: DependencyCacheProgress) => void,
-  budget = DEPENDENCY_CACHE_BYTE_BUDGET,
-): Promise<void> => {
-  if (!Number.isSafeInteger(budget) || budget < 0) {
-    throw new DependencyCacheBudgetError("invalid-byte-budget");
-  }
-  const budgetBytes = BigInt(budget);
-  const handle = await openCacheLock(cacheRoot);
-  let locked = false;
-  try {
-    // This is deliberately blocking. Shared restore and publication owners
-    // must finish before this snapshot can be sized or entries removed.
-    await flockAsync(handle.fd, "ex");
-    locked = true;
-    try {
-      const usageRoot = join(cacheRoot, CACHE_USAGE_DIRECTORY);
-      let entries: RetentionEntry[];
-      try {
-        entries = await retentionEntries(cacheRoot, report);
-      } catch (error: unknown) {
-        const integrityError = asRetentionIntegrityError(error);
-        if (!(error instanceof DependencyCacheIntegrityError)) {
-          report({ event: "integrity-refusal", condition: integrityError.condition });
-        }
-        throw integrityError;
-      }
-      const protectedKey = currentKey && CACHE_KEY.test(currentKey) ? currentKey : undefined;
-      let total = totalRetentionBytes(entries);
-      if (total > budgetBytes) {
-        let victimKeys: string[];
-        try {
-          victimKeys = selectDependencyCacheEvictions(
-            entries.map(({ key, bytes, usedMs }) => {
-              const numericBytes = Number(bytes);
-              if (!Number.isSafeInteger(numericBytes)) throw new DependencyCacheIntegrityError("allocated-size-overflow");
-              return { key, bytes: numericBytes, usedMs };
-            }),
-            protectedKey,
-            budget,
-          );
-        } catch (error: unknown) {
-          if (error instanceof DependencyCacheBudgetError
-            && newlyPublishedKey
-            && CACHE_KEY.test(newlyPublishedKey)) {
-            await rollbackPublishedEntry(cacheRoot, newlyPublishedKey, report);
-          }
-          const condition = error instanceof DependencyCacheBudgetError
-            ? error.condition
-            : asRetentionIntegrityError(error).condition;
-          report({
-            event: "integrity-refusal",
-            ...(protectedKey ? { key: protectedKey.slice(0, 16) } : {}),
-            condition,
-          });
-          throw error instanceof DependencyCacheBudgetError ? error : new DependencyCacheIntegrityError(condition);
-        }
-        const entriesByKey = new Map(entries.map((entry) => [entry.key, entry] as const));
-        for (const victimKey of victimKeys) {
-          const victim = entriesByKey.get(victimKey);
-          if (victim === undefined) throw new DependencyCacheBudgetError("byte-budget-invariant-unmet");
-          try {
-            await removeRetentionEntry(victim, usageRoot);
-          } catch (error: unknown) {
-            const condition = error instanceof DependencyCacheBudgetError ? error.condition : "eviction-failed";
-            report({ event: "integrity-refusal", key: victim.key.slice(0, 16), condition });
-            if (newlyPublishedKey && newlyPublishedKey !== victim.key && CACHE_KEY.test(newlyPublishedKey)) {
-              await rollbackPublishedEntry(cacheRoot, newlyPublishedKey, report);
-            }
-            throw error instanceof DependencyCacheBudgetError ? error : new DependencyCacheBudgetError(condition);
-          }
-          total -= victim.bytes;
-          report({ event: "eviction", key: victim.key.slice(0, 16), condition: "byte-budget" });
-        }
-      }
-
-      // The exclusive lock has covered the initial walk and every deletion,
-      // so this tracked total is the authoritative final invariant without a
-      // second full manifest parse and inode walk.
-      if (total <= budgetBytes) return;
-
-      const protectedEntry = protectedKey === undefined
-        ? undefined
-        : entries.find((entry) => entry.key === protectedKey);
-      const condition = protectedEntry !== undefined && protectedEntry.bytes > budgetBytes
-        ? "protected-entry-exceeds-byte-budget"
-        : "byte-budget-invariant-unmet";
-      if (newlyPublishedKey && CACHE_KEY.test(newlyPublishedKey)) {
-        const published = entries.find((entry) => entry.key === newlyPublishedKey) ?? {
-          key: newlyPublishedKey,
-          path: join(cacheRoot, "entries", newlyPublishedKey),
-          usedMs: 0,
-          bytes: 0n,
-        } satisfies RetentionEntry;
-        await rollbackPublishedEntry(cacheRoot, published.key, report);
-      }
-      report({
-        event: "integrity-refusal",
-        ...(protectedKey ? { key: protectedKey.slice(0, 16) } : {}),
-        condition,
-      });
-      throw new DependencyCacheBudgetError(condition);
-    } finally {
-      await flockAsync(handle.fd, "un");
-      locked = false;
-    }
-  } finally {
-    if (locked) await flockAsync(handle.fd, "un").catch(() => undefined);
-    await handle.close();
-  }
-};
-
 const restoreEntry = async (
   config: RunnerConfig,
-  metadata: CacheMetadata,
-  entry: string,
+  store: CacheEntryStore,
+  document: CacheEntryDocument,
   workspace: string,
   env: NodeJS.ProcessEnv,
   execute: DependencyCommandExecutor,
 ): Promise<void> => {
-  await clearTargets(config, workspace, metadata.targets.map(({ path }) => path), env, execute);
+  await clearTargets(config, workspace, document.targets.map(({ path }) => path), env, execute);
   try {
-    for (const target of metadata.targets) {
+    for (const target of document.targets) {
       if (!target.present) continue;
-      const source = resolve(entry, TREE_DIRECTORY, target.path);
-      const destination = assertTarget(workspace, target.path);
+      const source = store.targetSourcePath(document.key, target.path);
+      const destination = assertCacheTargetPath(workspace, target.path);
       const args = platform() === "darwin"
         ? ["-c", "-R", source, destination]
         : ["-a", "--reflink=always", source, destination];
       await execute(config, "/bin/cp", args, workspace, env);
       await execute(config, "/bin/chmod", ["-R", "u+w", destination], workspace, env);
     }
-    const restored = await findTargetManifest(workspace, metadata.targets.map(({ path }) => path));
-    if (!sameJson(restored, metadata.targets)) throw new Error("Restored dependency target manifest differs from the cache entry");
+    const restored = await describeTargetTrees(workspace, document.targets.map(({ path }) => path));
+    if (!sameJson(restored, document.targets)) throw new Error("Restored dependency target manifest differs from the cache entry");
   } catch (error: unknown) {
-    await clearTargets(config, workspace, metadata.targets.map(({ path }) => path), env, execute).catch(() => undefined);
+    await clearTargets(config, workspace, document.targets.map(({ path }) => path), env, execute).catch(() => undefined);
     throw error;
-  }
-};
-
-const snapshotTarget = async (source: string, destination: string): Promise<void> => {
-  await mkdir(dirname(destination), { recursive: true });
-  await cp(source, destination, {
-    recursive: true,
-    preserveTimestamps: true,
-    verbatimSymlinks: true,
-    mode: constants.COPYFILE_FICLONE,
-  });
-};
-
-const publishEntry = async (
-  cacheRoot: string,
-  entry: string,
-  metadata: CacheMetadata,
-  workspace: string,
-  expected: Omit<CacheMetadata, "targets"> & { targetPaths: string[] },
-): Promise<"published" | "converged" | "refused"> => {
-  if (await pathKind(entry) !== "missing") {
-    try {
-      await validateEntry(entry, expected, workspace);
-      return "converged";
-    } catch (error: unknown) {
-      if (error instanceof DependencyCacheIntegrityError) return "refused";
-      throw error;
-    }
-  }
-  const stagingParent = dirname(entry);
-  const staging = await mkdtemp(join(stagingParent, `.stage-${metadata.key.slice(0, 16)}-`));
-  if (!insideOrEqual(cacheRoot, await realpath(staging))) throw new Error("Dependency cache staging escaped its root");
-  try {
-    await mkdir(join(staging, TREE_DIRECTORY));
-    for (const target of metadata.targets) {
-      if (target.present) await snapshotTarget(assertTarget(workspace, target.path), resolve(staging, TREE_DIRECTORY, target.path));
-    }
-    await writeFile(join(staging, METADATA_FILE), `${JSON.stringify(metadata)}\n`, { mode: 0o400 });
-    await makeImmutable(staging);
-    await validateEntry(staging, expected, workspace);
-    try {
-      await rename(staging, entry);
-      return "published";
-    } catch (error: unknown) {
-      // Darwin reports EACCES rather than EEXIST when the winning directory is
-      // already immutable. The destination's independently verified state,
-      // not the platform-specific errno, decides whether this was a safe race.
-      if (await pathKind(entry) === "missing") throw error;
-      try {
-        await validateEntry(entry, expected, workspace);
-        return "converged";
-      } catch (validationError: unknown) {
-        if (validationError instanceof DependencyCacheIntegrityError) return "refused";
-        throw validationError;
-      }
-    }
-  } finally {
-    if (await pathKind(staging) !== "missing") {
-      await makeWritable(staging).catch(() => undefined);
-      await rm(staging, { recursive: true, force: true });
-    }
   }
 };
 
@@ -1284,7 +558,7 @@ const installDependencies = async (
   env: NodeJS.ProcessEnv,
   execute: DependencyCommandExecutor,
   retryOptions: RetryOptions = {},
-): Promise<TargetManifestEntry[]> => {
+): Promise<CacheEntryTarget[]> => {
   const args = ["ci", "--prefer-offline", "--no-audit", "--no-fund"];
   try {
     await runWithNetworkRetry("npm", args, async ({ timeoutMs }) => {
@@ -1295,7 +569,7 @@ const installDependencies = async (
       budgetMs: NPM_INSTALL_OPERATION_BUDGET_MS,
       ...retryOptions,
     });
-    return await findTargetManifest(workspace, targets);
+    return await installedTargetTrees(workspace, targets);
   } catch (error: unknown) {
     await clearTargets(config, workspace, targets, env, execute).catch(() => undefined);
     throw error;
@@ -1360,27 +634,25 @@ export const materializeWorkspaceDependencies = async (
       throw error;
     }
     const { key, toolchain, inputs, targets: targetPaths, nativeWorkspaces } = identity;
-    const cacheRoot = await ensureCacheRoot(
+    const store = await openCacheEntryStore(
       options.cacheRoot ?? config.dependencyCacheRoot ?? join(dirname(resolve(config.workspaceRoot)), "dependency-cache"),
       workspace,
     );
-    const entry = resolve(cacheRoot, "entries", key);
-    if (!insideOrEqual(cacheRoot, entry)) throw new Error("Dependency cache entry escaped its root");
-    const expected = { format: CACHE_FORMAT, key, toolchain, inputs, targetPaths } as const;
-    const locked = await withSharedCacheLock(cacheRoot, async () => {
+    const expected: CacheEntryExpectation = { key, toolchain, inputs, targetPaths };
+    const locked = await store.withSharedLock(async () => {
       try {
-        await validateCacheUseMarker(cacheRoot, key);
+        await store.validateUseMarker(key);
       } catch (error: unknown) {
         if (!(error instanceof DependencyCacheIntegrityError)) throw error;
         report({ event: "integrity-refusal", key: key.slice(0, 16), condition: error.condition });
         throw error;
       }
-      if (await pathKind(entry) !== "missing") {
+      if (await store.hasEntry(key)) {
         try {
-          const metadata = await timed("validate", report, () => validateEntry(entry, expected, workspace));
-          await timed("restore", report, () => restoreEntry(config, metadata, entry, workspace, env, execute));
+          const document = await timed("validate", report, () => store.readEntry(expected));
+          await timed("restore", report, () => restoreEntry(config, store, document, workspace, env, execute));
           await timed("rebuild", report, () => rebuildNativeWorkspaces(config, workspace, nativeWorkspaces, env, execute));
-          await recordCacheUse(cacheRoot, key);
+          await store.recordUse(key);
           return {
             result: { status: "restored", key } as DependencyCacheResult,
             usableKey: key,
@@ -1399,15 +671,14 @@ export const materializeWorkspaceDependencies = async (
       const targets = await timed("install", report, () => installDependencies(
         config, workspace, targetPaths, env, execute, options.installRetryOptions,
       ));
-      const metadata: CacheMetadata = { format: CACHE_FORMAT, key, toolchain, inputs, targets };
-      const publication = await timed("publish", report, () => publishEntry(cacheRoot, entry, metadata, workspace, expected));
+      const publication = await timed("publish", report, () => store.publishEntry(expected, targets, workspace));
       if (publication === "refused") {
         const integrityError = new DependencyCacheIntegrityError("concurrent-entry-invalid");
         report({ event: "integrity-refusal", key: key.slice(0, 16), condition: integrityError.condition });
         throw integrityError;
       }
       try {
-        await recordCacheUse(cacheRoot, key);
+        await store.recordUse(key);
       } catch (error: unknown) {
         if (!(error instanceof DependencyCacheIntegrityError)) throw error;
         report({ event: "integrity-refusal", key: key.slice(0, 16), condition: error.condition });
@@ -1422,8 +693,7 @@ export const materializeWorkspaceDependencies = async (
         } as DependencyCacheProgress,
       };
     });
-    await timed("retention", report, () => enforceDependencyCacheByteBudget(
-      cacheRoot,
+    await timed("retention", report, () => store.enforceByteBudget(
       locked.usableKey,
       locked.newlyPublishedKey,
       report,


### PR DESCRIPTION
## What changed

`packages/runner/src/dependency-cache-store.ts` is a new module: the on-disk
store of published dependency trees. Its vocabulary is keys, entries, bytes and
usage. Its interface names no `RunnerConfig`, no `env` and no executor.

`openCacheEntryStore(configuredRoot, disjointFrom)` creates the root layout and
returns a `CacheEntryStore` bound to one resolved root, so "did anyone call
`ensureCacheRoot` first" stops being an unstated ordering constraint. The handle
answers: where an entry and a stored target tree live (`entryPath`,
`targetSourcePath`), whether a key has an entry (`hasEntry`), read it under an
expectation (`readEntry`), publish one out of a source directory
(`publishEntry`), record and validate usage (`recordUse`, `validateUseMarker`),
run under the shared lock (`withSharedLock`), and hold the population inside a
byte budget (`enforceByteBudget`). `selectDependencyCacheEvictions`,
`accountDependencyCacheEntryBytes`, `describeTargetTrees` and
`assertCacheTargetPath` are module-level, since they need no root.

Lifted with it: entry layout and the metadata document, immutability
validation, publication and its staging race, the lock, usage markers, byte
accounting, eviction, orphan-stage reaping and publication rollback. Roughly
400 lines that knew nothing about npm and could only be reached through
`materializeWorkspaceDependencies`.

The seam this buys, not just a file split: entry validation no longer takes a
workspace. Target confinement is lexical -- a target path is relative and free
of "..", so whether a recorded symlink escapes depends on the target's depth
and the link's own "..", never on where the tree is restored. The store applies
the rule against one nominal root. Retention used to pass a synthetic
`.retention-workspace` per entry to get the same answer; now there is one rule,
one root, and the workspace is gone from the store's interface entirely.

`dependency-cache.ts` (1436 -> 712 lines) keeps identity derivation, npm
execution and orchestration, and reaches the store through the handle.
`restoreEntry` asks the store where a target tree lives instead of spelling
`trees/` itself; `installedTargetTrees` keeps the one npm rule ("npm ci did not
produce the root node_modules target") on the caller's side.

Tests: eight retention tests move to `dependency-cache-store.test.ts` and now
run on a bare temporary directory. `fakeInstallExecutor()` and
`publishFixtureVersions()` are gone from all of them; entries are made by
`store.publishEntry` out of a plain directory holding two `node_modules` trees.
The `dependencyCacheModule as unknown as DependencyCacheTestApi` cast that
reached for the old file's unexported retention functions is deleted -- the
store test imports what it calls. Four more store tests cover root layout,
publication convergence, usage-marker refusals and orphan-stage reaping.

What stays in `dependency-cache.test.ts` is the interaction that genuinely needs
both sides: byte-budget enforcement waiting behind a live materialization's
shared lock (restore and concurrent publication), plus every orchestration test
asserting that a refusal does not fall through to an uncached npm install.

## Evidence

Base `80f9acc9f5baee1073d9ab8bfe2a498fb57f2d10`; `origin/main` moved during the
lane, merged at `6cd0fc35` (clean, no conflict, none of the four owned files
touched by the merge). Everything below was run after the merge commit, which
is the head this PR carries.

- `npm run lint` (root): `Checked 743 files in 4s. No fixes applied.`, eslint
  clean.
- `npm run typecheck` (root): clean across every workspace.
- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm run test -w @anneal/runner`:
  `tests 507 / pass 505 / fail 0 / skipped 2`. The two skips are the pre-existing
  root-only uid tests.
- `node --conditions=development --import tsx --test src/dependency-cache-store.test.ts`:
  12 tests, all pass, no npm workspace and no command executor anywhere in the
  file.
- `test:db` not run: no local PostgreSQL, and this change touches no `.dbtest.ts`.

## Decisions taken

Anchors re-verified on the base: every symbol the findings named at `3229f9b0`
was still present and unchanged in `dependency-cache.ts`, so the whole lane
remained to deliver.

The findings list 14 symbols, but retention could not move without the entry
format moving with it: `retentionEntries` validates each entry through
`readMetadata` and `validateImmutableEntryContents` before sizing it. Splitting
those would have left the on-disk format owned in two places, so the store took
the whole format -- document shape, tree manifest, immutability, publication --
and `dependency-cache.ts` kept identity derivation, which is the half that is
about npm and the repository rather than about disk.

`CACHE_ENTRY_FORMAT` is exported from the store and imported by the key
derivation, because the derived key must change when the entry format does. The
recorded fixture key is unchanged, which the existing pin proves.

`accountDependencyCacheEntryBytes` stays a free function on a path rather than a
store method: it answers a question about a directory, and the store's own
budget enforcement is its only other caller.

Small leaf predicates (`pathKind`, `errorCode`, `insideOrEqual`, `sha256`,
`sameJson`) exist in both files. Exporting them from the store would widen its
interface with knowledge that is not keys, entries, bytes or usage, which is
the thing this lane is for; a shared third module is outside the fence. Two
private copies of a leaf predicate was judged the smaller cost.

One error message changed. When a restore's target trees come back different
from the entry, `restoreEntry` used to raise the install-side message "npm ci
did not produce the root node_modules target" if the root target was missing;
it now always raises "Restored dependency target manifest differs from the cache
entry", which is what actually happened. The npm-side message is unchanged where
it belongs, in `installedTargetTrees`.

`openCacheEntryStore` requires `disjointFrom` to be an already-resolved real
path. The comparison is lexical and the production caller passes the realpath'd
workspace, as it always did; this is now stated at the interface rather than
implied.

## Fence widened

None. Only `packages/runner/src/dependency-cache.ts`,
`packages/runner/src/dependency-cache.test.ts` and the one new sibling module
with its test were edited.

## Reported but unfixed

- `packages/runner/src/dependency-cache.ts` still threads
  `(config, workspace, env, execute)` by position through `clearTargets`,
  `restoreEntry`, `installDependencies` and `rebuildNativeWorkspaces`. That is
  Candidate R3's territory and this lane deliberately did not touch it.
- `DependencyCacheProgress` still carries `phase` and `elapsed` events that only
  `timed()` emits, alongside the store's `integrity-refusal` and `eviction`. The
  store now declares its own narrower `CacheStoreEvent`; folding the caller's
  audit vocabulary down to what each producer can actually emit was outside this
  brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsZjAjVwKSi2dcVQk6kfkL
