### PR TITLE
feat(db): prove every native projection serializes to its browser contract

### DIFF
--- a/packages/api/src/board.ts
+++ b/packages/api/src/board.ts
@@ -27,13 +27,13 @@ import type {
   BoardLatestRun as BoardContractLatestRun,
   BoardMoveTarget as BoardContractMoveTarget,
   ChainAggregate as BoardContractChainAggregate,
-  ChainFrontier as BoardContractChainFrontier,
   RepairBinding as BoardContractRepairBinding,
   RunStatus as BoardRunStatus,
   TaskList as TaskListContract,
   UsageCost as BoardUsageCost,
 } from "@anneal/db/board-contract";
 import { compare } from "@anneal/db/chain-order";
+import type { SerializesTo } from "@anneal/db/wire-serialization";
 
 import { chainExecutionOwner } from "./chain-execution-owner.js";
 import {
@@ -63,42 +63,15 @@ import { taskMoveAuthority } from "./task-move-authority.js";
  * point of the shape is that its cost is legible.
  */
 export type BoardMoveTarget = BoardContractMoveTarget;
-export type BoardCard = BoardContractCard<Date>;
+/** Compile-time proof that JSON serialization turns the native projection into
+ * the exact shared browser contract, at every depth. `boardCard` returns this
+ * type, so a projected key the contract does not name, or a `Date` the browser
+ * reads as a `string`, fails where the projection is written. */
+export type BoardCard = SerializesTo<BoardContractCard<Date>, BoardContractCard>;
 export type BoardLatestRun = BoardContractLatestRun<Date>;
 export type BoardChainActivationState = BoardContractChainActivationState;
 export type RepairBinding = BoardContractRepairBinding;
 export type BoardChainControl = Pick<ChainControlSnapshot, "state" | "held" | "heldLayer" | "heldAt" | "holdReason">;
-
-type JsonSerialized<T> = T extends Date
-  ? string
-  : T extends readonly (infer Item)[]
-    ? JsonSerialized<Item>[]
-    : T extends object
-      ? { [Key in keyof T]: JsonSerialized<T[Key]> }
-      : T;
-type ExactKeys<Left, Right> = [
-  Exclude<keyof Left, keyof Right>,
-  Exclude<keyof Right, keyof Left>,
-] extends [never, never] ? true : false;
-type ContractCheck<
-  Projection extends BoardContractCard,
-  Proof extends [true, true, true, true, false, false],
-> = Proof extends [true, true, true, true, false, false] ? Projection : never;
-/** Compile-time proof that JSON serialization turns the native projection into
- * the exact shared browser contract, including every nested aggregate, frontier
- * and latest-run key. The final two checks prove missing and surplus adapter keys
- * both fail the bidirectional key comparison. */
-export type SerializedBoardCardProjection = ContractCheck<
-  JsonSerialized<BoardCard>,
-  [
-    ExactKeys<JsonSerialized<BoardCard>, BoardContractCard>,
-    ExactKeys<NonNullable<JsonSerialized<BoardCard>["chainAggregate"]>, BoardContractChainAggregate>,
-    ExactKeys<NonNullable<JsonSerialized<BoardCard>["chainAggregate"]>["frontier"], BoardContractChainFrontier>,
-    ExactKeys<NonNullable<JsonSerialized<BoardCard>["latestRun"]>, BoardContractLatestRun>,
-    ExactKeys<Omit<JsonSerialized<BoardCard>, "id">, BoardContractCard>,
-    ExactKeys<JsonSerialized<BoardCard> & { surplus: never }, BoardContractCard>,
-  ]
->;
 
 /** The Prisma row shape `boardCard` needs — declared structurally so `readBoard`
  *  can select exactly these columns and nothing else. */
@@ -1127,7 +1100,7 @@ const taskListInclude = {
   },
 } as const satisfies Prisma.TaskInclude;
 
-export type TaskListRow = TaskListContract<Date, Prisma.Decimal>;
+export type TaskListRow = SerializesTo<TaskListContract<Date, Prisma.Decimal>, TaskListContract>;
 
 /** Read the full task list and optionally attach its expensive enrichment. */
 export const readTaskList = async (

--- a/packages/api/src/costs.ts
+++ b/packages/api/src/costs.ts
@@ -9,7 +9,11 @@ import {
   type PrismaClient,
   type UsageCost,
 } from "@anneal/db";
-import type { CostsReport as CostsReportContract } from "@anneal/db/board-contract";
+import type {
+  CostsChain as CostsChainContract,
+  CostsReport as CostsReportContract,
+} from "@anneal/db/board-contract";
+import type { SerializesTo } from "@anneal/db/wire-serialization";
 import { stepRole, type StepRole } from "@anneal/db/merge-integrator";
 
 import {
@@ -92,32 +96,13 @@ export type CostsChainData = {
   until: Date;
 };
 
-type NativeCostsWaste = {
-  totalUsd: Prisma.Decimal;
-  operatorCancelledUsd: Prisma.Decimal;
-  failedUsd: Prisma.Decimal;
-  byFailureClass: Array<{ failureClass: string; usd: Prisma.Decimal; runs: number }>;
-};
+/** The report as this module builds it, and the proof that JSON serialization
+ * turns it into exactly the browser contract: every `Prisma.Decimal` amount
+ * reaches the browser as a string, `since` and every top run start as an ISO
+ * string, and no key is carried that the contract does not name. */
+export type CostsResponse = SerializesTo<CostsReportContract<Date, Prisma.Decimal>, CostsReportContract>;
 
-type NativeCostsChain = {
-  chainId: string;
-  detailTaskId: string;
-  chainName: string | null;
-  taskCount: number;
-  leadMinutes: number;
-  busyMinutes: number;
-  busyPct: number;
-  repairs: { gateFix: number; refreshConflict: number; reviewFix: number };
-  costUsd: Prisma.Decimal | null;
-  costByRole: Record<string, Prisma.Decimal>;
-  costUnavailableRuns: number;
-  longestGap: { minutes: number; beforeTaskName: string | null };
-};
-
-type NativeCostsReport = CostsReportContract<Date, Prisma.Decimal> & {
-  waste: NativeCostsWaste;
-  chains: NativeCostsChain[];
-};
+type NativeCostsChain = CostsChainContract<Prisma.Decimal>;
 
 const ZERO = new Prisma.Decimal(0);
 
@@ -489,7 +474,7 @@ export const aggregateCosts = (
   days: number,
   timeZone: string,
   chainData: CostsChainData,
-): NativeCostsReport => {
+): CostsResponse => {
   const daily = new Map<string, Map<string, Prisma.Decimal>>(
     windowDays(since, days, timeZone).map((date) => [date, new Map<string, Prisma.Decimal>()]),
   );
@@ -678,7 +663,7 @@ export const readProjectCosts = async (
   days: number,
   timeZone: string,
   now: Date = new Date(),
-): Promise<NativeCostsReport> => {
+): Promise<CostsResponse> => {
   const since = costsWindowStart(now, days, timeZone);
   const until = costsWindowEnd(now, timeZone);
   // Costs is a bounded report, but a matching Chain is not: its first run can

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -8,9 +8,10 @@ import type {
   Project as ProjectContract,
   Secret as SecretContract,
 } from "@anneal/db/wire-contract";
+import type { SerializesTo } from "@anneal/db/wire-serialization";
 import { z } from "zod";
 
-import { COSTS_DEFAULT_DAYS, COSTS_RANGE_DAYS, isValidTimeZone, readProjectCosts } from "../costs.js";
+import { COSTS_DEFAULT_DAYS, COSTS_RANGE_DAYS, isValidTimeZone, readProjectCosts, type CostsResponse } from "../costs.js";
 import { createProjectBootstrap, projectFields, projectInput } from "../project-bootstrap.js";
 import { encryptSecret } from "../secrets.js";
 import { withoutUndefined } from "../without-undefined.js";
@@ -50,8 +51,13 @@ const secretInput = z.object({ ...secretFields, description: secretFields.descri
 const secretPatch = z.object(secretFields).partial().extend({ value: z.string().min(1).max(100_000).optional() })
   .refine((value) => Object.keys(value).length > 0);
 
-type ProjectResponse = ProjectContract<Date, Prisma.Decimal>;
-type SecretResponse = SecretContract<Date>;
+/** Each response names both its native projection and the browser contract that
+ * projection must JSON-serialize to, so every `satisfies` below proves the
+ * whole wire claim rather than the native half of it. `Environment` holds no
+ * date or amount, and the proof is what says so. */
+type EnvironmentResponse = SerializesTo<EnvironmentContract, EnvironmentContract>;
+type ProjectResponse = SerializesTo<ProjectContract<Date, Prisma.Decimal>, ProjectContract>;
+type SecretResponse = SerializesTo<SecretContract<Date>, SecretContract>;
 
 export const registerAdminRoutes = (app: RouteApp, { db, projectBootstrapLoaders }: RouteDeps): void => {
   app.get("/projects", async (context) => validated(context,
@@ -89,27 +95,29 @@ export const registerAdminRoutes = (app: RouteApp, { db, projectBootstrapLoaders
     if (days === undefined) {
       return context.json({ error: `days must be one of ${COSTS_RANGE_DAYS.join(", ")}` }, 400);
     }
-    return context.json(await readProjectCosts(db, id.parse(context.req.param("projectId")), days, timeZone));
+    return context.json(
+      await readProjectCosts(db, id.parse(context.req.param("projectId")), days, timeZone) satisfies CostsResponse,
+    );
   });
 
   app.get("/projects/:projectId/environments", async (context) => context.json((await db.environment.findMany({
     where: { projectId: id.parse(context.req.param("projectId")) },
     orderBy: { createdAt: "asc" },
-  })) satisfies EnvironmentContract[]));
+  })) satisfies EnvironmentResponse[]));
   app.post("/projects/:projectId/environments", async (context) => context.json((await db.environment.create({
     data: { projectId: id.parse(context.req.param("projectId")), ...await readJson(context.req.raw, environmentInput) },
-  })) satisfies EnvironmentContract, 201));
+  })) satisfies EnvironmentResponse, 201));
   app.get("/environments/:environmentId", async (context) => {
     const environment = await db.environment.findUnique({
       where: { id: id.parse(context.req.param("environmentId")) },
       include: { secrets: { include: { secret: { select: secretPublicSelect } } } },
     });
-    return environment ? context.json(environment satisfies EnvironmentContract) : context.json({ error: "Environment not found" }, 404);
+    return environment ? context.json(environment satisfies EnvironmentResponse) : context.json({ error: "Environment not found" }, 404);
   });
   app.patch("/environments/:environmentId", async (context) => context.json((await db.environment.update({
     where: { id: id.parse(context.req.param("environmentId")) },
     data: withoutUndefined(await readJson(context.req.raw, environmentPatch)),
-  })) satisfies EnvironmentContract));
+  })) satisfies EnvironmentResponse));
   app.delete("/environments/:environmentId", async (context) => {
     await db.environment.delete({ where: { id: id.parse(context.req.param("environmentId")) } });
     return context.body(null, 204);

--- a/packages/api/src/routes/session.ts
+++ b/packages/api/src/routes/session.ts
@@ -24,6 +24,7 @@ import {
 } from "@anneal/db";
 import type { PrismaClient } from "@anneal/db";
 import type { Session as SessionContract } from "@anneal/db/board-contract";
+import type { SerializesTo } from "@anneal/db/wire-serialization";
 import { z } from "zod";
 
 import {
@@ -176,7 +177,10 @@ const cancelRunInput = z.object({
   parkTask: z.boolean().default(false),
 });
 
-type SessionResponse = SessionContract<Date, Prisma.Decimal>;
+/** The response names both its native projection and the browser contract that
+ * projection must JSON-serialize to, so every `satisfies` below proves the
+ * whole wire claim rather than the native half of it. */
+type SessionResponse = SerializesTo<SessionContract<Date, Prisma.Decimal>, SessionContract>;
 
 export function registerSessionRoutes(app: RouteApp, deps: RouteDeps): () => void {
   const { db, releaseChainLease, appendFencedActivity } = deps;

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -43,6 +43,7 @@ import type {
   TaskStartability as TaskStartabilityContract,
   TaskStepOutput as TaskStepOutputContract,
 } from "@anneal/db/board-contract";
+import type { SerializesTo } from "@anneal/db/wire-serialization";
 import { z } from "zod";
 
 import {
@@ -167,12 +168,17 @@ const chainResumeInput = z.object({
   requestId: z.string().trim().min(1).max(200),
 }).strict();
 
-type RecurringFireResponse = RecurringFireContract<Date>;
-type RunResponse = RunContract<Date, Prisma.Decimal>;
-type TaskActivityResponse = TaskActivityContract<Date>;
-type TaskDetailResponse = TaskDetailContract<Date, Prisma.Decimal>;
-type TaskStartabilityResponse = TaskStartabilityContract;
-type TaskStepOutputResponse = TaskStepOutputContract<Date>;
+/** Each response names both its native projection and the browser contract that
+ * projection must JSON-serialize to, so every `satisfies` below proves the
+ * whole wire claim rather than the native half of it. */
+type ChainResponse = SerializesTo<ChainContract<Date>, ChainContract>;
+type ChainStepResponse = SerializesTo<ChainStepContract<Date>, ChainStepContract>;
+type RecurringFireResponse = SerializesTo<RecurringFireContract<Date>, RecurringFireContract>;
+type RunResponse = SerializesTo<RunContract<Date, Prisma.Decimal>, RunContract>;
+type TaskActivityResponse = SerializesTo<TaskActivityContract<Date>, TaskActivityContract>;
+type TaskDetailResponse = SerializesTo<TaskDetailContract<Date, Prisma.Decimal>, TaskDetailContract>;
+type TaskStartabilityResponse = SerializesTo<TaskStartabilityContract, TaskStartabilityContract>;
+type TaskStepOutputResponse = SerializesTo<TaskStepOutputContract<Date>, TaskStepOutputContract>;
 
 export const registerTasksRoutes = (app: RouteApp, deps: RouteDeps): void => {
   const { db } = deps;
@@ -380,7 +386,7 @@ export const registerTasksRoutes = (app: RouteApp, deps: RouteDeps): void => {
     const detail = await readChainDetail(db, taskId);
     if (detail.kind === "not-found") return context.json({ error: "Task not found" }, 404);
     if (detail.kind === "chainless") {
-      return context.json({ chainId: null, total: 0, done: 0, control: null, steps: [] } satisfies ChainContract<Date>);
+      return context.json({ chainId: null, total: 0, done: 0, control: null, steps: [] } satisfies ChainResponse);
     }
     const { admissions, chainId, control, dispatchAfter, firstTaskId, rows: chainRows } = detail;
     const mergeRecovery = mergeRecoveryProjection(detail.recoveryRow);
@@ -423,8 +429,8 @@ export const registerTasksRoutes = (app: RouteApp, deps: RouteDeps): void => {
           ? { taskId: dispatchAfter.id, name: dispatchAfter.name, status: dispatchAfter.status }
           : null,
         mergeRecovery,
-      } satisfies ChainStepContract<Date>)),
-    } satisfies ChainContract<Date>);
+      } satisfies ChainStepResponse)),
+    } satisfies ChainResponse);
   });
   app.post("/tasks/:taskId/chain/hold", async (context) => {
     const taskId = id.parse(context.req.param("taskId"));

--- a/packages/api/src/routes/templates.ts
+++ b/packages/api/src/routes/templates.ts
@@ -13,6 +13,7 @@ import type {
   TriggerDetail as TriggerDetailContract,
   TriggerFire as TriggerFireContract,
 } from "@anneal/db/board-contract";
+import type { SerializesTo } from "@anneal/db/wire-serialization";
 import type { Context } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
@@ -92,9 +93,12 @@ const webhookConfigPatch = z.object({
   webhookReplayWindowSec: z.number().int().min(0).max(86_400).nullable().optional(),
 }).refine((value) => Object.keys(value).length > 0);
 
-type TriggerResponse = TriggerContract<Date>;
-type TriggerDetailResponse = TriggerDetailContract<Date>;
-type TriggerFireResponse = TriggerFireContract<Date>;
+/** Each response names both its native projection and the browser contract that
+ * projection must JSON-serialize to, so every `satisfies` below proves the
+ * whole wire claim rather than the native half of it. */
+type TriggerResponse = SerializesTo<TriggerContract<Date>, TriggerContract>;
+type TriggerDetailResponse = SerializesTo<TriggerDetailContract<Date>, TriggerDetailContract>;
+type TriggerFireResponse = SerializesTo<TriggerFireContract<Date>, TriggerFireContract>;
 
 export const registerTemplateRoutes = (app: RouteApp, { db }: RouteDeps): (() => void) => {
   app.use("/hooks/templates/:templateId", bodyLimit({

--- a/packages/build-info/exports.test.mjs
+++ b/packages/build-info/exports.test.mjs
@@ -20,6 +20,7 @@ const mappings = [
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./chain-hold", source: "./src/chain-hold.ts", dist: "./dist/chain-hold.js" },
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./gate-toggle", source: "./src/gate-toggle.ts", dist: "./dist/gate-toggle.js" },
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./wire-contract", source: "./src/wire-contract.ts", dist: "./dist/wire-contract.js" },
+  { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./wire-serialization", source: "./src/wire-serialization.ts", dist: "./dist/wire-serialization.js" },
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./claim-contract", source: "./src/claim-contract.ts", dist: "./dist/claim-contract.js" },
   { packageName: "@anneal/db", packageDirectory: "packages/db", subpath: "./service-lock", source: "./src/service-maintenance-lock.ts", dist: "./dist/service-maintenance-lock.js" },
   { packageName: "@anneal/runner", packageDirectory: "packages/runner", subpath: "./adapters", source: "./src/adapters.ts", dist: "./dist/adapters.js" },
@@ -29,7 +30,7 @@ const mappings = [
   { packageName: "@anneal/github-client", packageDirectory: "packages/github-client", subpath: ".", source: "./src/index.ts", dist: "./dist/index.js" },
 ];
 
-assert.equal(mappings.length, 17);
+assert.equal(mappings.length, 18);
 
 const packageSpecifier = ({ packageName, subpath }) =>
   subpath === "." ? packageName : `${packageName}/${subpath.slice(2)}`;
@@ -78,7 +79,7 @@ const resolveInChild = (conditions) => {
   return JSON.parse(execFileSync(process.execPath, args, { cwd: repositoryRoot, encoding: "utf8" }));
 };
 
-test("all seventeen source-backed exports have ordered development targets", () => {
+test("all eighteen source-backed exports have ordered development targets", () => {
   const entriesByPackage = new Map();
   for (const mapping of mappings) {
     const manifest = readManifest(mapping.packageDirectory);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -56,6 +56,11 @@
       "development": "./src/wire-contract.ts",
       "import": "./dist/wire-contract.js"
     },
+    "./wire-serialization": {
+      "types": "./src/wire-serialization.ts",
+      "development": "./src/wire-serialization.ts",
+      "import": "./dist/wire-serialization.js"
+    },
     "./claim-contract": {
       "types": "./src/claim-contract.ts",
       "development": "./src/claim-contract.ts",

--- a/packages/db/src/wire-serialization.test.ts
+++ b/packages/db/src/wire-serialization.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Prisma } from "@prisma/client";
+
+import type { JsonSerialized, SerializesTo } from "./wire-serialization.js";
+
+/** A contract written the way the shared ones are: wire forms by default, and
+ *  the native forms supplied by the projecting route. */
+type Report<DateTime = string, DecimalValue = string> = {
+  id: string;
+  startedAt: DateTime | null;
+  usd: DecimalValue;
+  tags: string[];
+  nested: { at: DateTime };
+};
+
+type NativeReport = Report<Date, Prisma.Decimal>;
+
+const nativeReport = (): NativeReport => ({
+  id: "run-1",
+  startedAt: new Date(0),
+  usd: new Prisma.Decimal("1.25"),
+  tags: ["merge"],
+  nested: { at: new Date(0) },
+});
+
+const wireReport: Report = {
+  id: "run-1",
+  startedAt: "1970-01-01T00:00:00.000Z",
+  usd: "1.25",
+  tags: ["merge"],
+  nested: { at: "1970-01-01T00:00:00.000Z" },
+};
+
+test("the serialized form the proof claims is the one JSON.stringify produces", () => {
+  const projection = nativeReport() satisfies SerializesTo<NativeReport, Report>;
+  const serialized: JsonSerialized<NativeReport> = JSON.parse(JSON.stringify(projection));
+  assert.deepEqual(serialized, wireReport);
+});
+
+test("a contract that still declares a Decimal is refused", () => {
+  type DecimalContract = Omit<Report, "usd"> & { usd: Prisma.Decimal };
+  // @ts-expect-error the projected Decimal reaches the browser as a string, never as a Decimal.
+  const projection = nativeReport() satisfies SerializesTo<NativeReport, DecimalContract>;
+  assert.equal(projection.usd.toString(), "1.25");
+});
+
+test("a nested Date the contract leaves unserialized is refused", () => {
+  type NestedDateContract = Omit<Report, "nested"> & { nested: { at: Date } };
+  // @ts-expect-error the nested Date reaches the browser as an ISO string.
+  const projection = nativeReport() satisfies SerializesTo<NativeReport, NestedDateContract>;
+  assert.equal(projection.nested.at.getTime(), 0);
+});
+
+test("a key the contract does not name is refused", () => {
+  type SurplusReport = NativeReport & { internalRowVersion: number };
+  const surplus: SurplusReport = { ...nativeReport(), internalRowVersion: 3 };
+  // @ts-expect-error the projection carries a key no browser contract names.
+  const projection = surplus satisfies SerializesTo<SurplusReport, Report>;
+  assert.equal(projection.internalRowVersion, 3);
+});
+
+test("a key the contract names and the projection drops is refused", () => {
+  type PartialReport = Omit<NativeReport, "tags">;
+  const { tags, ...withoutTags } = nativeReport();
+  assert.deepEqual(tags, ["merge"]);
+  // @ts-expect-error the contract names `tags` and the projection never emits it.
+  const projection = withoutTags satisfies SerializesTo<PartialReport, Report>;
+  assert.equal(projection.id, "run-1");
+});
+
+test("a key the projection makes optional and the contract requires is refused", () => {
+  type OptionalTagsReport = Omit<NativeReport, "tags"> & { tags?: string[] };
+  const optional: OptionalTagsReport = nativeReport();
+  // @ts-expect-error an absent key is not the same wire shape as a present one,
+  // which is why the proof compares type identity and not assignability.
+  const projection = optional satisfies SerializesTo<OptionalTagsReport, Report>;
+  assert.deepEqual(projection.tags, ["merge"]);
+});

--- a/packages/db/src/wire-serialization.ts
+++ b/packages/db/src/wire-serialization.ts
@@ -1,0 +1,88 @@
+/**
+ * Compile-time proof that a native projection JSON-serializes to exactly its
+ * browser contract.
+ *
+ * A projecting route builds its response from Prisma rows, so it holds native
+ * `Date` and `Prisma.Decimal` values, and hands the result to Hono, which
+ * serializes it with `JSON.stringify`. The browser reads the same contract
+ * instantiated with its wire defaults. Binding the projection with
+ * `satisfies SomeContract<Date, Prisma.Decimal>` proves only the native half:
+ * it cannot see a `Decimal` the contract declares as `string`, a nested `Date`
+ * left where the browser expects a `string`, or a key the projection carries
+ * and the contract does not name.
+ *
+ * `SerializesTo` names both sides at once, so the route's existing `satisfies`
+ * carries the whole claim. Nothing here exists at runtime; the module is types
+ * only, and Prisma is imported as a type.
+ */
+
+import type { Prisma } from "@prisma/client";
+
+/**
+ * What `JSON.stringify` makes of a native projection type.
+ *
+ * `Date` and `Prisma.Decimal` both define `toJSON` and reach the browser as
+ * strings. Everything else is mapped through. The object mapping is
+ * homomorphic, so optional and readonly modifiers, tuples, arrays and index
+ * signatures survive it unchanged, and the conditional distributes over
+ * unions, which keeps `Date | null` honest.
+ */
+export type JsonSerialized<T> = T extends Date | Prisma.Decimal
+  ? string
+  : T extends object
+    ? { [Key in keyof T]: JsonSerialized<T[Key]> }
+    : T;
+
+/**
+ * The same structural flattening with the native leaves left alone.
+ *
+ * Contracts are written both as plain object types and as an intersection with
+ * a shared base. An intersection and the object type holding the same members
+ * are the same wire shape but not the same *type*, so the comparison flattens
+ * both sides. Leaving `Date` and `Prisma.Decimal` in place is the point: a
+ * contract that still declares one is the mismatch being looked for.
+ */
+type Flattened<T> = T extends Date | Prisma.Decimal
+  ? T
+  : T extends object
+    ? { [Key in keyof T]: Flattened<T[Key]> }
+    : T;
+
+/**
+ * Type identity, not mutual assignability.
+ *
+ * Assignability in both directions accepts a surplus *optional* key on either
+ * side and cannot separate `field?: string` from `field: string | undefined`.
+ * Both are differences a browser sees. The two probe signatures are identical
+ * only when TypeScript holds the two types to be the same type, at every depth.
+ */
+type Identical<Left, Right> =
+  (<Probe>() => Probe extends Left ? 1 : 2) extends (<Probe>() => Probe extends Right ? 1 : 2)
+    ? true
+    : false;
+
+/**
+ * What `SerializesTo` resolves to when the proof fails. No projection can
+ * satisfy it, so the failure is reported at the line that projects, naming
+ * both the native shape and the contract it was claimed to serialize to.
+ */
+export type WireSerializationMismatch<Native, Wire> = {
+  readonly wireSerializationMismatch:
+    "this native projection does not JSON-serialize to exactly this browser contract";
+  readonly native: Native;
+  readonly wire: Wire;
+};
+
+/**
+ * `Native` when JSON serialization turns it into exactly `Wire`, and an
+ * unsatisfiable mismatch otherwise.
+ *
+ * Written as the projection's own type — `type FooResponse = SerializesTo<
+ * FooContract<Date, Prisma.Decimal>, FooContract>` — so every `satisfies
+ * FooResponse` in the route already carries the proof, and a contract that
+ * needs no instantiation still proves it holds no unserialized value.
+ */
+export type SerializesTo<Native, Wire> =
+  Identical<JsonSerialized<Native>, Flattened<Wire>> extends true
+    ? Native
+    : WireSerializationMismatch<Native, Wire>;


### PR DESCRIPTION
## What changed

`packages/db/src/wire-serialization.ts` is a new module that owns one claim:
*this native projection JSON-serializes to exactly this browser contract*. Its
interface is two type names.

- `JsonSerialized<T>` — what `JSON.stringify` makes of a native projection
  type. `Date` and `Prisma.Decimal` both define `toJSON` and become `string`;
  everything else is mapped through homomorphically, so optional and readonly
  modifiers, tuples, arrays and index signatures survive.
- `SerializesTo<Native, Wire>` — `Native` when the serialized form is
  *identical* to `Wire`, and an unsatisfiable `WireSerializationMismatch`
  otherwise, so the failure is reported on the line that projects and names
  both sides.

Written at each projecting route as its response type, so the route's existing
`satisfies` now carries the whole wire claim instead of the native half:

| module | proven |
| --- | --- |
| `routes/tasks.ts` | `Chain`, `ChainStep` (both were bound inline), `RecurringFire`, `Run`, `TaskActivity`, `TaskDetail`, `TaskStartability`, `TaskStepOutput` |
| `routes/session.ts` | `Session` |
| `routes/templates.ts` | `Trigger`, `TriggerDetail`, `TriggerFire` |
| `routes/admin.ts` | `Project`, `Secret`, `Environment`, and `GET /projects/:projectId/costs`, which had no binding at all |
| `costs.ts` | `CostsReport`, carried through `aggregateCosts` and `readProjectCosts` to the route |
| `board.ts` | `BoardCard` on `boardCard`'s return type, and `TaskListRow` on `readTaskList`, which never had one |

`board.ts` imports the shared machinery. Its local `JsonSerialized`,
`ExactKeys`, `ContractCheck` and `SerializedBoardCardProjection` are deleted,
along with the now-unused `ChainFrontier` import.

`costs.ts` loses `NativeCostsWaste` and `NativeCostsReport`. The first restated
`CostsWaste<Prisma.Decimal>` field for field; the second intersected
`CostsReport<Date, Prisma.Decimal>` with hand-copies of its own `waste` and
`chains` members, which an intersection cannot override — had the copies ever
drifted, the result would have been a silently impossible type rather than an
error. `NativeCostsChain` becomes a one-line alias of `CostsChain<Prisma.Decimal>`.

`packages/db/package.json` gains a `./wire-serialization` export subpath,
matching its siblings `./wire-contract` and `./board-contract`, and
`packages/build-info/exports.test.mjs` registers the new mapping: it pins the
explicit list of source-backed subpaths and the exact key order of each
manifest's `exports`, so the addition fails it until the mapping is listed.

## Evidence

Base `6cd0fc35dec2b08aec915e0af48296c1165e2e82`. `origin/main` moved to
`a352dbb96701e90604ee515582118ceaeac73ca0` (PR #424, lane r2) while the gate
was running; merged in with `git merge origin/main`, no conflicts, disjoint
files (`packages/runner/src/dependency-cache*`).

Anchors re-verified on the base before editing: `board.ts:72-101` held the
three type-machinery declarations and `SerializedBoardCardProjection`, which
was exported and referenced nowhere else in the repository (`grep -rn` over
`packages apps scripts`: one hit, its own declaration); `admin.ts:92` was a
bare `context.json(await readProjectCosts(...))`; `costs.ts:117` was the
`NativeCostsReport` intersection. All still present, all addressed.

The machinery bites, not vacuously. Two independent demonstrations:

1. Applying it to `readTaskList` failed on the first compile —
   `TaskList<DateTime, DecimalValue>` is an intersection with `TaskBase`, and
   TypeScript's identity relation separates an intersection from the object
   type holding the same members. That is what produced the `Flattened` half
   of the comparison; both sides are now flattened, and native leaves are
   deliberately left in place on the contract side so a contract that still
   declares a `Decimal` is still caught.
2. A scratch probe (written, compiled, deleted) confirmed that
   `SerializesTo<Run<Date, Decimal> & { surplus: number }, Run>`,
   `SerializesTo<Session<Date, Decimal>, Session<Date, Decimal>>` and
   `SerializesTo<CostsReport<Date, Decimal>, CostsReport<string, Decimal>>`
   all resolve to `WireSerializationMismatch`, while
   `SerializesTo<TaskDetail<Date, Decimal>, TaskDetail>` resolves to the
   native contract.

`packages/db/src/wire-serialization.test.ts` is both a type-level and a runtime
test. One case asserts that `JSON.parse(JSON.stringify(projection))` really is
the shape `JsonSerialized` claims (`Date` to ISO string, `Prisma.Decimal` to
string) — the runtime fact the compile-time proof rests on. Five
`@ts-expect-error` cases prove the check rejects: a contract still declaring a
`Decimal`, a nested `Date` left unserialized, a surplus projected key, a
dropped key, and a key the projection makes optional where the contract
requires it. `tsc` reports an unused `@ts-expect-error` as an error, so
`npm run typecheck` passing is itself the proof that all five still fail.

Commands run in the worktree after the final commit, with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh `mktemp -d`:

- `npm run lint` — exit 0 (biome: 743 files, no fixes; eslint clean)
- `npm run typecheck` — exit 0
- `npm run test -w @anneal/db` — exit 0, 404 tests, 404 pass, 0 fail
- `npm run test -w @anneal/api` — exit 0, 823 tests, 822 pass, 0 fail, 1 skipped (pre-existing)

`npm run test -w @anneal/build-info` — exit 0, 28 tests, 28 pass, 0 fail. Not one
of the brief's commands, and that is how the first gate found the failure this
change caused: `exports.test.mjs` pins `@anneal/db`'s export list, and the new
subpath broke it. Fixed in the second commit and now run alongside the others.

`test:db` not run: no local PostgreSQL, it is merge gate evidence. No `*.dbtest.ts`
was changed. Nothing under `docs/` was touched and no HTTP route was added,
removed or altered, so `test:snapshot-scan` and `docs/operator-api.md` do not apply.

Merge gate, dispatched with the fallback worker refused
(`AGENTOS_GATE_FALLBACK_SERVER=""`) per the coordinating window's notice:

- attempt 1, head `4075690b67c20c85e4ca6e7d036e79ce1a315f27` — `MERGE GATE: FAIL
  (unit tests (all workspaces))`, one failing test across the whole run:
  `packages/build-info/exports.test.mjs` "all seventeen source-backed exports
  have ordered development targets", on the added `./wire-serialization` key.
  Genuinely caused by this change; fixed rather than re-dispatched.
- attempt 2, head `2f0830f44182f1299640a2acb485af0b6a500e96` —
  `MERGE GATE: PASS 2f0830f44182f1299640a2acb485af0b6a500e96`.

## Decisions taken

**The proof is one deep identity comparison, not the brief's three lifted
types.** The brief asked for `JsonSerialized`, `ExactKeys` and `ContractCheck`
to move as they stand. They do not generalise: `ExactKeys` compares only
top-level keys, which is why `board.ts` had to hand-enumerate the chain
aggregate, that aggregate's frontier and the latest run, and why it proved
nothing about a *type* mismatch at any depth — a `Prisma.Decimal` the contract
declares as `string` passes every one of those key comparisons. `CostsReport`
nests four levels deep and would have needed a longer enumeration for a weaker
guarantee. `SerializesTo` compares the whole serialized shape to the whole
contract for type identity, which subsumes every `ExactKeys` line, catches
type mismatches the old form could not see, and takes no per-call-site proof
argument. The two deliberate negative controls `board.ts` carried inline
(`Omit<..., "id">` and `& { surplus: never }`) move into the module's own test,
where they are five cases instead of two and are checked once rather than
re-stated by every future caller.

**Identity rather than mutual assignability.** Assignability in both directions
accepts a surplus *optional* key on either side and cannot separate
`field?: string` from `field: string | undefined`. Both are differences a
browser sees, and both are covered by a test case.

**The proof fires at the projection, not at a free-standing type alias.**
`SerializedBoardCardProjection` was exported and used nowhere; deleting it
would have broken nothing, which is a weak place for a proof to live. Each
response type now resolves to the mismatch marker on failure, so the error
surfaces at the `satisfies` or the return type of the function that builds the
value.

**`Environment` and `TaskStartability` are proven too, though they take no type
parameters.** `SerializesTo<X, X>` is not vacuous: it asserts that `X` holds no
`Date` and no `Decimal` at any depth. A nested `Date` added to either contract
later is a compile error rather than a browser reading `[object Object]`.

**Runtime validation on the browser side was not touched.** `apps/web/src/lib/api.ts:164`
is out of scope per the brief and remains `JSON.parse(text) as T`.

## Fence widened

- `packages/db/package.json` — one added `exports` entry for the new
  `./wire-serialization` subpath. `QUEUE.md` assigns this file to lane b1
  (`packages/db/package.json (exports)`), whose state is `merged`, so rule 1
  applies.
- `packages/build-info/exports.test.mjs` — one added mapping row, the count
  `17` to `18`, and the test title. `QUEUE.md` assigns this file to no lane,
  and it is a test whose assertions this change necessarily breaks, so it is
  inside the fence on both counts.

## Reported but unfixed

- `apps/web/src/lib/api.ts:164` decodes every response with
  `JSON.parse(text) as T`. This change proves the server emits the contract; it
  proves nothing about what the browser received. Out of scope by the brief,
  and recorded here as the remaining half of the question.
- `packages/api/src/routes/inbox.ts`, `goals.ts` and `system.ts` now bind to
  `@anneal/db/console-contract` (lane b1, merged) but bind only the native
  half, exactly as the routes in this change did before it. `routes/runner.ts`
  still has no binding at all: zero `satisfies` and no contract import.
  Applying `SerializesTo` to the console contracts is a clean follow-up that
  needs no new machinery; those four files are lane b1's paths, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMvfEYAwB6xH7uRKCZWxxC
