### PR TITLE
refactor(runner): bind the workspace command run once

### DIFF
--- a/packages/runner/src/delivery.test.ts
+++ b/packages/runner/src/delivery.test.ts
@@ -11,10 +11,10 @@ import type { ExitEvidence } from "./adapters.js";
 import type { RunnerConfig } from "./config.js";
 import {
   deliverWorkspace, pullRequestTitle, salvageWorkspace,
-  type CommandExecutor, type DeliveryClaim,
+  type DeliveryClaim,
 } from "./delivery.js";
 import { completionEnvelope } from "./envelope.js";
-import { CommandTimeoutError, KILL_OVERHEAD_MS } from "./exec.js";
+import { CommandTimeoutError, KILL_OVERHEAD_MS, type CommandRunner } from "./exec.js";
 import {
   deliveryDeadline, NETWORK_COMMAND_TIMEOUT_MS, WORKSPACE_HEAD_TIMEOUT_MS,
 } from "./network-retry.js";
@@ -153,8 +153,8 @@ const canonicalFinalOutputs = (
 
 test("canonical PR implementation creates the deterministic initial handover body", async () => {
   const calls: Array<{ executable: string; args: string[] }> = [];
-  const fake: CommandExecutor = async (executable, args) => {
-    calls.push({ executable, args });
+  const fake: CommandRunner = async (executable, args) => {
+    calls.push({ executable, args: [...args] });
     if (executable === "gh" && args[1] === "list") return "[]";
     if (executable === "gh" && args[1] === "create") return "https://github.com/acme/app/pull/1\n";
     return "";
@@ -190,8 +190,8 @@ test("canonical PR implementation creates the deterministic initial handover bod
 test("canonical PR implementation edits an existing PR and reads back the initial body", async () => {
   const calls: Array<{ executable: string; args: string[] }> = [];
   let body = "";
-  const fake: CommandExecutor = async (executable, args) => {
-    calls.push({ executable, args });
+  const fake: CommandRunner = async (executable, args) => {
+    calls.push({ executable, args: [...args] });
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/2", number: 2 }]);
     if (executable === "gh" && args[1] === "edit") { body = args.at(-1)!; return ""; }
     if (executable === "gh" && args[1] === "view") return body;
@@ -222,8 +222,8 @@ test("canonical PR implementation edits an existing PR and reads back the initia
 test("canonical PR final delivery publishes a clean head and the complete review handover body", async () => {
   const calls: Array<{ executable: string; args: string[] }> = [];
   let body = "";
-  const fake: CommandExecutor = async (executable, args) => {
-    calls.push({ executable, args });
+  const fake: CommandRunner = async (executable, args) => {
+    calls.push({ executable, args: [...args] });
     if (executable === "git" && args[0] === "ls-tree") return "";
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/3", number: 3 }]);
     if (executable === "gh" && args[1] === "edit") { body = args.at(-1)!; return ""; }
@@ -271,7 +271,7 @@ test("canonical PR final body states when reviews required no code change", asyn
   fixed.closedFindings = [];
   outputs[3] = { ...outputs[3]!, body: JSON.stringify(fixed) };
   let body = "";
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "ls-tree") return "";
     if (executable === "gh" && args[1] === "list") {
       return JSON.stringify([{ url: "https://github.com/acme/app/pull/8", number: 8 }]);
@@ -292,7 +292,7 @@ test("canonical PR final body states when reviews required no code change", asyn
 
 test("canonical PR final delivery rejects retained chain bookkeeping before push", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "git" && args[0] === "ls-tree") return ".chain/fix/pr-workflow/spec.md\n";
     throw new Error(`unexpected command: ${executable} ${args.join(" ")}`);
@@ -311,7 +311,7 @@ test("canonical PR final delivery rejects retained chain bookkeeping before push
 test("canonical PR final delivery allows an already-pushed clean retry without a new commit", async () => {
   const calls: string[] = [];
   let body = "";
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "git" && args[0] === "ls-tree") return "";
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/4", number: 4 }]);
@@ -351,7 +351,7 @@ test("canonical PR implementation refuses an unchanged required-commit head befo
 test("canonical PR implementation reports an empty command list factually", async () => {
   let body = "";
   const output = canonicalImplementationOutput(canonicalImplementationSha, canonicalBaseSha, []);
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") return "[]";
     if (executable === "gh" && args[1] === "create") { body = args.at(-1)!; return "https://github.com/acme/app/pull/5\n"; }
     return "";
@@ -372,7 +372,7 @@ for (const failure of [
   { name: "unequal read-back", operation: "gh pr view", edit: null, view: "stale body" },
 ] as const) {
   test(`canonical PR final delivery fails on ${failure.name}`, async () => {
-    const fake: CommandExecutor = async (executable, args) => {
+    const fake: CommandRunner = async (executable, args) => {
       if (executable === "git" && args[0] === "ls-tree") return "";
       if (executable === "gh" && args[1] === "list") {
         return JSON.stringify([{ url: "https://github.com/acme/app/pull/6", number: 6 }]);
@@ -400,7 +400,7 @@ for (const failure of [
 }
 
 test("canonical PR final delivery fails when no open pull request exists", async () => {
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "ls-tree") return "";
     if (executable === "gh" && args[1] === "list") return "[]";
     return "";
@@ -417,7 +417,7 @@ test("canonical PR final delivery fails when no open pull request exists", async
 });
 
 test("canonical PR final delivery fails when open-PR lookup is malformed", async () => {
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "ls-tree") return "";
     if (executable === "gh" && args[1] === "list") return "not-json";
     return "";
@@ -436,7 +436,7 @@ test("canonical PR final delivery fails when open-PR lookup is malformed", async
 test("canonical PR final delivery fails for a non-GitHub remote after publishing", async () => {
   const finalClaim = canonicalClaim("fixed-implementation", "task-fixed", 4);
   finalClaim.repo.remoteUrl = "ssh://git.example.test/acme/app.git";
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "ls-tree") return "";
     return "";
   };
@@ -562,7 +562,7 @@ test("canonical PR final delivery pushes the exact descendant cleanup commit fro
     const implementationSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repository, encoding: "utf8" }).trim();
     const calls: string[] = [];
     let body = "";
-    const command: CommandExecutor = async (executable, args, cwd, env) => {
+    const command: CommandRunner = async (executable, args) => {
       calls.push(`${executable} ${args.join(" ")}`);
       if (executable === "gh" && args[1] === "list") {
         return JSON.stringify([{ url: "https://github.com/acme/app/pull/7", number: 7 }]);
@@ -570,9 +570,9 @@ test("canonical PR final delivery pushes the exact descendant cleanup commit fro
       if (executable === "gh" && args[1] === "edit") { body = args.at(-1)!; return ""; }
       if (executable === "gh" && args[1] === "view") return body;
       if (executable === "gh") return "gh version fixture";
-      return execFileSync(executable, args, {
-        cwd,
-        env: { ...env, PATH: process.env.PATH },
+      return execFileSync(executable, [...args], {
+        cwd: repository,
+        env: { PATH: process.env.PATH },
         encoding: "utf8",
       });
     };
@@ -624,7 +624,7 @@ test("canonical PR final delivery pushes the exact descendant cleanup commit fro
 
 test("a missing requiresCommit defaults to required and fails before publication", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     return "";
   };
@@ -644,7 +644,7 @@ test("a missing requiresCommit defaults to required and fails before publication
 test("a workspace-head read failure is reported without any remote operation", async () => {
   const calls: string[] = [];
   const headError = new Error("fatal: not a git repository");
-  const fake: CommandExecutor = async (executable, args, _cwd, _env, options) => {
+  const fake: CommandRunner = async (executable, args, options) => {
     calls.push(`${executable} ${args.join(" ")}`);
     assert.equal(options?.timeoutMs, WORKSPACE_HEAD_TIMEOUT_MS);
     throw headError;
@@ -659,7 +659,7 @@ test("a workspace-head read failure is reported without any remote operation", a
 
 test("a clean no-PR session with no commit also fails before publication", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     return executable === "git" && args[0] === "rev-parse" ? workspace.baseSha : "";
   };
@@ -675,7 +675,7 @@ test("a clean no-PR session with no commit also fails before publication", async
 test("an unchanged optional-commit step still publishes its branch", async () => {
   const calls: string[] = [];
   const publications: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     return "";
   };
@@ -697,7 +697,7 @@ test("an unchanged optional-commit step still publishes its branch", async () =>
 
 test("a session with a captured commit keeps the existing push and pull-request path", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "gh" && args[1] === "list") {
       return JSON.stringify([{ url: "https://github.com/acme/app/pull/7", number: 7 }]);
@@ -716,7 +716,7 @@ test("a session with a captured commit keeps the existing push and pull-request 
 test("delivery fails loudly with the gh probe error when gh is unavailable", async () => {
   const calls: string[] = [];
   const probeError = new Error("ENOENT");
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "gh") throw probeError;
     return "";
@@ -732,7 +732,7 @@ test("delivery fails loudly with the gh probe error when gh is unavailable", asy
 
 test("delivery records a pushed branch without invoking gh for a non-GitHub remote", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => { calls.push(`${executable} ${args.join(" ")}`); return ""; };
+  const fake: CommandRunner = async (executable, args) => { calls.push(`${executable} ${args.join(" ")}`); return ""; };
   const result = await deliverWorkspace(config, {
     ...claim, repo: { ...claim.repo, remoteUrl: "ssh://git@example.test/acme/app.git" },
   }, workspace, { command: fake });
@@ -744,7 +744,7 @@ test("delivery records a pushed branch without invoking gh for a non-GitHub remo
 
 test("a chain step reuses the open pull request on its shared head branch", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/7", number: 7 }]);
     return "";
@@ -756,7 +756,7 @@ test("a chain step reuses the open pull request on its shared head branch", asyn
 
 test("a failed initial pull-request lookup fails delivery with the lookup error", async () => {
   const lookupError = new Error("gh: API rate limit exceeded");
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") throw lookupError;
     return "";
   };
@@ -771,7 +771,7 @@ test("a failed initial pull-request lookup fails delivery with the lookup error"
 test("delivery opens one pull request titled after the chain, not the step", async () => {
   const calls: string[] = [];
   let created = false;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "gh" && args[1] === "create") { created = true; return ""; }
     if (executable === "gh" && args[1] === "list") {
@@ -792,7 +792,7 @@ test("delivery opens one pull request titled after the chain, not the step", asy
 test("a custom chain base is preserved in gh pr create", async () => {
   const calls: string[] = [];
   let created = false;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "gh" && args[1] === "create") created = true;
     if (executable === "gh" && args[1] === "list") {
@@ -808,7 +808,7 @@ test("a custom chain base is preserved in gh pr create", async () => {
 
 test("publication is acknowledged immediately after push and before GitHub work", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/7", number: 7 }]);
     return "";
@@ -827,7 +827,7 @@ test("publication is acknowledged immediately after push and before GitHub work"
 
 test("a pull request created between list and create is confirmed and reused", async () => {
   let listCalls = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") {
       listCalls += 1;
       return listCalls === 1 ? "[]" : JSON.stringify([{ url: "https://github.com/acme/app/pull/7", number: 7 }]);
@@ -843,7 +843,7 @@ test("a pull request created between list and create is confirmed and reused", a
 
 test("transient push failures succeed on the third attempt", async () => {
   let pushes = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "push") {
       pushes += 1;
       if (pushes < 3) throw new Error("LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443");
@@ -860,7 +860,7 @@ test("transient push failures succeed on the third attempt", async () => {
 
 test("deterministic authentication failures are not retried", async () => {
   let pushes = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "push") {
       pushes += 1;
       throw new Error("remote: HTTP 403 Forbidden: permission denied");
@@ -876,7 +876,7 @@ test("deterministic authentication failures are not retried", async () => {
 test("an EOF after PR creation is resolved by head lookup without duplicate creation", async () => {
   let listCalls = 0;
   let createCalls = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") {
       listCalls += 1;
       return listCalls === 1 ? "[]" : JSON.stringify([{ url: "https://github.com/acme/app/pull/12", number: 12 }]);
@@ -902,7 +902,7 @@ test("a read-back that cannot be completed preserves its typed failure and never
   let listCalls = 0;
   const createError = new CommandTimeoutError("gh", ["pr", "create"], 20_000);
   const readBackError = new CommandTimeoutError("gh", ["pr", "list"], 20_000);
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") {
       listCalls += 1;
       if (listCalls === 1) return "[]";
@@ -946,7 +946,7 @@ test("a deterministic create failure is read back once and never resent", async 
   // fail again. It is still read back — the platform saying no is not evidence
   // that no pull request exists — and then reported.
   let createCalls = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") return "[]";
     if (executable === "gh" && args[1] === "create") {
       createCalls += 1;
@@ -963,7 +963,7 @@ test("a deterministic create failure is read back once and never resent", async 
 
 test("gh names the pull request it made, so a confirmed create needs no lookup at all", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.slice(0, 2).join(" ")}`);
     if (executable === "gh" && args[1] === "list") return "[]";
     if (executable === "gh" && args[1] === "create") {
@@ -988,7 +988,7 @@ test("a create that succeeded and a lookup that failed never asks for a second c
   let createCalls = 0;
   let listCalls = 0;
   const lookupError = new Error("Get https://api.github.com/repos/acme/app/pulls: EOF");
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") {
       listCalls += 1;
       if (listCalls === 1) return "[]";
@@ -1012,7 +1012,7 @@ test("a create that succeeded and a lookup that failed never asks for a second c
 
 test("a successful but unnamed create fails when no open pull request can be found", async () => {
   let listCalls = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") {
       listCalls += 1;
       return "[]";
@@ -1035,7 +1035,7 @@ test("a bare EOF is a lost response, so a read-back that finds nothing earns exa
   // landed — the safe direction, but not the one the ticket asks for.
   let createCalls = 0;
   let listCalls = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") {
       listCalls += 1;
       return createCalls >= 2 ? JSON.stringify([{ url: "https://github.com/acme/app/pull/21", number: 21 }]) : "[]";
@@ -1061,7 +1061,7 @@ test("a resend is not started with less budget than one attempt needs", async ()
   // remaining budget would buy a five-second command that overruns the lease.
   let clock = 0;
   let createCalls = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "git" || args[0] === "--version") return "";
     if (args[1] === "list") return "[]";
     createCalls += 1;
@@ -1086,7 +1086,7 @@ test("a resend is not started with less budget than one attempt needs", async ()
 
 test("a pushed branch remains published when PR retries are exhausted, but delivery fails", async () => {
   let createCalls = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") return "[]";
     if (executable === "gh" && args[1] === "create") {
       createCalls += 1;
@@ -1105,7 +1105,7 @@ test("a pushed branch remains published when PR retries are exhausted, but deliv
 
 test("git's Author identity error is a tool failure, not an auth failure", async () => {
   let pushes = 0;
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "push") {
       pushes += 1;
       throw new Error("Author identity unknown\n*** Please tell me who you are.\nfatal: unable to auto-detect email address");
@@ -1120,7 +1120,7 @@ test("git's Author identity error is a tool failure, not an auth failure", async
 
 test("a failed run commits uncommitted changes, pushes them as WIP, and opens no pull request", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "git" && args[0] === "status") return "M tracked.ts\n?? new.ts";
     return executable === "git" && args[0] === "rev-parse" ? "salvage-sha" : "";
@@ -1143,7 +1143,7 @@ test("a failed run commits uncommitted changes, pushes them as WIP, and opens no
 
 test("a failed run with no new commit is not pushed at all", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     return executable === "git" && args[0] === "rev-parse" ? workspace.baseSha : "";
   };
@@ -1153,7 +1153,7 @@ test("a failed run with no new commit is not pushed at all", async () => {
 
 test("a failed run still pushes commits the agent made before crashing", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     return executable === "git" && args[0] === "rev-parse" ? "agent-commit-sha" : "";
   };
@@ -1173,7 +1173,7 @@ const noPrClaim = { ...claim, run: { ...claim.run, opensPullRequest: false } } s
 
 test("a step that does not open pull requests still pushes its branch", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "gh" && args[1] === "list") return "[]";
     return "";
@@ -1187,7 +1187,7 @@ test("a step that does not open pull requests still pushes its branch", async ()
 });
 
 test("a step that does not open pull requests says so instead of failing", async () => {
-  const fake: CommandExecutor = async (executable, args) => (executable === "gh" && args[1] === "list" ? "[]" : "");
+  const fake: CommandRunner = async (executable, args) => (executable === "gh" && args[1] === "list" ? "[]" : "");
   const result = await deliverWorkspace(config, noPrClaim, workspace, { command: fake });
   assert.equal(result.pullRequestUrl, undefined);
   assert.match(result.deliveryInstructions ?? "", /Branch 'feature\/test' was pushed/);
@@ -1196,7 +1196,7 @@ test("a step that does not open pull requests says so instead of failing", async
 
 test("a late documentation step reports the chain's existing pull request", async () => {
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     calls.push(`${executable} ${args.join(" ")}`);
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/7", number: 7 }]);
     return "";
@@ -1209,7 +1209,7 @@ test("a late documentation step reports the chain's existing pull request", asyn
 });
 
 test("no gh and no pull request by design reads as design, not as a degraded path", async () => {
-  const fake: CommandExecutor = async (executable) => { if (executable === "gh") throw new Error("ENOENT"); return ""; };
+  const fake: CommandRunner = async (executable) => { if (executable === "gh") throw new Error("ENOENT"); return ""; };
   const result = await deliverWorkspace(config, noPrClaim, workspace, { command: fake });
   assert.match(result.deliveryInstructions ?? "", /does not open a pull request/);
   assert.doesNotMatch(result.deliveryInstructions ?? "", /manually/);
@@ -1221,7 +1221,7 @@ test("a failed pull-request lookup does not fail a step that opens no pull reque
   // documentation step *after* its push, and a delivery failure carrying a
   // failureClass is marked non-retryable — one rate-limited lookup would wedge
   // the step permanently.
-  const fake: CommandExecutor = async (executable, args) => {
+  const fake: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") throw new Error("gh: API rate limit exceeded");
     return "";
   };
@@ -1240,13 +1240,13 @@ test("the ref that was actually pushed is recorded on every path that pushed", a
   //   (d) below is the direction where a salvage push SUCCEEDED against a
   //       per-run branch while `branch` still reads the shared one — the next
   //       chain step would clone a ref nobody created.
-  const created: CommandExecutor = async (executable, args) => {
+  const created: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") return JSON.stringify([{ url: "https://github.com/acme/app/pull/9", number: 9 }]);
     return "";
   };
   assert.equal((await deliverWorkspace(config, claim, workspace, { command: created })).pushedBranch, "feature/test");
 
-  const prFails: CommandExecutor = async (executable, args) => {
+  const prFails: CommandRunner = async (executable, args) => {
     if (executable === "gh" && args[1] === "list") return "[]";
     if (executable === "gh" && args[1] === "create") throw new Error("gh: API rate limit exceeded");
     return "";
@@ -1255,13 +1255,13 @@ test("the ref that was actually pushed is recorded on every path that pushed", a
   assert.equal(failed.pushStatus, "FAILED");
   assert.equal(failed.pushedBranch, "feature/test");
 
-  const pushFails: CommandExecutor = async (executable, args) => {
+  const pushFails: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "push") throw new Error("remote rejected");
     return "";
   };
   assert.equal((await deliverWorkspace(config, claim, workspace, { command: pushFails })).pushedBranch, undefined);
 
-  const salvage: CommandExecutor = async (executable, args) => {
+  const salvage: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "status") return "M tracked.ts";
     return executable === "git" && args[0] === "rev-parse" ? "salvage-sha" : "";
   };
@@ -1278,7 +1278,7 @@ const LEASE_MS = 60_000;
 test("a hung push is timed out and reported as a transient failure, not a lease-eating stall", async () => {
   let clock = 0;
   const timeouts: Array<number | undefined> = [];
-  const fake: CommandExecutor = async (executable, args, _cwd, _env, options) => {
+  const fake: CommandRunner = async (executable, args, options) => {
     if (executable === "git" && args[0] === "rev-parse") return "changed-head";
     timeouts.push(options?.timeoutMs);
     clock += (options?.timeoutMs ?? 0) + KILL_OVERHEAD_MS;
@@ -1320,7 +1320,7 @@ test("a hung push is timed out and reported as a transient failure, not a lease-
  */
 test("a hung push arrives at the API as a typed timeout, not as a failed task", async () => {
   let clock = 0;
-  const fake: CommandExecutor = async (executable, args, _cwd, _env, options) => {
+  const fake: CommandRunner = async (executable, args, options) => {
     if (executable === "git" && args[0] === "rev-parse") return "changed-head";
     clock += (options?.timeoutMs ?? 0) + KILL_OVERHEAD_MS;
     throw new CommandTimeoutError("git", ["push"], options?.timeoutMs ?? 0);
@@ -1406,7 +1406,7 @@ test("every command of a slow delivery is capped, and the whole phase fits one l
   // drawing on the single phase deadline, measured from the delivery heartbeat.
   let clock = 0;
   const calls: string[] = [];
-  const fake: CommandExecutor = async (executable, args, _cwd, _env, options) => {
+  const fake: CommandRunner = async (executable, args, options) => {
     calls.push(`${executable} ${args.slice(0, 2).join(" ")}`);
     const timeoutMs = options?.timeoutMs;
     // Nothing in delivery may run uncapped: an uncapped command is a hole in
@@ -1436,7 +1436,7 @@ test("a hung pull-request creation and its probe cannot open a second budget", a
   let clock = 0;
   const calls: string[] = [];
   const ghTimeouts: Array<number | undefined> = [];
-  const fake: CommandExecutor = async (executable, args, _cwd, _env, options) => {
+  const fake: CommandRunner = async (executable, args, options) => {
     calls.push(`${executable} ${args.slice(0, 2).join(" ")}`);
     if (executable === "git") return "";
     if (args[0] === "--version") return "gh version 2.0.0";
@@ -1473,7 +1473,7 @@ test("retries across the delivery chain cannot stack into more than one lease", 
   // budgets back to back; with one phase deadline it is one.
   let clock = 0;
   const attempted = new Map<string, number>();
-  const fake: CommandExecutor = async (executable, args, _cwd, _env, options) => {
+  const fake: CommandRunner = async (executable, args, options) => {
     const key = `${executable} ${args.slice(0, 2).join(" ")}`;
     const seen = (attempted.get(key) ?? 0) + 1;
     attempted.set(key, seen);

--- a/packages/runner/src/delivery.ts
+++ b/packages/runner/src/delivery.ts
@@ -3,7 +3,7 @@ import { canonicalOutputSchema, PR_TEMPLATE_NAME, type PrHandoffKind, type PrHan
 
 import type { ClaimedTask, FailureClass } from "./api.js";
 import type { RunnerConfig } from "./config.js";
-import { isCommandTimeout, KILL_OVERHEAD_MS, platformCommitArgs, runCommand, type CommandOptions } from "./exec.js";
+import { bindCommandRunner, isCommandTimeout, KILL_OVERHEAD_MS, platformCommitArgs, type CommandRunner } from "./exec.js";
 import {
   boundedTimeout, budgetRemains, GH_PROBE_TIMEOUT_MS, MIN_ATTEMPT_TIMEOUT_MS, NETWORK_ATTEMPTS,
   NETWORK_COMMAND_TIMEOUT_MS, runWithNetworkRetry, transientBackoff, WORKSPACE_HEAD_TIMEOUT_MS,
@@ -50,14 +50,6 @@ export type DeliveryFailure = {
   error: unknown;
 };
 
-export type CommandExecutor = (
-  executable: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  options?: CommandOptions,
-) => Promise<string>;
-
 export type DeliveryClaim = {
   task: Pick<ClaimedTask["task"], "id" | "name" | "templateStep"> & {
     /** The full task description is used only by the canonical PR body. */
@@ -71,7 +63,7 @@ export type DeliveryClaim = {
 };
 
 export type DeliverWorkspaceDependencies = {
-  command?: CommandExecutor;
+  command?: CommandRunner;
   /** HEAD already captured by the runner before delivery. Direct callers may
    *  omit it and let delivery resolve the commit itself. */
   headSha?: string;
@@ -82,17 +74,9 @@ export type DeliverWorkspaceDependencies = {
 };
 
 export type SalvageWorkspaceDependencies = {
-  command?: CommandExecutor;
+  command?: CommandRunner;
   retryOptions?: RetryOptions;
 };
-
-export const executeCommand = (config: RunnerConfig): CommandExecutor => (
-  executable,
-  args,
-  cwd,
-  env,
-  options,
-) => runCommand(config.runAsPrefix, executable, args, cwd, env, options ?? {});
 
 const githubRepo = (remote: string): string | null => {
   const ssh = remote.match(/^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/i);
@@ -455,10 +439,10 @@ export const deliverWorkspace = async (
   workspace: Workspace,
   dependencies: DeliverWorkspaceDependencies = {},
 ): Promise<DeliveryResult> => {
-  const command = dependencies.command ?? executeCommand(config);
+  const command = dependencies.command
+    ?? bindCommandRunner(config.runAsPrefix, workspace.path, workspaceEnvironment(config));
   const recordPublication = dependencies.recordPublication ?? (async () => undefined);
   const retryOptions = dependencies.retryOptions ?? {};
-  const env = workspaceEnvironment(config);
   const remote = claim.repo.remoteUrl;
   const canonicalImplementation = isCanonicalPrImplementation(claim);
   const canonicalFinal = isCanonicalPrFinal(claim);
@@ -522,7 +506,7 @@ export const deliverWorkspace = async (
   // contract requires a commit. Optional-commit Runs still publish the shared
   // branch below so later Chain Steps have a durable remote ref.
   try {
-    const head = dependencies.headSha ?? await command("git", ["rev-parse", "HEAD"], workspace.path, env,
+    const head = dependencies.headSha ?? await command("git", ["rev-parse", "HEAD"],
       { timeoutMs: boundedTimeout(retryOptions, WORKSPACE_HEAD_TIMEOUT_MS) });
     if (canonicalPr) {
       const currentOutput = canonicalOutputs?.at(-1);
@@ -558,7 +542,7 @@ export const deliverWorkspace = async (
   }
   if (canonicalFinal) {
     try {
-      const trackedChain = await command("git", ["ls-tree", "-r", "--name-only", "HEAD", "--", ".chain"], workspace.path, env,
+      const trackedChain = await command("git", ["ls-tree", "-r", "--name-only", "HEAD", "--", ".chain"],
         { timeoutMs: boundedTimeout(retryOptions, WORKSPACE_HEAD_TIMEOUT_MS) });
       if (trackedChain.trim().length > 0) {
         const reason = "canonical PR final delivery requires a clean tracked .chain tree";
@@ -586,7 +570,7 @@ export const deliverWorkspace = async (
   // lets the *next* step of the chain clone it.
   try {
     await runWithNetworkRetry("git", ["push"],
-      ({ timeoutMs }) => command("git", ["push", "--set-upstream", "origin", workspace.branch], workspace.path, env, { timeoutMs }),
+      ({ timeoutMs }) => command("git", ["push", "--set-upstream", "origin", workspace.branch], { timeoutMs }),
       retryOptions,
     );
   } catch (error: unknown) {
@@ -631,7 +615,7 @@ export const deliverWorkspace = async (
     // Capped against the same phase deadline as everything else here: this is
     // the one command in delivery that is not on the retry allowlist, and a
     // hung `gh` would otherwise stall the phase before the budget applies.
-    await command("gh", ["--version"], workspace.path, env, { timeoutMs: boundedTimeout(retryOptions, GH_PROBE_TIMEOUT_MS) });
+    await command("gh", ["--version"], { timeoutMs: boundedTimeout(retryOptions, GH_PROBE_TIMEOUT_MS) });
   } catch (error: unknown) {
     if (!opensPullRequest && !canonicalFinal) return noPullRequest(workspace.branch, remote);
     const reason = messageOf(error);
@@ -657,7 +641,7 @@ export const deliverWorkspace = async (
       "pr", "list", "--repo", repo, "--head", workspace.branch, "--state", "open", "--limit", "1", "--json", "url,number",
     ];
     const raw = await runWithNetworkRetry("gh", args,
-      ({ timeoutMs }) => command("gh", args, workspace.path, env, { timeoutMs }),
+      ({ timeoutMs }) => command("gh", args, { timeoutMs }),
       { ...retryOptions, ...(inherited.deadline === undefined ? {} : { deadline: inherited.deadline }) },
     );
     let parsed: unknown;
@@ -688,14 +672,13 @@ export const deliverWorkspace = async (
     const editArguments = [
       "pr", "edit", String(pullRequest.number), "--repo", repo, "--body", body,
     ];
-    await command("gh", editArguments, workspace.path, env,
-      { timeoutMs: boundedTimeout(retryOptions, NETWORK_COMMAND_TIMEOUT_MS) });
+    await command("gh", editArguments, { timeoutMs: boundedTimeout(retryOptions, NETWORK_COMMAND_TIMEOUT_MS) });
     const readArguments = [
       "pr", "view", String(pullRequest.number), "--repo", repo, "--json", "body", "--jq", ".body",
     ];
     let readBack: string;
     try {
-      readBack = readPullRequestBody(await command("gh", readArguments, workspace.path, env,
+      readBack = readPullRequestBody(await command("gh", readArguments,
         { timeoutMs: boundedTimeout(retryOptions, NETWORK_COMMAND_TIMEOUT_MS) }));
     } catch (error: unknown) {
       throw new Error(`pull request body read-back was unreadable: ${messageOf(error)}`, { cause: error });
@@ -770,7 +753,7 @@ export const deliverWorkspace = async (
       ),
       attempt: async () => {
         try {
-          const stdout = await command("gh", createArguments, workspace.path, env,
+          const stdout = await command("gh", createArguments,
             { timeoutMs: boundedTimeout(retryOptions, NETWORK_COMMAND_TIMEOUT_MS) });
           // `gh pr create` prints the URL of the pull request it made. Taking
           // the identity from the write's own answer is what removes the
@@ -910,30 +893,25 @@ export const salvageWorkspace = async (
   workspace: Workspace,
   dependencies: SalvageWorkspaceDependencies = {},
 ): Promise<DeliveryResult | null> => {
-  const command = dependencies.command ?? executeCommand(config);
+  const command = dependencies.command
+    ?? bindCommandRunner(config.runAsPrefix, workspace.path, workspaceEnvironment(config));
   const retryOptions = dependencies.retryOptions ?? {};
-  const env = workspaceEnvironment(config);
   const remote = identity.remoteUrl ?? "origin";
   const branch = `agentos/${identity.taskId}/run-${identity.runNumber}`;
   try {
     // Respect .gitignore while including tracked deletions and untracked files.
-    await command("git", ["add", "-A"], workspace.path, env);
-    const status = await command("git", ["status", "--porcelain"], workspace.path, env);
+    await command("git", ["add", "-A"]);
+    const status = await command("git", ["status", "--porcelain"]);
     if (status) {
-      await command(
-        "git",
-        platformCommitArgs(`WIP salvage for Anneal run ${identity.runId}`),
-        workspace.path,
-        env,
-      );
+      await command("git", platformCommitArgs(`WIP salvage for Anneal run ${identity.runId}`));
     }
-    const head = await command("git", ["rev-parse", "HEAD"], workspace.path, env);
+    const head = await command("git", ["rev-parse", "HEAD"]);
     // A clean run branch that never diverged from its base has nothing to push.
     if (head === workspace.baseSha) return null;
     // Plain push, never forced: the run branch is unique per (task, run), so a
     // rejection means something else is there and salvaging must not clobber it.
     await runWithNetworkRetry("git", ["push"],
-      ({ timeoutMs }) => command("git", ["push", "origin", `HEAD:refs/heads/${branch}`], workspace.path, env, { timeoutMs }),
+      ({ timeoutMs }) => command("git", ["push", "origin", `HEAD:refs/heads/${branch}`], { timeoutMs }),
       retryOptions,
     );
     return {

--- a/packages/runner/src/dependency-cache.test.ts
+++ b/packages/runner/src/dependency-cache.test.ts
@@ -18,9 +18,9 @@ import {
   DEPENDENCY_PROVISIONING_MANIFEST_MISSING, DependencyCacheInputMissError,
   DependencyProvisioningManifestMissingError, deriveDependencyCacheKey,
   materializeWorkspaceDependencies,
-  type DependencyCacheProgress, type DependencyCommandExecutor,
+  type DependencyCacheProgress,
 } from "./dependency-cache.js";
-import { CommandTimeoutError, runCommand } from "./exec.js";
+import { bindCommandRunner, CommandTimeoutError, runCommand, type CommandRunner } from "./exec.js";
 import { provisionWorkspace, workspaceEnvironment, type WorkspaceProvisionClaim } from "./workspace.js";
 
 const TOOLCHAIN: DependencyCacheToolchain = {
@@ -89,8 +89,9 @@ const createFixture = async (workspace: string, withLifecycle = true): Promise<v
   ]);
 };
 
-const realExecutor: DependencyCommandExecutor = (runnerConfig, executable, args, cwd, env, options) =>
-  runCommand(runnerConfig.runAsPrefix, executable, args, cwd, env, options);
+/** The production runner, bound the way a caller of the cache binds it. */
+const boundRun = (configured: RunnerConfig, cwd: string): CommandRunner =>
+  bindCommandRunner(configured.runAsPrefix, cwd, workspaceEnvironment(configured));
 
 const fakeInstallExecutor = (
   onInstall: (cwd: string) => Promise<void> = async (cwd) => {
@@ -99,20 +100,20 @@ const fakeInstallExecutor = (
     await writeFile(join(cwd, "node_modules/fake-package/index.js"), "cached root\n");
     await writeFile(join(cwd, "packages/db/node_modules/nested-package/index.js"), "cached nested\n");
   },
-): { execute: DependencyCommandExecutor; installs: () => number; calls: Array<{ executable: string; args: string[]; prefix: string[] }> } => {
+): { run: (workspace: string) => CommandRunner; installs: () => number; calls: Array<{ executable: string; args: string[] }> } => {
   let installCalls = 0;
-  const calls: Array<{ executable: string; args: string[]; prefix: string[] }> = [];
+  const calls: Array<{ executable: string; args: string[] }> = [];
   return {
     calls,
     installs: () => installCalls,
-    execute: async (runnerConfig, executable, args, cwd, env, options) => {
-      calls.push({ executable, args: [...args], prefix: [...runnerConfig.runAsPrefix] });
+    run: (workspace) => async (executable, args, options) => {
+      calls.push({ executable, args: [...args] });
       if (executable === "node" && args[0] === "--input-type=commonjs") return JSON.stringify(TOOLCHAIN);
       if (executable === "npm" && args[0] === "--version") return TOOLCHAIN.npm;
       if (executable === "npm" && args[0] === "config") return '{"install-links":true,"//registry.npmjs.org/:_authToken":"must-not-be-hashed"}';
       if (executable === "npm" && args[0] === "ci") {
         installCalls += 1;
-        await onInstall(cwd);
+        await onInstall(workspace);
         return "";
       }
       // The fake proves restore behavior without making unit coverage depend on
@@ -123,9 +124,7 @@ const fakeInstallExecutor = (
         await cp(source, destination, { recursive: true, preserveTimestamps: true, verbatimSymlinks: true });
         return "";
       }
-      // Tests use a synthetic prefix to prove routing; executing it would test
-      // the host launcher rather than this boundary.
-      return runCommand([], executable, args, cwd, env, options);
+      return runCommand([], executable, args, options?.cwd ?? workspace, process.env, options);
     },
   };
 };
@@ -133,17 +132,12 @@ const fakeInstallExecutor = (
 const entryPath = (root: string, key: string): string => join(root, "cache", "entries", key);
 
 // The key is derived through the path a run takes, so a derivation needs the
-// run's configuration, environment, and command executor.
+// run's command runner.
 const deriveFixtureKey = (
-  root: string,
   workspace: string,
   toolchain: DependencyCacheToolchain = TOOLCHAIN,
-): ReturnType<typeof deriveDependencyCacheKey> => {
-  const configured = config(root);
-  return deriveDependencyCacheKey(
-    configured, workspace, workspaceEnvironment(configured), { execute: fakeInstallExecutor().execute }, { toolchain },
-  );
-};
+): ReturnType<typeof deriveDependencyCacheKey> =>
+  deriveDependencyCacheKey(workspace, fakeInstallExecutor().run(workspace), { toolchain });
 
 const makeWritable = async (path: string): Promise<void> => {
   const info = await lstat(path);
@@ -178,7 +172,7 @@ const publishFixtureVersions = async (root: string, versions: string[]) => {
     await createFixture(workspace);
     await writeFile(join(workspace, "package-lock.json"), packageLock(version));
     const result = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(result.key);
@@ -234,7 +228,7 @@ test("a miss publishes complete root and workspace targets, then a hit restores 
     const events: DependencyCacheProgress[] = [];
     const configured = config(root);
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(first.status, "installed");
@@ -259,7 +253,7 @@ test("a miss publishes complete root and workspace targets, then a hit restores 
     await writeFile(join(workspace, "node_modules/fake-package/index.js"), "workspace mutation\n");
 
     const second = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(second.status, "restored");
@@ -294,8 +288,7 @@ test("NPM_CI fails loudly when the root package manifest is missing and audits t
       materializeWorkspaceDependencies(
         configured,
         workspace,
-        workspaceEnvironment(configured),
-        { execute: fake.execute },
+        fake.run(workspace),
         { report: (event) => events.push(event) },
       ),
       (error: unknown) => error instanceof DependencyProvisioningManifestMissingError
@@ -327,19 +320,19 @@ test("a cache hit rebuilds binding.gyp workspaces whose install artifacts live o
       await writeFile(nativeOutput, "installed native addon\n");
     });
     const rebuilds: string[][] = [];
-    const execute: DependencyCommandExecutor = async (runnerConfig, executable, args, cwd, env, options) => {
+    const configured = config(root);
+    const execute: CommandRunner = async (executable, args, options) => {
       if (executable === "npm" && args[0] === "rebuild") {
         rebuilds.push([...args]);
         await mkdir(dirname(nativeOutput), { recursive: true });
         await writeFile(nativeOutput, "rebuilt native addon\n");
         return "";
       }
-      return fake.execute(runnerConfig, executable, args, cwd, env, options);
+      return fake.run(workspace)(executable, args, options);
     };
-    const configured = config(root);
 
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute },
+      configured, workspace, execute,
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(first.status, "installed");
@@ -347,7 +340,7 @@ test("a cache hit rebuilds binding.gyp workspaces whose install artifacts live o
     await rm(join(workspace, "apps/web/build"), { recursive: true });
 
     const second = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute },
+      configured, workspace, execute,
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(second.status, "restored");
@@ -363,7 +356,7 @@ test("every dependency input and toolchain coordinate changes the cache key", as
   try {
     const workspace = join(root, "workspace");
     await createFixture(workspace);
-    const baseline = await deriveFixtureKey(root, workspace);
+    const baseline = await deriveFixtureKey(workspace);
     assert.ok(baseline);
     const cases: Array<{ path: string; content: string }> = [
       { path: "package-lock.json", content: packageLock("1.0.1") },
@@ -376,13 +369,13 @@ test("every dependency input and toolchain coordinate changes the cache key", as
       const absolute = join(workspace, change.path);
       const original = await readFile(absolute, "utf8");
       await writeFile(absolute, change.content);
-      const changed = await deriveFixtureKey(root, workspace);
+      const changed = await deriveFixtureKey(workspace);
       assert.ok(changed);
       assert.notEqual(changed.key, baseline.key, `${change.path} did not change the key`);
       await writeFile(absolute, original);
     }
     for (const coordinate of Object.keys(TOOLCHAIN) as Array<keyof DependencyCacheToolchain>) {
-      const changed = await deriveFixtureKey(root, workspace, { ...TOOLCHAIN, [coordinate]: `${TOOLCHAIN[coordinate]}-drift` });
+      const changed = await deriveFixtureKey(workspace, { ...TOOLCHAIN, [coordinate]: `${TOOLCHAIN[coordinate]}-drift` });
       assert.ok(changed);
       assert.notEqual(changed.key, baseline.key, `${coordinate} did not change the key`);
     }
@@ -399,11 +392,11 @@ test("the shipped cache key stays byte-identical to the recorded fixture key", a
     const configured = config(root);
     const fake = fakeInstallExecutor();
     const shipped = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(shipped.key, FIXTURE_CACHE_KEY, "a changed key misses every published cache entry");
-    const derived = await deriveFixtureKey(root, workspace);
+    const derived = await deriveFixtureKey(workspace);
     assert.equal(derived?.key, FIXTURE_CACHE_KEY);
   } finally {
     await cleanupRoot(root);
@@ -415,18 +408,16 @@ test("the effective npm configuration is one of the derived inputs", async () =>
   try {
     const workspace = join(root, "workspace");
     await createFixture(workspace);
-    const configured = config(root);
     const fake = fakeInstallExecutor();
     let effective = '{"install-links":true}';
-    const execute: DependencyCommandExecutor = (runnerConfig, executable, args, cwd, env, options) =>
+    const execute: CommandRunner = (executable, args, options) =>
       executable === "npm" && args[0] === "config"
         ? Promise.resolve(effective)
-        : fake.execute(runnerConfig, executable, args, cwd, env, options);
-    const environment = workspaceEnvironment(configured);
-    const baseline = await deriveDependencyCacheKey(configured, workspace, environment, { execute }, { toolchain: TOOLCHAIN });
+        : fake.run(workspace)(executable, args, options);
+    const baseline = await deriveDependencyCacheKey(workspace, execute, { toolchain: TOOLCHAIN });
     assert.ok(baseline);
     effective = '{"install-links":false}';
-    const drifted = await deriveDependencyCacheKey(configured, workspace, environment, { execute }, { toolchain: TOOLCHAIN });
+    const drifted = await deriveDependencyCacheKey(workspace, execute, { toolchain: TOOLCHAIN });
     assert.ok(drifted);
     assert.notEqual(drifted.key, baseline.key, "effective npm configuration drift must change the key");
   } finally {
@@ -441,7 +432,7 @@ test("missing required inputs are named misses while unreadable or ambiguous inp
     await createFixture(workspace);
     await rm(join(workspace, "packages/db/prisma/schema.prisma"));
     await assert.rejects(
-      deriveFixtureKey(root, workspace),
+      deriveFixtureKey(workspace),
       (error: unknown) => error instanceof DependencyCacheInputMissError
         && error.condition === "required-input-missing:packages/db/prisma/schema.prisma",
     );
@@ -449,7 +440,7 @@ test("missing required inputs are named misses while unreadable or ambiguous inp
     const configured = config(root);
     const events: DependencyCacheProgress[] = [];
     const installed = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(installed.status, "installed");
@@ -460,11 +451,11 @@ test("missing required inputs are named misses while unreadable or ambiguous inp
     await writeFile(join(workspace, "packages/db/prisma/schema.prisma"), "generator client { provider = \"prisma-client-js\" }\n");
     await rm(join(workspace, "package-lock.json"));
     await symlink(join(workspace, "package.json"), join(workspace, "package-lock.json"));
-    await assert.rejects(deriveFixtureKey(root, workspace), /package-lock\.json is symlink/u);
+    await assert.rejects(deriveFixtureKey(workspace), /package-lock\.json is symlink/u);
     await rm(join(workspace, "package-lock.json"));
     await writeFile(join(workspace, "package-lock.json"), packageLock());
     await chmod(join(workspace, ".npmrc"), 0o000);
-    await assert.rejects(deriveFixtureKey(root, workspace), /Unreadable dependency input: \.npmrc/u);
+    await assert.rejects(deriveFixtureKey(workspace), /Unreadable dependency input: \.npmrc/u);
     await chmod(join(workspace, ".npmrc"), 0o600);
   } finally {
     await cleanupRoot(root);
@@ -482,41 +473,38 @@ test("effective user npm configuration and the child Node tuple determine the pr
     const configured = { ...config(root), home };
     const fake = fakeInstallExecutor();
     let child = { node: "v22.1.0", operatingSystem: "darwin", architecture: "arm64" };
-    const childProbes: Array<{ prefix: string[]; home: string | undefined; timeoutMs: number | undefined }> = [];
-    const execute: DependencyCommandExecutor = async (runnerConfig, executable, args, cwd, env, options) => {
+    const childProbes: Array<{ timeoutMs: number | undefined }> = [];
+    const execute: CommandRunner = async (executable, args, options) => {
       if (executable === "node" && args[0] === "--input-type=commonjs") {
-        childProbes.push({ prefix: [...runnerConfig.runAsPrefix], home: env.HOME, timeoutMs: options?.timeoutMs });
+        childProbes.push({ timeoutMs: options?.timeoutMs });
         return JSON.stringify(child);
       }
       if (executable === "npm" && args[0] === "config") {
-        const content = await readFile(join(runnerConfig.home, ".npmrc"), "utf8");
+        const content = await readFile(join(configured.home, ".npmrc"), "utf8");
         const omit = /^omit=(.+)$/mu.exec(content)?.[1] ?? "";
         const token = /_authToken=(.+)$/mu.exec(content)?.[1] ?? "";
         return JSON.stringify({ omit, "//registry.npmjs.org/:_authToken": token });
       }
-      return fake.execute(runnerConfig, executable, args, cwd, env, options);
+      return fake.run(workspace)(executable, args, options);
     };
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute }, { report: () => undefined },
+      configured, workspace, execute, { report: () => undefined },
     );
     await writeFile(join(home, ".npmrc"), "omit=dev\n//registry.npmjs.org/:_authToken=second-secret\n");
     const configDrift = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute }, { report: () => undefined },
+      configured, workspace, execute, { report: () => undefined },
     );
     assert.notEqual(configDrift.key, first.key, "effective user config drift must change the key");
     child = { ...child, node: "v23.0.0", architecture: "x64" };
     const childDrift = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute }, { report: () => undefined },
+      configured, workspace, execute, { report: () => undefined },
     );
     assert.notEqual(childDrift.key, configDrift.key, "the key must follow child Node coordinates");
     assert.equal(fake.installs(), 3);
     assert.ok(childProbes.length >= 3);
-    assert.ok(childProbes.every((probe) => probe.home === home && probe.timeoutMs === 10_000));
-    assert.ok(childProbes.every(({ prefix }) => assert.deepEqual(prefix, configured.runAsPrefix) === undefined));
+    assert.ok(childProbes.every((probe) => probe.timeoutMs === 10_000));
     const metadata = await readFile(join(entryPath(root, childDrift.key!), "metadata.json"), "utf8");
     assert.ok(!metadata.includes("first-secret") && !metadata.includes("second-secret"));
-    const probes = fake.calls.filter(({ executable }) => executable === "npm");
-    assert.ok(probes.every(({ prefix }) => assert.deepEqual(prefix, configured.runAsPrefix) === undefined));
   } finally {
     await cleanupRoot(root);
   }
@@ -535,7 +523,7 @@ test("non-Prisma and alternate-schema repositories install and key their actual 
     const configured = config(root);
     const events: DependencyCacheProgress[] = [];
     const plain = await materializeWorkspaceDependencies(
-      configured, nonPrisma, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, nonPrisma, fake.run(nonPrisma),
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(plain.status, "installed");
@@ -548,10 +536,10 @@ test("non-Prisma and alternate-schema repositories install and key their actual 
     await writeFile(join(alternate, "package.json"), `${JSON.stringify(alternateManifest)}\n`);
     await mkdir(join(alternate, "config"));
     await writeFile(join(alternate, "config/alternate.prisma"), "generator client { provider = \"prisma-client-js\" }\n");
-    const first = await deriveFixtureKey(root, alternate);
+    const first = await deriveFixtureKey(alternate);
     assert.ok(first);
     await writeFile(join(alternate, "config/alternate.prisma"), "generator client { provider = \"prisma-client-js\" output = \"../generated\" }\n");
-    const drifted = await deriveFixtureKey(root, alternate);
+    const drifted = await deriveFixtureKey(alternate);
     assert.ok(drifted);
     assert.notEqual(drifted.key, first.key);
   } finally {
@@ -572,7 +560,7 @@ test("symlinked workspace targets and cache roots are rejected without following
     const configured = config(root);
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
+        configured, workspace, fake.run(workspace), { toolchain: TOOLCHAIN, report: () => undefined },
       ),
       /Dependency target is a symlink: node_modules/u,
     );
@@ -584,7 +572,7 @@ test("symlinked workspace targets and cache roots are rejected without following
     await symlink(join(root, "outside-cache"), join(root, "cache-link"));
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+        configured, workspace, fake.run(workspace),
         { cacheRoot: join(root, "cache-link"), toolchain: TOOLCHAIN, report: () => undefined },
       ),
       /Dependency cache root is a symlink/u,
@@ -658,14 +646,14 @@ for (const corruption of corruptions) test(`refuses ${corruption.name} cache ent
     const fake = fakeInstallExecutor();
     const configured = config(root);
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
+      configured, workspace, fake.run(workspace), { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(first.key);
     await corruption.corrupt(entryPath(root, first.key), root);
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+        configured, workspace, fake.run(workspace),
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /(?:integrity|cache).*?(?:refusal|unsafe|malformed|missing|mismatch|escape|directory)/iu,
@@ -687,11 +675,11 @@ test("an unrelated malformed retention entry refuses the pass after a valid hit"
     await Promise.all([createFixture(firstWorkspace), createFixture(secondWorkspace)]);
     await writeFile(join(secondWorkspace, "package-lock.json"), packageLock("2.0.0"));
     const first = await materializeWorkspaceDependencies(
-      configured, firstWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, firstWorkspace, fake.run(firstWorkspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     const second = await materializeWorkspaceDependencies(
-      configured, secondWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, secondWorkspace, fake.run(secondWorkspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     const firstKey = first.key;
@@ -703,7 +691,7 @@ test("an unrelated malformed retention entry refuses the pass after a valid hit"
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, secondWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
+        configured, secondWorkspace, fake.run(secondWorkspace),
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /(?:integrity|retention|malformed|unsafe)/iu,
@@ -755,7 +743,7 @@ for (const malformed of malformedRetentionMetadata) {
       const events: DependencyCacheProgress[] = [];
       await assert.rejects(
         materializeWorkspaceDependencies(
-          configured, current.workspace, workspaceEnvironment(configured), { execute: fake.execute },
+          configured, current.workspace, fake.run(current.workspace),
           { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
         ),
         /metadata-malformed/u,
@@ -845,7 +833,7 @@ for (const corruption of unrelatedRetentionCorruptions) {
       const events: DependencyCacheProgress[] = [];
       await assert.rejects(
         materializeWorkspaceDependencies(
-          configured, current.workspace, workspaceEnvironment(configured), { execute: fake.execute },
+          configured, current.workspace, fake.run(current.workspace),
           { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
         ),
         corruption.condition,
@@ -873,7 +861,7 @@ test("orphan publication stages and non-key usage files do not brick retention",
     await writeFile(strayUsage, "not a cache usage marker\n");
 
     const result = await materializeWorkspaceDependencies(
-      configured, current.workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, current.workspace, fake.run(current.workspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
 
@@ -896,11 +884,11 @@ test("an unsafe usage marker refuses retention instead of allowing an over-budge
     await Promise.all([createFixture(firstWorkspace), createFixture(secondWorkspace)]);
     await writeFile(join(secondWorkspace, "package-lock.json"), packageLock("2.1.0"));
     const first = await materializeWorkspaceDependencies(
-      configured, firstWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, firstWorkspace, fake.run(firstWorkspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     const second = await materializeWorkspaceDependencies(
-      configured, secondWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, secondWorkspace, fake.run(secondWorkspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     const firstKey = first.key;
@@ -912,7 +900,7 @@ test("an unsafe usage marker refuses retention instead of allowing an over-budge
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, secondWorkspace, workspaceEnvironment(configured), { execute: fake.execute },
+        configured, secondWorkspace, fake.run(secondWorkspace),
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /(?:integrity|usage|marker|unsafe)/iu,
@@ -932,7 +920,7 @@ test("a selected unsafe usage marker refuses before a missing entry can trigger 
     const configured = config(root);
     const fake = fakeInstallExecutor();
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(first.key);
@@ -945,7 +933,7 @@ test("a selected unsafe usage marker refuses before a missing entry can trigger 
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+        configured, workspace, fake.run(workspace),
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /unsafe-usage-marker/u,
@@ -969,11 +957,11 @@ test("dependency-cache audit payloads retain stable event names and fields", asy
     const configured = config(root);
     const events: DependencyCacheProgress[] = [];
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     const second = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
     );
     assert.equal(second.status, "restored");
@@ -1015,7 +1003,7 @@ test("cache materialization blocks behind an existing exclusive root lock", asyn
     const configured = config(root);
     const fake = fakeInstallExecutor();
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.ok(first.key);
@@ -1023,7 +1011,7 @@ test("cache materialization blocks behind an existing exclusive root lock", asyn
     try {
       let settled = false;
       const blocked = materializeWorkspaceDependencies(
-        configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+        configured, workspace, fake.run(workspace),
         { toolchain: TOOLCHAIN, report: () => undefined },
       ).finally(() => { settled = true; });
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -1060,7 +1048,7 @@ test("concurrent publishers converge on one valid immutable entry", async () => 
     });
     const configured = config(root);
     const results = await Promise.all(workspaces.map((workspace) => materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
+      configured, workspace, fake.run(workspace), { toolchain: TOOLCHAIN, report: () => undefined },
     )));
     assert.equal(fake.installs(), 2);
     assert.equal(new Set(results.map(({ key }) => key)).size, 1);
@@ -1094,16 +1082,16 @@ test("over-budget enforcement waits for an active restore and evicts only the sa
     const restoreBarrier = new Promise<void>((resolve) => { releaseRestore = resolve; });
     let paused = false;
     const fake = fakeInstallExecutor();
-    const execute: DependencyCommandExecutor = async (...args) => {
-      if (args[1] === "/bin/cp" && !paused) {
+    const execute: CommandRunner = async (executable, args, options) => {
+      if (executable === "/bin/cp" && !paused) {
         paused = true;
         restoreArrived();
         await restoreBarrier;
       }
-      return fake.execute(...args);
+      return fake.run(active.workspace)(executable, args, options);
     };
     const restoring = materializeWorkspaceDependencies(
-      configured, active.workspace, workspaceEnvironment(configured), { execute },
+      configured, active.workspace, execute,
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     await restoreStarted;
@@ -1141,8 +1129,8 @@ test("over-budget enforcement waits for concurrent publication convergence and p
       await createFixture(workspace);
       await writeFile(join(workspace, "package-lock.json"), packageLock("6.2.1"));
     }));
-    const publishedKey = (await deriveFixtureKey(root, workspaces[0]!))?.key;
-    assert.ok(publishedKey && publishedKey === (await deriveFixtureKey(root, workspaces[1]!))?.key);
+    const publishedKey = (await deriveFixtureKey(workspaces[0]!))?.key;
+    assert.ok(publishedKey && publishedKey === (await deriveFixtureKey(workspaces[1]!))?.key);
     let arrivals = 0;
     let publishersArrived!: () => void;
     const publishersStarted = new Promise<void>((resolve) => { publishersArrived = resolve; });
@@ -1158,7 +1146,7 @@ test("over-budget enforcement waits for concurrent publication convergence and p
       await writeFile(join(cwd, "packages/db/node_modules/nested-package/index.js"), "converged nested\n");
     });
     const resultsPromise = Promise.all(workspaces.map((workspace) => materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     )));
     await publishersStarted;
@@ -1198,7 +1186,7 @@ test("a malformed unrelated size walk emits integrity refusal without invoking n
     const events: DependencyCacheProgress[] = [];
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, current.workspace, workspaceEnvironment(configured), { execute: fake.execute },
+        configured, current.workspace, fake.run(current.workspace),
         { toolchain: TOOLCHAIN, report: (event) => events.push(event) },
       ),
       /special-file/u,
@@ -1209,30 +1197,6 @@ test("a malformed unrelated size walk emits integrity refusal without invoking n
       events.find(({ event }) => event === "integrity-refusal"),
       { event: "integrity-refusal", key: unrelated.key.slice(0, 16), condition: "special-file" },
     );
-  } finally {
-    await cleanupRoot(root);
-  }
-});
-
-test("workspace mutations always flow through the configured run-as execution identity", async () => {
-  const root = await mkdtemp(join(tmpdir(), "runner-dependency-cache-prefix-"));
-  try {
-    const workspace = join(root, "workspace");
-    await createFixture(workspace);
-    const prefix = ["synthetic-launcher", "--account", "agent-runner"];
-    const configured = config(root, prefix);
-    const fake = fakeInstallExecutor();
-    await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
-    );
-    await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute }, { toolchain: TOOLCHAIN, report: () => undefined },
-    );
-    const mutations = fake.calls.filter(({ executable, args }) =>
-      (executable === "npm" && args[0] === "ci") || ["/bin/rm", "/bin/cp", "/bin/chmod"].includes(executable));
-    assert.ok(mutations.some(({ executable }) => executable === "npm"));
-    assert.ok(mutations.some(({ executable }) => executable === "/bin/cp"));
-    assert.ok(mutations.every(({ prefix: observed }) => assert.deepEqual(observed, prefix) === undefined));
   } finally {
     await cleanupRoot(root);
   }
@@ -1257,7 +1221,7 @@ test("dependency discovery does not enumerate a workspace root without read perm
     });
     const configured = config(root);
     const result = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute: fake.execute },
+      configured, workspace, fake.run(workspace),
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(result.status, "installed");
@@ -1287,24 +1251,25 @@ test("a distinct run-as uid restores readable cache entries and owns the workspa
     await chmod(root, 0o755);
     await chmod(workspace, 0o711);
     const configured = config(root, ["/usr/bin/sudo", "-n", "-u", targetUser, "--"]);
-    const execute: DependencyCommandExecutor = async (runnerConfig, executable, args, cwd, env, options) => {
+    const real = boundRun(configured, workspace);
+    const execute: CommandRunner = async (executable, args, options) => {
       if (executable === "npm" && args[0] === "config") return "{}";
       if (executable === "npm" && args[0] === "ci") {
-        return runCommand(runnerConfig.runAsPrefix, "/bin/sh", [
+        return real("/bin/sh", [
           "-c",
           "mkdir -p node_modules/owned-package packages/db/node_modules/owned-nested && printf owned > node_modules/owned-package/index.js && printf nested > packages/db/node_modules/owned-nested/index.js",
-        ], cwd, env, options);
+        ], options);
       }
-      return realExecutor(runnerConfig, executable, args, cwd, env, options);
+      return real(executable, args, options);
     };
     const first = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute },
+      configured, workspace, execute,
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(first.status, "installed");
     await runCommand(configured.runAsPrefix, "/bin/sh", ["-c", "printf changed > node_modules/owned-package/index.js"], workspace, workspaceEnvironment(configured));
     const second = await materializeWorkspaceDependencies(
-      configured, workspace, workspaceEnvironment(configured), { execute },
+      configured, workspace, execute,
       { toolchain: TOOLCHAIN, report: () => undefined },
     );
     assert.equal(second.status, "restored");
@@ -1322,17 +1287,18 @@ test("a non-terminating npm install receives a process-group timeout", async () 
     const workspace = join(root, "workspace");
     await createFixture(workspace);
     const configured = config(root);
-    const execute: DependencyCommandExecutor = async (runnerConfig, executable, args, cwd, env, options) => {
+    const real = boundRun(configured, workspace);
+    const execute: CommandRunner = async (executable, args, options) => {
       if (executable === "npm" && args[0] === "config") return "{}";
       if (executable === "npm" && args[0] === "ci") {
-        return runCommand(runnerConfig.runAsPrefix, process.execPath, ["-e", "setInterval(() => {}, 1000)"], cwd, env, options);
+        return real(process.execPath, ["-e", "setInterval(() => {}, 1000)"], options);
       }
-      return realExecutor(runnerConfig, executable, args, cwd, env, options);
+      return real(executable, args, options);
     };
     const started = Date.now();
     await assert.rejects(
       materializeWorkspaceDependencies(
-        configured, workspace, workspaceEnvironment(configured), { execute },
+        configured, workspace, execute,
         {
           toolchain: TOOLCHAIN,
           installRetryOptions: { attempts: 1, commandTimeoutMs: 50, budgetMs: 10_000 },
@@ -1377,10 +1343,11 @@ test("branch and pinned-detached provisioning materialize a usable scratch repos
     const configured = config(root);
     await mkdir(configured.workspaceRoot, { recursive: true });
     let installs = 0;
-    const execute: DependencyCommandExecutor = async (runnerConfig, executable, args, cwd, env, options) => {
+    const real = boundRun(configured, configured.workspaceRoot);
+    const execute: CommandRunner = async (executable, args, options) => {
       if (executable === "npm" && args[0] === "ci") installs += 1;
       if (executable === "npm" && args[0] === "config") return '{"install-links":true}';
-      return realExecutor(runnerConfig, executable, args, cwd, env, options);
+      return real(executable, args, options);
     };
     const branchClaim = {
       executionMode: "agent",
@@ -1404,7 +1371,7 @@ test("branch and pinned-detached provisioning materialize a usable scratch repos
       branchClaim,
       { provision: true },
       {
-        execute,
+        run: execute,
         retryOptions: { attempts: 1 },
         dependencyCacheOptions: { report: () => undefined },
       },
@@ -1441,7 +1408,7 @@ test("branch and pinned-detached provisioning materialize a usable scratch repos
       pinnedClaim,
       { provision: true },
       {
-        execute,
+        run: execute,
         retryOptions: { attempts: 1 },
         dependencyCacheOptions: { report: () => undefined },
       },

--- a/packages/runner/src/dependency-cache.ts
+++ b/packages/runner/src/dependency-cache.ts
@@ -9,25 +9,12 @@ import {
   type CacheEntryDocument, type CacheEntryExpectation, type CacheEntryInput, type CacheEntryStore,
   type CacheEntryTarget, type DependencyCacheToolchain,
 } from "./dependency-cache-store.js";
-import type { CommandOptions } from "./exec.js";
+import { commandRunnerIn, type CommandRunner } from "./exec.js";
 import {
   NPM_INSTALL_COMMAND_TIMEOUT_MS, NPM_INSTALL_OPERATION_BUDGET_MS, runWithNetworkRetry, type RetryOptions,
 } from "./network-retry.js";
 
 const NPM_PROBE_TIMEOUT_MS = 10_000;
-
-export type DependencyCommandExecutor = (
-  config: RunnerConfig,
-  executable: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  options?: CommandOptions,
-) => Promise<string>;
-
-export type DependencyCacheDependencies = {
-  execute: DependencyCommandExecutor;
-};
 
 type DependencyProject = {
   inputs: CacheEntryInput[];
@@ -394,18 +381,10 @@ const validatedToolchain = (toolchain: DependencyCacheToolchain): DependencyCach
   return toolchain;
 };
 
-const currentToolchain = async (
-  config: RunnerConfig,
-  workspace: string,
-  env: NodeJS.ProcessEnv,
-  execute: DependencyCommandExecutor,
-): Promise<DependencyCacheToolchain> => {
-  const childCoordinates = parseJsonObject(await execute(
-    config,
+const currentToolchain = async (run: CommandRunner): Promise<DependencyCacheToolchain> => {
+  const childCoordinates = parseJsonObject(await run(
     "node",
     ["--input-type=commonjs", "-e", "process.stdout.write(JSON.stringify({node:process.version,operatingSystem:process.platform,architecture:process.arch}))"],
-    workspace,
-    env,
     { timeoutMs: NPM_PROBE_TIMEOUT_MS },
   ), "child Node toolchain");
   const coordinate = (name: "node" | "operatingSystem" | "architecture"): string => {
@@ -415,7 +394,7 @@ const currentToolchain = async (
   };
   return validatedToolchain({
     node: coordinate("node"),
-    npm: (await execute(config, "npm", ["--version"], workspace, env, { timeoutMs: NPM_PROBE_TIMEOUT_MS })).trim(),
+    npm: (await run("npm", ["--version"], { timeoutMs: NPM_PROBE_TIMEOUT_MS })).trim(),
     operatingSystem: coordinate("operatingSystem"),
     architecture: coordinate("architecture"),
   });
@@ -444,13 +423,8 @@ const canonicalValue = (value: unknown, key = ""): unknown => {
   return value;
 };
 
-const effectiveNpmConfigInput = async (
-  config: RunnerConfig,
-  workspace: string,
-  env: NodeJS.ProcessEnv,
-  execute: DependencyCommandExecutor,
-): Promise<CacheEntryInput> => {
-  const raw = await execute(config, "npm", ["config", "ls", "--json"], workspace, env, { timeoutMs: NPM_PROBE_TIMEOUT_MS });
+const effectiveNpmConfigInput = async (run: CommandRunner): Promise<CacheEntryInput> => {
+  const raw = await run("npm", ["config", "ls", "--json"], { timeoutMs: NPM_PROBE_TIMEOUT_MS });
   const parsed = parseJsonObject(raw, "effective npm configuration");
   const filtered = canonicalValue(parsed);
   return { path: "<effective-npm-config>", sha256: sha256(`${JSON.stringify(filtered)}\n`) };
@@ -469,31 +443,27 @@ export type DependencyCacheIdentity = {
 // configuration, and the toolchain. No caller can key a run on a smaller input
 // set than the one this module tests.
 export const deriveDependencyCacheKey = async (
-  config: RunnerConfig,
   workspacePath: string,
-  env: NodeJS.ProcessEnv,
-  dependencies: DependencyCacheDependencies,
+  run: CommandRunner,
   options: { toolchain?: DependencyCacheToolchain } = {},
 ): Promise<DependencyCacheIdentity | null> => {
-  const execute = dependencies.execute;
   const project = await inspectDependencyProject(workspacePath);
   if (project === null) return null;
   if (project.inputMissCondition) throw new DependencyCacheInputMissError(project.inputMissCondition, project.targets);
   const workspace = await realpath(resolve(workspacePath));
+  const inWorkspace = commandRunnerIn(run, workspace);
   const { inputs, targets, nativeWorkspaces } = project;
-  inputs.push(await effectiveNpmConfigInput(config, workspace, env, execute));
+  inputs.push(await effectiveNpmConfigInput(inWorkspace));
   inputs.sort((left, right) => left.path.localeCompare(right.path, "en"));
-  const toolchain = options.toolchain ?? await currentToolchain(config, workspace, env, execute);
+  const toolchain = options.toolchain ?? await currentToolchain(inWorkspace);
   const key = sha256(`${JSON.stringify({ format: CACHE_ENTRY_FORMAT, toolchain: validatedToolchain(toolchain), inputs })}\n`);
   return { key, toolchain, inputs, targets, nativeWorkspaces };
 };
 
 const clearTargets = async (
-  config: RunnerConfig,
+  run: CommandRunner,
   workspace: string,
   targets: string[],
-  env: NodeJS.ProcessEnv,
-  execute: DependencyCommandExecutor,
 ): Promise<void> => {
   const existing: Array<{ absolute: string; target: string }> = [];
   for (const target of targets) {
@@ -505,7 +475,7 @@ const clearTargets = async (
     if (kind === "directory") existing.push({ absolute, target });
   }
   for (const { absolute, target } of existing) {
-    await execute(config, "/bin/rm", ["-rf", "--", absolute], workspace, env);
+    await run("/bin/rm", ["-rf", "--", absolute]);
     if (await pathKind(absolute) !== "missing") throw new Error(`Dependency target could not be cleared: ${target}`);
   }
 };
@@ -524,14 +494,12 @@ const installedTargetTrees = async (workspace: string, targets: string[]): Promi
 };
 
 const restoreEntry = async (
-  config: RunnerConfig,
+  run: CommandRunner,
   store: CacheEntryStore,
   document: CacheEntryDocument,
   workspace: string,
-  env: NodeJS.ProcessEnv,
-  execute: DependencyCommandExecutor,
 ): Promise<void> => {
-  await clearTargets(config, workspace, document.targets.map(({ path }) => path), env, execute);
+  await clearTargets(run, workspace, document.targets.map(({ path }) => path));
   try {
     for (const target of document.targets) {
       if (!target.present) continue;
@@ -540,30 +508,28 @@ const restoreEntry = async (
       const args = platform() === "darwin"
         ? ["-c", "-R", source, destination]
         : ["-a", "--reflink=always", source, destination];
-      await execute(config, "/bin/cp", args, workspace, env);
-      await execute(config, "/bin/chmod", ["-R", "u+w", destination], workspace, env);
+      await run("/bin/cp", args);
+      await run("/bin/chmod", ["-R", "u+w", destination]);
     }
     const restored = await describeTargetTrees(workspace, document.targets.map(({ path }) => path));
     if (!sameJson(restored, document.targets)) throw new Error("Restored dependency target manifest differs from the cache entry");
   } catch (error: unknown) {
-    await clearTargets(config, workspace, document.targets.map(({ path }) => path), env, execute).catch(() => undefined);
+    await clearTargets(run, workspace, document.targets.map(({ path }) => path)).catch(() => undefined);
     throw error;
   }
 };
 
 const installDependencies = async (
-  config: RunnerConfig,
+  run: CommandRunner,
   workspace: string,
   targets: string[],
-  env: NodeJS.ProcessEnv,
-  execute: DependencyCommandExecutor,
   retryOptions: RetryOptions = {},
 ): Promise<CacheEntryTarget[]> => {
   const args = ["ci", "--prefer-offline", "--no-audit", "--no-fund"];
   try {
     await runWithNetworkRetry("npm", args, async ({ timeoutMs }) => {
-      await clearTargets(config, workspace, targets, env, execute);
-      return execute(config, "npm", args, workspace, env, { timeoutMs });
+      await clearTargets(run, workspace, targets);
+      return run("npm", args, { timeoutMs });
     }, {
       commandTimeoutMs: NPM_INSTALL_COMMAND_TIMEOUT_MS,
       budgetMs: NPM_INSTALL_OPERATION_BUDGET_MS,
@@ -571,25 +537,19 @@ const installDependencies = async (
     });
     return await installedTargetTrees(workspace, targets);
   } catch (error: unknown) {
-    await clearTargets(config, workspace, targets, env, execute).catch(() => undefined);
+    await clearTargets(run, workspace, targets).catch(() => undefined);
     throw error;
   }
 };
 
 const rebuildNativeWorkspaces = async (
-  config: RunnerConfig,
-  workspace: string,
+  run: CommandRunner,
   nativeWorkspaces: string[],
-  env: NodeJS.ProcessEnv,
-  execute: DependencyCommandExecutor,
 ): Promise<void> => {
   for (const name of nativeWorkspaces) {
-    await execute(
-      config,
+    await run(
       "npm",
       ["rebuild", "-w", name, "--no-audit", "--no-fund"],
-      workspace,
-      env,
       { timeoutMs: NPM_INSTALL_COMMAND_TIMEOUT_MS },
     );
   }
@@ -602,13 +562,11 @@ const rebuildNativeWorkspaces = async (
  * (`dependency-provisioning.ts`); reaching here means the answer was yes.
  */
 export const materializeWorkspaceDependencies = async (
-  config: RunnerConfig,
+  config: Pick<RunnerConfig, "workspaceRoot" | "dependencyCacheRoot">,
   workspacePath: string,
-  env: NodeJS.ProcessEnv,
-  dependencies: DependencyCacheDependencies,
+  run: CommandRunner,
   options: DependencyCacheOptions = {},
 ): Promise<DependencyCacheResult> => {
-  const execute = dependencies.execute;
   const started = Date.now();
   const report = options.report ?? progressReporter;
   const requestedWorkspace = resolve(workspacePath);
@@ -616,15 +574,16 @@ export const materializeWorkspaceDependencies = async (
     throw new Error("Run workspace is not a real directory");
   }
   const workspace = await realpath(requestedWorkspace);
+  const inWorkspace = commandRunnerIn(run, workspace);
   try {
     let identity: DependencyCacheIdentity | null;
     try {
-      identity = await timed("identity", report, () => deriveDependencyCacheKey(config, workspace, env, { execute }, options));
+      identity = await timed("identity", report, () => deriveDependencyCacheKey(workspace, inWorkspace, options));
     } catch (error: unknown) {
       if (!(error instanceof DependencyCacheInputMissError)) throw error;
       report({ event: "miss", condition: error.condition });
       await timed("install", report, () => installDependencies(
-        config, workspace, error.targets, env, execute, options.installRetryOptions,
+        inWorkspace, workspace, error.targets, options.installRetryOptions,
       ));
       return { status: "installed", condition: error.condition };
     }
@@ -650,8 +609,8 @@ export const materializeWorkspaceDependencies = async (
       if (await store.hasEntry(key)) {
         try {
           const document = await timed("validate", report, () => store.readEntry(expected));
-          await timed("restore", report, () => restoreEntry(config, store, document, workspace, env, execute));
-          await timed("rebuild", report, () => rebuildNativeWorkspaces(config, workspace, nativeWorkspaces, env, execute));
+          await timed("restore", report, () => restoreEntry(inWorkspace, store, document, workspace));
+          await timed("rebuild", report, () => rebuildNativeWorkspaces(inWorkspace, nativeWorkspaces));
           await store.recordUse(key);
           return {
             result: { status: "restored", key } as DependencyCacheResult,
@@ -669,7 +628,7 @@ export const materializeWorkspaceDependencies = async (
       }
 
       const targets = await timed("install", report, () => installDependencies(
-        config, workspace, targetPaths, env, execute, options.installRetryOptions,
+        inWorkspace, workspace, targetPaths, options.installRetryOptions,
       ));
       const publication = await timed("publish", report, () => store.publishEntry(expected, targets, workspace));
       if (publication === "refused") {

--- a/packages/runner/src/exec.test.ts
+++ b/packages/runner/src/exec.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
 import test from "node:test";
 
-import { CommandTimeoutError, KILL_GRACE_MS, platformCommitArgs, runCommand } from "./exec.js";
+import {
+  bindCommandRunner, commandRunnerIn, CommandTimeoutError, KILL_GRACE_MS, platformCommitArgs, runCommand,
+} from "./exec.js";
 import { isTransientNetworkError } from "./network-retry.js";
 
 const env = { PATH: process.env.PATH ?? "/usr/bin:/bin" };
@@ -141,4 +143,37 @@ test("the runner's own CLI preflight timeout is not mistaken for a network timeo
 
 test("fetch transport failures are classified as transient", () => {
   assert.equal(isTransientNetworkError(new TypeError("fetch failed")), true);
+});
+
+test("a bound runner carries the run-as prefix, its directory and its environment into every call", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "agentos-bound-runner-")));
+  try {
+    const nested = join(root, "nested");
+    await mkdir(nested);
+    const log = join(root, "launcher.log");
+    const launcher = join(root, "launcher.sh");
+    // Records the two prefix arguments it was handed, then becomes the command.
+    // A call that bypassed the prefix would leave the log one entry short.
+    await writeFile(launcher, `#!/bin/sh\nprintf '%s\\n' "$1" "$2" >> ${log}\nshift 2\nexec "$@"\n`);
+    await chmod(launcher, 0o755);
+    const probe = ["-c", 'printf "%s|%s|%s" "$(pwd -P)" "$MARK" "${EXTRA-}"'];
+    const run = bindCommandRunner([launcher, "--account", "agent-runner"], root, { ...env, MARK: "bound" });
+
+    assert.equal(await run("/bin/sh", probe), `${root}|bound|`);
+    // The per-call directory covers a command that belongs in a subdirectory;
+    // the per-call environment covers addressing git by GIT_DIR.
+    assert.equal(await run("/bin/sh", probe, { cwd: nested }), `${nested}|bound|`);
+    assert.equal(await run("/bin/sh", probe, { env: { EXTRA: "merged" } }), `${root}|bound|merged`);
+
+    const inNested = commandRunnerIn(run, nested);
+    assert.equal(await inNested("/bin/sh", probe), `${nested}|bound|`);
+    assert.equal(await inNested("/bin/sh", probe, { cwd: root }), `${root}|bound|`);
+
+    assert.deepEqual(
+      (await readFile(log, "utf8")).trimEnd().split("\n"),
+      Array.from({ length: 5 }, () => ["--account", "agent-runner"]).flat(),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/runner/src/exec.ts
+++ b/packages/runner/src/exec.ts
@@ -153,3 +153,60 @@ export const runCommand = (
     else reject(new Error(`${executable} failed (${signal ?? code}): ${stderr.trim()}`));
   }));
 });
+
+/**
+ * Extra per-call knobs a bound runner accepts on top of `CommandOptions`.
+ *
+ * Both are deliberately narrow. `cwd` covers the two cases where one command
+ * of a workspace's sequence belongs somewhere else: the run directory a
+ * provisioning sequence rooted at the workspace root writes into, and the
+ * shared temporary root a prefixed command must be launched from because node
+ * chdirs as the daemon's uid before the prefix runs. `env` covers addressing
+ * git by `GIT_DIR` rather than by cwd.
+ */
+export type BoundCommandOptions = CommandOptions & {
+  /** Run this one command elsewhere, leaving the binding intact. */
+  cwd?: string | undefined;
+  /** Entries merged over the bound child environment for this call only. */
+  env?: NodeJS.ProcessEnv | undefined;
+};
+
+/**
+ * A command runner bound to one run-as prefix, working directory and child
+ * environment, so callers name only the program and its arguments.
+ *
+ * Every workspace mutation runs through here so that, when RUNNER_RUN_AS_PREFIX
+ * is set, whatever it creates is owned by the launched account rather than by
+ * the runner daemon's own uid. `input` exists for the same reason: a secret
+ * reaches the launched account on stdin, never in argv, which `ps` shows to
+ * every account on the host.
+ *
+ * It delegates to `runCommand` like every other external command in the runner
+ * — the process-group kill and the timeout ceiling are not properties a second
+ * spawn point should be allowed to miss. Binding the prefix once, where the
+ * workspace is opened, is what keeps the internals from being able to miss it:
+ * there is no parameter left for them to drop.
+ */
+export type CommandRunner = (
+  executable: string,
+  args: readonly string[],
+  options?: BoundCommandOptions,
+) => Promise<string>;
+
+export const bindCommandRunner = (
+  runAsPrefix: readonly string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): CommandRunner => (executable, args, options = {}) => runCommand(
+  runAsPrefix,
+  executable,
+  args,
+  options.cwd ?? cwd,
+  options.env === undefined ? env : { ...env, ...options.env },
+  options,
+);
+
+/** The same runner with a different bound working directory. A per-call `cwd`
+ *  still wins, so a rebound runner composes rather than freezing the choice. */
+export const commandRunnerIn = (run: CommandRunner, cwd: string): CommandRunner =>
+  (executable, args, options = {}) => run(executable, args, { ...options, cwd: options.cwd ?? cwd });

--- a/packages/runner/src/git-provenance.ts
+++ b/packages/runner/src/git-provenance.ts
@@ -3,22 +3,13 @@ import { isAbsolute, join, resolve, sep } from "node:path";
 
 import type { ClaimedTask } from "./api.js";
 import type { GitIdentity, RunnerConfig } from "./config.js";
-import type { CommandOptions } from "./exec.js";
+import type { CommandRunner } from "./exec.js";
 
 /** The run and Chain identity used to author commit provenance. */
 export type GitProvenanceClaim = Pick<ClaimedTask, "executionMode" | "runner"> & {
   task: Pick<ClaimedTask["task"], "chainId" | "chainIndex" | "templateStep">;
   run: Pick<ClaimedTask["run"], "id">;
 };
-
-export type GitCommandExecutor = (
-  config: RunnerConfig,
-  executable: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  options?: CommandOptions,
-) => Promise<string>;
 
 const validIdentityPart = (value: string): boolean => value.trim().length > 0 && !/[\0\r\n]/u.test(value);
 
@@ -33,15 +24,13 @@ const requireIdentity = (identity: GitIdentity | null): GitIdentity => {
 };
 
 export const resolveRunnerGitIdentity = async (
-  config: RunnerConfig,
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  execute: GitCommandExecutor,
+  config: Pick<RunnerConfig, "gitIdentity">,
+  run: CommandRunner,
 ): Promise<GitIdentity> => {
   if (config.gitIdentity !== null && config.gitIdentity !== undefined) return requireIdentity(config.gitIdentity);
   const read = async (key: "user.name" | "user.email"): Promise<string | null> => {
     try {
-      return await execute(config, "git", ["config", "--global", "--get", key], cwd, env);
+      return await run("git", ["config", "--global", "--get", key]);
     } catch {
       return null;
     }
@@ -148,19 +137,17 @@ ANNEAL_PROVENANCE
  * selected in local config: only the provider child environment activates it,
  * so a retained workspace cannot mislabel a later human commit. */
 export const configureWorkspaceGit = async (
-  config: RunnerConfig,
   claim: GitProvenanceClaim,
   workspacePath: string,
   identity: GitIdentity,
-  env: NodeJS.ProcessEnv,
-  execute: GitCommandExecutor,
+  run: CommandRunner,
 ): Promise<string | null> => {
-  await execute(config, "git", ["config", "--local", "user.name", identity.name], workspacePath, env);
-  await execute(config, "git", ["config", "--local", "user.email", identity.email], workspacePath, env);
+  await run("git", ["config", "--local", "user.name", identity.name]);
+  await run("git", ["config", "--local", "user.email", identity.email]);
 
   const provenance = provenanceFor(claim);
   if (!provenance) return null;
-  const rawCommonDir = await execute(config, "git", ["rev-parse", "--git-common-dir"], workspacePath, env);
+  const rawCommonDir = await run("git", ["rev-parse", "--git-common-dir"]);
   const commonDir = await realpath(isAbsolute(rawCommonDir) ? rawCommonDir : resolve(workspacePath, rawCommonDir));
   const canonicalWorkspace = await realpath(workspacePath);
   if (commonDir !== canonicalWorkspace && !commonDir.startsWith(`${canonicalWorkspace}${sep}`)) {
@@ -168,13 +155,10 @@ export const configureWorkspaceGit = async (
   }
   const hooksPath = join(commonDir, "anneal-hooks");
   const hookPath = join(hooksPath, "prepare-commit-msg");
-  await execute(config, "/bin/mkdir", ["-p", hooksPath], workspacePath, env);
-  await execute(
-    config,
+  await run("/bin/mkdir", ["-p", hooksPath]);
+  await run(
     "/bin/sh",
     ["-c", 'umask 077; cat > "$1"; chmod 700 "$1"', "anneal-commit-hook", hookPath],
-    workspacePath,
-    env,
     { input: hookBody(claim, canonicalWorkspace, commonDir, provenance) },
   );
   return hooksPath;

--- a/packages/runner/src/provision-failure.test.ts
+++ b/packages/runner/src/provision-failure.test.ts
@@ -1,16 +1,16 @@
 import assert from "node:assert/strict";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { test } from "node:test";
 
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { RUNNER_EXCEPTION_REASON, runnerExceptionEnvelope } from "./envelope.js";
-import { runCommand } from "./exec.js";
+import { bindCommandRunner, type CommandRunner } from "./exec.js";
 import { executeClaim } from "./runner.js";
 import { createControlPlaneDouble, envelopeOf } from "./test-control-plane.js";
-import { provisionWorkspace } from "./workspace.js";
+import { provisionWorkspace, workspaceEnvironment } from "./workspace.js";
 
 /**
  * What the API actually receives when provisioning fails.
@@ -151,19 +151,23 @@ test("a transient mirror fetch failure escapes provisioning as a transient error
   // rethrow are the production ones, and the backoff is the only thing skipped.
   const message = "git failed (128): fatal: unable to access 'https://example.test/repo.git/': "
     + "LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to example.test:443";
+  const configured = config(root);
+  const production = bindCommandRunner(
+    configured.runAsPrefix, resolve(configured.workspaceRoot), workspaceEnvironment(configured),
+  );
   const escaped = await provisionWorkspace(
-    config(root),
+    configured,
     claim("https://example.test/repo.git"),
     // The mirror fetch fails before dependencies are ever reached.
     { provision: false, evidence: "Dependency provisioning skipped: Repo.dependencyProvisioning=NONE" },
     {
-      execute: async (executorConfig, executable, args, cwd, env) => {
+      run: (async (executable, args, options) => {
         // Only git is faked: the mirror's own filesystem bookkeeping is real work
         // in a temporary directory, and the retry under test rides on the fetch.
-        if (executable === "/bin/sh") return runCommand(executorConfig.runAsPrefix, executable, args, cwd, env, {});
+        if (executable === "/bin/sh") return production(executable, args, options);
         if (args[0] === "fetch") throw new Error(message);
         return "";
-      },
+      }) satisfies CommandRunner,
       retryOptions: { attempts: 1 },
     },
   ).then(() => null, (error: unknown) => error);

--- a/packages/runner/src/repo-mirror.test.ts
+++ b/packages/runner/src/repo-mirror.test.ts
@@ -2,20 +2,17 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import test from "node:test";
 
 import type { RunnerConfig } from "./config.js";
 import type { DependencyProvisioningDecision } from "./dependency-provisioning.js";
-import { runCommand } from "./exec.js";
+import { bindCommandRunner, type CommandRunner } from "./exec.js";
 import {
   mirrorRevisionsPresent, repoMirrorPath, RepoMirrorError, withRepoMirror,
-  type MirrorCommandExecutor, type RepoMirrorProgress,
+  type RepoMirrorProgress,
 } from "./repo-mirror.js";
-import {
-  provisionWorkspace, workspaceEnvironment,
-  type WorkspaceCommandExecutor, type WorkspaceProvisionClaim,
-} from "./workspace.js";
+import { provisionWorkspace, workspaceEnvironment, type WorkspaceProvisionClaim } from "./workspace.js";
 
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 
@@ -74,15 +71,22 @@ const claimFor = (remote: string, id: string): WorkspaceProvisionClaim => ({
   },
 });
 
-/** The production executor, with every argv it is handed recorded. */
-const recorded = (calls: { args: string[]; cwd: string }[]): WorkspaceCommandExecutor =>
-  async (config, executable, args, cwd, env, options = {}) => {
-    calls.push({ args, cwd });
-    return runCommand(config.runAsPrefix, executable, args, cwd, env, options);
-  };
+/** The production runner, bound the way provisioning binds it. */
+const bound = (config: RunnerConfig, cwd: string): CommandRunner =>
+  bindCommandRunner(config.runAsPrefix, cwd, workspaceEnvironment(config));
 
-const passthrough: MirrorCommandExecutor = (config, executable, args, cwd, env, options = {}) =>
-  runCommand(config.runAsPrefix, executable, args, cwd, env, options);
+/** The production runner, with every argv it is handed recorded. */
+const recorded = (
+  calls: { args: string[]; cwd: string }[],
+  config: RunnerConfig,
+  cwd: string,
+): CommandRunner => {
+  const run = bound(config, cwd);
+  return async (executable, args, options) => {
+    calls.push({ args: [...args], cwd: options?.cwd ?? cwd });
+    return run(executable, args, options);
+  };
+};
 
 
 const silent = (): ((progress: RepoMirrorProgress) => void) => (): void => undefined;
@@ -103,7 +107,7 @@ test("the second run reuses the machine's mirror and fetches only what changed",
       config,
       claimFor(remote, "two"),
       NO_DEPENDENCIES,
-      { execute: recorded(calls), mirrorOptions: { report: silent() } },
+      { run: recorded(calls, config, resolve(config.workspaceRoot)), mirrorOptions: { report: silent() } },
     );
 
     // Same mirror directory, not a rebuilt one, and the run sees the commit
@@ -185,14 +189,13 @@ test("a mirror that is not a readable git repository is refused, not rebuilt", a
 
 test("a held lock is waited for, and one left behind by a dead holder is stolen", async () => {
   const { root, remote, config, mirror } = await fixture("lock");
-  const env = workspaceEnvironment(config);
   try {
     const lock = `${mirror}.lock`;
     await mkdir(join(root, "mirrors"), { recursive: true });
     await mkdir(lock);
 
     const refused = await withRepoMirror(
-      config, remote, root, env, passthrough,
+      config, remote, bound(config, root),
       { lockWaitMs: 10, lockPollMs: 1, report: silent() },
       async () => "unreachable",
     ).then(() => null, (error: unknown) => error);
@@ -204,7 +207,7 @@ test("a held lock is waited for, and one left behind by a dead holder is stolen"
     await utimes(lock, stale, stale);
     let steals = 0;
     const taken = await withRepoMirror(
-      config, remote, root, env, passthrough,
+      config, remote, bound(config, root),
       {
         lockWaitMs: 10,
         lockPollMs: 1,
@@ -224,7 +227,6 @@ test("a held lock is waited for, and one left behind by a dead holder is stolen"
 
 test("a file where the lock directory belongs is stolen rather than waited on", async () => {
   const { root, remote, config, mirror } = await fixture("lock-file");
-  const env = workspaceEnvironment(config);
   try {
     // What a heartbeat that raced its own release leaves behind. No mkdir can
     // ever acquire it, so waiting out the stale window would wedge the machine
@@ -232,7 +234,7 @@ test("a file where the lock directory belongs is stolen rather than waited on", 
     await mkdir(join(root, "mirrors"), { recursive: true });
     await writeFile(`${mirror}.lock`, "");
     const taken = await withRepoMirror(
-      config, remote, root, env, passthrough,
+      config, remote, bound(config, root),
       { lockWaitMs: 10, lockPollMs: 1, report: silent() },
       async (path) => path,
     );
@@ -244,10 +246,9 @@ test("a file where the lock directory belongs is stolen rather than waited on", 
 
 test("a holder that was taken over does not delete its successor's lock", async () => {
   const { root, remote, config, mirror } = await fixture("release");
-  const env = workspaceEnvironment(config);
   const lock = `${mirror}.lock`;
   try {
-    await withRepoMirror(config, remote, root, env, passthrough, { report: silent() }, async () => {
+    await withRepoMirror(config, remote, bound(config, root), { report: silent() }, async () => {
       // What a stale takeover looks like from inside the declared-dead holder:
       // its lock is gone and someone else's is at the path.
       await rm(lock, { recursive: true, force: true });
@@ -307,7 +308,6 @@ test("every mirror command runs through the run-as prefix, so the account with t
 
 test("a mirror root reached through a symlinked ancestor still counts as inside the workspace root", async () => {
   const { root, remote, config } = await fixture("overlap");
-  const env = workspaceEnvironment(config);
   try {
     // Nothing textual connects these two paths; the link is what puts the
     // mirror inside the tree the runner reclaims between runs.
@@ -316,7 +316,7 @@ test("a mirror root reached through a symlinked ancestor still counts as inside 
     const overlapping = { ...config, repoMirrorRoot: join(root, "alias", "mirrors") } as RunnerConfig;
 
     await assert.rejects(
-      withRepoMirror(overlapping, remote, root, env, passthrough, { report: silent() }, async () => undefined),
+      withRepoMirror(overlapping, remote, bound(overlapping, root), { report: silent() }, async () => undefined),
       /overlaps the workspace root/u,
     );
   } finally {
@@ -326,7 +326,6 @@ test("a mirror root reached through a symlinked ancestor still counts as inside 
 
 test("staging the sweep could not remove is reported rather than swallowed", async () => {
   const { root, remote, config, mirrorRoot } = await fixture("staging");
-  const env = workspaceEnvironment(config);
   const stranded = join(mirrorRoot, ".stage-abandoned");
   try {
     await mkdir(mirrorRoot, { recursive: true });
@@ -341,7 +340,7 @@ test("staging the sweep could not remove is reported rather than swallowed", asy
 
     const progress: RepoMirrorProgress[] = [];
     await withRepoMirror(
-      config, remote, root, env, passthrough,
+      config, remote, bound(config, root),
       { report: (event) => progress.push(event) },
       async () => undefined,
     );
@@ -360,14 +359,14 @@ test("staging the sweep could not remove is reported rather than swallowed", asy
 
 test("mirror git runs are addressed by GIT_DIR, never by entering the mirror the daemon cannot", async () => {
   const { root, remote, config, mirror } = await fixture("git-dir");
-  const env = workspaceEnvironment(config);
   const runs: { args: string[]; cwd: string; gitDir: string | undefined }[] = [];
-  const observed: MirrorCommandExecutor = (mirrorConfig, executable, args, cwd, commandEnv, options = {}) => {
-    if (executable === "git") runs.push({ args, cwd, gitDir: commandEnv.GIT_DIR });
-    return runCommand(mirrorConfig.runAsPrefix, executable, args, cwd, commandEnv, options);
+  const passthrough = bound(config, root);
+  const observed: CommandRunner = (executable, args, options) => {
+    if (executable === "git") runs.push({ args: [...args], cwd: options?.cwd ?? root, gitDir: options?.env?.GIT_DIR });
+    return passthrough(executable, args, options);
   };
   try {
-    await withRepoMirror(config, remote, root, env, observed, { report: silent() }, async () => undefined);
+    await withRepoMirror(config, remote, observed, { report: silent() }, async () => undefined);
 
     const bare = runs.filter((run) => run.args[0] === "fetch" || run.args[0] === "config");
     assert.equal(bare.length > 0, true);
@@ -388,13 +387,12 @@ test("mirror git runs are addressed by GIT_DIR, never by entering the mirror the
 
 test("object presence is read from cat-file's own answer, never from an exit code", async () => {
   const { root, remote, seed, config } = await fixture("objects");
-  const env = workspaceEnvironment(config);
   try {
     const present = git(seed, "rev-parse", "HEAD");
     const absent = "0".repeat(40);
     const answers = await withRepoMirror(
-      config, remote, root, env, passthrough, { report: silent() },
-      (mirror) => mirrorRevisionsPresent(config, mirror, [present, absent], root, env, passthrough),
+      config, remote, bound(config, root), { report: silent() },
+      (mirror) => mirrorRevisionsPresent(bound(config, root), mirror, [present, absent]),
     );
     assert.equal(answers.get(present), true);
     assert.equal(answers.get(absent), false);

--- a/packages/runner/src/repo-mirror.ts
+++ b/packages/runner/src/repo-mirror.ts
@@ -3,7 +3,7 @@ import { realpathSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
 
 import type { RunnerConfig } from "./config.js";
-import type { CommandOptions } from "./exec.js";
+import type { CommandRunner } from "./exec.js";
 import {
   CLONE_COMMAND_TIMEOUT_MS, CLONE_OPERATION_BUDGET_MS, runWithNetworkRetry, type RetryOptions,
 } from "./network-retry.js";
@@ -47,15 +47,6 @@ import {
  *   remove a lock another contender has already replaced, and a holder that is
  *   merely slow is never mistaken for a dead one.
  */
-
-export type MirrorCommandExecutor = (
-  config: RunnerConfig,
-  executable: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  options?: CommandOptions,
-) => Promise<string>;
 
 export type RepoMirrorProgress = {
   event: "created" | "refreshed" | "object-top-up" | "lock-wait" | "lock-steal" | "staging-retained" | "elapsed";
@@ -180,24 +171,22 @@ export const repoMirrorPath = (root: string, remoteUrl: string): string =>
 /**
  * Run a shell fragment as the task principal.
  *
- * `cwd` is not where the work happens — every path the fragment touches is
- * absolute — it is only somewhere node can chdir *before* the prefix runs, as
- * the daemon's own uid. The mirror's own directories are not that place.
+ * The runner's bound directory is not where the work happens — every path the
+ * fragment touches is absolute — it is only somewhere node can chdir *before*
+ * the prefix runs, as the daemon's own uid. The mirror's own directories are
+ * not that place.
  */
 const shell = (
-  config: RunnerConfig,
-  execute: MirrorCommandExecutor,
-  cwd: string,
-  env: NodeJS.ProcessEnv,
+  run: CommandRunner,
   body: string,
   ...args: string[]
-): Promise<string> => execute(config, "/bin/sh", ["-c", body, "agentos-mirror", ...args], cwd, env);
+): Promise<string> => run("/bin/sh", ["-c", body, "agentos-mirror", ...args]);
 
-/** Git addressed by GIT_DIR rather than by cwd, for the same reason. Keeping
- *  the subcommand at argv[0] also keeps network-retry.ts's allowlist — and the
- *  timeout that rides on it — matching what it is meant to match. */
-const gitEnvironment = (env: NodeJS.ProcessEnv, mirror: string): NodeJS.ProcessEnv =>
-  ({ ...env, GIT_DIR: mirror });
+/** Git addressed by GIT_DIR rather than by the bound directory, for the same
+ *  reason. Keeping the subcommand at argv[0] also keeps network-retry.ts's
+ *  allowlist — and the timeout that rides on it — matching what it is meant to
+ *  match. */
+const gitDirectory = (mirror: string): NodeJS.ProcessEnv => ({ GIT_DIR: mirror });
 
 const ENSURE_ROOT = 'mkdir -p "$1" && chmod 700 "$1" && [ ! -L "$1" ] || exit 1;'
   // Staging left behind by a process that died between mktemp and mv. Nothing
@@ -241,10 +230,7 @@ const ACQUIRE = 'if mkdir "$1" 2>/dev/null; then'
 const RELEASE = 'if [ "$(cat "$1/owner" 2>/dev/null)" = "$2" ]; then rm -rf "$1"; fi';
 
 const acquireMirrorLock = async (
-  config: RunnerConfig,
-  execute: MirrorCommandExecutor,
-  cwd: string,
-  env: NodeJS.ProcessEnv,
+  run: CommandRunner,
   lockPath: string,
   owner: string,
   options: RepoMirrorOptions,
@@ -260,7 +246,7 @@ const acquireMirrorLock = async (
   const held = `${owner}:${process.pid}:${randomUUID()}`;
   let waited = false;
   for (;;) {
-    const outcome = await shell(config, execute, cwd, env, ACQUIRE, lockPath, held, String(staleMinutes));
+    const outcome = await shell(run, ACQUIRE, lockPath, held, String(staleMinutes));
     if (outcome === "acquired") {
       // A holder that stops touching its lock is a holder that died. Without
       // this, the staleness threshold would have to bound the uncapped local
@@ -271,12 +257,12 @@ const acquireMirrorLock = async (
         // and the touch are still two operations, so the guard narrows that
         // window rather than closing it; what closes it is that the next
         // acquisition steals anything at the path that is not a directory.
-        void shell(config, execute, cwd, env, 'if [ -d "$1" ]; then touch "$1"; fi', lockPath).catch(() => undefined);
+        void shell(run, 'if [ -d "$1" ]; then touch "$1"; fi', lockPath).catch(() => undefined);
       }, heartbeatMs);
       heartbeat.unref?.();
       return async (): Promise<void> => {
         clearInterval(heartbeat);
-        await shell(config, execute, cwd, env, RELEASE, lockPath, held);
+        await shell(run, RELEASE, lockPath, held);
       };
     }
     if (outcome === "stolen") {
@@ -302,12 +288,9 @@ const acquireMirrorLock = async (
 };
 
 const fetchFromRemote = async (
-  config: RunnerConfig,
+  run: CommandRunner,
   mirror: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  execute: MirrorCommandExecutor,
+  args: readonly string[],
   retryOptions: RetryOptions,
 ): Promise<void> => {
   // The clone profile, not delivery's. The first fetch into an empty mirror
@@ -315,75 +298,63 @@ const fetchFromRemote = async (
   // while the runner heartbeat holds the lease, so the bound only has to
   // separate "hung" from "slow".
   await runWithNetworkRetry("git", args,
-    ({ timeoutMs }) => execute(config, "git", args, cwd, gitEnvironment(env, mirror), { timeoutMs }),
+    ({ timeoutMs }) => run("git", args, { env: gitDirectory(mirror), timeoutMs }),
     { commandTimeoutMs: CLONE_COMMAND_TIMEOUT_MS, budgetMs: CLONE_OPERATION_BUDGET_MS, ...retryOptions },
   );
 };
 
 const REFRESH_ARGS = ["fetch", "--prune", "--prune-tags", "--tags", "--quiet", "origin"] as const;
 
-const configureMirror = async (
-  config: RunnerConfig,
-  mirror: string,
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  execute: MirrorCommandExecutor,
-): Promise<void> => {
-  const gitEnv = gitEnvironment(env, mirror);
+const configureMirror = async (run: CommandRunner, mirror: string): Promise<void> => {
+  const env = gitDirectory(mirror);
   // Heads only: GitHub advertises refs/pull/*, which no run has ever needed and
   // which would make every fetch pay for the repository's whole review history.
-  await execute(config, "git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"], cwd, gitEnv);
+  await run("git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"], { env });
   // Blind-review provisioning fetches an exact object id out of this mirror.
   // upload-pack refuses unadvertised objects by default, and the refusal would
   // read as a mirror fault rather than as the policy it is.
-  await execute(config, "git", ["config", "uploadpack.allowAnySHA1InWant", "true"], cwd, gitEnv);
+  await run("git", ["config", "uploadpack.allowAnySHA1InWant", "true"], { env });
 };
 
 const createMirror = async (
-  config: RunnerConfig,
+  run: CommandRunner,
   root: string,
   mirror: string,
   remoteUrl: string,
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  execute: MirrorCommandExecutor,
   retryOptions: RetryOptions,
   report: (progress: RepoMirrorProgress) => void,
 ): Promise<void> => {
   // Staged beside the destination and renamed only after the first fetch
   // succeeds, so an interrupted creation can never leave a directory that later
   // runs would mistake for a populated mirror.
-  const staging = await shell(config, execute, cwd, env, 'd=$(mktemp -d "$1/.stage-XXXXXXXX") && printf %s "$d"', root);
+  const staging = await shell(run, 'd=$(mktemp -d "$1/.stage-XXXXXXXX") && printf %s "$d"', root);
   if (!insideOrEqual(root, staging)) throw new Error(`Runner repository mirror staging escaped its root: ${staging}`);
   try {
-    await execute(config, "git", ["init", "--bare", "--quiet", staging], cwd, env);
-    await execute(config, "git", ["remote", "add", "origin", remoteUrl], cwd, gitEnvironment(env, staging));
-    await configureMirror(config, staging, cwd, env, execute);
-    await fetchFromRemote(config, staging, [...REFRESH_ARGS], cwd, env, execute, retryOptions);
-    await shell(config, execute, cwd, env, 'mv "$1" "$2"', staging, mirror);
+    await run("git", ["init", "--bare", "--quiet", staging]);
+    await run("git", ["remote", "add", "origin", remoteUrl], { env: gitDirectory(staging) });
+    await configureMirror(run, staging);
+    await fetchFromRemote(run, staging, REFRESH_ARGS, retryOptions);
+    await shell(run, 'mv "$1" "$2"', staging, mirror);
   } finally {
     // The sweep in ENSURE_ROOT is what covers a process that dies before this
     // runs; a failure here is reported rather than swallowed, because a staging
     // directory is close to a whole repository in size.
-    await shell(config, execute, cwd, env, 'rm -rf "$1"', staging)
+    await shell(run, 'rm -rf "$1"', staging)
       .catch(() => { report({ event: "staging-retained", mirror: staging }); });
   }
 };
 
 const validateMirror = async (
-  config: RunnerConfig,
+  run: CommandRunner,
   mirror: string,
   remoteUrl: string,
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  execute: MirrorCommandExecutor,
 ): Promise<void> => {
-  const gitEnv = gitEnvironment(env, mirror);
+  const env = gitDirectory(mirror);
   let bare: string;
   let configured: string;
   try {
-    bare = await execute(config, "git", ["rev-parse", "--is-bare-repository"], cwd, gitEnv);
-    configured = await execute(config, "git", ["config", "--get", "remote.origin.url"], cwd, gitEnv);
+    bare = await run("git", ["rev-parse", "--is-bare-repository"], { env });
+    configured = await run("git", ["config", "--get", "remote.origin.url"], { env });
   } catch (error: unknown) {
     throw new RepoMirrorError(mirror, "not-a-readable-git-repository", { cause: error });
   }
@@ -399,17 +370,14 @@ const validateMirror = async (
  * genuinely broken object database from being read as "not fetched yet".
  */
 export const mirrorRevisionsPresent = async (
-  config: RunnerConfig,
+  run: CommandRunner,
   mirror: string,
   revisions: readonly string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  execute: MirrorCommandExecutor,
 ): Promise<Map<string, boolean>> => {
   if (revisions.length === 0) return new Map();
-  const output = await execute(
-    config, "git", ["cat-file", "--batch-check=%(objectname) %(objecttype)"], cwd, gitEnvironment(env, mirror),
-    { input: `${revisions.join("\n")}\n` },
+  const output = await run(
+    "git", ["cat-file", "--batch-check=%(objectname) %(objecttype)"],
+    { env: gitDirectory(mirror), input: `${revisions.join("\n")}\n` },
   );
   const lines = output.split("\n");
   if (lines.length !== revisions.length) {
@@ -425,21 +393,18 @@ export const mirrorRevisionsPresent = async (
  * was deleted upstream after the object was recorded.
  */
 export const ensureMirrorRevisions = async (
-  config: RunnerConfig,
+  run: CommandRunner,
   mirror: string,
   revisions: readonly string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  execute: MirrorCommandExecutor,
   retryOptions: RetryOptions = {},
   report: (progress: RepoMirrorProgress) => void = progressReporter,
 ): Promise<void> => {
-  const present = await mirrorRevisionsPresent(config, mirror, revisions, cwd, env, execute);
+  const present = await mirrorRevisionsPresent(run, mirror, revisions);
   const missing = revisions.filter((revision) => present.get(revision) !== true);
   if (missing.length === 0) return;
   report({ event: "object-top-up", mirror, condition: missing.join(",") });
-  await fetchFromRemote(config, mirror, ["fetch", "--no-tags", "--quiet", "origin", ...missing], cwd, env, execute, retryOptions);
-  const settled = await mirrorRevisionsPresent(config, mirror, missing, cwd, env, execute);
+  await fetchFromRemote(run, mirror, ["fetch", "--no-tags", "--quiet", "origin", ...missing], retryOptions);
+  const settled = await mirrorRevisionsPresent(run, mirror, missing);
   const absent = missing.filter((revision) => settled.get(revision) !== true);
   // Not a RepoMirrorError: the mirror did what it was asked and the remote came
   // back without the object. Rebuilding the mirror would not change that answer.
@@ -449,16 +414,13 @@ export const ensureMirrorRevisions = async (
 /** Whether the mirror carries this branch. Read after a refresh, this is the
  *  same truth an `ls-remote` would have returned, without the round trip. */
 export const mirrorHasBranch = async (
-  config: RunnerConfig,
+  run: CommandRunner,
   mirror: string,
   branch: string,
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  execute: MirrorCommandExecutor,
 ): Promise<boolean> => {
   const reference = `refs/heads/${branch}`;
-  const listed = await execute(
-    config, "git", ["for-each-ref", "--format=%(refname)", reference], cwd, gitEnvironment(env, mirror),
+  const listed = await run(
+    "git", ["for-each-ref", "--format=%(refname)", reference], { env: gitDirectory(mirror) },
   );
   return listed.split("\n").includes(reference);
 };
@@ -468,15 +430,14 @@ export const mirrorHasBranch = async (
  * the machine-wide lock is still held, so nothing repacks the object database
  * while a workspace is being cloned out of it.
  *
- * `cwd` must be a directory the runner daemon's own uid can enter: node chdirs
- * into it before the run-as prefix executes. The workspace root is one.
+ * `run` must be bound to a directory the runner daemon's own uid can enter:
+ * node chdirs into it before the run-as prefix executes. The workspace root is
+ * one.
  */
 export const withRepoMirror = async <T>(
   config: RunnerConfig,
   remoteUrl: string,
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  execute: MirrorCommandExecutor,
+  run: CommandRunner,
   options: RepoMirrorOptions,
   use: (mirror: string) => Promise<T>,
 ): Promise<T> => {
@@ -492,24 +453,22 @@ export const withRepoMirror = async <T>(
       `Runner repository mirror root ${root} overlaps the workspace root ${config.workspaceRoot}`,
     );
   }
-  const retained = await shell(config, execute, cwd, env, ENSURE_ROOT, root, String(staleMinutes));
+  const retained = await shell(run, ENSURE_ROOT, root, String(staleMinutes));
   for (const staging of retained.split("\n").map((line) => line.trim()).filter(Boolean)) {
     report({ event: "staging-retained", mirror: staging });
   }
   const mirror = repoMirrorPath(root, remoteUrl);
-  const release = await acquireMirrorLock(
-    config, execute, cwd, env, `${mirror}.lock`, config.runnerId, options, report,
-  );
+  const release = await acquireMirrorLock(run, `${mirror}.lock`, config.runnerId, options, report);
   try {
-    const state = await shell(config, execute, cwd, env, PROBE, mirror);
+    const state = await shell(run, PROBE, mirror);
     if (state === "unusable") throw new RepoMirrorError(mirror, "not-a-directory");
     if (state === "present") {
-      await validateMirror(config, mirror, remoteUrl, cwd, env, execute);
-      await configureMirror(config, mirror, cwd, env, execute);
-      await fetchFromRemote(config, mirror, [...REFRESH_ARGS], cwd, env, execute, retryOptions);
+      await validateMirror(run, mirror, remoteUrl);
+      await configureMirror(run, mirror);
+      await fetchFromRemote(run, mirror, REFRESH_ARGS, retryOptions);
       report({ event: "refreshed", mirror });
     } else {
-      await createMirror(config, root, mirror, remoteUrl, cwd, env, execute, retryOptions, report);
+      await createMirror(run, root, mirror, remoteUrl, retryOptions, report);
       report({ event: "created", mirror });
     }
     return await use(mirror);

--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -9,12 +9,12 @@ import test from "node:test";
 import type { RunnerConfig } from "./config.js";
 import type { DependencyProvisioningDecision } from "./dependency-provisioning.js";
 import { CLONE_COMMAND_TIMEOUT_MS } from "./network-retry.js";
-import { runCommand } from "./exec.js";
+import { bindCommandRunner, runCommand, type CommandRunner } from "./exec.js";
 import { runtimeToolPaths } from "./runtime-tools.js";
 import {
   cleanupAgentScratch, materializeRuntimeTools, provisionAgentScratch, provisionSessionConfig, provisionWorkspace, sessionConfigBaselineRoot,
   workspaceEnvironment, writeSessionCredentials,
-  type WorkspaceCommandExecutor, type WorkspaceProvisionClaim,
+  type WorkspaceProvisionClaim,
 } from "./workspace.js";
 
 const git = (cwd: string, ...args: string[]): string => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -52,14 +52,16 @@ const pathWithNoopCommand = async (root: string, command: "chmod"): Promise<stri
 /**
  * Faking git means faking a repository, but the mirror's bookkeeping — its
  * root, its lock, its staging directory — is real filesystem work in a
- * temporary directory. These executors run that for real and answer only for
+ * temporary directory. These runners run that for real and answer only for
  * `git`, so the lock protocol under test is the production one.
  */
 const realShell = async (
-  config: RunnerConfig, executable: string, args: string[], cwd: string, env: NodeJS.ProcessEnv,
-): Promise<string | null> => (executable === "/bin/sh"
-  ? runCommand(config.runAsPrefix, executable, args, cwd, env, {})
-  : null);
+  run: CommandRunner, executable: string, args: readonly string[],
+): Promise<string | null> => (executable === "/bin/sh" ? run(executable, args) : null);
+
+/** The runner provisioning binds, reproduced so a fake can wrap it. */
+const provisioningRun = (config: RunnerConfig): CommandRunner =>
+  bindCommandRunner(config.runAsPrefix, resolve(config.workspaceRoot), workspaceEnvironment(config));
 
 type WorkspaceClaimFixture = {
   task: Pick<WorkspaceProvisionClaim["task"], "id">
@@ -145,9 +147,10 @@ test("an explicit false template step skips all dependency inspection after chec
       home: root,
       gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
     } as unknown as RunnerConfig;
-    const execute: WorkspaceCommandExecutor = async (runnerConfig, executable, args, cwd, env, options) => {
+    const production = provisioningRun(config);
+    const execute: CommandRunner = async (executable, args, options) => {
       calls.push(`${executable} ${args.join(" ")}`);
-      return runCommand(runnerConfig.runAsPrefix, executable, args, cwd, env, options);
+      return production(executable, args, options);
     };
     const workspace = await provisionWorkspace(config, workspaceClaim({
       task: {
@@ -157,7 +160,7 @@ test("an explicit false template step skips all dependency inspection after chec
       repo: { remoteUrl: remote, defaultBranch: "main" },
       run: { id: "run-review", runNumber: 1, targetBranch: "main", branch: "main" },
     }), NO_DEPENDENCIES_FOR_REVIEW, {
-      execute,
+      run: execute,
       dependencyCacheOptions: { cacheRoot: join(root, "dependency-cache"), report: (event) => progress.push(event) },
     });
 
@@ -543,8 +546,9 @@ test("the mirror fetch retries two transient failures and succeeds on the third 
       },
       run: { id: "run-retry", runNumber: 1, targetBranch: "main", branch: "main" },
     });
-    const fake = async (config: RunnerConfig, executable: string, args: string[], cwd: string, env: NodeJS.ProcessEnv): Promise<string> => {
-      const shell = await realShell(config, executable, args, cwd, env);
+    const production = provisioningRun(config);
+    const fake: CommandRunner = async (executable, args) => {
+      const shell = await realShell(production, executable, args);
       if (shell !== null) return shell;
       if (executable === "git" && args[0] === "fetch") {
         fetchCalls += 1;
@@ -556,7 +560,7 @@ test("the mirror fetch retries two transient failures and succeeds on the third 
       return "";
     };
     const workspace = await provisionWorkspace(config, claim, NO_DEPENDENCIES, {
-      execute: fake,
+      run: fake,
       retryOptions: { wait: async () => undefined },
     });
     // The retried operation is now the mirror's fetch. The clone that follows
@@ -575,10 +579,15 @@ type RecordedCommand = { args: string[]; cwd: string; timeoutMs: number | undefi
 const recordingExecutor = (
   calls: RecordedCommand[],
   answer: (args: string[]) => string,
-): WorkspaceCommandExecutor => async (config, executable, args, cwd, env, options) => {
-  calls.push({ args, cwd, timeoutMs: options?.timeoutMs });
-  const shell = await realShell(config, executable, args, cwd, env);
-  return shell ?? answer(args);
+  config: RunnerConfig,
+): CommandRunner => {
+  const root = resolve(config.workspaceRoot);
+  const production = provisioningRun(config);
+  return async (executable, args, options) => {
+    calls.push({ args: [...args], cwd: options?.cwd ?? root, timeoutMs: options?.timeoutMs });
+    const shell = await realShell(production, executable, args);
+    return shell ?? answer([...args]);
+  };
 };
 
 test("the mirror's remote fetch carries a per-command ceiling while local git commands stay uncapped", async () => {
@@ -607,9 +616,9 @@ test("the mirror's remote fetch carries a per-command ceiling while local git co
       if (args[0] === "for-each-ref") return args[2] === "refs/heads/main" ? "refs/heads/main" : "";
       if (args[0] === "rev-parse") return "base-sha";
       return "";
-    });
+    }, config);
     await provisionWorkspace(config, claim, NO_DEPENDENCIES, {
-      execute: fake,
+      run: fake,
       retryOptions: { wait: async () => undefined },
     });
     const ceiling = (name: string): number | undefined => calls.find(({ args }) => args[0] === name)?.timeoutMs;
@@ -668,9 +677,9 @@ test("the pinned range is fetched out of the mirror, and only the mirror's own f
       if (args[0] === "cat-file") return "impl-base-sha commit\npinned-sha commit";
       if (args[0] === "rev-parse") return "pinned-sha";
       return "";
-    });
+    }, config);
     await provisionWorkspace(config, claim, NO_DEPENDENCIES, {
-      execute: fake,
+      run: fake,
       retryOptions: { wait: async () => undefined },
     });
     const remoteFetch = calls.find(({ args }) => args[0] === "fetch" && args.includes("origin"));

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -12,7 +12,7 @@ import { defaultSessionConfigBaselineRoot, type RunnerConfig, type RunnerKind } 
 import { runtimeToolPaths } from "./runtime-tools.js";
 import { materializeWorkspaceDependencies, type DependencyCacheOptions } from "./dependency-cache.js";
 import type { DependencyProvisioningDecision } from "./dependency-provisioning.js";
-import { platformCommitArgs, runCommand, type CommandOptions } from "./exec.js";
+import { bindCommandRunner, commandRunnerIn, platformCommitArgs, type CommandRunner } from "./exec.js";
 import {
   configureWorkspaceGit, resolveRunnerGitIdentity, type GitProvenanceClaim,
 } from "./git-provenance.js";
@@ -58,11 +58,9 @@ const assertMaterializationPathIsPlain = async (workspace: string, path: string)
 };
 
 const materializePreparedSpecification = async (
-  config: RunnerConfig,
   prepared: ClaimedTask["specificationMaterialization"],
   workspace: Workspace,
-  execute: WorkspaceCommandExecutor,
-  env: NodeJS.ProcessEnv,
+  run: CommandRunner,
 ): Promise<Workspace> => {
   if (!prepared) return workspace;
   if (workspace.pinnedBaseSha) throw new Error("Pinned review workspace cannot materialize a direct implementation specification");
@@ -74,35 +72,17 @@ const materializePreparedSpecification = async (
   if (!inside(workspace.path, absolutePath)) throw new Error("Prepared specification escaped the controlled workspace");
   await assertMaterializationPathIsPlain(workspace.path, absolutePath);
 
-  await execute(
-    config,
+  await run(
     "/bin/sh",
     ["-c", 'umask 022; mkdir -p -- "$1"; cat > "$2"', "agentos-specification", dirname(absolutePath), absolutePath],
-    workspace.path,
-    env,
     { input: prepared.body },
   );
-  await execute(config, "git", ["add", "-f", "--", prepared.path], workspace.path, env);
-  const status = await execute(config, "git", ["status", "--porcelain", "--", prepared.path], workspace.path, env);
+  await run("git", ["add", "-f", "--", prepared.path]);
+  const status = await run("git", ["status", "--porcelain", "--", prepared.path]);
   if (!status) return workspace;
-  await execute(
-    config,
-    "git",
-    platformCommitArgs("Materialize direct-chain specification", prepared.path),
-    workspace.path,
-    env,
-  );
-  return { ...workspace, baseSha: await execute(config, "git", ["rev-parse", "HEAD"], workspace.path, env) };
+  await run("git", platformCommitArgs("Materialize direct-chain specification", prepared.path));
+  return { ...workspace, baseSha: await run("git", ["rev-parse", "HEAD"]) };
 };
-
-export type WorkspaceCommandExecutor = (
-  config: RunnerConfig,
-  executable: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  options?: CommandOptions,
-) => Promise<string>;
 
 export type WorkspaceProvisionClaim = GitProvenanceClaim & Pick<ClaimedTask, "specificationMaterialization"> & {
   task: GitProvenanceClaim["task"] & Pick<ClaimedTask["task"], "id">;
@@ -127,42 +107,21 @@ export type WorkspaceReuseClaim = GitProvenanceClaim & {
 };
 
 export type ProvisionWorkspaceDependencies = {
-  execute?: WorkspaceCommandExecutor;
+  /** Bound to the workspace root; provisioning rebinds it to the run directory
+   *  for the commands that belong there. */
+  run?: CommandRunner;
   retryOptions?: RetryOptions;
   dependencyCacheOptions?: DependencyCacheOptions;
   mirrorOptions?: RepoMirrorOptions;
 };
 
-/**
- * Every workspace mutation runs through here so that, when RUNNER_RUN_AS_PREFIX
- * is set, whatever it creates is owned by the launched account rather than by
- * the runner daemon's own uid. `input` exists for the same reason: a secret
- * reaches the launched account on stdin, never in argv, which `ps` shows to
- * every account on the host.
- *
- * It delegates to exec.ts's runCommand like every other external command in the
- * runner — the process-group kill and the timeout ceiling are not properties a
- * second spawn point should be allowed to miss.
- */
-const commandWithInput = (
-  config: Pick<RunnerConfig, "runAsPrefix">,
-  executable: string,
-  args: string[],
+/** The runner's commands for one directory, under the run-as prefix and the
+ *  provider child environment. See `CommandRunner` for why the prefix is bound
+ *  here rather than threaded through every internal call. */
+const workspaceCommands = (
+  config: Pick<RunnerConfig, "runAsPrefix" | "path" | "home">,
   cwd: string,
-  env: NodeJS.ProcessEnv,
-  input: string | null,
-): Promise<string> => runCommand(
-  config.runAsPrefix, executable, args, cwd, env, input === null ? {} : { input },
-);
-
-const command: WorkspaceCommandExecutor = (
-  config: RunnerConfig,
-  executable: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  options: CommandOptions = {},
-): Promise<string> => runCommand(config.runAsPrefix, executable, args, cwd, env, options);
+): CommandRunner => bindCommandRunner(config.runAsPrefix, cwd, workspaceEnvironment(config));
 
 export type AgentScratch = {
   /** The disposable directory both runner roots live in; removed when the run ends. */
@@ -280,8 +239,6 @@ trap - EXIT HUP INT TERM
 export type RuntimeToolsMaterializationOptions = {
   /** Override only for tests that construct a release fixture. */
   sourceRoot?: string;
-  /** Override the runner command for failure-injection tests. */
-  execute?: WorkspaceCommandExecutor;
 };
 
 export const sessionConfigBaselineRoot = defaultSessionConfigBaselineRoot;
@@ -328,13 +285,11 @@ export const sessionConfigRootExists = async (scratch: AgentScratch): Promise<bo
  */
 export const provisionAgentScratch = async (config: RunnerConfig, sessionId = `anonymous-${randomUUID()}`): Promise<AgentScratch> => {
   const temporaryRoot = await realpath(tmpdir());
+  const run = workspaceCommands(config, temporaryRoot);
   const base = config.runAsPrefix.length > 0
-    ? await realpath((await command(
-      config,
+    ? await realpath((await run(
       "/usr/bin/mktemp",
       ["-d", join(temporaryRoot, "agentos-run-scratch-XXXXXX")],
-      temporaryRoot,
-      workspaceEnvironment(config),
     )).trim())
     : await realpath(await mkdtemp(join(temporaryRoot, "agentos-run-scratch-")));
   const workspaceRoot = join(base, "workspaces");
@@ -348,13 +303,14 @@ export const provisionAgentScratch = async (config: RunnerConfig, sessionId = `a
     // base as well as both roots below it. No cross-account writable or
     // traversable scratch directory is left behind.
     try {
-      await command(config, "/bin/chmod", ["700", base], temporaryRoot, workspaceEnvironment(config));
-      // Node enters cwd before it execs the run-as launcher. The daemon cannot
-      // enter the target principal's 0700 base, so keep cwd on the shared temp
-      // root and let the launched principal mutate the absolute child paths.
-      await command(config, "/bin/mkdir", ["-m", "700", workspaceRoot, stateDir], temporaryRoot, workspaceEnvironment(config));
+      await run("/bin/chmod", ["700", base]);
+      // Node enters the bound directory before it execs the run-as launcher.
+      // The daemon cannot enter the target principal's 0700 base, so this
+      // runner stays bound to the shared temp root and lets the launched
+      // principal mutate the absolute child paths.
+      await run("/bin/mkdir", ["-m", "700", workspaceRoot, stateDir]);
     } catch (error: unknown) {
-      await command(config, "/bin/rm", ["-rf", "--", base], temporaryRoot, workspaceEnvironment(config)).catch(() => undefined);
+      await run("/bin/rm", ["-rf", "--", base]).catch(() => undefined);
       throw error;
     }
   } else {
@@ -382,17 +338,13 @@ export const materializeRuntimeTools = async (
   options: RuntimeToolsMaterializationOptions = {},
 ): Promise<void> => {
   const sourceRoot = options.sourceRoot ?? runtimeToolsSourceRoot;
-  const execute = options.execute ?? command;
-  // A prefixed command changes identity only after Node has entered cwd. The
-  // target-owned 0700 base is therefore valid as an argument, but not as cwd
-  // for the daemon that launches the command.
+  // A prefixed command changes identity only after Node has entered the bound
+  // directory. The target-owned 0700 base is therefore valid as an argument,
+  // but not as the directory the daemon launches the command from.
   const commandCwd = config.runAsPrefix.length > 0 ? await realpath(tmpdir()) : scratch.base;
-  await execute(
-    config,
+  await workspaceCommands(config, commandCwd)(
     "/bin/sh",
     ["-c", runtimeToolsMaterializationScript, "agentos-runtime-tools", sourceRoot, scratch.toolsDir],
-    commandCwd,
-    workspaceEnvironment(config),
   );
 };
 
@@ -409,8 +361,7 @@ export const cleanupAgentScratch = async (
       scratch.toolsDir,
       ...(options.retainConfigRoot ? [] : [scratch.configRoot]),
     ];
-    await command(
-      config,
+    await workspaceCommands(config, await realpath(tmpdir()))(
       "/bin/sh",
       [
         "-c",
@@ -419,8 +370,6 @@ export const cleanupAgentScratch = async (
         ...targetOwnedRoots,
         scratch.base,
       ],
-      await realpath(tmpdir()),
-      workspaceEnvironment(config),
     );
     if (!options.retainConfigRoot) await rm(configParent, { recursive: true, force: true });
   } else {
@@ -448,14 +397,14 @@ export const provisionWorkspace = async (
   provisioning: DependencyProvisioningDecision,
   dependencies: ProvisionWorkspaceDependencies = {},
 ): Promise<Workspace> => {
-  const execute = dependencies.execute ?? command;
   const retryOptions = dependencies.retryOptions ?? {};
   const dependencyCacheOptions = dependencies.dependencyCacheOptions ?? {};
   const mirrorOptions = dependencies.mirrorOptions ?? {};
   const root = resolve(config.workspaceRoot);
   const workspace = resolve(root, claim.run.id);
   if (!inside(root, workspace)) throw new Error("Resolved workspace escaped the controlled root");
-  const env = workspaceEnvironment(config);
+  const run = dependencies.run ?? workspaceCommands(config, root);
+  const inWorkspace = commandRunnerIn(run, workspace);
   if (config.runAsPrefix.length > 0) {
     const rootInfo = await stat(root);
     if (!rootInfo.isDirectory()) throw new Error("RUNNER_WORKSPACE_ROOT is not a directory");
@@ -473,13 +422,13 @@ export const provisionWorkspace = async (
     // sticky workspace root, which is what stops one account unlinking or
     // renaming another's run directory; the session token is protected by its
     // own 0600 mode, and CLI credentials by the per-account home.
-    await command(config, "/bin/sh", ["-c", 'mkdir "$1"; chmod 711 "$1"', "agentos-workspace", workspace], root, env);
+    await run("/bin/sh", ["-c", 'mkdir "$1"; chmod 711 "$1"', "agentos-workspace", workspace]);
   } else {
     await mkdir(root, { recursive: true, mode: 0o750 });
     await mkdir(workspace, { recursive: false, mode: 0o750 });
   }
   try {
-    const identity = await resolveRunnerGitIdentity(config, root, env, execute);
+    const identity = await resolveRunnerGitIdentity(config, run);
     const target = claim.run.targetBranch ?? claim.repo.defaultBranch;
     const branch = claim.run.branch ?? `agentos/${claim.task.id}/run-${claim.run.runNumber}`;
     const pinnedBaseSha = claim.run.pinnedBaseSha;
@@ -493,9 +442,7 @@ export const provisionWorkspace = async (
     const provisioned = await withRepoMirror(
       config,
       claim.repo.remoteUrl,
-      root,
-      env,
-      execute,
+      run,
       { fetchRetryOptions: retryOptions, ...mirrorOptions },
       async (mirror): Promise<Workspace> => {
         if (pinnedBaseSha) {
@@ -520,17 +467,15 @@ export const provisionWorkspace = async (
           // processes of its own user (see api/src/onboarding.ts). The property
           // is that provisioning does not *hand* a blind reviewer its
           // predecessor's report, and that is what the object-id fetch keeps.
-          await ensureMirrorRevisions(
-            config, mirror, [implementationBaseSha, pinnedBaseSha], root, env, execute, retryOptions,
-          );
-          await execute(config, "git", ["init"], workspace, env);
-          const commitHooksPath = await configureWorkspaceGit(config, claim, workspace, identity, env, execute);
-          await execute(config, "git", ["remote", "add", "origin", claim.repo.remoteUrl], workspace, env);
+          await ensureMirrorRevisions(run, mirror, [implementationBaseSha, pinnedBaseSha], retryOptions);
+          await inWorkspace("git", ["init"]);
+          const commitHooksPath = await configureWorkspaceGit(claim, workspace, identity, inWorkspace);
+          await inWorkspace("git", ["remote", "add", "origin", claim.repo.remoteUrl]);
           // Local transport: slow on a large range, but it cannot hang on a
           // network that is no longer in the path, so it carries no ceiling.
-          await execute(config, "git", ["fetch", "--no-tags", mirror, implementationBaseSha, pinnedBaseSha], workspace, env);
-          await execute(config, "git", ["checkout", "--detach", pinnedBaseSha], workspace, env);
-          const baseSha = await execute(config, "git", ["rev-parse", "HEAD"], workspace, env);
+          await inWorkspace("git", ["fetch", "--no-tags", mirror, implementationBaseSha, pinnedBaseSha]);
+          await inWorkspace("git", ["checkout", "--detach", pinnedBaseSha]);
+          const baseSha = await inWorkspace("git", ["rev-parse", "HEAD"]);
           if (baseSha !== pinnedBaseSha) {
             throw new Error(`Pinned workspace resolved ${baseSha}, expected ${pinnedBaseSha}`);
           }
@@ -547,10 +492,10 @@ export const provisionWorkspace = async (
         // the same answer `git ls-remote` used to make a round trip for.
         let cloneTarget = target;
         if (branch !== target && !claim.run.targetBranchPublished
-          && await mirrorHasBranch(config, mirror, branch, root, env, execute)) {
+          && await mirrorHasBranch(run, mirror, branch)) {
           cloneTarget = branch;
         }
-        if (!await mirrorHasBranch(config, mirror, cloneTarget, root, env, execute)) {
+        if (!await mirrorHasBranch(run, mirror, cloneTarget)) {
           // The mirror was pruned against the remote moments ago, so this is the
           // remote's answer, not a mirror fault: the branch the run was told to
           // start from does not exist.
@@ -563,11 +508,11 @@ export const provisionWorkspace = async (
         // refuses the link — Linux protected_hardlinks, with the mirror owned by
         // the daemon and the clone running as another account — git copies the
         // file instead. That is still local disk, and still not the remote.
-        await execute(config, "git", ["clone", "--branch", cloneTarget, "--single-branch", mirror, workspace], root, env);
-        const commitHooksPath = await configureWorkspaceGit(config, claim, workspace, identity, env, execute);
+        await run("git", ["clone", "--branch", cloneTarget, "--single-branch", mirror, workspace]);
+        const commitHooksPath = await configureWorkspaceGit(claim, workspace, identity, inWorkspace);
         // Delivery pushes to `origin`; the mirror is a provisioning detail and
         // must never become the run's publication target.
-        await execute(config, "git", ["remote", "set-url", "origin", claim.repo.remoteUrl], workspace, env);
+        await inWorkspace("git", ["remote", "set-url", "origin", claim.repo.remoteUrl]);
         // `clone --single-branch` writes one fetch refspec, covering only the
         // branch it cloned. When that branch is the run's own published head,
         // nothing in the workspace resolves `origin/<target>`: an agent asking
@@ -577,25 +522,23 @@ export const provisionWorkspace = async (
         // it from the mirror so the ref exists before the agent starts.
         if (cloneTarget !== target) {
           const targetRefspec = `+refs/heads/${target}:refs/remotes/origin/${target}`;
-          await execute(config, "git", ["config", "--add", "remote.origin.fetch", targetRefspec], workspace, env);
-          await execute(config, "git", ["fetch", "--no-tags", mirror, targetRefspec], workspace, env);
+          await inWorkspace("git", ["config", "--add", "remote.origin.fetch", targetRefspec]);
+          await inWorkspace("git", ["fetch", "--no-tags", mirror, targetRefspec]);
         }
-        const baseSha = await execute(config, "git", ["rev-parse", "HEAD"], workspace, env);
-        if (branch !== cloneTarget) await execute(config, "git", ["switch", "-c", branch], workspace, env);
+        const baseSha = await inWorkspace("git", ["rev-parse", "HEAD"]);
+        if (branch !== cloneTarget) await inWorkspace("git", ["switch", "-c", branch]);
         return { path: workspace, branch, baseSha, ...(commitHooksPath ? { commitHooksPath } : {}) };
       },
     );
     const materialized = await materializePreparedSpecification(
-      config,
       claim.specificationMaterialization,
       provisioned,
-      execute,
-      env,
+      inWorkspace,
     );
     // The decision was made when the claim was admitted; provisioning does not
     // re-read the template step or the repository policy.
     if (provisioning.provision) {
-      await materializeWorkspaceDependencies(config, workspace, env, { execute }, dependencyCacheOptions);
+      await materializeWorkspaceDependencies(config, workspace, inWorkspace, dependencyCacheOptions);
     }
     return materialized;
   } catch (error: unknown) {
@@ -611,9 +554,9 @@ export const reuseWorkspace = async (config: RunnerConfig, claim: WorkspaceReuse
   if (!inside(root, workspace)) throw new Error("Resumed workspace escaped the controlled root");
   const info = await stat(workspace);
   if (!info.isDirectory()) throw new Error("Resumed workspace is not a directory");
-  const env = workspaceEnvironment(config);
-  const identity = await resolveRunnerGitIdentity(config, workspace, env, command);
-  const commitHooksPath = await configureWorkspaceGit(config, claim, workspace, identity, env, command);
+  const run = workspaceCommands(config, workspace);
+  const identity = await resolveRunnerGitIdentity(config, run);
+  const commitHooksPath = await configureWorkspaceGit(claim, workspace, identity, run);
   return {
     path: workspace,
     branch: claim.run.branch,
@@ -653,10 +596,10 @@ export const writeSessionCredentials = async (
     // file it is able to read. Writing through the prefix is what makes the
     // file's owner and its reader the same account. `umask 077` closes the
     // window in which the token would exist under the default 0644.
-    const env = workspaceEnvironment(config);
-    await commandWithInput(config, "/bin/sh", ["-c", 'umask 077; mkdir -p "$1"; chmod 700 "$1"', "agentos-credentials", directory], workspace.path, env, null);
-    await commandWithInput(config, "/bin/sh", ["-c", 'umask 077; cat > "$1"; chmod 600 "$1"', "agentos-credentials", path], workspace.path, env, payload);
-    await commandWithInput(config, "/bin/sh", ["-c", 'cat >> "$1"', "agentos-credentials", exclude], workspace.path, env, "\n/.agentos/\n").catch(() => undefined);
+    const run = workspaceCommands(config, workspace.path);
+    await run("/bin/sh", ["-c", 'umask 077; mkdir -p "$1"; chmod 700 "$1"', "agentos-credentials", directory]);
+    await run("/bin/sh", ["-c", 'umask 077; cat > "$1"; chmod 600 "$1"', "agentos-credentials", path], { input: payload });
+    await run("/bin/sh", ["-c", 'cat >> "$1"', "agentos-credentials", exclude], { input: "\n/.agentos/\n" }).catch(() => undefined);
     return path;
   }
   await mkdir(directory, { recursive: true, mode: 0o700 });
@@ -669,11 +612,11 @@ export const captureWorkspaceResult = async (
   config: RunnerConfig,
   workspace: Workspace,
 ): Promise<{ branch: string; baseSha: string; headSha: string }> => {
-  const env = workspaceEnvironment(config);
+  const run = workspaceCommands(config, workspace.path);
   const branch = workspace.pinnedBaseSha
     ? workspace.branch
-    : await command(config, "git", ["branch", "--show-current"], workspace.path, env);
-  const headSha = await command(config, "git", ["rev-parse", "HEAD"], workspace.path, env);
+    : await run("git", ["branch", "--show-current"]);
+  const headSha = await run("git", ["rev-parse", "HEAD"]);
   return { branch, baseSha: workspace.baseSha, headSha };
 };
 
@@ -692,17 +635,17 @@ export const captureWorkspaceSnapshot = async (
   config: RunnerConfig,
   workspace: Workspace,
 ): Promise<WorkspaceSnapshot> => {
-  const env = workspaceEnvironment(config);
+  const run = workspaceCommands(config, workspace.path);
   const [headSha, status, trackedDiff, untrackedOutput] = await Promise.all([
-    command(config, "git", ["rev-parse", "HEAD"], workspace.path, env),
-    command(config, "git", ["status", "--porcelain=v1", "-z", "--untracked-files=all"], workspace.path, env),
-    command(config, "git", ["diff", "--binary", "HEAD", "--"], workspace.path, env),
-    command(config, "git", ["ls-files", "-z", "--others", "--exclude-standard"], workspace.path, env),
+    run("git", ["rev-parse", "HEAD"]),
+    run("git", ["status", "--porcelain=v1", "-z", "--untracked-files=all"]),
+    run("git", ["diff", "--binary", "HEAD", "--"]),
+    run("git", ["ls-files", "-z", "--others", "--exclude-standard"]),
   ]);
   const untrackedPaths = untrackedOutput.split("\0").filter(Boolean);
   const untrackedFiles = await Promise.all(untrackedPaths.map(async (path) => ({
     path,
-    objectId: await command(config, "git", ["hash-object", "--", path], workspace.path, env),
+    objectId: await run("git", ["hash-object", "--", path]),
   })));
   return { headSha, status, trackedDiff, untrackedFiles };
 };
@@ -715,7 +658,7 @@ export const cleanupWorkspace = async (
   const workspace = resolve(workspacePath);
   if (!inside(root, workspace) || workspace === root) throw new Error("Refusing to clean a path outside the controlled workspace root");
   if (config.runAsPrefix.length > 0) {
-    await command(config, "/bin/rm", ["-rf", "--", workspace], root, workspaceEnvironment(config));
+    await workspaceCommands(config, root)("/bin/rm", ["-rf", "--", workspace]);
   } else {
     await rm(workspace, { recursive: true, force: true });
   }

--- a/packages/runner/src/worktree-observer.test.ts
+++ b/packages/runner/src/worktree-observer.test.ts
@@ -5,10 +5,8 @@ import { join, resolve } from "node:path";
 import test from "node:test";
 
 import type { RunnerConfig } from "./config.js";
-import {
-  observeExternalWorktrees,
-  type WorktreeObserverCommandExecutor,
-} from "./worktree-observer.js";
+import type { CommandRunner } from "./exec.js";
+import { observeExternalWorktrees } from "./worktree-observer.js";
 
 const config = (root: string): RunnerConfig => ({
   apiUrl: "http://api.invalid",
@@ -40,9 +38,9 @@ test("reports every registered worktree outside the resolved run workspace", asy
     const workspace = join(root, "run");
     const outside = join(root, "operator", "pool");
     const newlinePath = join(root, "operator", "line\nbreak");
-    const calls: Array<{ executable: string; args: string[]; cwd: string }> = [];
-    const execute: WorktreeObserverCommandExecutor = async (_config, executable, args, cwd) => {
-      calls.push({ executable, args, cwd });
+    const calls: Array<{ executable: string; args: string[] }> = [];
+    const execute: CommandRunner = async (executable, args) => {
+      calls.push({ executable, args: [...args] });
       return porcelain(
         [
           `worktree ${workspace}`,
@@ -70,7 +68,6 @@ test("reports every registered worktree outside the resolved run workspace", asy
     assert.deepEqual(calls, [{
       executable: "git",
       args: ["worktree", "list", "--porcelain", "-z"],
-      cwd: workspace,
     }]);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -81,7 +78,7 @@ test("returns no observation when all registered worktrees resolve inside the ru
   const root = await mkdtemp(join(tmpdir(), "agentos-worktree-observer-compliant-"));
   try {
     const workspace = join(root, "run");
-    const execute: WorktreeObserverCommandExecutor = async () => porcelain(
+    const execute: CommandRunner = async () => porcelain(
       [
         `worktree ${workspace}`,
         "HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -106,8 +103,8 @@ test("falls back to quoted porcelain output when Git does not support -z", async
     const workspace = join(root, "run");
     const newlinePath = join(root, "operator", "line\nbreak");
     const calls: string[][] = [];
-    const execute: WorktreeObserverCommandExecutor = async (_config, _executable, args) => {
-      calls.push(args);
+    const execute: CommandRunner = async (_executable, args) => {
+      calls.push([...args]);
       if (args.includes("-z")) throw new Error("git failed (129): error: unknown switch `z'");
       return [
         `worktree ${workspace}`,
@@ -135,7 +132,7 @@ test("an unresolvable worktree path does not hide other outside worktrees", asyn
     const notDirectory = join(root, "not-a-directory");
     const otherOutside = join(root, "operator", "linked");
     await writeFile(notDirectory, "file\n");
-    const execute: WorktreeObserverCommandExecutor = async () => porcelain(
+    const execute: CommandRunner = async () => porcelain(
       `worktree ${workspace}`,
       `worktree ${notDirectory}/linked`,
       `worktree ${otherOutside}`,

--- a/packages/runner/src/worktree-observer.ts
+++ b/packages/runner/src/worktree-observer.ts
@@ -2,31 +2,8 @@ import { realpath } from "node:fs/promises";
 import { resolve, sep } from "node:path";
 
 import type { RunnerConfig } from "./config.js";
-import { runCommand, type CommandOptions } from "./exec.js";
+import { bindCommandRunner, type CommandRunner } from "./exec.js";
 import { workspaceEnvironment } from "./adapters/environment.js";
-
-/**
- * The command surface used by worktree observation. Keeping this injectable
- * lets completion tests exercise the parser without creating a repository;
- * production uses the runner's single external-command implementation below.
- */
-export type WorktreeObserverCommandExecutor = (
-  config: RunnerConfig,
-  executable: string,
-  args: string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv,
-  options?: CommandOptions,
-) => Promise<string>;
-
-const command: WorktreeObserverCommandExecutor = (
-  config,
-  executable,
-  args,
-  cwd,
-  env,
-  options = {},
-): Promise<string> => runCommand(config.runAsPrefix, executable, args, cwd, env, options);
 
 const WORKTREE_FIELD = "worktree ";
 
@@ -109,32 +86,22 @@ const resolvedPath = async (path: string): Promise<ResolvedPath> => {
  * report-only: an outside path is data, never a reason to mutate or throw.
  * Callers should invoke it while the workspace is available, before disposing
  * it, and decide separately how to persist the returned observation.
+ *
+ * `run` is bound to the workspace by default; passing one lets completion tests
+ * exercise the parser without creating a repository.
  */
 export const observeExternalWorktrees = async (
   config: RunnerConfig,
   workspacePath: string,
-  execute: WorktreeObserverCommandExecutor = command,
+  run: CommandRunner = bindCommandRunner(config.runAsPrefix, workspacePath, workspaceEnvironment(config)),
 ): Promise<string[]> => {
-  const env = workspaceEnvironment(config);
   let worktreePaths: string[];
   try {
-    const output = await execute(
-      config,
-      "git",
-      ["worktree", "list", "--porcelain", "-z"],
-      workspacePath,
-      env,
-    );
+    const output = await run("git", ["worktree", "list", "--porcelain", "-z"]);
     worktreePaths = listedWorktreePaths(output);
   } catch (error: unknown) {
     if (!lacksNulWorktreeOutput(error)) throw error;
-    const output = await execute(
-      config,
-      "git",
-      ["-c", "core.quotePath=false", "worktree", "list", "--porcelain"],
-      workspacePath,
-      env,
-    );
+    const output = await run("git", ["-c", "core.quotePath=false", "worktree", "list", "--porcelain"]);
     worktreePaths = legacyListedWorktreePaths(output);
   }
   const lexicalRoot = resolve(workspacePath);


### PR DESCRIPTION
## What changed

`exec.ts` gains one bound command runner. `bindCommandRunner(runAsPrefix, cwd, env)` fixes the run-as prefix, the working directory and the child environment where a workspace is opened; the resulting `CommandRunner` is called with only the program and its arguments. Two per-call overrides carry the cases that actually exist: `cwd` for a command that belongs in another directory (the run directory under a root-bound provisioning sequence, and the shared temporary root a prefixed command must be launched from), and `env` for addressing git by `GIT_DIR`. `commandRunnerIn(run, cwd)` rebinds a runner to a subdirectory; a per-call `cwd` still wins over it.

That one interface replaces six structurally identical types: `WorkspaceCommandExecutor`, `DependencyCommandExecutor`, `MirrorCommandExecutor`, `GitCommandExecutor`, `WorktreeObserverCommandExecutor` and delivery's `CommandExecutor`. All six are deleted, together with `workspace.ts`'s `command` and `commandWithInput` and `delivery.ts`'s `executeCommand`. About twenty internal functions in `dependency-cache.ts`, `repo-mirror.ts`, `git-provenance.ts` and `workspace.ts` shed the positional `(config, ..., cwd, env, execute)` threading; several lose their `RunnerConfig` parameter entirely (`configureWorkspaceGit`, `deriveDependencyCacheKey`, every internal in `repo-mirror.ts`), and `materializeWorkspaceDependencies` narrows to `Pick<RunnerConfig, "workspaceRoot" | "dependencyCacheRoot">`.

The depth gain is that the run-as prefix stops being a parameter an internal can drop. It is bound once, at the seam where the workspace is opened, and there is no argument left downstream for a new call site to get wrong. The invariant comment that lived at `workspace.ts:133-142` moves to `CommandRunner`, which is now where the prefix is applied.

Public entry points keep their positional shape, so `runner.ts` and `dispose-workspace.ts` are untouched. The injection points are renamed to match what they now carry: `ProvisionWorkspaceDependencies.execute` becomes `run`, and `withRepoMirror` / `observeExternalWorktrees` take a `CommandRunner` in place of `(cwd, env, execute)`.

`runCommand` stays exported: `regression-output-handoff.ts`, `task-output-receipt.ts` and `adapters/session-config.ts` each spawn a single command and are outside this lane's fence.

## Evidence

Re-verified on base `a352dbb96701e90604ee515582118ceaeac73ca0`. All six executor types were present at their findings anchors (line numbers had moved; `dependency-cache.ts` is 706 lines after lane r2's store split, not 1440). Nothing in Candidate R3 was already fixed.

Run in the worktree after the final commit `5dee7cf9`, in the order 00-COMMON requires:

- `export RUNNER_WORKSPACE_ROOT=$(mktemp -d)`
- `npm run lint` — pass. Biome: `Checked 743 files in 4s. No fixes applied.` eslint: clean.
- `npm run typecheck` — pass, exit 0, every workspace.
- `npm run test -w @anneal/runner` — `tests 507 / pass 505 / fail 0 / skipped 2`. The two skips are the pre-existing root-only ones (a distinct run-as uid; permission bits under root).

`test:db` not attempted: no local PostgreSQL, database tests are merge gate evidence. No `*.dbtest.ts` was touched. Nothing under `docs/` was touched, so `test:snapshot-scan` does not apply. No HTTP route added or renamed.

The fakes shrank as the brief asked: `recordingExecutor` (`workspace.test.ts`), `fakeInstallExecutor` (`dependency-cache.test.ts`) and the four in `worktree-observer.test.ts` all lost the three parameters they ignored.

## Decisions taken

**The bound runner needs a per-call environment, not only a per-call directory.** The brief named a `cwd` override. `repo-mirror.ts` addresses git by `GIT_DIR` rather than by directory on every call — deliberately, because the daemon's uid cannot enter a task account's 0700 home — and that is the only reason it composed an environment per command. Rather than leave `env` threaded through `repo-mirror.ts` alone, the runner takes `env` as a per-call override whose entries are merged over the bound environment. `gitEnvironment(env, mirror)` becomes `gitDirectory(mirror)`, which no longer needs the base environment to exist.

**`RuntimeToolsMaterializationOptions.execute` is deleted rather than converted.** It was documented as an override "for failure-injection tests" and no test used it; the four runtime-tools failure tests inject through `PATH` instead. Converting it would have kept a configuration option with no caller.

**Two assertions that proved routing through an ignored parameter are gone, and the property moved to where it now lives.** `dependency-cache.test.ts`'s "workspace mutations always flow through the configured run-as execution identity" asserted that the cache handed `config.runAsPrefix` down to `runCommand`; the same file's child-probe test asserted the fake saw `runAsPrefix` and `env.HOME`. Under a bound runner the cache never sees the prefix or the environment at all, so those assertions would have been checking that the test's own fixture reached the test's own fake. `worktree-observer.test.ts` similarly stopped asserting the recorded `cwd`, which the default binding in the signature now fixes.

The property itself is not dropped — it is proven once, structurally, in `exec.test.ts`: a new test drives a real synthetic launcher and asserts that the prefix is applied on every one of five calls, that the bound directory and environment reach the child, that `cwd` and `env` overrides work, and that `commandRunnerIn` rebinds while a per-call `cwd` still wins. That is a stronger statement than six per-module fakes recording an argument they were handed, and it is the only place the prefix is applied now.

**`commandRunnerIn` merges as `{ ...options, cwd: options.cwd ?? cwd }`.** The naive `{ cwd, ...options }` would let a caller that spreads an options object carrying an explicit `cwd: undefined` silently fall back to the outer binding.

## Fence widened

None. Every file changed is in lane r3's owned paths (`exec.ts`, `workspace.ts`, `dependency-cache.ts`, `repo-mirror.ts`, `git-provenance.ts`, `worktree-observer.ts`, `delivery.ts`) or a test whose assertions the type change necessarily broke: `exec.test.ts`, `workspace.test.ts`, `dependency-cache.test.ts`, `repo-mirror.test.ts`, `worktree-observer.test.ts`, `delivery.test.ts`, `provision-failure.test.ts`. `git-provenance.test.ts` needed no change.

## Reported but unfixed

- `packages/runner/src/adapters/session-config.ts:22` defines a seventh single-command helper of the same family (`(config, executable, args, cwd) => runCommand(config.runAsPrefix, ..., workspaceEnvironment(config))`) and re-tests `config.runAsPrefix.length > 0` at four sites. It is a natural consumer of a bound runner, but the file belongs to the session-config side that the findings assign to lanes E and F, so it is left alone.
- `packages/runner/src/regression-output-handoff.ts:36`/`:104` and `packages/runner/src/task-output-receipt.ts:63` each call `runCommand(config.runAsPrefix, ...)` directly. Both are outside this lane's fence and neither threads the prefix through internals, so neither is a bypass risk; they would simply read better bound.
- `packages/runner/src/workspace.ts` still branches on `config.runAsPrefix.length > 0` at six sites to choose between a prefixed command and node's own `fs`. That is a genuine two-mode decision (the daemon cannot write into a launched account's tree), not threading, and collapsing it is a different lane's question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZ2nb7niziMQtWeUoCY672
