### PR TITLE
fix(gate-worker): declare jq as a worker prerequisite

### DIFF
--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -334,8 +334,9 @@ ssh primary-worker 'bash /tmp/provision.sh --apply'
 
 It pins Node to the version in `.nvmrc` (`v22.17.0`; a repository test keeps the
 standalone script's repeated default synchronized), installs Docker with
-registry mirrors, the native Node build dependencies, and a Git fixture
-identity when the account has none; it points npm at
+registry mirrors, the native Node build dependencies, `jq` (the gate's tests
+invoke it directly, and `run-gate.sh` refuses to return a verdict without it),
+and a Git fixture identity when the account has none; it points npm at
 `registry.npmmirror.com`, pre-pulls `postgres:16-alpine`, and creates `~/gate/`.
 On a VMware guest it also disables VMware's time synchronization and enables
 Ubuntu NTP. Two independent time disciplines caused the guest wall clock to

--- a/packages/runner/runtime-tools/gate-worker/run-gate.sh
+++ b/packages/runner/runtime-tools/gate-worker/run-gate.sh
@@ -159,6 +159,7 @@ no_verdict() {
 command -v git >/dev/null 2>&1 || no_verdict "git is not installed on the worker"
 command -v node >/dev/null 2>&1 || no_verdict "node is not installed on the worker"
 command -v flock >/dev/null 2>&1 || no_verdict "flock is not installed on the worker"
+command -v jq >/dev/null 2>&1 || no_verdict "jq is not installed on the worker"
 # Docker is deliberately not pre-checked here. merge-gate.sh requires it too, and
 # does so after the frozen-record rules, which need neither a daemon nor an
 # install: a documentation branch that rewrites history should be told that,

--- a/packages/runner/src/dependency-cache.test.ts
+++ b/packages/runner/src/dependency-cache.test.ts
@@ -983,13 +983,16 @@ test("dependency-cache audit payloads retain stable event names and fields", asy
     const serialized = events.map((candidate) => JSON.stringify({ audit: "dependency-cache", ...candidate }));
     const parsed = serialized.map((line) => JSON.parse(line) as Record<string, unknown>);
     assert.deepEqual(new Set(parsed.map(({ event: name }) => name)), new Set(events.map(({ event: name }) => name)));
-    const tally = execFileSync("/bin/sh", ["-c", "jq -r .event | sort | uniq -c"], {
+    // jq itself, not a shell pipeline: a missing jq must throw ENOENT here rather
+    // than leave an empty tally behind the exit status of the last pipeline stage.
+    const names = execFileSync("jq", ["-r", ".event"], {
       encoding: "utf8",
       input: `${serialized.join("\n")}\n`,
-    });
-    assert.match(tally, /\bhit\b/u);
-    assert.match(tally, /\bmiss\b/u);
-    assert.match(tally, /\bpublication\b/u);
+    }).split("\n").filter((line) => line !== "");
+    const tally = new Set(names);
+    assert.ok(tally.has("hit"));
+    assert.ok(tally.has("miss"));
+    assert.ok(tally.has("publication"));
   } finally {
     await cleanupRoot(root);
   }

--- a/scripts/gate-worker/gate-worker.test.mjs
+++ b/scripts/gate-worker/gate-worker.test.mjs
@@ -80,7 +80,7 @@ const git = (cwd, ...args) =>
 
 test("provisioning includes the native Node build/runtime dependencies and Git identity", () => {
   const source = readFileSync(provisionPath, "utf8");
-  for (const pkg of ["python3", "build-essential", "libatomic1"]) {
+  for (const pkg of ["jq", "python3", "build-essential", "libatomic1"]) {
     assert.match(source, new RegExp(`for pkg in [^\\n]*\\b${pkg}\\b`), `${pkg} is not provisioned`);
   }
   assert.match(source, /git config --global user\.name/);

--- a/scripts/gate-worker/provision.sh
+++ b/scripts/gate-worker/provision.sh
@@ -150,7 +150,7 @@ fi
 
 step "Base packages"
 missing_pkgs=""
-for pkg in git curl ca-certificates xz-utils util-linux python3 build-essential libatomic1; do
+for pkg in git curl ca-certificates xz-utils util-linux jq python3 build-essential libatomic1; do
   if dpkg -s "$pkg" >/dev/null 2>&1; then
     ok "$pkg"
   else


### PR DESCRIPTION
The dependency-cache audit test shells out to jq to prove the serialized audit lines are jq-consumable. On the fallback worker `agentos-gate`, jq was never installed: the `sh -c "jq -r .event | sort | uniq -c"` pipeline exited 0 with `uniq`'s status and produced an empty tally, so `packages/runner/src/dependency-cache.test.ts` failed with a misleading empty-actual assertion on that host alone. This closes the declaration gap rather than the one host.

- `scripts/gate-worker/provision.sh`: `jq` joins the base apt package list, and the provisioning-contract test pins it alongside the other packages.
- `packages/runner/runtime-tools/gate-worker/run-gate.sh`: a worker without jq now yields `GATE NOT RUN` next to the git/node/flock checks, instead of letting the harness report a FAIL that says nothing about the commit.
- `packages/runner/src/dependency-cache.test.ts`: calls `jq` directly via `execFileSync` and tallies event names in JS. The three assertions are unchanged; a missing jq now throws ENOENT loudly.
- `docs/runbooks/gate-worker.md`: one sentence naming jq where the runbook describes what provision.sh installs.

Verification: `npm run test -w packages/runner` (505 pass, 0 fail), `node --test scripts/gate-worker/gate-worker.test.mjs` (41 pass), `node --test packages/runner/scripts/build-runtime-tools.test.mjs` (7 pass), `npm run lint`, `npm run typecheck -w packages/runner`, `npm run test:snapshot-scan` (21 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bWhYgT4iH15aYwyjN9NEh