### PR TITLE
fix(merge-executor): serialise a nested Error instead of `{}`

### DIFF
--- a/packages/merge-executor/src/redaction.test.ts
+++ b/packages/merge-executor/src/redaction.test.ts
@@ -47,3 +47,37 @@ test("a run-scoped logger adds installation-token redaction on the same sink", (
   assert.equal(lines[0]!.includes(startupSecret), false);
   assert.equal(lines[0]!.includes(installationToken), false);
 });
+
+test("an Error inside a context object is readable rather than `{}`", () => {
+  // Every crash this daemon reports is logged as `log.error(msg, { runId, error })`,
+  // and an Error carries no enumerable own properties: this is the one line an
+  // operator reads after a crash, and it used to read `"error":{}`.
+  const lines: string[] = [];
+  const sink = { log: (line: string) => lines.push(line), warn: (line: string) => lines.push(line), error: (line: string) => lines.push(line) };
+  makeLog(makeRedactor(), sink).error("mechanical run crashed", { runId: "run-1", error: new Error("Anneal API 409: fencing token refused") });
+  assert.equal(lines[0]!.includes('"error":{}'), false, lines[0]);
+  assert.match(lines[0]!, /"name":"Error"/u);
+  assert.match(lines[0]!, /"message":"Anneal API 409: fencing token refused"/u);
+  assert.match(lines[0]!, /"stack":"Error: Anneal API 409/u);
+});
+
+test("a nested Error keeps its whole cause chain, aggregate members included", () => {
+  // `fetch` reports a refused connection as a message-less AggregateError under
+  // the cause of a bare "fetch failed"; the reason exists nowhere else.
+  const text = makeRedactor()({
+    error: new Error("fetch failed", { cause: new AggregateError([new Error("connect ECONNREFUSED 127.0.0.1:3000")], "") }),
+  });
+  assert.match(text, /"message":"fetch failed"/u);
+  assert.match(text, /"name":"AggregateError"/u);
+  assert.match(text, /connect ECONNREFUSED 127\.0\.0\.1:3000/u);
+});
+
+test("a token inside a nested Error's message, stack or cause is redacted", () => {
+  const text = makeRedactor(TOKEN)({
+    runId: "run-1",
+    error: new Error(`request failed with Bearer ${TOKEN}`, { cause: new Error(`minted ${TOKEN}`) }),
+  });
+  assert.equal(text.includes(TOKEN), false, text);
+  assert.ok(text.includes(`request failed with Bearer ${REDACTED}`), text);
+  assert.ok(text.includes(`minted ${REDACTED}`), text);
+});

--- a/packages/merge-executor/src/redaction.ts
+++ b/packages/merge-executor/src/redaction.ts
@@ -15,11 +15,36 @@ export const REDACTED = "[redacted-merge-credential]";
 
 export type Redactor = (value: unknown) => string;
 
+/**
+ * An Error has no enumerable own properties, so `JSON.stringify` renders one as
+ * `{}`. Every crash line this daemon writes passes the thrown value inside a
+ * context object — `log.error("mechanical run crashed", { runId, error })` —
+ * which is exactly the line an operator reads first and exactly the line that
+ * said `{"runId":"...","error":{}}` until this replacer existed.
+ *
+ * What is returned here is walked by the same replacer, so a `cause` that is
+ * itself an Error is expanded in place and the whole chain survives. An
+ * `AggregateError` is unwrapped too: `fetch` reports a failed connection as an
+ * otherwise message-less aggregate whose `errors` hold the only readable
+ * reason.
+ */
+const errorReplacer = (_key: string, value: unknown): unknown => {
+  if (!(value instanceof Error)) return value;
+  const { name, message, stack, cause } = value;
+  const aggregated = (value as { errors?: unknown }).errors;
+  return {
+    name,
+    message,
+    ...(stack === undefined ? {} : { stack }),
+    ...(cause === undefined ? {} : { cause }),
+    ...(Array.isArray(aggregated) ? { errors: aggregated } : {}),
+  };
+};
+
 const stringify = (value: unknown): string => {
   if (typeof value === "string") return value;
-  if (value instanceof Error) return `${value.name}: ${value.message}${value.stack ? `\n${value.stack}` : ""}`;
   try {
-    return JSON.stringify(value) ?? String(value);
+    return JSON.stringify(value, errorReplacer) ?? String(value);
   } catch {
     return String(value);
   }


### PR DESCRIPTION
The redactor formatted a bare Error readably, but every crash line the merge
executor writes passes the thrown value inside a context object —
`log.error("mechanical run crashed", { runId, error })` — and that path went
through `JSON.stringify`, which renders an Error as `{}` because its name,
message and stack are not enumerable own properties.

So the one diagnostic the source comment calls the backstop recorded nothing.
A merge executor that crashed after authorization and then failed its own
completion left exactly two lines, both `{"runId":"...","error":{}}`, and the
real exception was unrecoverable from the host.

`JSON.stringify` now takes a replacer that expands an Error at any depth into
its name, message and stack. What the replacer returns is walked again, so a
`cause` that is itself an Error is expanded in place and the whole chain
survives; an `AggregateError` is unwrapped too, because `fetch` reports a
refused connection as an otherwise message-less aggregate whose `errors` hold
the only readable reason.

Redaction is unchanged and still applies last, over the serialised text: a
token in a nested Error's message, stack or cause is replaced like any other,
and the new path is covered by a test that asserts it.

Verified: `npm run lint` (root), `npm run typecheck -w @anneal/merge-executor`,
`npm run test -w @anneal/merge-executor` (96 pass, 1 skipped schema gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JC4Mg8Dnr1CPzaUK925vr4