### PR TITLE
fix(merge-executor): run when started through a symlinked release

### DIFF
--- a/packages/merge-executor/src/index.test.ts
+++ b/packages/merge-executor/src/index.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import type { Stats } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import type { RunOutcome } from "@anneal/db";
 
@@ -294,4 +299,33 @@ test("a minted installation token cannot escape through run evidence or completi
   assert.ok(completion);
   assert.equal(completion.body.includes(installationToken), false);
   assert.match(completion.body, /crashed during mechanical execution/u);
+});
+
+test("the daemon still starts when it is reached through a symlinked release directory", () => {
+  // The operator runbook installs versioned releases and starts the daemon
+  // through a `current` -> releases/<oid> symlink. ESM resolves that before it
+  // sets import.meta.url, so an entrypoint guard comparing raw strings skipped
+  // `main` entirely: node exited 0 with no output at all and the service
+  // manager respawned the silence forever. Assert the loud behaviour, because
+  // silence is the failure this is standing in front of.
+  const here = fileURLToPath(new URL(".", import.meta.url));
+  const scratch = mkdtempSync(join(tmpdir(), "merge-executor-entrypoint-"));
+  try {
+    const link = join(scratch, "current");
+    symlinkSync(here, link, "dir");
+    const started = spawnSync(
+      process.execPath,
+      ["--conditions=development", "--import", import.meta.resolve("tsx"), join(link, "index.ts")],
+      {
+        // No configuration and an empty working directory, so the startup gate
+        // refuses immediately and this never reaches a control plane.
+        cwd: scratch,
+        env: { PATH: process.env.PATH ?? "" },
+        encoding: "utf8",
+      },
+    );
+    assert.match(started.stderr, /merge-executor startup refused:/u, `stderr was ${JSON.stringify(started.stderr)}`);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
 });

--- a/packages/merge-executor/src/index.ts
+++ b/packages/merge-executor/src/index.ts
@@ -12,6 +12,9 @@
 
 import "dotenv/config";
 
+import { realpathSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
 import { INTEGRATOR_OUTPUT_KIND, MERGE_INTEGRATOR_KIND, MERGE_INTEGRATOR_SCHEMA_VERSION, serializeMergeResult } from "@anneal/db/merge-integrator";
 
 import { makeAgentOsClient, type MechanicalCancellation, type MechanicalClaim } from "./agentos.js";
@@ -252,6 +255,20 @@ export const main = async (): Promise<void> => {
   log.info("merge executor stopped");
 };
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * `import.meta.url` is the *resolved* location: ESM follows symlinks before it
+ * is set, while `process.argv[1]` is the path as spelled on the command line.
+ * Comparing those two strings made this condition false in exactly the layout
+ * this package's operator runbook prescribes — the daemon is started through a
+ * `current` symlink into `releases/<oid>` — so `main` was never called, node
+ * exited 0 having written nothing to either log, and the service manager
+ * respawned that silence forever under KeepAlive.
+ *
+ * Resolve the invoked path the same way the loader did, and build the URL with
+ * `pathToFileURL` rather than string concatenation, which also gets a path
+ * containing a space or a non-ASCII character right.
+ */
+const invokedAs = process.argv[1];
+if (invokedAs && import.meta.url === pathToFileURL(realpathSync(invokedAs)).href) {
   await main();
 }


### PR DESCRIPTION
The entrypoint guard compared `import.meta.url` with `file://${process.argv[1]}`.
Those are not the same path: ESM resolves symlinks before it sets
`import.meta.url`, while `argv[1]` is the path as spelled on the command line.

`docs/runbooks/merge-executor.md` installs versioned releases and starts the
daemon through a `current` -> `releases/<oid>` symlink, and both the
LaunchDaemon and systemd profiles it ships name that path. In that layout — the
only layout this package documents — the comparison was always false, so `main`
was never called. Node exited 0 having written nothing to stdout or stderr, and
the service manager respawned that silence forever under KeepAlive: a daemon
that looks installed, is reported as running, and does no work.

Observed on a real deployment: `launchctl print` reported `runs = 74` with
`last exit code = 0`, and both log files were unchanged since before the
install. Running the same file through its real path printed the startup gate's
refusals immediately.

The fix resolves the invoked path the way the loader did, and builds the URL
with `pathToFileURL` rather than concatenation, which also gets a path holding a
space or a non-ASCII character right.

The test asserts the loud behaviour rather than an internal state: it starts the
entrypoint through a symlinked directory and requires the startup gate to speak.
Silence is the failure being stood in front of, so silence is what the assertion
catches. Verified to fail against the previous guard and pass against this one.

Verified: `npm run lint` (root), `npm run typecheck -w @anneal/merge-executor`,
`npm run test -w @anneal/merge-executor` (97 pass, 1 skipped schema gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JC4Mg8Dnr1CPzaUK925vr4