### PR TITLE
Runner: regression FAIL excerpts carry pytest failures for Python-gated repositories

### DIFF
--- a/.chain/fix/regression-excerpt-pytest/spec.md
+++ b/.chain/fix/regression-excerpt-pytest/spec.md
@@ -1,0 +1,20 @@
+Goal: when a managed repository's merge gate runs pytest, a Regression FAIL records the failing test node ids and assertion lines in the excerpt instead of "no per-test output in gate log".
+
+Background: `packages/runner/runtime-tools/regression-verification.sh` extracts the failure excerpt from the gate log with shapes taken from node:test output: `not ok` lines, `✖`/`×` markers, `AssertionError`, `Error:`, and file context matched by `\.(test|spec|dbtest)\.[cm]?[jt]sx?`. pytest prints none of those. Its failure shapes are: a `FAILED <path>::<name>[ - <message>]` or `ERROR <path>::<name>` line in the short test summary, section headers `____ <name> ____`, assertion detail lines starting with `E   `, and node ids of the form `<path>.py::<name>`. The word-factory repository (registered project `word-factory`, gate `scripts/merge-gate.sh` -> `scripts/pytest_regression_gate.py`) additionally prints a machine line `PYTEST-REGRESSION: UNMET ...` and a JSON line `PYTEST-REGRESSION-RESULT {...}` naming business failures and unknown failures. With the current extractor every pytest gate FAIL for that repository lands as `<stage>: no per-test output in gate log`, so the review-fail step cannot see which test failed. Tests for the extractor live in `packages/runner/src/regression-verification-script.test.ts`.
+
+Changes:
+1. In the extractor, treat a line matching `^\s*(FAILED|ERROR)\s+\S+\.py::` as a failure marker (same handling as `not ok`), and a line containing `\S+\.py::\S+` as file context (same handling as the `.test.js` context), so the node id is retained with the failure.
+2. Treat lines starting with `E   ` (pytest assertion detail) as assertion lines while a failure is open, under the same 32-line adjacency bound as the existing `Error:` handling.
+3. Treat a line matching `^[A-Z][A-Z0-9-]*: (UNMET|FAIL|FAILED|ERROR)\b` (repository gate verdict lines such as `PYTEST-REGRESSION: UNMET`) as a failure marker so a repository-level verdict line is always recorded even when per-test lines are cut by the worker's tail.
+4. Add test cases to `packages/runner/src/regression-verification-script.test.ts` with a pytest-shaped gate log (short summary with two FAILED lines, one `E   assert` block, one `PYTEST-REGRESSION: UNMET` line) asserting the excerpt contains both node ids, the assertion line, and the verdict line, and does not contain the "no per-test output" fallback for that stage; and one case proving node:test extraction is unchanged.
+5. Update `docs/runbooks/add-a-project.md` "Full-tail readiness" with one paragraph stating which pytest output shapes the excerpt recognizes, so a Python repository's gate does not need to emit TAP.
+
+Out of scope: no change to gate-worker scripts (`run-gate.sh`, `gate-dispatch.sh`), to `docs/repo-contract/merge-gate.sh`, or to word-factory; no change to the MAX_LINES cap or the stage attribution rules; no generic "any line with FAIL" heuristic.
+
+Constraints: existing node:test excerpt behaviour and all current test cases stay byte-identical in output; the extractor remains a single inline script inside regression-verification.sh (no new file in the runtime-tools bundle, which is inventoried by release tests); no emoji in project files.
+
+Acceptance:
+- `npm run test -w packages/runner` is green, including the new pytest-shaped cases.
+- `npm run lint` and `npm run typecheck` are green.
+- The runtime-tools inventory tests (`release-snapshot`, `build-runtime-tools`) still list exactly the same six files.
+- `docs/runbooks/add-a-project.md` names the recognized pytest shapes (FAILED/ERROR node id lines, `E   ` lines, repository verdict lines).

--- a/docs/runbooks/add-a-project.md
+++ b/docs/runbooks/add-a-project.md
@@ -268,6 +268,10 @@ mechanical checks.
 The target repository carries exactly one repository-owned Tier 1 file,
 `scripts/merge-gate.sh`. The runner supplies the Regression verification
 tooling; the target file follows the standalone reference contract below.
+For Python gates, the excerpt recognizes pytest `FAILED` and `ERROR` lines
+with `.py::` node IDs, assertion-detail lines beginning `E   `, and repository
+verdict lines such as `PYTEST-REGRESSION: UNMET`; the gate does not need to emit
+TAP.
 
 #### 2. Control-plane prerequisites
 

--- a/packages/runner/runtime-tools/regression-verification.sh
+++ b/packages/runner/runtime-tools/regression-verification.sh
@@ -237,6 +237,8 @@ const fallbackStages = stages.length > 0 ? stages : [summary.trim() || "gate"];
 const stripAnsi = (line) => line.replace(/\u001b\[[0-9;]*m/gu, "");
 const records = [];
 const recordsByLine = new Map();
+const repositoryFailures = [];
+const repositoryFailuresByLine = new Set();
 const stageOutput = new Set();
 const pendingContexts = [];
 let currentStage = null;
@@ -266,6 +268,14 @@ const addRecord = (line, index, stage) => {
   records.push(record);
 };
 
+const addRepositoryFailure = (line, index, stage) => {
+  if (stage) stageOutput.add(stage);
+  else if (stages.length === 1) stageOutput.add(stages[0]);
+  if (repositoryFailuresByLine.has(line)) return;
+  repositoryFailuresByLine.add(line);
+  repositoryFailures.push({ line, index });
+};
+
 const readLog = async () => {
   let index = 0;
   const lines = createInterface({ input: createReadStream(logPath, { encoding: "utf8" }), crlfDelay: Infinity });
@@ -279,7 +289,8 @@ const readLog = async () => {
   // `test at ...`/`location: ...` and a marked failure. Accept either shape so
   // a file path is retained even when the worker forwards only a short tail.
   const isFileContext = /(?:\b(?:test|spec|dbtest)\.[cm]?[jt]sx?(?::\d+(?::\d+)?)?\b|\S+\.py::\S+)/u.test(visible);
-  if (isSubtestContext || isFileContext) {
+  const isPytestNonFailureResult = /\S+\.py::\S+.*\b(?:PASSED|SKIPPED|XFAIL|XPASS)\b/u.test(visible);
+  if ((isSubtestContext || isFileContext) && !isPytestNonFailureResult) {
     pendingContexts.push({ line: visible, index, stage: currentStage });
     if (pendingContexts.length > 12) pendingContexts.shift();
   }
@@ -291,6 +302,11 @@ const readLog = async () => {
   const isAssertion = /\bAssertionError\b/u.test(visible);
   const isError = /\bError:/u.test(visible);
   const isPytestAssertion = /^E {3}/u.test(visible);
+  const isPytestFailureSection = /^\s*_{4,}.+_{4,}\s*$/u.test(visible);
+  if (isPytestFailureSection) {
+    failureOpen = true;
+    failureAge = 0;
+  }
   if (isNotOk || isFailureMarker || isPytestFailure || isRepositoryFailure) {
     const failureStage = currentStage;
     for (const context of pendingContexts) {
@@ -299,7 +315,8 @@ const readLog = async () => {
       }
     }
     pendingContexts.length = 0;
-    addRecord(visible, index, failureStage);
+    if (isRepositoryFailure) addRepositoryFailure(visible, index, failureStage);
+    else addRecord(visible, index, failureStage);
     failureOpen = true;
     failureAge = 0;
   } else if (isAssertion || (failureOpen && (isError || isPytestAssertion))) {
@@ -334,6 +351,7 @@ if (mode !== "failure") throw new Error(`unknown gate log extraction mode: ${mod
 await readLog();
 
 records.sort((left, right) => left.index - right.index);
+repositoryFailures.sort((left, right) => left.index - right.index);
 for (const record of records) {
   for (const stage of record.stages) stageOutput.add(stage);
 }
@@ -341,18 +359,19 @@ for (const record of records) {
 const missingStages = fallbackStages.filter((stage) => !stageOutput.has(stage));
 const fallbackLines = missingStages.map((stage) => `${stage}: no per-test output in gate log`);
 
-// Reserve room for notices before taking log lines. Otherwise forty noisy test
-// lines could crowd out the explicit "no per-test output" fact for another stage.
-const boundedFallback = takeBounded(fallbackLines, MAX_LINES, MAX_BYTES);
+// Reserve room for repository verdicts and notices before taking ordinary log
+// lines. Otherwise forty noisy test lines could crowd out either durable fact.
+const reservedLines = [...repositoryFailures.map((record) => record.line), ...fallbackLines];
+const boundedReserved = takeBounded(reservedLines, MAX_LINES, MAX_BYTES);
 
-const candidateLimit = Math.max(0, MAX_LINES - boundedFallback.lines.length);
+const candidateLimit = Math.max(0, MAX_LINES - boundedReserved.lines.length);
 const candidateBudget = Math.max(
   0,
-  MAX_BYTES - boundedFallback.bytes - (boundedFallback.lines.length > 0 ? 1 : 0),
+  MAX_BYTES - boundedReserved.bytes - (boundedReserved.lines.length > 0 ? 1 : 0),
 );
 const selected = takeBounded(records.map((record) => record.line), candidateLimit, candidateBudget);
 
-process.stdout.write([...selected.lines, ...boundedFallback.lines].join("\n"));
+process.stdout.write([...selected.lines, ...boundedReserved.lines].join("\n"));
 };
 
 main().catch((error) => {

--- a/packages/runner/runtime-tools/regression-verification.sh
+++ b/packages/runner/runtime-tools/regression-verification.sh
@@ -278,17 +278,20 @@ const readLog = async () => {
   // Node's TAP reporter uses `# Subtest`, while the default reporter prints
   // `test at ...`/`location: ...` and a marked failure. Accept either shape so
   // a file path is retained even when the worker forwards only a short tail.
-  const isFileContext = /\b(?:test|spec|dbtest)\.[cm]?[jt]sx?(?::\d+(?::\d+)?)?\b/u.test(visible);
+  const isFileContext = /(?:\b(?:test|spec|dbtest)\.[cm]?[jt]sx?(?::\d+(?::\d+)?)?\b|\S+\.py::\S+)/u.test(visible);
   if (isSubtestContext || isFileContext) {
     pendingContexts.push({ line: visible, index, stage: currentStage });
     if (pendingContexts.length > 12) pendingContexts.shift();
   }
 
   const isNotOk = /\bnot ok\b/u.test(visible);
+  const isPytestFailure = /^\s*(?:FAILED|ERROR)\s+\S+\.py::/u.test(visible);
+  const isRepositoryFailure = /^[A-Z][A-Z0-9-]*: (?:UNMET|FAIL|FAILED|ERROR)\b/u.test(visible);
   const isFailureMarker = /^\s*[✖×]\s+(?!failing tests?:)/u.test(visible);
   const isAssertion = /\bAssertionError\b/u.test(visible);
   const isError = /\bError:/u.test(visible);
-  if (isNotOk || isFailureMarker) {
+  const isPytestAssertion = /^E {3}/u.test(visible);
+  if (isNotOk || isFailureMarker || isPytestFailure || isRepositoryFailure) {
     const failureStage = currentStage;
     for (const context of pendingContexts) {
       if (context.stage === failureStage || !context.stage || !failureStage) {
@@ -299,7 +302,7 @@ const readLog = async () => {
     addRecord(visible, index, failureStage);
     failureOpen = true;
     failureAge = 0;
-  } else if (isAssertion || (failureOpen && isError)) {
+  } else if (isAssertion || (failureOpen && (isError || isPytestAssertion))) {
     addRecord(visible, index, currentStage);
   }
 

--- a/packages/runner/src/regression-verification-script.test.ts
+++ b/packages/runner/src/regression-verification-script.test.ts
@@ -422,6 +422,57 @@ test("gate FAIL preserves its proof without touching the merge lease", () => {
   });
 });
 
+test("gate FAIL records pytest node ids, assertion details, and repository verdicts", () => {
+  const seeded = fixture();
+  assert.equal(run(seeded, "prepare").status, 0);
+  seeded.env.REGRESSION_FIXTURE_GATE_NOISE = [
+    "=========================== short test summary info ============================",
+    "FAILED tests/test_alpha.py::test_alpha - assert actual == expected",
+    "FAILED tests/test_beta.py::test_beta - business rule unmet",
+    "E   assert actual == expected",
+    "PYTEST-REGRESSION: UNMET business failure",
+  ].join("\n");
+  seeded.env.REGRESSION_FIXTURE_GATE_PROOF = "MERGE GATE: FAIL (python tests)";
+  seeded.env.REGRESSION_FIXTURE_GATE_EXIT = "1";
+
+  const finalized = run(seeded, "finalize");
+  assert.equal(finalized.status, 0, finalized.stderr);
+  const verdict = JSON.parse(handoff(seeded).body) as Record<string, unknown>;
+  const excerpt = verdict.gateFailureExcerpt;
+  assert.equal(typeof excerpt, "string");
+  if (typeof excerpt !== "string") throw new Error("gate failure excerpt was not persisted as a string");
+  assert.match(excerpt, /tests\/test_alpha\.py::test_alpha/u);
+  assert.match(excerpt, /tests\/test_beta\.py::test_beta/u);
+  assert.match(excerpt, /E   assert actual == expected/u);
+  assert.match(excerpt, /PYTEST-REGRESSION: UNMET business failure/u);
+  assert.doesNotMatch(excerpt, /python tests: no per-test output in gate log/u);
+});
+
+test("gate FAIL keeps node:test extraction byte-identical", () => {
+  const seeded = fixture();
+  assert.equal(run(seeded, "prepare").status, 0);
+  seeded.env.REGRESSION_FIXTURE_GATE_NOISE = [
+    "== unit tests (all workspaces)",
+    "# Subtest: packages/example.test.ts",
+    "    not ok 1 - broken assertion",
+    "      AssertionError: broken assertion",
+  ].join("\n");
+  seeded.env.REGRESSION_FIXTURE_GATE_PROOF = "MERGE GATE: FAIL (unit tests (all workspaces))";
+  seeded.env.REGRESSION_FIXTURE_GATE_EXIT = "1";
+
+  const finalized = run(seeded, "finalize");
+  assert.equal(finalized.status, 0, finalized.stderr);
+  const verdict = JSON.parse(handoff(seeded).body) as Record<string, unknown>;
+  assert.equal(
+    verdict.gateFailureExcerpt,
+    [
+      "# Subtest: packages/example.test.ts",
+      "    not ok 1 - broken assertion",
+      "      AssertionError: broken assertion",
+    ].join("\n"),
+  );
+});
+
 test("gate FAIL records bounded node:test failures and missing-stage output", () => {
   const seeded = fixture();
   assert.equal(run(seeded, "prepare").status, 0);

--- a/packages/runner/src/regression-verification-script.test.ts
+++ b/packages/runner/src/regression-verification-script.test.ts
@@ -426,10 +426,15 @@ test("gate FAIL records pytest node ids, assertion details, and repository verdi
   const seeded = fixture();
   assert.equal(run(seeded, "prepare").status, 0);
   seeded.env.REGRESSION_FIXTURE_GATE_NOISE = [
+    "=================================== FAILURES ===================================",
+    "_________________________________ test_alpha __________________________________",
+    ">       assert actual == expected",
+    "E   assert actual == expected",
+    "__________________________________ test_beta __________________________________",
+    "E   RuntimeError: business rule unmet",
     "=========================== short test summary info ============================",
     "FAILED tests/test_alpha.py::test_alpha - assert actual == expected",
     "FAILED tests/test_beta.py::test_beta - business rule unmet",
-    "E   assert actual == expected",
     "PYTEST-REGRESSION: UNMET business failure",
   ].join("\n");
   seeded.env.REGRESSION_FIXTURE_GATE_PROOF = "MERGE GATE: FAIL (python tests)";
@@ -448,7 +453,56 @@ test("gate FAIL records pytest node ids, assertion details, and repository verdi
   assert.doesNotMatch(excerpt, /python tests: no per-test output in gate log/u);
 });
 
-test("gate FAIL keeps node:test extraction byte-identical", () => {
+test("gate FAIL preserves a terminal repository verdict after forty pytest failures", () => {
+  const seeded = fixture();
+  assert.equal(run(seeded, "prepare").status, 0);
+  seeded.env.REGRESSION_FIXTURE_GATE_NOISE = [
+    "=========================== short test summary info ============================",
+    ...Array.from(
+      { length: 45 },
+      (_, index) => `FAILED tests/test_module_${index}.py::test_case_${index} - assertion failed`,
+    ),
+    "PYTEST-REGRESSION: UNMET business failures=45 unknown=0",
+  ].join("\n");
+  seeded.env.REGRESSION_FIXTURE_GATE_PROOF = "MERGE GATE: FAIL (python tests)";
+  seeded.env.REGRESSION_FIXTURE_GATE_EXIT = "1";
+
+  const finalized = run(seeded, "finalize");
+  assert.equal(finalized.status, 0, finalized.stderr);
+  const verdict = JSON.parse(handoff(seeded).body) as Record<string, unknown>;
+  const excerpt = verdict.gateFailureExcerpt;
+  assert.equal(typeof excerpt, "string");
+  if (typeof excerpt !== "string") throw new Error("gate failure excerpt was not persisted as a string");
+  assert.match(excerpt, /PYTEST-REGRESSION: UNMET business failures=45 unknown=0/u);
+  assert.ok(excerpt.split("\n").length <= 40, "failure excerpt exceeded its line cap");
+  assert.ok(Buffer.byteLength(excerpt, "utf8") <= 4000, "failure excerpt exceeded its byte cap");
+});
+
+test("gate FAIL omits passing pytest node ids from failure context", () => {
+  const seeded = fixture();
+  assert.equal(run(seeded, "prepare").status, 0);
+  seeded.env.REGRESSION_FIXTURE_GATE_NOISE = [
+    "== python tests",
+    ...Array.from(
+      { length: 20 },
+      (_, index) => `tests/test_module_${index}.py::test_case_${index} PASSED [${index + 1}%]`,
+    ),
+    "FAILED tests/test_failure.py::test_failure - assert false",
+  ].join("\n");
+  seeded.env.REGRESSION_FIXTURE_GATE_PROOF = "MERGE GATE: FAIL (python tests)";
+  seeded.env.REGRESSION_FIXTURE_GATE_EXIT = "1";
+
+  const finalized = run(seeded, "finalize");
+  assert.equal(finalized.status, 0, finalized.stderr);
+  const verdict = JSON.parse(handoff(seeded).body) as Record<string, unknown>;
+  const excerpt = verdict.gateFailureExcerpt;
+  assert.equal(typeof excerpt, "string");
+  if (typeof excerpt !== "string") throw new Error("gate failure excerpt was not persisted as a string");
+  assert.match(excerpt, /FAILED tests\/test_failure\.py::test_failure/u);
+  assert.doesNotMatch(excerpt, /\bPASSED\b/u);
+});
+
+test("gate FAIL extracts a node:test subtest, not ok, and assertion block", () => {
   const seeded = fixture();
   assert.equal(run(seeded, "prepare").status, 0);
   seeded.env.REGRESSION_FIXTURE_GATE_NOISE = [


### PR DESCRIPTION
Automated delivery for Anneal task cmtl9b6mc02kdmp2ocaqc1e9i.