### PR TITLE
fix(db): register the pre-optional-review prompt rollover

### DIFF
--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -408,6 +408,104 @@ test("sync rolls the checkout Regression prompt generation once and preserves ch
   }), 2);
 });
 
+test("sync rolls the deployed pre-optional-review prompt generation once", async (t) => {
+  // The generation production ran when the blind review step became optional:
+  // runner-provided Regression tooling was already installed, only the fix and
+  // Regression prompts still required both review reports.
+  const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
+  const templateNames = ["direct-engineer-workflow", "compound-engineer-workflow"] as const;
+  const templates = await prisma.taskTemplate.findMany({
+    where: { projectId: project.id, name: { in: [...templateNames] } },
+    include: { steps: { orderBy: { stepIndex: "asc" } } },
+    orderBy: { name: "asc" },
+  });
+  assert.equal(templates.length, templateNames.length);
+
+  const taskIds: string[] = [];
+  const legacyTemplateIds: string[] = [];
+  const retired = new Map<string, { templateId: string; fixTaskId: string; prompt: string }>();
+  t.after(async () => {
+    await prisma.task.deleteMany({ where: { id: { in: taskIds } } });
+    await prisma.taskTemplate.deleteMany({ where: { id: { in: legacyTemplateIds } } });
+  });
+
+  for (const template of templates) {
+    await prisma.taskTemplateStep.updateMany({
+      where: { taskTemplateId: template.id },
+      data: { provisionDependencies: true, optional: false },
+    });
+    const fix = template.steps.find(({ outputKind }) => outputKind === "fixed-implementation");
+    const regression = template.steps.find(({ outputKind }) => outputKind === "regression-verification-v2");
+    assert.ok(fix);
+    assert.ok(regression);
+    const outgoingFixPrompt = restorePreOptionalReviewPrompt(fix.prompt);
+    const outgoingRegressionPrompt = restorePreOptionalReviewPrompt(regression.prompt);
+    assert.notEqual(outgoingFixPrompt, fix.prompt);
+    assert.notEqual(outgoingRegressionPrompt, regression.prompt);
+    await prisma.taskTemplateStep.update({ where: { id: fix.id }, data: { prompt: outgoingFixPrompt } });
+    await prisma.taskTemplateStep.update({ where: { id: regression.id }, data: { prompt: outgoingRegressionPrompt } });
+
+    const chainId = `pre-optional-review-${template.name}-${randomBytes(4).toString("hex")}`;
+    let fixTaskId = "";
+    for (const step of template.steps) {
+      const task = await prisma.task.create({ data: {
+        projectId: project.id,
+        templateId: template.id,
+        templateStepId: step.id,
+        name: `pre-optional review ${template.name} ${step.stepIndex}`,
+        description: "prompt-generation rollover fixture",
+        assigneeAgentId: step.assigneeAgentId,
+        assigneeType: step.assigneeType,
+        status: TaskStatus.DONE,
+        chainId,
+        chainIndex: step.stepIndex,
+        chainLayer: step.layer,
+      } });
+      taskIds.push(task.id);
+      if (step.id === fix.id) fixTaskId = task.id;
+    }
+    assert.notEqual(fixTaskId, "");
+    retired.set(template.name, { templateId: template.id, fixTaskId, prompt: outgoingFixPrompt });
+  }
+
+  const synced = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
+  assert.equal(synced.status, 0, synced.output);
+  assert.match(synced.output, /"createdCanonicalTemplates":2/u);
+
+  for (const templateName of templateNames) {
+    const old = retired.get(templateName)!;
+    const legacyName = `${templateName}-legacy-pre-optional-review-omission-${old.templateId}`;
+    const legacy = await prisma.taskTemplate.findUniqueOrThrow({
+      where: { projectId_name: { projectId: project.id, name: legacyName } },
+      include: { steps: { orderBy: { stepIndex: "asc" } } },
+    });
+    assert.equal(legacy.id, old.templateId);
+    legacyTemplateIds.push(legacy.id);
+    const oldTask = await prisma.task.findUniqueOrThrow({
+      where: { id: old.fixTaskId },
+      include: { templateStep: true },
+    });
+    assert.equal(oldTask.templateStep?.prompt, old.prompt);
+
+    const current = await prisma.taskTemplate.findUniqueOrThrow({
+      where: { projectId_name: { projectId: project.id, name: templateName } },
+      include: { steps: { orderBy: { stepIndex: "asc" } } },
+    });
+    assert.notEqual(current.id, old.templateId);
+    const currentFix = current.steps.find(({ outputKind }) => outputKind === "fixed-implementation");
+    assert.ok(currentFix);
+    assert.match(currentFix.prompt, /when it is absent, the Sol report is the sole report/u);
+    assert.equal(current.steps.find(({ outputKind }) => outputKind === "blind-findings")?.optional, true);
+  }
+
+  const second = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
+  assert.equal(second.status, 0, second.output);
+  assert.match(second.output, /"createdCanonicalTemplates":0/u);
+  assert.equal(await prisma.taskTemplate.count({
+    where: { projectId: project.id, name: { contains: "legacy-pre-optional-review-omission" } },
+  }), 2);
+});
+
 test("sync rolls parked and not-yet-started v1 chains forward without changing them", async () => {
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   // The canonical source is now eight-step for bound chains. Reconstruct the

--- a/packages/db/src/canonical-template-transition.test.ts
+++ b/packages/db/src/canonical-template-transition.test.ts
@@ -397,6 +397,26 @@ test("runner-provided Regression tooling is a registered prompt-only rollover in
   }
 });
 
+test("optional review omission is a registered prompt-only rollover in both templates", async () => {
+  const sources = await loadAllTemplateStepSources();
+  const retiredDigests = {
+    "direct-engineer-workflow": "e8fdf5533275e85e33b0cf812db9474b00214de2401e4c97bb6eb0732f864df8",
+    "compound-engineer-workflow": "c3b3bb4692bda266e5afd81bb6ad258f58bd1eed14240f272338e0f44fa5e97e",
+  } as const;
+
+  for (const templateName of PROMPT_ROLLOVER_TEMPLATES) {
+    const current = sources.get(templateName);
+    assert.ok(current);
+    const generation = generationOf(templateName, "pre-optional-review-omission");
+    assert.equal(generation.promptDigest, retiredDigests[templateName]);
+    assert.equal(templatePromptGenerationDigest(current), generation.successorPromptDigest);
+    assert.notEqual(generation.promptDigest, generation.successorPromptDigest);
+    // The retired generation is the one runner-provided tooling rolled to.
+    assert.equal(generationOf(templateName, "pre-runner-provided-regression-tooling").successorPromptDigest, generation.successorPromptDigest);
+    assert.equal(matchedLegacyGeneration(templateName, asPersisted(current)), null);
+  }
+});
+
 test("every prompt-only generation can roll straight to the current source", async () => {
   const sources = await loadAllTemplateStepSources();
   const markers = {
@@ -407,12 +427,14 @@ test("every prompt-only generation can roll straight to the current source", asy
       "pre-internal-npm-scope-rename",
       "pre-product-rename-anneal",
       "pre-runner-provided-regression-tooling",
+      "pre-optional-review-omission",
     ],
     "compound-engineer-workflow": [
       "pre-regression-step-split",
       "pre-internal-npm-scope-rename",
       "pre-product-rename-anneal",
       "pre-runner-provided-regression-tooling",
+      "pre-optional-review-omission",
     ],
   } as const;
   for (const templateName of PROMPT_ROLLOVER_TEMPLATES) {

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -47,6 +47,9 @@ export type LegacyStepRecord = Readonly<{
  * platform by its former product name. Prompt-only in both templates.
  * `pre-runner-provided-regression-tooling`: the graphs whose Regression
  * prompts still resolved the platform script through the repository checkout.
+ * `pre-optional-review-omission`: the graphs whose fix and Regression prompts
+ * still required both review reports, before the blind review step became
+ * optional. Prompt-only in both templates.
  * `pre-pr-handover-quality`: the pull-request graph whose prompts still used
  * the placeholder delivery body and left chain bookkeeping in the published
  * tree.
@@ -245,6 +248,21 @@ const legacyTemplateGenerations = {
         { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
       ],
     },
+    {
+      marker: "pre-optional-review-omission",
+      promptDigest: "e8fdf5533275e85e33b0cf812db9474b00214de2401e4c97bb6eb0732f864df8",
+      successorPromptDigest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
+      shape: [
+        { name: "Revalidate specification", agentName: "spec-revalidator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+      ],
+    },
   ],
   "compound-engineer-workflow": [
     {
@@ -382,6 +400,25 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-runner-provided-regression-tooling",
       promptDigest: "27d552a220439bc091956173bc5ee12e5e7158b160fb015443a68f2e744e85d8",
+      successorPromptDigest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9",
+      shape: [
+        { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+        { name: "Librarian", agentName: "librarian", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "documentation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 8, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 9, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 10, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
+      ],
+    },
+    {
+      marker: "pre-optional-review-omission",
+      promptDigest: "c3b3bb4692bda266e5afd81bb6ad258f58bd1eed14240f272338e0f44fa5e97e",
       successorPromptDigest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },


### PR DESCRIPTION
## Why

Mac auto-deploy of c7425712 escalated with `canonical-prompt-sync-refused`: PR #452 changed the fix and Regression prompts of `direct-engineer-workflow` (steps 5, 6) and `compound-engineer-workflow` (steps 8, 10) but only re-pinned `successorPromptDigest` on the existing generations. The generation production rows actually carry (runner-provided Regression tooling, mandatory blind review) had no registry entry, so sync could neither adopt the prompt on referenced steps nor roll the template over.

## What

- Register `pre-optional-review-omission` in both templates. `promptDigest` is the digest computed from the production rows (`e8fdf553...` direct, `c3b3bb46...` compound, which are also the successor digests the previous generation was pinned to); `successorPromptDigest` is the current source digest.
- Unit test asserts the registry against the current source and the chain of successors.
- dbtest reproduces the deployed generation from the current prompts, runs sync twice, and checks the legacy rename plus the optional blind step on the successor row.

## Verification

- `npm run test -w packages/db`: 424 pass.
- `npm run lint -w packages/db`, `npm run typecheck -w packages/db`: clean.
- Restored prompts reproduce the production digests exactly (checked with the transition digest function against the source tree).
- Production rollover blockers checked read-only: no active Runs, no chain-less open tasks, no webhook config on the four template rows.
- Merge gate: see comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3Z7APNySdzWuyA4Ww9fq4