### PR TITLE
fix(db): match legacy shapes on per-step dependency provisioning

### DIFF
--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -432,7 +432,7 @@ test("sync rolls the deployed pre-optional-review prompt generation once", async
   for (const template of templates) {
     await prisma.taskTemplateStep.updateMany({
       where: { taskTemplateId: template.id },
-      data: { provisionDependencies: true, optional: false },
+      data: { optional: false },
     });
     const fix = template.steps.find(({ outputKind }) => outputKind === "fixed-implementation");
     const regression = template.steps.find(({ outputKind }) => outputKind === "regression-verification-v2");

--- a/packages/db/src/canonical-template-transition.test.ts
+++ b/packages/db/src/canonical-template-transition.test.ts
@@ -414,6 +414,16 @@ test("optional review omission is a registered prompt-only rollover in both temp
     // The retired generation is the one runner-provided tooling rolled to.
     assert.equal(generationOf(templateName, "pre-runner-provided-regression-tooling").successorPromptDigest, generation.successorPromptDigest);
     assert.equal(matchedLegacyGeneration(templateName, asPersisted(current)), null);
+    // The deployed rows carry the outgoing prompts on the current shape: no
+    // optional steps, and the review steps opting out of dependency
+    // provisioning as the source does.
+    assert.equal(
+      legacyGenerationMatches(
+        { marker: generation.marker, shape: generation.shape },
+        asPersisted(current).map((step) => ({ ...step, optional: false })),
+      ),
+      true,
+    );
   }
 });
 

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -17,6 +17,11 @@ export type LegacyStepRecord = Readonly<{
   baseFromStepIndex: number | null;
   layer: number;
   spawnPolicy: Prisma.JsonValue;
+  /**
+   * Defaults to true: generations registered before this field existed
+   * predate steps that opt out of dependency provisioning.
+   */
+  provisionDependencies?: boolean;
 }>;
 
 /**
@@ -255,8 +260,8 @@ const legacyTemplateGenerations = {
       shape: [
         { name: "Revalidate specification", agentName: "spec-revalidator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
-        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null },
-        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
         { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
@@ -426,8 +431,8 @@ const legacyTemplateGenerations = {
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
         { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
-        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
-        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null, provisionDependencies: false },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null, provisionDependencies: false },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
         { name: "Librarian", agentName: "librarian", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "documentation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 8, spawnPolicy: null },
         { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 9, spawnPolicy: null },
@@ -650,7 +655,7 @@ const shapeMatches = (
       || step.attachmentsFromPrevious !== expectedStep.attachmentsFromPrevious
       || step.opensPullRequest !== expectedStep.opensPullRequest
       || step.requiresCommit !== (expectedStep.outputKind === "plan" || expectedStep.outputKind === "implementation")
-      || step.provisionDependencies !== true
+      || step.provisionDependencies !== (expectedStep.provisionDependencies ?? true)
       || step.baseFromStepIndex !== expectedStep.baseFromStepIndex
       || step.layer !== expectedStep.layer
       || !isDeepStrictEqual(step.spawnPolicy, expectedStep.spawnPolicy)) {


### PR DESCRIPTION
## Why

Mac auto-deploy escalated three times with `canonical-prompt-sync-refused` on the direct/compound rows after #452 and #453. Root cause: `shapeMatches` hard-coded `provisionDependencies === true` for every step, but the deployed review steps (direct 3/4, compound 6/7) are `false`, matching the source templates. So the `pre-optional-review-omission` generation registered in #453 never matched, and sync refused to change prompts on steps referenced by instantiated tasks. The dbtest hid this by forcing every fixture row to `true` before running.

## What

- `LegacyStepRecord` gains optional `provisionDependencies` (defaults to `true` for generations registered before the field existed).
- `shapeMatches` compares each step against that expectation.
- Both `pre-optional-review-omission` entries mark the two review steps `false`.
- dbtest fixture no longer forces `provisionDependencies: true`; unit test asserts the current rows carrying the outgoing prompts match the registered generation.

## Verification

- `RUNNER_WORKSPACE_ROOT=$(mktemp -d) npm run test -w packages/db`: 424 pass
- `npm run lint -w packages/db`, `npm run typecheck -w packages/db`: clean
- Merge gate: dispatched to ci-desktop-worker, result appended below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Askk9gsFwAzuUCVk4wr6TB
