### PR TITLE
Gate: local gate slots are accounted per runner account, not per Codex session

### DIFF
--- a/.chain/fix/gate-slots-per-account/spec.md
+++ b/.chain/fix/gate-slots-per-account/spec.md
@@ -1,0 +1,73 @@
+Gate: local gate slots are accounted per runner account, not per Codex session
+
+Goal: `AGENTOS_GATE_LOCAL_SLOTS=N` bounds the local gates a runner account can run at once, regardless of how many Codex sessions that account has.
+
+Background: `packages/runner/runtime-tools/gate-worker/gate-dispatch.sh:88`
+derives its slot directory as
+`SLOT_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch"`, and the comment at
+lines 19-20 says the slots "belong to the machines". Slot ownership is a hard
+link created in that directory (`gate_slot_try`, `lib.sh:159-247`). The Codex
+adapter relocates `HOME` for every session: `codexChildEnvironment` in
+`packages/runner/src/adapters/codex.ts:285-293` sets `HOME` and `CODEX_HOME` to
+`scratch.configRoot`, a per-session directory under the session scratch
+(`workspace.ts:134,300`). Each Codex Run therefore gets a fresh, empty slot
+directory and `AGENTOS_GATE_LOCAL_SLOTS=N` grants every Run its own N slots. On
+a sixteen-runner host with `RUNNER_GATE_LOCAL_SLOTS=1` that is sixteen
+concurrent local gates, each a PostgreSQL container plus a full build and test
+run; the remote path bounds itself (`run-gate.sh:226` holds a worker-wide
+`flock` against `worker-capacity`), the local path does not.
+
+The runner already exports the account's real home to every child as
+`AGENTOS_RUNNER_HOME` (`packages/runner/src/adapters.ts`, `buildChildEnvironment`,
+forwarded through `COMMON_LAUNCHER_ENVIRONMENT` in `adapters/runtime.ts:266-270`)
+precisely for tooling that a relocated `HOME` would cut off. The Claude adapter
+does not relocate `HOME` (`adapters/claude.ts`), so its slots were already
+per account. `docs/runbooks/gate-worker.md` ("First deployment") documents
+`RUNNER_GATE_LOCAL_SLOTS` as a per-runner-owned choice without stating the
+accounting unit.
+
+Changes:
+1. `gate-dispatch.sh` derives `SLOT_ROOT` from `AGENTOS_RUNNER_HOME` when it is
+   set (`$AGENTOS_RUNNER_HOME/.cache/gate-dispatch`), and only otherwise from
+   `XDG_CACHE_HOME` / `HOME`, so every session of one runner account contends
+   for the same slot files whatever `HOME` the adapter gave it.
+2. The startup log line that names the slot directory (or a new one, if none
+   exists) prints the resolved `SLOT_ROOT` and which variable it came from, so
+   a gate excerpt shows which accounting unit applied.
+3. `docs/runbooks/gate-worker.md` states the accounting unit: local slots are
+   per runner account (the account that owns `AGENTOS_RUNNER_HOME`); on a host
+   with one account and many runners, `RUNNER_GATE_LOCAL_SLOTS` is the host
+   ceiling; on a host with one account per runner it is a per-runner ceiling
+   and the host ceiling is the sum. The runbook's first-deployment guidance
+   recommends the remote worker (`RUNNER_GATE_SERVER`) for multi-runner hosts.
+
+Out of scope:
+- A cross-account, host-wide slot root (would need a world-writable directory
+  and a different stale-holder reclaim); hosts with per-runner accounts route
+  through `RUNNER_GATE_SERVER`.
+- Any change to the runner's child environment, `AGENTOS_RUNNER_HOME`, or the
+  Codex `HOME` relocation.
+- `run-gate.sh`, `remote-gate.sh`, the worker-capacity file, and slot-count
+  limits.
+- The slot acquisition mechanism in `lib.sh` (hard link, witness, reclaim).
+
+Constraints:
+- Outside a Run (`AGENTOS_RUNNER_HOME` unset), behaviour is byte-identical to
+  today.
+- The runtime-tools bundle is built from these sources; no hand-edited copy is
+  introduced and the byte-identity checks stay green.
+
+Acceptance:
+1. `scripts/gate-worker/gate-dispatch.test.mjs` has a test that runs two
+   dispatches with different `HOME` values and the same `AGENTOS_RUNNER_HOME`
+   under `AGENTOS_GATE_LOCAL_SLOTS=1`, and asserts the second waits for (or is
+   refused by) the slot held by the first; and a test that with
+   `AGENTOS_RUNNER_HOME` unset the slot directory resolves under `HOME`
+   exactly as before.
+2. The dispatch log names the resolved slot directory and its source variable.
+3. `packages/runner/src/runner.test.ts` and `workspace.test.ts` runtime-tools
+   materialization tests are green against the rebuilt bundle.
+4. `docs/runbooks/gate-worker.md` contains the accounting-unit paragraph;
+   `npm run test:snapshot-scan` is green.
+5. `npm run test -w packages/runner` and the `scripts/gate-worker` suites are
+   green.

--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -148,35 +148,33 @@ AGENTOS_WORKSPACE_PATH="$(git rev-parse --show-toplevel)" AGENTOS_GATE_SERVER=pr
   verdict exists, and re-dispatching is the recovery. A timeout that recurs
   means the queue is systemically full, which is a capacity question, not a
   code question.
-- A slot whose lock cannot be *operated* — a read-only runner-account cache, a lock left
-  by the pre-#132 dispatcher, a lock naming no pid — is not busy and is never
-  waited on. The dispatcher keeps using whatever slots still work; if none do it
-  exits **76** immediately with `GATE NOT RUN:` naming the slots to clear, and
-  if it waited on a busy slot and the wait ran out with a broken lock still
-  around it exits 76 rather than 75. Waiting for a lock nobody can take is
-  waiting for nothing, and reporting it as a full queue hides what to fix.
+- A slot whose lock cannot be *operated* — a read-only slot root, a lock left by
+  the pre-#132 dispatcher, a lock naming no pid — is not busy and is never waited
+  on. The dispatcher keeps using whatever slots still work; if none do it exits
+  **76** immediately with `GATE NOT RUN:` naming the slots to clear, and if it
+  waited on a busy slot and the wait ran out with a broken lock still around it
+  exits 76 rather than 75. Waiting for a lock nobody can take is waiting for
+  nothing, and reporting it as a full queue hides what to fix.
 
 The dispatcher accounts for `remote-1`, `remote-1-2`, `remote-2`, and, when
-local dispatch is enabled, `local-1` through `local-N` under
-`$AGENTOS_RUNNER_HOME/.cache/gate-dispatch/` when
-`AGENTOS_RUNNER_HOME` is set, or `${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch/`
-otherwise, outside any repository because the slots belong to the runner
-account. A direct `merge-gate.sh` bypasses that accounting. A direct
-`remote-gate.sh` bypasses the local lock too, but it cannot exceed worker
-capacity: every installed `run-gate.sh` contends for the worker-wide
-`~/gate/.full-gate.lock` and, only on a capacity-two host,
+local dispatch is enabled, `local-1` through `local-N` in the slot directory
+described below, outside any repository. A direct `merge-gate.sh` bypasses that
+accounting. A direct `remote-gate.sh` bypasses the local lock too, but it cannot
+exceed worker capacity: every installed `run-gate.sh` contends for the
+worker-wide `~/gate/.full-gate.lock` and, only on a capacity-two host,
 `~/gate/.full-gate-2.lock`. Each is held with `flock` for the real process
 lifetime. If an SSH connection drops while its remote process survives, that
 process keeps its worker slot and a later invocation waits instead of exceeding
 the configured capacity.
 
 Local slots are accounted per runner account: the account that owns
-`AGENTOS_RUNNER_HOME` owns the shared slot directory. On a host with one
-account and many runners, `RUNNER_GATE_LOCAL_SLOTS` is the host ceiling. On a
-host with one account per runner, it is a per-runner ceiling and the host
-ceiling is the sum of those per-runner counts. Outside a runner,
-`AGENTOS_RUNNER_HOME` is unset and the slot directory continues to resolve
-from `XDG_CACHE_HOME` or `HOME` as before.
+`AGENTOS_RUNNER_HOME` owns the shared slot directory at
+`$AGENTOS_RUNNER_HOME/.cache/gate-dispatch/`. On a host with one account and
+many runners, `RUNNER_GATE_LOCAL_SLOTS` is the host ceiling. On a host with one
+account per runner, it is a per-runner ceiling and the host ceiling is the sum
+of those per-runner counts. Outside a runner, `AGENTOS_RUNNER_HOME` is unset and
+the slot directory continues to resolve to
+`${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch/` as before.
 
 A lock is a file created with `ln`, holding the pid of the dispatcher that owns
 it. That shape is deliberate and `packages/runner/runtime-tools/gate-worker/lib.sh` explains it:
@@ -523,13 +521,12 @@ changing host capacity.
 
 **`GATE NOT RUN: the slot locks are unusable (...)`** — the named slots have a
 lock this dispatcher cannot operate, so nothing was gated and nothing will be
-until they are cleared. Look at the runner account's cache
-(`$AGENTOS_RUNNER_HOME/.cache/gate-dispatch/` in a Run, otherwise
-`${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch/`): a `<slot>.lock`
+until they are cleared. Look in the slot directory named by the dispatcher's
+startup line (see the accounting-unit paragraph above): a `<slot>.lock`
 *directory* is a leftover from the pre-#132 dispatcher and can go once no old
 `gate-dispatch.sh` is running; a `<slot>.slot` file that does not contain a pid
 was not written by this script and is cleared by hand, again only once no gate
-is running; and a message about not being able to write a lock means the cache
+is running; and a message about not being able to write a lock means the slot
 directory itself is read-only or full. Re-dispatch after clearing.
 
 **`docker: permission denied` / `the docker daemon is not reachable`** — the
@@ -601,10 +598,8 @@ must be reported with its verdict.
 
 ## Undoing it
 
-The local machine carries only the slot lock files under
-the runner account's cache (`$AGENTOS_RUNNER_HOME/.cache/gate-dispatch/` in a
-Run, otherwise `${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch/`), which are inert
-when nothing runs. To return a
+The local machine carries only the slot lock files in the directory named by the
+dispatcher's startup line; they are inert when nothing runs. To return a
 capacity-two worker to one slot, remove `~/gate/worker-capacity` after its gates
 finish. To retire one repository from the worker, delete `~/gate/<repo>` on it;
 to decommission the worker, delete `~/gate`.

--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -158,8 +158,10 @@ AGENTOS_WORKSPACE_PATH="$(git rev-parse --show-toplevel)" AGENTOS_GATE_SERVER=pr
 
 The dispatcher accounts for `remote-1`, `remote-1-2`, `remote-2`, and, when
 local dispatch is enabled, `local-1` through `local-N` under
-`~/.cache/gate-dispatch/`, outside any repository because the slots belong to
-the machines. A direct `merge-gate.sh` bypasses that accounting. A direct
+`$AGENTOS_RUNNER_HOME/.cache/gate-dispatch/` when
+`AGENTOS_RUNNER_HOME` is set, or `${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch/`
+otherwise, outside any repository because the slots belong to the runner
+account. A direct `merge-gate.sh` bypasses that accounting. A direct
 `remote-gate.sh` bypasses the local lock too, but it cannot exceed worker
 capacity: every installed `run-gate.sh` contends for the worker-wide
 `~/gate/.full-gate.lock` and, only on a capacity-two host,
@@ -167,6 +169,14 @@ capacity: every installed `run-gate.sh` contends for the worker-wide
 lifetime. If an SSH connection drops while its remote process survives, that
 process keeps its worker slot and a later invocation waits instead of exceeding
 the configured capacity.
+
+Local slots are accounted per runner account: the account that owns
+`AGENTOS_RUNNER_HOME` owns the shared slot directory. On a host with one
+account and many runners, `RUNNER_GATE_LOCAL_SLOTS` is the host ceiling. On a
+host with one account per runner, it is a per-runner ceiling and the host
+ceiling is the sum of those per-runner counts. Outside a runner,
+`AGENTOS_RUNNER_HOME` is unset and the slot directory continues to resolve
+from `XDG_CACHE_HOME` or `HOME` as before.
 
 A lock is a file created with `ln`, holding the pid of the dispatcher that owns
 it. That shape is deliberate and `packages/runner/runtime-tools/gate-worker/lib.sh` explains it:
@@ -324,6 +334,12 @@ Task secrets cannot override either runner-owned choice. If
 `RUNNER_GATE_SERVER`
 provides no remote capacity to a canonical regression step, but a configured
 local count can still provide an explicit local-only path.
+
+For a host running multiple runners, the first deployment should prefer a
+remote worker configured with `RUNNER_GATE_SERVER` over local capacity. This
+keeps the gate workload on the explicitly provisioned worker and avoids
+mistaking per-account local capacity for a host-wide limit when runner accounts
+are split across the host.
 
 ```
 Host primary-worker

--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -148,7 +148,7 @@ AGENTOS_WORKSPACE_PATH="$(git rev-parse --show-toplevel)" AGENTOS_GATE_SERVER=pr
   verdict exists, and re-dispatching is the recovery. A timeout that recurs
   means the queue is systemically full, which is a capacity question, not a
   code question.
-- A slot whose lock cannot be *operated* — a read-only `~/.cache`, a lock left
+- A slot whose lock cannot be *operated* — a read-only runner-account cache, a lock left
   by the pre-#132 dispatcher, a lock naming no pid — is not busy and is never
   waited on. The dispatcher keeps using whatever slots still work; if none do it
   exits **76** immediately with `GATE NOT RUN:` naming the slots to clear, and
@@ -523,7 +523,9 @@ changing host capacity.
 
 **`GATE NOT RUN: the slot locks are unusable (...)`** — the named slots have a
 lock this dispatcher cannot operate, so nothing was gated and nothing will be
-until they are cleared. Look at `~/.cache/gate-dispatch/`: a `<slot>.lock`
+until they are cleared. Look at the runner account's cache
+(`$AGENTOS_RUNNER_HOME/.cache/gate-dispatch/` in a Run, otherwise
+`${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch/`): a `<slot>.lock`
 *directory* is a leftover from the pre-#132 dispatcher and can go once no old
 `gate-dispatch.sh` is running; a `<slot>.slot` file that does not contain a pid
 was not written by this script and is cleared by hand, again only once no gate
@@ -600,7 +602,9 @@ must be reported with its verdict.
 ## Undoing it
 
 The local machine carries only the slot lock files under
-`~/.cache/gate-dispatch/`, which are inert when nothing runs. To return a
+the runner account's cache (`$AGENTOS_RUNNER_HOME/.cache/gate-dispatch/` in a
+Run, otherwise `${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch/`), which are inert
+when nothing runs. To return a
 capacity-two worker to one slot, remove `~/gate/worker-capacity` after its gates
 finish. To retire one repository from the worker, delete `~/gate/<repo>` on it;
 to decommission the worker, delete `~/gate`.

--- a/packages/runner/runtime-tools/gate-worker/gate-dispatch.sh
+++ b/packages/runner/runtime-tools/gate-worker/gate-dispatch.sh
@@ -17,12 +17,13 @@
 # slots only when --allow-local (or AGENTOS_GATE_ALLOW_LOCAL=1) says this
 # invocation may spend its resources, and those slots are tried before remotes.
 #
-# The accounting is one lock file per configured slot under
-# ${XDG_CACHE_HOME:-~/.cache}/gate-dispatch/, outside any repository because the
-# slots belong to the machines, not to a checkout. lib.sh holds the locking
-# itself and says why it is shaped the way it is. Every dispatch on this machine
-# contends for the same slots. A direct merge-gate.sh is invisible to this
-# accounting. A direct
+# The accounting is one lock file per configured slot under the runner account's
+# cache: AGENTOS_RUNNER_HOME/.cache/gate-dispatch/ in a Run, otherwise
+# ${XDG_CACHE_HOME:-~/.cache}/gate-dispatch/. It is outside any repository because
+# the slots belong to the account, not to a checkout. lib.sh holds the locking
+# itself and says why it is shaped the way it is. Sessions of one account contend
+# for the same slots. A direct merge-gate.sh is invisible to this accounting. A
+# direct
 # remote-gate.sh bypasses the local accounting too, but run-gate.sh enforces the
 # worker's configured capacity with worker-wide execution locks held for the
 # real process lifetime.

--- a/packages/runner/runtime-tools/gate-worker/gate-dispatch.sh
+++ b/packages/runner/runtime-tools/gate-worker/gate-dispatch.sh
@@ -23,10 +23,9 @@
 # the slots belong to the account, not to a checkout. lib.sh holds the locking
 # itself and says why it is shaped the way it is. Sessions of one account contend
 # for the same slots. A direct merge-gate.sh is invisible to this accounting. A
-# direct
-# remote-gate.sh bypasses the local accounting too, but run-gate.sh enforces the
-# worker's configured capacity with worker-wide execution locks held for the
-# real process lifetime.
+# direct remote-gate.sh bypasses the local accounting too, but run-gate.sh
+# enforces the worker's configured capacity with worker-wide execution locks
+# held for the real process lifetime.
 #
 # The optional local slots are only eligible when this worktree is already the
 # thing a local gate would test: HEAD at the requested commit and the tree clean.

--- a/packages/runner/runtime-tools/gate-worker/gate-dispatch.sh
+++ b/packages/runner/runtime-tools/gate-worker/gate-dispatch.sh
@@ -86,7 +86,16 @@ ALLOW_LOCAL="${AGENTOS_GATE_ALLOW_LOCAL:-0}"
 LOCAL_SLOT_COUNT="${AGENTOS_GATE_LOCAL_SLOTS-1}"
 POLL_SECONDS="${GATE_DISPATCH_POLL_SECONDS:-30}"
 TIMEOUT_MINUTES="${GATE_DISPATCH_TIMEOUT_MINUTES:-60}"
-SLOT_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/gate-dispatch"
+if [ -n "${AGENTOS_RUNNER_HOME:-}" ]; then
+  SLOT_ROOT="${AGENTOS_RUNNER_HOME}/.cache/gate-dispatch"
+  SLOT_ROOT_SOURCE="AGENTOS_RUNNER_HOME"
+elif [ -n "${XDG_CACHE_HOME:-}" ]; then
+  SLOT_ROOT="${XDG_CACHE_HOME}/gate-dispatch"
+  SLOT_ROOT_SOURCE="XDG_CACHE_HOME"
+else
+  SLOT_ROOT="$HOME/.cache/gate-dispatch"
+  SLOT_ROOT_SOURCE="HOME"
+fi
 
 OID=""
 MASTER_OID=""
@@ -326,7 +335,8 @@ else
 fi
 [ -n "$FALLBACK_SERVER" ] && printf ', fallback %s(1)' "$FALLBACK_SERVER" >&2
 [ "$ALLOW_LOCAL" -eq 1 ] && printf ', local(%s, explicit)' "$LOCAL_SLOT_COUNT_NUM" >&2
-printf ', poll %ss, timeout %smin\n' "$POLL_SECONDS" "$TIMEOUT_MINUTES" >&2
+printf ', poll %ss, timeout %smin, slot root %s (from %s)\n' \
+  "$POLL_SECONDS" "$TIMEOUT_MINUTES" "$SLOT_ROOT" "$SLOT_ROOT_SOURCE" >&2
 printf 'gate-dispatch: baseline %s%s\n' "$MASTER_OID" "${DEFAULT_REF:+ (${DEFAULT_REF})}" >&2
 
 # --- dispatch ----------------------------------------------------------------

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -706,7 +706,6 @@ test("local slots are shared by sessions of one runner account", async (t) => {
 test("without a runner account home, local slots remain under HOME", (t) => {
   const repo = fixtureRepo(t, {});
   const home = join(scratch(t), "legacy-home");
-  const cache = join(scratch(t), "legacy-xdg-cache");
   mkdirSync(home, { recursive: true });
   const result = dispatch(t, repo, [repo.head, "--master", repo.head, "--allow-local"], {
     AGENTOS_RUNNER_HOME: undefined,
@@ -718,9 +717,8 @@ test("without a runner account home, local slots remain under HOME", (t) => {
   const homeSlots = join(home, ".cache", "gate-dispatch");
   const rootLine = startupLineFor(result.stderr, homeSlots);
   assert.ok(rootLine, result.stderr);
-  assert.match(rootLine, /HOME/u);
+  assert.match(rootLine, /\(from HOME\)/u);
   assert.ok(existsSync(homeSlots));
-  assert.equal(existsSync(join(cache, "gate-dispatch")), false);
 });
 
 test("an invalid local slot count is a usage error before any lock is touched", (t) => {

--- a/scripts/gate-worker/gate-dispatch.test.mjs
+++ b/scripts/gate-worker/gate-dispatch.test.mjs
@@ -29,6 +29,7 @@ import { execFileSync, spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
   cpSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -411,6 +412,9 @@ const waitFor = async (condition, message, timeoutMs = 10_000) => {
   assert.fail(message);
 };
 
+const startupLineFor = (stderr, path) =>
+  stderr.split(/\r?\n/u).find((line) => line.includes(path));
+
 // A cache root with the named slots already taken, so a case states its queue
 // as a precondition instead of racing one into place.
 const busyCache = (t, busySlots = []) => {
@@ -614,6 +618,109 @@ test("local capacity is named local-1 through local-N and an extra dispatch wait
       await Promise.allSettled(active.map((run) => run.done));
     }
   }
+});
+
+test("local slots are shared by sessions of one runner account", async (t) => {
+  const calls = join(scratch(t), "account-slot-calls.log");
+  const release = join(scratch(t), "account-slot-release");
+  writeFileSync(calls, "");
+  const repo = fixtureRepo(t, {
+    mergeGate: `
+      printf '%s\\n' "$$" >> "$GATE_FIXTURE_CALLS"
+      while [ ! -e "$GATE_FIXTURE_RELEASE" ]; do sleep 0.05; done
+      printf 'MERGE GATE: PASS account-slot-%s\\n' "$$"
+      exit 0
+    `,
+    mirrorPush: 'printf "REMOTE MUST NOT RUN\\n"; exit 1',
+    remoteGate: 'printf "REMOTE MUST NOT RUN\\n"; exit 1',
+  });
+  const runnerHome = join(scratch(t), "runner-home");
+  const homeOne = join(scratch(t), "home-one");
+  const homeTwo = join(scratch(t), "home-two");
+  const cacheOne = join(scratch(t), "cache-one");
+  const cacheTwo = join(scratch(t), "cache-two");
+  mkdirSync(runnerHome, { recursive: true });
+  mkdirSync(homeOne, { recursive: true });
+  mkdirSync(homeTwo, { recursive: true });
+  const args = [repo.head, "--master", repo.head, "--allow-local"];
+  const envFor = (home) => ({
+    AGENTOS_GATE_PRIMARY_SERVER: "",
+    AGENTOS_GATE_FALLBACK_SERVER: "",
+    AGENTOS_GATE_LOCAL_SLOTS: "1",
+    AGENTOS_RUNNER_HOME: runnerHome,
+    // Give the two sessions distinct legacy roots as well. With the account
+    // root unset, the old implementation would therefore give each process
+    // an independent local slot despite their different HOME values.
+    XDG_CACHE_HOME: undefined,
+    HOME: home,
+    GATE_FIXTURE_CALLS: calls,
+    GATE_FIXTURE_RELEASE: release,
+  });
+  const sharedSlots = join(runnerHome, ".cache", "gate-dispatch");
+  const active = [];
+  let second;
+
+  try {
+    const first = startDispatch(repo, cacheOne, args, envFor(homeOne));
+    active.push(first);
+    await waitFor(
+      () => readFileSync(calls, "utf8").trim().split("\n").filter(Boolean).length === 1,
+      "the first local gate did not start",
+    );
+    await waitFor(
+      () => existsSync(join(sharedSlots, "local-1.slot")),
+      "the first local gate did not hold the runner-account slot",
+    );
+
+    const firstRootLine = startupLineFor(first.stderr, sharedSlots);
+    assert.ok(firstRootLine, first.stderr);
+    assert.match(firstRootLine, /AGENTOS_RUNNER_HOME/u);
+
+    second = startDispatch(repo, cacheTwo, args, envFor(homeTwo));
+    active.push(second);
+    await waitFor(
+      () => second.stderr.includes("1 slot(s) busy"),
+      "the second session did not wait for the runner-account slot",
+    );
+    assert.equal(second.child.exitCode, null);
+    assert.equal(readFileSync(calls, "utf8").trim().split("\n").filter(Boolean).length, 1);
+    assert.ok(existsSync(join(sharedSlots, "local-1.slot")));
+
+    writeFileSync(release, "release\n");
+    const results = await Promise.all(active.map((run) => run.done));
+    for (const result of results) {
+      assert.equal(result.status, 0, result.stdout + result.stderr);
+      assert.match(result.stdout, /MERGE GATE: PASS account-slot/u);
+      assert.doesNotMatch(result.stdout + result.stderr, /REMOTE MUST NOT RUN/u);
+    }
+    assert.equal(readFileSync(calls, "utf8").trim().split("\n").filter(Boolean).length, 2);
+  } finally {
+    writeFileSync(release, "release\n");
+    for (const run of active) {
+      if (run.child.exitCode === null && run.child.signalCode === null) run.child.kill("SIGTERM");
+    }
+    await Promise.allSettled(active.map((run) => run.done));
+  }
+});
+
+test("without a runner account home, local slots remain under HOME", (t) => {
+  const repo = fixtureRepo(t, {});
+  const home = join(scratch(t), "legacy-home");
+  const cache = join(scratch(t), "legacy-xdg-cache");
+  mkdirSync(home, { recursive: true });
+  const result = dispatch(t, repo, [repo.head, "--master", repo.head, "--allow-local"], {
+    AGENTOS_RUNNER_HOME: undefined,
+    XDG_CACHE_HOME: undefined,
+    HOME: home,
+  });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+
+  const homeSlots = join(home, ".cache", "gate-dispatch");
+  const rootLine = startupLineFor(result.stderr, homeSlots);
+  assert.ok(rootLine, result.stderr);
+  assert.match(rootLine, /HOME/u);
+  assert.ok(existsSync(homeSlots));
+  assert.equal(existsSync(join(cache, "gate-dispatch")), false);
 });
 
 test("an invalid local slot count is a usage error before any lock is touched", (t) => {

--- a/scripts/gate-worker/gate-env.mjs
+++ b/scripts/gate-worker/gate-env.mjs
@@ -24,8 +24,15 @@ export const GATE_ENV_PREFIXES = ["AGENTOS_GATE_", "AGENTOS_RUN_", "GATE_DISPATC
 // run-gate.sh's two are not prefixed but are read the same way: GATE_HOME
 // relocates the whole gate directory a fixture built for itself — at the real
 // worker's mirror, worktrees and logs — and STALE_WORKTREE_MINUTES decides what
-// its sweep reclaims.
-export const GATE_ENV_NAMES = ["AGENTOS_WORKSPACE_PATH", "GATE_HOME", "STALE_WORKTREE_MINUTES"];
+// its sweep reclaims. AGENTOS_RUNNER_HOME is likewise a runner-provided account
+// root for shared local gate slots; a fixture must set it explicitly when that
+// accounting behavior is under test, never inherit the host's account root.
+export const GATE_ENV_NAMES = [
+  "AGENTOS_WORKSPACE_PATH",
+  "AGENTOS_RUNNER_HOME",
+  "GATE_HOME",
+  "STALE_WORKTREE_MINUTES",
+];
 
 // The other half of the same question, and the reason for each entry. Every
 // name the gate scripts read is either stripped by isHostGateConfig or stated


### PR DESCRIPTION
Automated delivery for Anneal task cmtn3qi4q001rdb9lt26q4yzh.