### PR TITLE
refactor(db): pin the canonical source prompt generation once per template

### DIFF
--- a/packages/db/src/canonical-template-installation.test.ts
+++ b/packages/db/src/canonical-template-installation.test.ts
@@ -64,59 +64,61 @@ const row = (steps: readonly PersistedTransitionStep[]): CanonicalInstallationRo
   steps,
 });
 
-test("installation planning decides successor drift, half migrations, and spawnPolicy without a database", async () => {
+test("installation planning decides source generation drift, half migrations, and spawnPolicy without a database", async () => {
   const loaded = await loadTemplateStepSources("direct-engineer-workflow");
   const sources = (steps: readonly TemplateStepSource[]): CanonicalInstallationSources => new Map([
     ["direct-engineer-workflow", steps],
   ]);
   const generation = LEGACY_TEMPLATE_GENERATIONS["direct-engineer-workflow"]
     .find((candidate) => candidate.marker === "pre-adjudication")!;
-  const mutableGeneration = generation as LegacyTemplateGeneration & { successorPromptDigest?: string };
-  const originalSuccessorDigest = mutableGeneration.successorPromptDigest;
 
-    const halfMigrated = asPersisted(loaded);
-    halfMigrated[0] = { ...halfMigrated[0]!, approvalGate: !halfMigrated[0]!.approvalGate };
-    const missingRevalidator = asPersisted(loaded);
-    missingRevalidator[0] = { ...missingRevalidator[0]!, assigneeAgent: null };
-    const spawnPolicy = { mode: "parallel", limit: 2 };
+  const halfMigrated = asPersisted(loaded);
+  halfMigrated[0] = { ...halfMigrated[0]!, approvalGate: !halfMigrated[0]!.approvalGate };
+  const missingRevalidator = asPersisted(loaded);
+  missingRevalidator[0] = { ...missingRevalidator[0]!, assigneeAgent: null };
+  const spawnPolicy = { mode: "parallel", limit: 2 };
   const sourceWithSpawnPolicy = loaded.map((step, index) => index === 0 ? { ...step, spawnPolicy } : step);
+  // Prompts edited after the rollover was registered: the retired row still
+  // matches, so only the pinned source generation can refuse this.
+  const editedSource = loaded.map((step, index) => (
+    index === 0 ? { ...step, prompt: `${step.prompt}\n\nunregistered edit` } : step
+  ));
 
-  try {
-    mutableGeneration.successorPromptDigest = "0".repeat(64);
-    const cases = [
-      {
-        name: "registered row whose source is not its pinned successor",
-        plan: planCanonicalInstallation([row(generationAsPersisted(generation))], sources(loaded)),
-        kind: "refused",
-        reason: /registered to install prompt generation/u,
-      },
-      {
-        name: "half-migrated current row",
-        plan: planCanonicalInstallation([row(halfMigrated)], sources(loaded)),
-        kind: "refused",
-        reason: /Template direct-engineer-workflow \(template\), direct-engineer-workflow step 1 \(step-1\) differs from the canonical source in approvalGate/u,
-      },
-      {
-        name: "current row with a named spawnPolicy",
-        plan: planCanonicalInstallation([row(asPersisted(sourceWithSpawnPolicy))], sources(sourceWithSpawnPolicy)),
-        kind: "current",
-      },
-      {
-        name: "current row with a temporarily missing revalidator Agent",
-        plan: planCanonicalInstallation([row(missingRevalidator)], sources(loaded)),
-        kind: "current",
-      },
-    ] as const;
+  const cases = [
+    {
+      name: "registered row whose source is not the pinned generation",
+      plan: planCanonicalInstallation([row(generationAsPersisted(generation))], sources(editedSource)),
+      kind: "refused",
+      reason: /registered to install prompt generation/u,
+    },
+    {
+      name: "registered row whose source is the pinned generation",
+      plan: planCanonicalInstallation([row(generationAsPersisted(generation))], sources(loaded)),
+      kind: "rollover",
+    },
+    {
+      name: "half-migrated current row",
+      plan: planCanonicalInstallation([row(halfMigrated)], sources(loaded)),
+      kind: "refused",
+      reason: /Template direct-engineer-workflow \(template\), direct-engineer-workflow step 1 \(step-1\) differs from the canonical source in approvalGate/u,
+    },
+    {
+      name: "current row with a named spawnPolicy",
+      plan: planCanonicalInstallation([row(asPersisted(sourceWithSpawnPolicy))], sources(sourceWithSpawnPolicy)),
+      kind: "current",
+    },
+    {
+      name: "current row with a temporarily missing revalidator Agent",
+      plan: planCanonicalInstallation([row(missingRevalidator)], sources(loaded)),
+      kind: "current",
+    },
+  ] as const;
 
-    for (const candidate of cases) {
-      assert.equal(candidate.plan.length, 1, candidate.name);
-      const action = candidate.plan[0]!;
-      assert.equal(action.kind, candidate.kind, candidate.name);
-      if (action.kind === "refused" && "reason" in candidate) assert.match(action.reason, candidate.reason, candidate.name);
-    }
-  } finally {
-    if (originalSuccessorDigest === undefined) delete mutableGeneration.successorPromptDigest;
-    else mutableGeneration.successorPromptDigest = originalSuccessorDigest;
+  for (const candidate of cases) {
+    assert.equal(candidate.plan.length, 1, candidate.name);
+    const action = candidate.plan[0]!;
+    assert.equal(action.kind, candidate.kind, candidate.name);
+    if (action.kind === "refused" && "reason" in candidate) assert.match(action.reason, candidate.reason, candidate.name);
   }
 });
 

--- a/packages/db/src/canonical-template-installation.test.ts
+++ b/packages/db/src/canonical-template-installation.test.ts
@@ -170,3 +170,28 @@ test("current installation adopts review provisioning and the optional-step addi
     /provisionDependencies/u,
   );
 });
+
+test("first installation is refused when the source tree is not the pinned generation", async () => {
+  const loaded = await loadTemplateStepSources("direct-engineer-workflow");
+  const editedSource = loaded.map((step, index) => (
+    index === 0 ? { ...step, prompt: `${step.prompt}\n\nunregistered edit` } : step
+  ));
+  const sources = (steps: readonly TemplateStepSource[]): CanonicalInstallationSources => new Map([
+    ["direct-engineer-workflow", steps],
+  ]);
+
+  assert.deepEqual(planCanonicalInstallation([], sources(loaded), ["project"]), [{
+    kind: "create",
+    templateName: "direct-engineer-workflow",
+    projectId: "project",
+  }]);
+
+  const refusal = planCanonicalInstallation([], sources(editedSource), ["project"]);
+  assert.equal(refusal.length, 1);
+  assert.equal(refusal[0]?.kind, "refused");
+  assert.equal(refusal[0]?.kind === "refused" ? refusal[0].rowId : "unset", null);
+  assert.match(
+    refusal[0]?.kind === "refused" ? refusal[0].reason : "",
+    /registered to install prompt generation/u,
+  );
+});

--- a/packages/db/src/canonical-template-installation.ts
+++ b/packages/db/src/canonical-template-installation.ts
@@ -82,12 +82,16 @@ export const planCanonicalInstallation = (
   const plan: CanonicalInstallationAction[] = [];
   for (const [templateName, sourceSteps] of sources) {
     const matchingRows = rows.filter((row) => row.name === templateName);
-    // Every rollover of this template installs the same graph, so the source
-    // is authenticated once, before any row decides what to do.
+    // Every write of this template installs the same graph, so the source is
+    // authenticated once, before any row decides what to do. A created row is
+    // referenced by no task, exactly as a rolled-over row is, so first
+    // installation is guarded by the same pin.
     const sourceDrift = sourcePromptGenerationDrift(templateName, sourceSteps);
     for (const projectId of requiredProjectIds) {
       if (!matchingRows.some((row) => row.projectId === projectId)) {
-        plan.push({ kind: "create", templateName, projectId });
+        plan.push(sourceDrift === null
+          ? { kind: "create", templateName, projectId }
+          : { kind: "refused", templateName, projectId, rowId: null, reason: sourceDrift });
       }
     }
     for (const row of matchingRows) {

--- a/packages/db/src/canonical-template-installation.ts
+++ b/packages/db/src/canonical-template-installation.ts
@@ -3,9 +3,8 @@ import { AssigneeType, Prisma, RunStatus, TaskStatus } from "@prisma/client";
 import { canonicalStepDrift } from "./canonical-step-adoption.js";
 import {
   legacyTemplateName,
-  LEGACY_TEMPLATE_GENERATIONS,
   matchedLegacyGeneration,
-  successorPromptDrift,
+  sourcePromptGenerationDrift,
   templateRolloverBlockerCount,
   type PersistedTransitionStep,
 } from "./canonical-template-transition.js";
@@ -34,7 +33,6 @@ export type CanonicalInstallationAction =
     rowId: string;
     marker: string;
     legacyName: string;
-    successorVerified: boolean;
   }>
   | Readonly<{
     kind: "refused";
@@ -84,6 +82,9 @@ export const planCanonicalInstallation = (
   const plan: CanonicalInstallationAction[] = [];
   for (const [templateName, sourceSteps] of sources) {
     const matchingRows = rows.filter((row) => row.name === templateName);
+    // Every rollover of this template installs the same graph, so the source
+    // is authenticated once, before any row decides what to do.
+    const sourceDrift = sourcePromptGenerationDrift(templateName, sourceSteps);
     for (const projectId of requiredProjectIds) {
       if (!matchingRows.some((row) => row.projectId === projectId)) {
         plan.push({ kind: "create", templateName, projectId });
@@ -92,10 +93,7 @@ export const planCanonicalInstallation = (
     for (const row of matchingRows) {
       const marker = matchedLegacyGeneration(templateName, row.steps);
       if (marker !== null) {
-        const generation = LEGACY_TEMPLATE_GENERATIONS[templateName]
-          .find((candidate) => candidate.marker === marker)!;
-        const drift = successorPromptDrift(templateName, marker, sourceSteps);
-        plan.push(drift === null
+        plan.push(sourceDrift === null
           ? {
             kind: "rollover",
             templateName,
@@ -103,21 +101,21 @@ export const planCanonicalInstallation = (
             rowId: row.id,
             marker,
             legacyName: legacyTemplateName(templateName, marker, row.id),
-            successorVerified: generation.successorPromptDigest !== undefined,
           }
-          : { kind: "refused", templateName, projectId: row.projectId, rowId: row.id, reason: drift });
+          : { kind: "refused", templateName, projectId: row.projectId, rowId: row.id, reason: sourceDrift });
         continue;
       }
       if (row.legacyNameOverride) {
-        plan.push({
-          kind: "rollover",
-          templateName,
-          projectId: row.projectId,
-          rowId: row.id,
-          marker: "pre-registry-seed",
-          legacyName: row.legacyNameOverride,
-          successorVerified: false,
-        });
+        plan.push(sourceDrift === null
+          ? {
+            kind: "rollover",
+            templateName,
+            projectId: row.projectId,
+            rowId: row.id,
+            marker: "pre-registry-seed",
+            legacyName: row.legacyNameOverride,
+          }
+          : { kind: "refused", templateName, projectId: row.projectId, rowId: row.id, reason: sourceDrift });
         continue;
       }
       const refusal = currentGraphRefusal(templateName, row.id, row.steps, sourceSteps);

--- a/packages/db/src/canonical-template-registry.test.ts
+++ b/packages/db/src/canonical-template-registry.test.ts
@@ -22,19 +22,13 @@ test("the pull-request template has current identity, prompt history, and explic
     generation: null,
   });
   assert.deepEqual(
-    LEGACY_TEMPLATE_GENERATIONS[PR_TEMPLATE_NAME].map(({ marker, promptDigest, successorPromptDigest }) => ({
-      marker,
-      promptDigest,
-      successorPromptDigest,
-    })),
+    LEGACY_TEMPLATE_GENERATIONS[PR_TEMPLATE_NAME].map(({ marker, promptDigest }) => ({ marker, promptDigest })),
     [{
       marker: "pre-pr-handover-quality",
       promptDigest: "93a72d354876a6c26020e8638b6c365fb15e4ca4a400a2d6ca80084994f249d6",
-      successorPromptDigest: "1c1169bf0586f6bb71f4ed34b3eb6b166828802a9b24c6b07844b2f526b5f8a8",
     }, {
       marker: "pre-pr-head-tree-check",
       promptDigest: "805b9e911be94c84e451cdbf4d1cdb93ab10031c031c6854947f56d306fb1906",
-      successorPromptDigest: "1c1169bf0586f6bb71f4ed34b3eb6b166828802a9b24c6b07844b2f526b5f8a8",
     }],
   );
   assert.deepEqual(CURRENT_CANONICAL_STEP_ORDINALS[PR_TEMPLATE_NAME], {

--- a/packages/db/src/canonical-template-transition.test.ts
+++ b/packages/db/src/canonical-template-transition.test.ts
@@ -3,13 +3,14 @@ import test from "node:test";
 
 import { PR_TEMPLATE_NAME } from "./agent-contract.js";
 import {
+  CANONICAL_SOURCE_PROMPT_GENERATIONS,
   canonicalStepOrdinals,
   canonicalTemplateIdentity,
   LEGACY_TEMPLATE_GENERATIONS,
   legacyGenerationMatches,
   legacyTemplateName,
   matchedLegacyGeneration,
-  successorPromptDrift,
+  sourcePromptGenerationDrift,
   templatePromptGenerationDigest,
   templateRolloverBlockerCount,
   type CanonicalTemplateRegistryName,
@@ -266,31 +267,66 @@ test("an unregistered prompt edit matches nothing, so sync refuses instead of ro
   }
 });
 
-test("a rollover refuses a source that is not the successor it was registered to install", async () => {
-  // The gap a single digest leaves: the outgoing row still matches, so the
-  // rename would fire, but the tree now holds prompts nobody registered. That
-  // edit would be installed on the registered transition's authority.
+test("the pinned source generation is the one agents/templates holds", async () => {
+  // The single fact 15 registry literals used to restate, checked here so a
+  // stale pin fails in this suite instead of on a production deploy.
+  const sources = await loadAllTemplateStepSources();
+  for (const [templateName, pinned] of Object.entries(CANONICAL_SOURCE_PROMPT_GENERATIONS)) {
+    const current = sources.get(templateName as CanonicalTemplateRegistryName);
+    assert.ok(current, `${templateName} must load from source`);
+    assert.equal(
+      templatePromptGenerationDigest(current),
+      pinned,
+      `${templateName} pin is stale: re-pin it from npm run db:template-digest`,
+    );
+  }
+  assert.deepEqual(
+    Object.keys(CANONICAL_SOURCE_PROMPT_GENERATIONS).sort((left, right) => left.localeCompare(right)),
+    Object.keys(LEGACY_TEMPLATE_GENERATIONS).sort((left, right) => left.localeCompare(right)),
+  );
+});
+
+test("every registered generation rolls forward to a pinned source generation", () => {
+  // The registry no longer restates the successor, so the only way an entry
+  // can fail to resolve one is by naming a template with no pin at all.
+  for (const [templateName, generations] of Object.entries(LEGACY_TEMPLATE_GENERATIONS)) {
+    const pinned = CANONICAL_SOURCE_PROMPT_GENERATIONS[templateName as CanonicalTemplateRegistryName];
+    assert.match(pinned ?? "", /^[0-9a-f]{64}$/u, `${templateName} must pin a source prompt generation`);
+    for (const generation of generations) {
+      assert.notEqual(
+        generation.promptDigest,
+        pinned,
+        `${templateName}:${generation.marker} retires the generation it rolls forward to`,
+      );
+    }
+  }
+});
+
+test("a rollover refuses a source that is not the generation it was registered to install", async () => {
+  // The gap the retired-row digest leaves: the outgoing row still matches, so
+  // the rename would fire, but the tree now holds prompts nobody registered.
+  // A rollover writes a brand-new row, which no instantiated task references,
+  // so the referenced-step prompt refusal cannot see the edit either.
   const sources = await loadAllTemplateStepSources();
   for (const templateName of PROMPT_ROLLOVER_TEMPLATES) {
     const current = sources.get(templateName);
     assert.ok(current);
 
     // The source as registered: no drift.
-    assert.equal(successorPromptDrift(templateName, "pre-runner-provided-regression-tooling", current), null);
+    assert.equal(sourcePromptGenerationDrift(templateName, current), null);
 
-    // The same rollover, with the prompts edited again after registration.
+    // The same source, with the prompts edited again after registration.
     const driftedSource = current.map((step) => (
       step.stepIndex === current[0]!.stepIndex ? { ...step, prompt: `${step.prompt}\n\nlater edit` } : step
     ));
-    const refusal = successorPromptDrift(templateName, "pre-runner-provided-regression-tooling", driftedSource);
+    const refusal = sourcePromptGenerationDrift(templateName, driftedSource);
     assert.ok(refusal, `${templateName} must refuse an unregistered successor`);
     assert.match(refusal, /registered to install prompt generation/u);
 
     // The outgoing row is unaffected by that edit and still matches, which is
-    // exactly why the successor has to be checked separately.
+    // exactly why the source has to be checked separately.
     const generation = generationOf(templateName, "pre-runner-provided-regression-tooling");
-    assert.ok(generation.successorPromptDigest);
-    assert.notEqual(generation.promptDigest, generation.successorPromptDigest);
+    assert.notEqual(generation.promptDigest, CANONICAL_SOURCE_PROMPT_GENERATIONS[templateName]);
   }
 });
 
@@ -342,7 +378,6 @@ test("the pull-request workflow has a registered prompt-only generation and curr
   assert.ok(current);
   const generation = generationOf(PR_TEMPLATE_NAME, "pre-pr-handover-quality");
   assert.equal(generation.promptDigest, "93a72d354876a6c26020e8638b6c365fb15e4ca4a400a2d6ca80084994f249d6");
-  assert.equal(generation.successorPromptDigest, "1c1169bf0586f6bb71f4ed34b3eb6b166828802a9b24c6b07844b2f526b5f8a8");
   assert.equal(generation.shape.length, 4);
   assert.deepEqual(
     generation.shape,
@@ -359,7 +394,7 @@ test("the pull-request workflow has a registered prompt-only generation and curr
       spawnPolicy,
     })),
   );
-  assert.equal(templatePromptGenerationDigest(current), generation.successorPromptDigest);
+  assert.equal(templatePromptGenerationDigest(current), CANONICAL_SOURCE_PROMPT_GENERATIONS[PR_TEMPLATE_NAME]);
   assert.equal(matchedLegacyGeneration(PR_TEMPLATE_NAME, asPersisted(current)), null);
   assert.deepEqual(canonicalStepOrdinals(PR_TEMPLATE_NAME, null), {
     implementation: 1,
@@ -369,7 +404,7 @@ test("the pull-request workflow has a registered prompt-only generation and curr
   });
   const reviewedGeneration = generationOf(PR_TEMPLATE_NAME, "pre-pr-head-tree-check");
   assert.equal(reviewedGeneration.promptDigest, "805b9e911be94c84e451cdbf4d1cdb93ab10031c031c6854947f56d306fb1906");
-  assert.equal(reviewedGeneration.successorPromptDigest, templatePromptGenerationDigest(current));
+  assert.notEqual(reviewedGeneration.promptDigest, templatePromptGenerationDigest(current));
   assert.deepEqual(reviewedGeneration.shape, generation.shape);
 });
 
@@ -384,8 +419,7 @@ test("the internal npm scope rename is a registered prompt-only rollover", async
     assert.ok(current);
     const generation = generationOf(templateName, "pre-internal-npm-scope-rename");
     assert.equal(generation.promptDigest, retiredDigests[templateName]);
-    assert.equal(templatePromptGenerationDigest(current), generation.successorPromptDigest);
-    assert.notEqual(generation.promptDigest, generation.successorPromptDigest);
+    assert.notEqual(generation.promptDigest, templatePromptGenerationDigest(current));
     assert.equal(matchedLegacyGeneration(templateName, asPersisted(current)), null);
   }
 });
@@ -402,8 +436,7 @@ test("the product rename is a registered prompt-only rollover in both templates"
     assert.ok(current);
     const generation = generationOf(templateName, "pre-product-rename-anneal");
     assert.equal(generation.promptDigest, retiredDigests[templateName]);
-    assert.equal(templatePromptGenerationDigest(current), generation.successorPromptDigest);
-    assert.notEqual(generation.promptDigest, generation.successorPromptDigest);
+    assert.notEqual(generation.promptDigest, templatePromptGenerationDigest(current));
     // The retired generation carries the current shape, so only the digest
     // tells it apart from the graph that replaced it.
     assert.equal(matchedLegacyGeneration(templateName, asPersisted(current)), null);
@@ -422,8 +455,7 @@ test("runner-provided Regression tooling is a registered prompt-only rollover in
     assert.ok(current);
     const generation = generationOf(templateName, "pre-runner-provided-regression-tooling");
     assert.equal(generation.promptDigest, retiredDigests[templateName]);
-    assert.equal(templatePromptGenerationDigest(current), generation.successorPromptDigest);
-    assert.notEqual(generation.promptDigest, generation.successorPromptDigest);
+    assert.notEqual(generation.promptDigest, templatePromptGenerationDigest(current));
     assert.equal(matchedLegacyGeneration(templateName, asPersisted(current)), null);
   }
 });
@@ -440,10 +472,7 @@ test("optional review omission is a registered prompt-only rollover in both temp
     assert.ok(current);
     const generation = generationOf(templateName, "pre-optional-review-omission");
     assert.equal(generation.promptDigest, retiredDigests[templateName]);
-    assert.equal(templatePromptGenerationDigest(current), generation.successorPromptDigest);
-    assert.notEqual(generation.promptDigest, generation.successorPromptDigest);
-    // The retired generation is the one runner-provided tooling rolled to.
-    assert.equal(generationOf(templateName, "pre-runner-provided-regression-tooling").successorPromptDigest, generation.successorPromptDigest);
+    assert.notEqual(generation.promptDigest, templatePromptGenerationDigest(current));
     assert.equal(matchedLegacyGeneration(templateName, asPersisted(current)), null);
     // The deployed rows carry the outgoing prompts on the current shape: no
     // optional steps, and the review steps opting out of dependency
@@ -458,36 +487,13 @@ test("optional review omission is a registered prompt-only rollover in both temp
   }
 });
 
-test("every prompt-only generation can roll straight to the current source", async () => {
+test("every registered generation, structural ones included, rolls straight to the current source", async () => {
+  // No hand-kept marker list: the registry itself is the list, so a newly
+  // registered generation is covered the moment it is added.
   const sources = await loadAllTemplateStepSources();
-  const markers = {
-    "direct-engineer-workflow": [
-      "pre-blind-review-retirement",
-      "pre-platform-spec-materialization",
-      "pre-regression-step-split",
-      "pre-internal-npm-scope-rename",
-      "pre-product-rename-anneal",
-      "pre-runner-provided-regression-tooling",
-      "pre-optional-review-omission",
-    ],
-    "compound-engineer-workflow": [
-      "pre-regression-step-split",
-      "pre-internal-npm-scope-rename",
-      "pre-product-rename-anneal",
-      "pre-runner-provided-regression-tooling",
-      "pre-optional-review-omission",
-    ],
-  } as const;
-  for (const templateName of PROMPT_ROLLOVER_TEMPLATES) {
+  for (const templateName of Object.keys(LEGACY_TEMPLATE_GENERATIONS) as CanonicalTemplateRegistryName[]) {
     const current = sources.get(templateName);
-    assert.ok(current);
-    for (const marker of markers[templateName]) {
-      assert.equal(successorPromptDrift(templateName, marker, current), null, `${templateName}:${marker}`);
-    }
+    assert.ok(current, `${templateName} must load from source`);
+    assert.equal(sourcePromptGenerationDrift(templateName, current), null, templateName);
   }
-});
-
-test("a structural generation pins no successor and is unaffected", () => {
-  const sources: { stepIndex: number; prompt: string }[] = [{ stepIndex: 1, prompt: "anything" }];
-  assert.equal(successorPromptDrift("direct-engineer-workflow", "pre-adjudication", sources), null);
 });

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -466,11 +466,13 @@ export const LEGACY_TEMPLATE_GENERATIONS: Readonly<
  * only half the transition: it says nothing about what the source tree holds
  * when the rollover finally runs. Everywhere else an unregistered prompt edit
  * refuses the deploy because the persisted step is referenced by instantiated
- * tasks and its prompt no longer matches source. A rollover has no such
- * witness: it renames the retired row away and writes a brand-new template row
- * from source, and a brand-new row is referenced by nothing. Without this pin,
- * prompts edited between registering a rollover and deploying it would be
- * installed on the registered transition's authority.
+ * tasks and its prompt no longer matches source. Writing a template row has no
+ * such witness: a rollover renames the retired row away and writes a brand-new
+ * row from source, first installation writes one into a project that had none,
+ * and a brand-new row is referenced by nothing. Without this pin, prompts
+ * edited between registering a rollover and deploying it would be installed on
+ * the registered transition's authority, and onboarding a project would install
+ * whatever the tree happened to hold.
  *
  * It is pinned rather than read from the tree on purpose: a digest computed
  * from the same tree it is meant to authenticate proves nothing. Re-pin it, in
@@ -683,11 +685,12 @@ const shapeMatches = (
  */
 /**
  * A named reason the source tree does not hold the prompt generation this
- * template's rollovers are registered to install, or null when it does.
+ * template is registered to install, or null when it does.
  *
- * Every rollover installs the same thing -- the current source graph -- so
- * this is asked once per template rather than once per retired generation, and
- * it covers structural rollovers as well as prompt-only ones.
+ * Every write of this template installs the same thing -- the current source
+ * graph -- so this is asked once per template rather than once per retired
+ * generation, and it covers first installation and structural rollovers as
+ * well as prompt-only ones.
  */
 export const sourcePromptGenerationDrift = (
   templateName: CanonicalTemplateRegistryName,
@@ -696,7 +699,7 @@ export const sourcePromptGenerationDrift = (
   const registered = CANONICAL_SOURCE_PROMPT_GENERATIONS[templateName];
   const actual = templatePromptGenerationDigest(sourceSteps);
   if (actual === registered) return null;
-  return `${templateName} rollover is registered to install prompt generation ${registered}, but the source tree holds ${actual}`;
+  return `${templateName} is registered to install prompt generation ${registered}, but the source tree holds ${actual}`;
 };
 
 export const legacyGenerationMatches = (

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -91,24 +91,12 @@ export type LegacyTemplateGeneration = Readonly<{
    * outgoing generation's digest here by hand, exactly as they write a shape,
    * and a prompt edit with no entry still refuses the deploy rather than
    * migrating anything on its own.
+   *
+   * The generation an entry rolls *forward to* is not stated here. Every
+   * rollover of a template installs that template's one current source
+   * generation, pinned once in `CANONICAL_SOURCE_PROMPT_GENERATIONS`.
    */
   promptDigest?: string;
-  /**
-   * The prompt generation this entry rolls *forward to*, as the same digest
-   * over the successor's ordered step prompts.
-   *
-   * `promptDigest` authenticates the row being retired. On its own that is only
-   * half the transition: it says nothing about what the source tree happens to
-   * contain when the rollover finally runs. If the prompts were edited again
-   * between registering this entry and deploying it, the rename would still
-   * fire and would install whatever the tree now holds -- the unregistered edit
-   * would ride in on the registered one's authority.
-   *
-   * Pinning the successor closes that. The rollover verifies the source against
-   * this digest before renaming anything, and a mismatch is refused exactly
-   * like any other unregistered drift.
-   */
-  successorPromptDigest?: string;
 }>;
 
 const legacyTemplateGenerations = {
@@ -143,7 +131,6 @@ const legacyTemplateGenerations = {
       // Structurally identical to the current graph on purpose: this transition
       // changed prompts only. `promptDigest` is what tells the two apart.
       promptDigest: "1b2447559a77e28added3509a6f6b17bce8a8cd7db9113bdaaa17d581d874165",
-      successorPromptDigest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
       shape: [
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
@@ -157,7 +144,6 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-platform-spec-materialization",
       promptDigest: "c1a9ec1f8e783c3c814c0d0f5f4a9b91d5759b9dc39473dc200447aeb96677c5",
-      successorPromptDigest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
       shape: [
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
@@ -173,7 +159,6 @@ const legacyTemplateGenerations = {
       // platform script while keeping the template graph unchanged.
       marker: "pre-regression-step-split",
       promptDigest: "a760a6ca04bc047b47831fc4a4064cf2157487142f32a480223d6b5d8187c4a1",
-      successorPromptDigest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
       shape: [
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
@@ -187,7 +172,6 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-internal-npm-scope-rename",
       promptDigest: "3b50afcdd5aef2d0f06b00b7644cc67fac3ffbd29414e44564dc6aeb9757580d",
-      successorPromptDigest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
       shape: [
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
@@ -231,7 +215,6 @@ const legacyTemplateGenerations = {
       // `pre-revalidate-step` above and rolls over structurally as before.
       marker: "pre-product-rename-anneal",
       promptDigest: "0aa379a51d722ec9b8b5d91bc6158d9dd9a1f5d380b50695613d5aece9afda46",
-      successorPromptDigest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
       shape: [
         { name: "Revalidate specification", agentName: "spec-revalidator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -246,7 +229,6 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-runner-provided-regression-tooling",
       promptDigest: "c0ec5acb70b82b85bc3f3aff5840029a303d31e6098b7171a2bef35f105f3371",
-      successorPromptDigest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
       shape: [
         { name: "Revalidate specification", agentName: "spec-revalidator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -261,7 +243,6 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-optional-review-omission",
       promptDigest: "e8fdf5533275e85e33b0cf812db9474b00214de2401e4c97bb6eb0732f864df8",
-      successorPromptDigest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
       shape: [
         { name: "Revalidate specification", agentName: "spec-revalidator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -332,7 +313,6 @@ const legacyTemplateGenerations = {
       // Structurally identical to the current graph on purpose: this transition
       // changed prompts only. `promptDigest` is what tells the two apart.
       promptDigest: "a9994d131d1cf2667c6d61cc7161f5653cf9903a6aae77ed55c18b1db6fb3cf2",
-      successorPromptDigest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -353,7 +333,6 @@ const legacyTemplateGenerations = {
       // platform script while keeping the template graph unchanged.
       marker: "pre-regression-step-split",
       promptDigest: "74fe9add0789494efce82d477ea472ce2a16132fe105e6f12c87223c18dbabf8",
-      successorPromptDigest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -372,7 +351,6 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-internal-npm-scope-rename",
       promptDigest: "79845a3badc75200d30ac22cb4fb10c6efa38308c31156e7b15f4c8475e9f7ff",
-      successorPromptDigest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -391,7 +369,6 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-product-rename-anneal",
       promptDigest: "606f9b5a667781cde3400d114cc7f2ebf00bada6995eee07a7019b63e7dd8424",
-      successorPromptDigest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -410,7 +387,6 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-runner-provided-regression-tooling",
       promptDigest: "27d552a220439bc091956173bc5ee12e5e7158b160fb015443a68f2e744e85d8",
-      successorPromptDigest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -429,7 +405,6 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-optional-review-omission",
       promptDigest: "c3b3bb4692bda266e5afd81bb6ad258f58bd1eed14240f272338e0f44fa5e97e",
-      successorPromptDigest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -454,7 +429,6 @@ const legacyTemplateGenerations = {
       // outgoing and successor generations.
       marker: "pre-pr-handover-quality",
       promptDigest: "93a72d354876a6c26020e8638b6c365fb15e4ca4a400a2d6ca80084994f249d6",
-      successorPromptDigest: "1c1169bf0586f6bb71f4ed34b3eb6b166828802a9b24c6b07844b2f526b5f8a8",
       shape: [
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
@@ -467,7 +441,6 @@ const legacyTemplateGenerations = {
       // committed HEAD tree, not the mutable index.
       marker: "pre-pr-head-tree-check",
       promptDigest: "805b9e911be94c84e451cdbf4d1cdb93ab10031c031c6854947f56d306fb1906",
-      successorPromptDigest: "1c1169bf0586f6bb71f4ed34b3eb6b166828802a9b24c6b07844b2f526b5f8a8",
       shape: [
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
@@ -483,6 +456,34 @@ export type CanonicalTemplateRegistryName = keyof typeof legacyTemplateGeneratio
 export const LEGACY_TEMPLATE_GENERATIONS: Readonly<
   Record<CanonicalTemplateRegistryName, readonly LegacyTemplateGeneration[]>
 > = legacyTemplateGenerations;
+
+/**
+ * The prompt generation each canonical template's source tree holds, as the
+ * digest `templatePromptGenerationDigest` computes over its ordered step
+ * prompts. One value per template; no registered generation restates it.
+ *
+ * `promptDigest` authenticates the row a rollover retires. On its own that is
+ * only half the transition: it says nothing about what the source tree holds
+ * when the rollover finally runs. Everywhere else an unregistered prompt edit
+ * refuses the deploy because the persisted step is referenced by instantiated
+ * tasks and its prompt no longer matches source. A rollover has no such
+ * witness: it renames the retired row away and writes a brand-new template row
+ * from source, and a brand-new row is referenced by nothing. Without this pin,
+ * prompts edited between registering a rollover and deploying it would be
+ * installed on the registered transition's authority.
+ *
+ * It is pinned rather than read from the tree on purpose: a digest computed
+ * from the same tree it is meant to authenticate proves nothing. Re-pin it, in
+ * the same change that edits a canonical prompt, from the value
+ * `npm run db:template-digest` prints. It cannot go stale unnoticed --
+ * `canonical-template-transition.test.ts` recomputes every entry here from
+ * `agents/templates/` and fails on a mismatch.
+ */
+export const CANONICAL_SOURCE_PROMPT_GENERATIONS = {
+  "direct-engineer-workflow": "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
+  "compound-engineer-workflow": "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9",
+  [PR_TEMPLATE_NAME]: "1c1169bf0586f6bb71f4ed34b3eb6b166828802a9b24c6b07844b2f526b5f8a8",
+} as const satisfies Readonly<Record<CanonicalTemplateRegistryName, string>>;
 
 export type CanonicalTemplateIdentity = Readonly<{
   canonicalName: CanonicalTemplateRegistryName;
@@ -549,7 +550,7 @@ export const canonicalStepOrdinals = (
     return generation === null ? CURRENT_CANONICAL_STEP_ORDINALS[canonicalName] ?? null : null;
   }
   if (generation === null && registered.successorStepOrdinals !== undefined) return registered.successorStepOrdinals;
-  if (generation === null && (registered.promptDigest === undefined || registered.successorPromptDigest === undefined)) {
+  if (generation === null && registered.promptDigest === undefined) {
     throw new Error(`Current ${canonicalName} Step ordinals are not derivable from its latest structural transition`);
   }
 
@@ -681,23 +682,21 @@ const shapeMatches = (
  * most one entry can match, and the current source graph matches none.
  */
 /**
- * A named reason the source graph is not the successor a matched generation was
- * registered to roll forward to, or null when it is.
+ * A named reason the source tree does not hold the prompt generation this
+ * template's rollovers are registered to install, or null when it does.
  *
- * Only entries that pin a successor are checked. A structural generation is
- * already authenticated by the shape the source has to match, and entries
- * predating this field keep their previous behaviour.
+ * Every rollover installs the same thing -- the current source graph -- so
+ * this is asked once per template rather than once per retired generation, and
+ * it covers structural rollovers as well as prompt-only ones.
  */
-export const successorPromptDrift = (
-  templateName: string,
-  marker: string,
+export const sourcePromptGenerationDrift = (
+  templateName: CanonicalTemplateRegistryName,
   sourceSteps: readonly { stepIndex: number; prompt: string }[],
 ): string | null => {
-  const generation = registeredGenerations(templateName)?.find((candidate) => candidate.marker === marker);
-  if (!generation?.successorPromptDigest) return null;
+  const registered = CANONICAL_SOURCE_PROMPT_GENERATIONS[templateName];
   const actual = templatePromptGenerationDigest(sourceSteps);
-  if (actual === generation.successorPromptDigest) return null;
-  return `${templateName} rollover ${marker} is registered to install prompt generation ${generation.successorPromptDigest}, but the source tree holds ${actual}`;
+  if (actual === registered) return null;
+  return `${templateName} rollover is registered to install prompt generation ${registered}, but the source tree holds ${actual}`;
 };
 
 export const legacyGenerationMatches = (
@@ -719,17 +718,3 @@ export const matchedLegacyGeneration = (
 ): string | null =>
   registeredGenerations(templateName)
     ?.find((generation) => legacyGenerationMatches(generation, steps))?.marker ?? null;
-
-/**
- * Return a named refusal reason when a canonical row is neither an exact
- * retired graph nor the exact current graph. The caller runs this for every row before
- * renaming or creating anything, so a refusal rolls back as an all-or-none
- * transition and cannot leave a half-installed template set.
- */
-export const legacyTemplateShapeRefusal = (
-  templateName: string,
-  steps: readonly PersistedTransitionStep[],
-): string | null => {
-  if (!registeredGenerations(templateName)) return `unknown canonical template ${templateName}`;
-  return matchedLegacyGeneration(templateName, steps) === null ? null : "legacy";
-};


### PR DESCRIPTION
## What changed

`canonical-template-transition.ts` restated one derivable fact fifteen times.
Every registered generation that rolls forward to the current source carried a
`successorPromptDigest` literal, and all seven direct entries held the same
value, all six compound entries a second, both pull-request entries a third.
Re-typing them was the whole content of `5d3c1c61` and half of `8dcabc75`, and
`2a558a72`'s production outage was a copy that was never made.

The interface now says the thing once. A registered generation names only the
graph it retires (`promptDigest`); the generation a rollover installs is a
property of the template, not of the entry, and lives in the new
`CANONICAL_SOURCE_PROMPT_GENERATIONS` — one value per template, three in total.
`successorPromptDrift(templateName, marker, source)` becomes
`sourcePromptGenerationDrift(templateName, source)`: the marker was never an
input to the answer. `planCanonicalInstallation` asks it once per template,
before any row decides what to do, instead of once per matched row.

Two things go away with it. `successorVerified` on the rollover action was
written and never read, and the distinction it encoded no longer exists now
that every rollover is checked the same way. `legacyTemplateShapeRefusal` had
no callers anywhere outside `dist/` (re-verified on this base).

The check got wider, not narrower. Structural generations pinned no successor
before, and the `pre-registry-seed` adapter pinned nothing at all; both install
the source graph, so both are now checked against the same pin. This cannot
refuse spuriously: a unit test recomputes the pin from `agents/templates/`, so
a released build always holds a pin equal to its own tree.

### How the safety property is preserved

The pinning exists because a rollover is the one path with no other witness.
Everywhere else an unregistered prompt edit refuses the deploy on its own:
`sync-canonical-prompts.ts` refuses a persisted step whose prompt differs from
source when instantiated tasks reference it, and `matchedLegacyGeneration`
requires the retired row's exact `promptDigest`. A rollover renames the retired
row away and writes a brand-new template row from source; a brand-new row is
referenced by nothing, so the prompt refusal cannot see it. Without a pin,
prompts edited between registering a rollover and deploying it would install on
the registered transition's authority.

That is exactly what the replacement keeps. The pin is still a literal, still
written by hand in the change that edits a prompt, and still compared against
the tree before any rename. What changed is its arity: one statement per
template rather than one per retired generation, so there is nothing left to
transcribe inconsistently, and adding a registered generation no longer touches
any digest at all.

## Evidence

Base `f103af192d0cc7ec3ba948f16ac1aaf7ea27da04`. All commands re-run in the lane
worktree after the final commit (`04b3a5f924c99bbf1b9a2c66ec1a2dd6378e0842`,
the disposition commit), with `RUNNER_WORKSPACE_ROOT` pointed at a fresh
temporary directory.

- `npm run lint` (root) — pass, exit 0. Biome checked 771 files, eslint clean.
- `npm run typecheck` (root) — pass, exit 0, every workspace.
- `npm run test -w @anneal/db` — 427 tests, 427 pass, 0 fail (426 at the
  implementation head; the disposition commit adds one).
- `npm run db:template-digest` — prints exactly the three values now pinned in
  `CANONICAL_SOURCE_PROMPT_GENERATIONS` (`8dbdb5fc…`, `e1e95c18…`, `1c1169bf…`).
- Negative proof that a stale pin fails in CI: with the direct-workflow pin
  temporarily set to 64 zeroes, `npm run test -w @anneal/db` reported 4 failures
  including `the pinned source generation is the one agents/templates holds`
  with the message `direct-engineer-workflow pin is stale: re-pin it from
  npm run db:template-digest`. The edit was reverted before committing.
- Merge gate, dispatched for this exact head:
  `MERGE GATE: PASS 04b3a5f924c99bbf1b9a2c66ec1a2dd6378e0842` on
  `ci-desktop-worker`, baseline `f103af192d0cc7ec3ba948f16ac1aaf7ea27da04`.
  No fallback worker was involved and no repair round was needed.
- No file was added and nothing under `docs/` was touched, so
  `test:snapshot-scan` does not apply. No HTTP route changed. No migration.
- `test:db` was not run: the two `canonical-prompt-sync*.dbtest.ts` files
  reference none of the removed identifiers (`grep` for
  `successorPromptDigest|successorPromptDrift|legacyTemplateShapeRefusal|successorVerified`
  across the repository outside `node_modules` and `dist` returns nothing), so
  neither needed an edit; both typecheck under the root `typecheck`.

Anchors re-verified on this base before editing: 15 `successorPromptDigest`
literals in the registry (7 + 6 + 2), a 16th in
`canonical-template-transition.test.ts`, two more in
`canonical-template-registry.test.ts`, a hand-kept marker list in the
"every prompt-only generation can roll straight to the current source" test,
and `legacyTemplateShapeRefusal` with zero callers.

## Decisions taken

**The successor digest stays pinned; it is not read from the source tree.** The
brief asks for the successor digest to be computed from `agents/templates/` at
plan time and never typed into the registry. Delivering that literally would
delete the property the brief also requires me to keep. The check is
"the tree holds the generation an operator reviewed"; a digest read out of the
same tree it is meant to authenticate is a tautology and would make
`sourcePromptGenerationDrift` incapable of ever returning a refusal. The
recommended shape, and the one delivered, is the brief's own fallback: pin the
source generation once per template. That removes fourteen of the fifteen
copies and every re-transcription round, keeps the refusal byte-for-byte, and
moves staleness from a production deploy into the unit suite.

**One pin per template, not a pin plus a marker list.** The brief describes the
pinned record as "the marker list plus its computed digest". The marker list is
already the registry; restating it beside the pin would reintroduce a second
copy of the same fact, and a test now asserts the pin's key set equals the
registry's. So the pin is the digest alone.

**Structural and seed rollovers are now checked too.** Uniform is simpler than
a documented exception, and the exception had no rationale: a structural
rollover installs the source graph exactly as a prompt-only one does.

**`successorVerified` deleted rather than re-derived.** It has no readers, and
under a uniform check it would be a constant.

**The registry test no longer pins the pull-request digest.** Asserting the
literal there would be the sixteenth copy; the dedicated recompute-from-source
test covers it.

## Fence widened

`packages/db/src/canonical-template-registry.test.ts` is not named in the lane's
owned paths but pinned two of the removed literals, so it belongs to the class
the common rules place inside the fence ("any test file whose assertions your
change necessarily breaks"). It belongs to no other lane. No file owned by a
`dispatched` or `ready` lane was touched: `template-sources.ts`,
`canonical-step-adoption.ts` and `canonical-sync-report.ts` are untouched, and
`shapeMatches` / `LegacyStepRecord` are unchanged for lane t2.

## Reported but unfixed

- **No documented registration procedure.** Nothing in `agents/`,
  `CONTRIBUTING.md` or `docs/` explains how to register a rollover or when to
  re-pin. The doc comment on `CANONICAL_SOURCE_PROMPT_GENERATIONS` now names
  the command, but the end-to-end procedure is unwritten. Lane t4 owns `docs/`
  and the release-side check for this candidate.
- **`shapeMatches` still derives `requiresCommit` from `outputKind` and
  compares twelve of the fourteen fields `templateStepStructureDifferences`
  owns**, leaving `priorOutputKinds` uncompared. Lane t2's candidate; untouched
  here as instructed.
- **`prisma/sync-canonical-prompts.ts` still performs a second, independent
  per-step comparison** after the whole-graph plan (around L474-540). Not in
  this candidate's scope.

## Disposition

Blind review returned `approve` with one advisory finding. Nothing was dropped.

- **Fixed** — *`create` installs the source prompt graph without consulting
  `sourceDrift`, so the pin guards rollovers but not first installation*
  (`canonical-template-installation.ts`). The finding is right and the argument
  is the one this PR itself makes: a created row, like a rolled-over row, is
  referenced by no task, so the referenced-step prompt refusal cannot see an
  unregistered prompt edit riding in on it. Leaving it would have made the
  guarantee half-applied — the same tree that refuses every rollover would
  install silently when a project is onboarded or an empty database is seeded.
  `sourceDrift` was already computed immediately above the create loop, so the
  fix is one condition: a `create` becomes a `refused` (with `rowId: null`) when
  the source tree is not the pinned generation. `sourcePromptGenerationDrift`'s
  message drops the word "rollover" accordingly, and a new unit test in
  `canonical-template-installation.test.ts` asserts both directions of the
  create path. Every caller of the create path (`prisma/seed.ts`,
  `prisma/sync-canonical-prompts.ts`, `api/project-bootstrap.ts`,
  `verify-agent-template.dbtest.ts`) passes real `loadTemplateStepSources`
  output, so no existing test or dbtest changes behaviour; the dbtests mutate
  persisted rows, never the source tree.

Generated with Claude Code (deepening round 6 lane t1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1KMxWcjsX23QvAQdGhWyC


