### PR TITLE
refactor(db): decide a Run's publish target once

### DIFF
--- a/packages/api/src/chain-branch.dbtest.ts
+++ b/packages/api/src/chain-branch.dbtest.ts
@@ -9,7 +9,7 @@ import { after, before, beforeEach, test } from "node:test";
 
 import {
   activateChainSuccessor, DependencyProvisioning, FAILURE_ENVELOPE_VERSION, type FailureEnvelope,
-  PrismaClient, type RunOutcome, TaskStatus,
+  PrismaClient, type RunOutcome, runOwnedHead, TaskStatus,
 } from "@anneal/db";
 import { buildChildEnvironment } from "@anneal/runner/adapters";
 import type { ClaimedTask } from "@anneal/runner/api";
@@ -575,21 +575,23 @@ test("T16: a pull-request failure after a successful push still counts as public
 
 // --- WI-4: POST /tasks -------------------------------------------------------
 
-test("T9: a non-chain task's first run is unchanged", async () => {
+test("T9: a non-chain task's first run publishes the ref that run owns", async () => {
   const seed = await seedProject("t9");
   const explicit = await postTask(seed.project.id, {
     name: "Solo", description: "d", assigneeAgentId: seed.agent.id, repoId: seed.repo.id, targetBranch: "some/branch",
   });
   const explicitRun = await db.run.findFirstOrThrow({ where: { taskId: explicit.body.id } });
   assert.equal(explicitRun.targetBranch, "some/branch");
-  assert.equal(explicitRun.branch, null);
+  // The control plane declares the head at birth, so the runner never has to
+  // invent one and the column carries a single fact.
+  assert.equal(explicitRun.branch, runOwnedHead(explicit.body.id, 1));
 
   const implicit = await postTask(seed.project.id, {
     name: "Solo 2", description: "d", assigneeAgentId: seed.agent.id, repoId: seed.repo.id,
   });
   const implicitRun = await db.run.findFirstOrThrow({ where: { taskId: implicit.body.id } });
   assert.equal(implicitRun.targetBranch, seed.repo.defaultBranch);
-  assert.equal(implicitRun.branch, null);
+  assert.equal(implicitRun.branch, runOwnedHead(implicit.body.id, 1));
 });
 
 // --- WI-5: operator retry and lost-lease requeue -----------------------------
@@ -756,7 +758,7 @@ test("T12: a non-chain requeue is unchanged", async () => {
   await reconcileDatabaseRuns(db, new Date());
   const requeued = await db.run.findFirstOrThrow({ where: { taskId: solo.body.id, runNumber: 2 } });
   assert.equal(requeued.targetBranch, "some/branch");
-  assert.equal(requeued.branch, null);
+  assert.equal(requeued.branch, runOwnedHead(solo.body.id, 1), "a lost lease keeps the head its run was told to publish");
 });
 
 test("T12c: a lost-lease requeue drops a base that is only this run's unpushed head", async () => {
@@ -931,7 +933,7 @@ test("T14a: an automatic retry of a non-chain task answers to publication eviden
   const retry = await db.run.findFirstOrThrow({ where: { taskId: solo.body.id, runNumber: 2 } });
   assert.notEqual(retry.targetBranch, poisoned, "nothing published this ref");
   assert.equal(retry.targetBranch, seed.repo.defaultBranch);
-  assert.equal(retry.branch, null, "this path still carries no branch forward");
+  assert.equal(retry.branch, runOwnedHead(solo.body.id, 2), "the previous Run's ref is not carried forward");
 
   // …and the salvage this completion just recorded is evidence in the same
   // transaction, so the next automatic retry keeps the work that reached the
@@ -956,7 +958,7 @@ test("T14: an automatic retry of a non-chain task is unchanged", async () => {
   });
   const retry = await db.run.findFirstOrThrow({ where: { taskId: solo.body.id, runNumber: 2 } });
   assert.equal(retry.targetBranch, "some/branch");
-  assert.equal(retry.branch, null, "this path has never carried branch forward; that asymmetry is preserved");
+  assert.equal(retry.branch, runOwnedHead(solo.body.id, 2), "the previous Run's ref is not carried forward");
 });
 
 // --- WI-7 / WI-8: the flag through the API ----------------------------------

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 
 import {
   asJsonObject,
-  enqueueTaskRun,
+  errorForOpenRunRefusal,
   isIntegratorStep,
   isRegressionVerificationOutputKind,
   latestMarker,
@@ -11,6 +11,7 @@ import {
   MERGE_TAIL_SCHEMA_VERSION,
   MergeRecoveryStatus,
   type Marker,
+  openRun,
   parseResolverResult,
   parseRegressionVerdict,
   Prisma,
@@ -675,11 +676,11 @@ export const createMergeTailRepairTask = async (
     // tail opens.
     maxSessionsPerTask: 2,
   } });
-  const repairRun = await enqueueTaskRun(tx, task.id, input.now);
-  await tx.run.update({
-    where: { id: repairRun.id },
-    data: { branch: input.sourceRun.branch, targetBranch: input.sourceRun.branch },
-  });
+  // The repair card's own intent, not an ordinary enqueue followed by a
+  // correction: `resolveRunBranches` reads the head off the Task's targetBranch
+  // above, so the Run is born publishing onto the chain head it repairs.
+  const opened = await openRun(tx, task.id, { kind: "merge-tail-repair", readyAt: input.now });
+  if (!opened.ok) throw errorForOpenRunRefusal(opened.refusal);
   await writeMarker(tx, regressionTask.id, "repairAttempt", {
     actorType: "control-plane",
     body: `Automatic ${input.repairKind} attempt queued at chain head ${input.headSha} against ${input.baseHeadSha}`,

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -275,7 +275,10 @@ const completeRepair = async (
 ) => {
   const run = await db.run.findFirstOrThrow({ where: { taskId: repairId, runNumber } });
   const repair = await db.task.findUniqueOrThrow({ where: { id: repairId } });
-  const publishBranch = run.branch ?? `agentos/${repairId}/run-${runNumber}`;
+  // The control plane declared this Run's head at birth; a fixture that
+  // rebuilds the name here would stop proving that it did.
+  const publishBranch = run.branch;
+  assert.ok(publishBranch, `repair Run ${runNumber} was born without a publish head`);
   const runnerId = `repair-runner-${run.id}`;
   const fencingToken = `repair:${run.id}:1`;
   await db.run.update({ where: { id: run.id }, data: {

--- a/packages/api/src/run-fence.test.ts
+++ b/packages/api/src/run-fence.test.ts
@@ -156,6 +156,7 @@ const authorityRun: LockedAuthorityRun = {
   runNumber: 4,
   pushedBranch: null,
   branch: "feature/task-1",
+  targetBranch: "main",
 };
 
 test("authority modes stay distinct while sharing one refusal vocabulary", () => {

--- a/packages/api/src/run-fence.ts
+++ b/packages/api/src/run-fence.ts
@@ -1,4 +1,4 @@
-import { lockRunRow, lockTaskRow, Prisma, RunStatus } from "@anneal/db";
+import { lockRunRow, lockTaskRow, Prisma, runOwnedHead, RunStatus } from "@anneal/db";
 
 import type { Refusal } from "./refusal.js";
 
@@ -149,6 +149,7 @@ export type LockedAuthorityRun = {
   runNumber: number;
   pushedBranch: string | null;
   branch: string | null;
+  targetBranch: string | null;
 };
 
 /**
@@ -178,6 +179,7 @@ export const lockAuthorityRun = async (
       runNumber: true,
       pushedBranch: true,
       branch: true,
+      targetBranch: true,
     },
   });
 };
@@ -213,7 +215,7 @@ export const salvageAuthorityRefusal = (
   if (!run) return "unknown-run";
   if (run.runnerId !== authority.runnerId) return "wrong-runner";
   if (run.fencingToken !== authority.fencingToken) return "stale-fence";
-  const expectedBranch = run.taskId ? `agentos/${run.taskId}/run-${run.runNumber}` : null;
+  const expectedBranch = run.taskId ? runOwnedHead(run.taskId, run.runNumber) : null;
   if (
     run.repoId === null
     || authority.pushedBranch !== expectedBranch

--- a/packages/api/src/run-lifecycle.test.ts
+++ b/packages/api/src/run-lifecycle.test.ts
@@ -43,6 +43,7 @@ const authorityRun = (overrides: Partial<LockedAuthorityRun> = {}): LockedAuthor
   runNumber: 1,
   pushedBranch: null,
   branch: "feature/task-1",
+  targetBranch: "main",
   ...overrides,
 });
 

--- a/packages/api/src/run-lifecycle.ts
+++ b/packages/api/src/run-lifecycle.ts
@@ -266,6 +266,7 @@ export const publishRun = async (
           taskId: run.taskId,
           runNumber: run.runNumber,
           branch: run.branch,
+          targetBranch: run.targetBranch,
         })
       : "none";
     return repair === "already-started"

--- a/packages/api/src/workflow.test.ts
+++ b/packages/api/src/workflow.test.ts
@@ -676,11 +676,12 @@ test("a non-chain retry inherits the prior branch as its base only against push 
     id: "task-1", projectId: "project-1", repoId: "repo-1", chainId: null, chainIndex: null,
     templateId: null, targetBranch: null, repo: { defaultBranch: "main" },
   };
-  const prior = { branch: "agentos/task-1/run-1" };
+  const prior = { branch: "agentos/task-1/run-1", targetBranch: null, runNumber: 1 };
+  const birth = { intent: "retry", runNumber: 2, prior } as const;
   // The production shape (issue #118, runs cmsy9kg5j0001mp76wb95xiyu and
   // siblings): run 1's push failed, so `branch` names a ref no remote has and
   // cloning it burns the retry. Falling back is what makes the retry runnable.
-  assert.deepEqual(await resolveRunBranches(branchTx([]), task, prior), {
+  assert.deepEqual(await resolveRunBranches(branchTx([]), task, birth), {
     branch: "agentos/task-1/run-1", targetBranch: "main",
   });
   // Evidence from another task or another remote is not evidence for this one.
@@ -688,14 +689,14 @@ test("a non-chain retry inherits the prior branch as its base only against push 
     { taskId: "task-9", chainId: null, repoId: "repo-1", runNumber: 1, pushedBranch: "agentos/task-1/run-1" },
     { taskId: "task-1", chainId: null, repoId: "repo-2", runNumber: 1, pushedBranch: "agentos/task-1/run-1" },
   ]);
-  assert.deepEqual(await resolveRunBranches(foreign, { ...task, targetBranch: "release/1.2" }, prior), {
+  assert.deepEqual(await resolveRunBranches(foreign, { ...task, targetBranch: "release/1.2" }, birth), {
     branch: "agentos/task-1/run-1", targetBranch: "release/1.2",
   });
   // The push landed: the ref exists, so the retry continues on top of it.
   const published = branchTx([
     { taskId: "task-1", chainId: null, repoId: "repo-1", runNumber: 1, pushedBranch: "agentos/task-1/run-1" },
   ]);
-  assert.deepEqual(await resolveRunBranches(published, task, prior), {
+  assert.deepEqual(await resolveRunBranches(published, task, birth), {
     branch: "agentos/task-1/run-1", targetBranch: "agentos/task-1/run-1",
   });
 });
@@ -710,7 +711,7 @@ test("a retry bases on the newest WIP salvage rather than discarding what did re
   assert.deepEqual(await resolveRunBranches(tx, {
     id: "task-1", projectId: "project-1", repoId: "repo-1", chainId: null, chainIndex: null,
     templateId: null, targetBranch: null, repo: { defaultBranch: "main" },
-  }, { branch: "agentos/task-1/run-1" }), {
+  }, { intent: "retry", runNumber: 3, prior: { branch: "agentos/task-1/run-1", targetBranch: null, runNumber: 1 } }), {
     branch: "agentos/task-1/run-1", targetBranch: "agentos/task-1/run-2",
   });
 });
@@ -721,7 +722,7 @@ test("a template retry falls back to its own targetBranch but still honours a si
   assert.deepEqual(await resolveRunBranches(branchTx([]), {
     id: "task-1", projectId: "project-1", repoId: "repo-1", chainId: "chain-1", chainIndex: 0,
     templateId: "template-1", targetBranch: "main", repo: { defaultBranch: "main" },
-  }, { branch: "agentos/task-1/run-1" }), {
+  }, { intent: "retry", runNumber: 2, prior: { branch: "agentos/task-1/run-1", targetBranch: null, runNumber: 1 } }), {
     branch: "agentos/task-1/run-1", targetBranch: "main",
   });
   // Step ②: the chain branch is shared across the template's tasks, so the
@@ -734,7 +735,7 @@ test("a template retry falls back to its own targetBranch but still honours a si
   assert.deepEqual(await resolveRunBranches(tx, {
     id: "task-2", projectId: "project-1", repoId: "repo-1", chainId: "chain-1", chainIndex: 1,
     templateId: "template-1", targetBranch: "main", repo: { defaultBranch: "main" },
-  }, { branch: "agentos/chain-1" }), {
+  }, { intent: "retry", runNumber: 2, prior: { branch: "agentos/chain-1", targetBranch: null, runNumber: 1 } }), {
     branch: "agentos/chain-1", targetBranch: "agentos/chain-1",
   });
 });
@@ -747,7 +748,7 @@ test("a template operator retry publishes the declared head while basing on the 
   assert.deepEqual(await resolveRunBranches(tx, {
     id: "task-1", projectId: "project-1", repoId: "repo-1", chainId: "chain-1", chainIndex: 0,
     templateId: "template-1", targetBranch: "main", repo: { defaultBranch: "main" },
-  }, { branch: salvage }), {
+  }, { intent: "retry", runNumber: 3, prior: { branch: salvage, targetBranch: null, runNumber: 2 } }), {
     branch: "declared/chain-head",
     targetBranch: salvage,
   });
@@ -761,7 +762,7 @@ test("a successor first run bases on the newest sibling publication whatever ref
   assert.deepEqual(await resolveRunBranches(tx, {
     id: "task-2", projectId: "project-1", repoId: "repo-1", chainId: "chain-1", chainIndex: 1,
     templateId: "template-1", targetBranch: "declared/chain-head", repo: { defaultBranch: "main" },
-  }, null), {
+  }, { intent: "enqueue", runNumber: 1, prior: null }), {
     branch: "declared/chain-head",
     targetBranch: salvage,
   });
@@ -772,7 +773,7 @@ test("a successor first run bases on the newest sibling publication whatever ref
   assert.deepEqual(await resolveRunBranches(declared, {
     id: "task-2", projectId: "project-1", repoId: "repo-1", chainId: "chain-1", chainIndex: 1,
     templateId: "template-1", targetBranch: "declared/chain-head", repo: { defaultBranch: "main" },
-  }, null), {
+  }, { intent: "enqueue", runNumber: 1, prior: null }), {
     branch: "declared/chain-head",
     targetBranch: "declared/chain-head",
   });
@@ -782,7 +783,7 @@ test("a deferred template first run recovers its shared head from a later step",
   assert.deepEqual(await resolveRunBranches(branchTx([], "custom/template-head"), {
     id: "task-1", projectId: "project-1", repoId: "repo-1", chainId: "chain-1", chainIndex: 0,
     templateId: "template-1", targetBranch: "main", repo: { defaultBranch: "main" },
-  }, null), {
+  }, { intent: "enqueue", runNumber: 1, prior: null }), {
     branch: "custom/template-head", targetBranch: "main",
   });
 });

--- a/packages/api/src/workspace-reclaim.ts
+++ b/packages/api/src/workspace-reclaim.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 
 import {
-  CleanupStatus, FailureClass, openRun, resolveRunBranches, RunStatus, SessionExecutionStatus,
+  CleanupStatus, FailureClass, openRun, resolveRunBranches, runOwnedHead, RunStatus, SessionExecutionStatus,
   type Prisma, type PrismaClient,
 } from "@anneal/db";
 
@@ -409,7 +409,7 @@ export const acknowledgeReclaimSalvage = async (
   input: { runnerId: string; runId: string; pushedBranch: string },
   repairReplacement: (
     tx: Prisma.TransactionClient,
-    run: { taskId: string; runNumber: number; branch: string | null },
+    run: { taskId: string; runNumber: number; branch: string | null; targetBranch: string | null },
   ) => Promise<ReplacementRepair> = repairReplacementAfterSalvage,
 ): Promise<false | ReplacementRepair> => {
   return db.$transaction(async (tx) => {
@@ -418,9 +418,10 @@ export const acknowledgeReclaimSalvage = async (
       select: {
         id: true, runnerId: true, taskId: true, runNumber: true, status: true,
         workspaceReclaimAt: true, workspaceReclaimedAt: true, pushedBranch: true, branch: true,
+        targetBranch: true,
       },
     });
-    const expected = run?.taskId ? `agentos/${run.taskId}/run-${run.runNumber}` : null;
+    const expected = run?.taskId ? runOwnedHead(run.taskId, run.runNumber) : null;
     if (!run || !ownedByCaller(run, input.runnerId) || !isTerminal(run.status)
       || !run.workspaceReclaimAt || run.workspaceReclaimedAt
       || input.pushedBranch !== expected
@@ -440,6 +441,7 @@ export const acknowledgeReclaimSalvage = async (
       taskId: run.taskId,
       runNumber: run.runNumber,
       branch: run.branch,
+      targetBranch: run.targetBranch,
     });
     if (repair === "already-started") {
       const replacement = await tx.run.findFirst({
@@ -467,7 +469,7 @@ export const acknowledgeReclaimSalvage = async (
  * attempt, and enqueue a fresh row with a distinct workspace id. */
 export const repairReplacementAfterSalvage = async (
   tx: Prisma.TransactionClient,
-  run: { taskId: string; runNumber: number; branch: string | null },
+  run: { taskId: string; runNumber: number; branch: string | null; targetBranch: string | null },
 ): Promise<ReplacementRepair> => {
   // Salvage can arrive after Hold has committed but before this replacement
   // reaches /start. Join the same Task/Chain mutex as every other Run producer,
@@ -542,7 +544,14 @@ export const repairReplacementAfterSalvage = async (
     include: { repo: true, templateStep: true },
   });
   if (!task?.repo) return "already-started";
-  const branches = await resolveRunBranches(tx, { ...task, repo: task.repo }, { branch: run.branch });
+  // The replacement was born from an ordinary enqueue; the late salvage only
+  // moved the evidence it resolves against, so it is re-decided by the same
+  // module under the same intent rather than patched here.
+  const branches = await resolveRunBranches(tx, { ...task, repo: task.repo }, {
+    intent: "enqueue",
+    runNumber: run.runNumber + 1,
+    prior: { branch: run.branch, targetBranch: run.targetBranch, runNumber: run.runNumber },
+  });
   const repaired = await tx.run.updateMany({
     where: { id: replacement.id, status: RunStatus.QUEUED },
     data: { branch: branches.branch, targetBranch: branches.targetBranch },

--- a/packages/api/src/workspace-reclaim.ts
+++ b/packages/api/src/workspace-reclaim.ts
@@ -544,17 +544,21 @@ export const repairReplacementAfterSalvage = async (
     include: { repo: true, templateStep: true },
   });
   if (!task?.repo) return "already-started";
-  // The replacement was born from an ordinary enqueue; the late salvage only
-  // moved the evidence it resolves against, so it is re-decided by the same
-  // module under the same intent rather than patched here.
-  const branches = await resolveRunBranches(tx, { ...task, repo: task.repo }, {
+  // A late salvage moves only the publication evidence the *base* resolves
+  // against, so only the base is repaired here. The replacement's head was
+  // decided at its own birth by `resolveRunBranches` and stays that Run's:
+  // re-deciding it from the salvaged Run would hand a replacement the ref its
+  // predecessor owns. The `enqueue` arm is what asks for the base under current
+  // evidence rather than the replacement's birth snapshot, which is exactly
+  // what a moved base means; the head that arm returns is discarded.
+  const { targetBranch } = await resolveRunBranches(tx, { ...task, repo: task.repo }, {
     intent: "enqueue",
     runNumber: run.runNumber + 1,
     prior: { branch: run.branch, targetBranch: run.targetBranch, runNumber: run.runNumber },
   });
   const repaired = await tx.run.updateMany({
     where: { id: replacement.id, status: RunStatus.QUEUED },
-    data: { branch: branches.branch, targetBranch: branches.targetBranch },
+    data: { targetBranch },
   });
   return repaired.count === 1 ? "repaired" : "already-started";
 };

--- a/packages/db/src/claim-contract.ts
+++ b/packages/db/src/claim-contract.ts
@@ -151,6 +151,15 @@ export type ClaimRun = {
   implementationHeadSha: string | null;
   promptHash: string | null;
   workspacePath: string | null;
+  /**
+   * The head this Run publishes, decided once at Run birth by
+   * `resolveRunBranches` (`run-open.ts`) and never derived by a consumer: a
+   * runner that invented its own name put two processes in disagreement about
+   * which ref a retry owns.
+   *
+   * Null only for a Run whose Task has no Repo, which publishes nothing.
+   * Provisioning refuses a claim that reaches it without a head.
+   */
   branch: string | null;
   baseSha: string | null;
 };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12,6 +12,7 @@ if (process.env.NODE_ENV !== "production") {
 
 export * from "@prisma/client";
 export * from "./chain-branch.js";
+export * from "./run-head.js";
 export * from "./agent-message.js";
 export * from "./maintenance-lock.js";
 export * from "./service-maintenance-lock.js";
@@ -64,6 +65,7 @@ export {
   compoundImplementationAssigneeValid,
   deriveRunConfig,
   enqueueTaskRun,
+  errorForOpenRunRefusal,
   EXTERNAL_FAILURE_REFUND_CAP,
   gateQuestion,
   isArchivedAssigneeError,

--- a/packages/db/src/open-run.test.ts
+++ b/packages/db/src/open-run.test.ts
@@ -18,6 +18,7 @@ import {
   pinnedImplementationRange,
   runBudgetCeiling,
 } from "./run-open.js";
+import { runOwnedHead } from "./run-head.js";
 
 const now = new Date("2026-08-26T12:00:00.000Z");
 
@@ -92,6 +93,7 @@ const taskRow = (overrides: Record<string, unknown> = {}) => ({
 const intents = (): OpenRunIntent[] => [
   { kind: "enqueue", readyAt: now },
   { kind: "merge-tail-requeue", readyAt: now, budgetGrant: 1 },
+  { kind: "merge-tail-repair", readyAt: now },
   { kind: "task-created", readyAt: now },
   { kind: "retry", readyAt: now },
   { kind: "integrator-authorized", readyAt: now },
@@ -295,7 +297,7 @@ test("a null resolved base cannot match an unpublished prior Run", async () => {
   assert.equal(creates[0]?.requiresCommit, true);
 });
 
-test("an automatic retry preserves its declared head while using salvage as its base", async () => {
+test("an automatic retry preserves a Task-owned head while using salvage as its base", async () => {
   const repo = { id: "repo-1", defaultBranch: "main" };
   const shared = "feat/shared";
   const salvage = "agentos/task-1/run-1";
@@ -330,15 +332,21 @@ test("an automatic retry preserves its declared head while using salvage as its 
     const opened = await openRun(tx, task.id, intent);
 
     assert.equal(opened.ok, true, `prior branch ${priorBranch ?? "null"}`);
-    assert.equal(creates[0]?.branch, priorBranch, `prior branch ${priorBranch ?? "null"}`);
+    // A head the Task owns carries forward; a prior Run that never received one
+    // leaves this Run to publish the ref it owns.
+    assert.equal(
+      creates[0]?.branch,
+      priorBranch ?? runOwnedHead(task.id, 4),
+      `prior branch ${priorBranch ?? "null"}`,
+    );
     assert.equal(creates[0]?.targetBranch, salvage, `prior branch ${priorBranch ?? "null"}`);
   }
 });
 
-test("automatic retries do not inherit the runner's per-Run fallback as a declared head", async () => {
+test("automatic retries publish the ref they own rather than the previous Run's", async () => {
   const repo = { id: "repo-1", defaultBranch: "main" };
-  const run1Salvage = "agentos/task-1/run-1";
-  const run2Salvage = "agentos/task-1/run-2";
+  const run1Salvage = runOwnedHead("task-1", 1);
+  const run2Salvage = runOwnedHead("task-1", 2);
   const publishedRuns = [
     { taskId: "task-1", repoId: repo.id, pushedBranch: run2Salvage },
     { taskId: "task-1", repoId: repo.id, pushedBranch: run1Salvage },
@@ -363,7 +371,7 @@ test("automatic retries do not inherit the runner's per-Run fallback as a declar
   });
 
   assert.equal(openedRun2.ok, true);
-  assert.equal(firstRetry.creates[0]?.branch, null);
+  assert.equal(firstRetry.creates[0]?.branch, run2Salvage);
   assert.equal(firstRetry.creates[0]?.targetBranch, run1Salvage);
 
   const run2 = priorRun({
@@ -386,8 +394,125 @@ test("automatic retries do not inherit the runner's per-Run fallback as a declar
   });
 
   assert.equal(openedRun3.ok, true);
-  assert.equal(secondRetry.creates[0]?.branch, null);
+  assert.equal(secondRetry.creates[0]?.branch, runOwnedHead("task-1", 3));
   assert.equal(secondRetry.creates[0]?.targetBranch, run2Salvage);
+});
+
+test("every birth intent takes its publish head from one module and none is left null", async () => {
+  const repo = { id: "repo-1", defaultBranch: "main" };
+  const chainHead = "agentos/chain/tail-deadbeef";
+  const priorHead = runOwnedHead("task-1", 3);
+  const withPrior = (overrides: Record<string, unknown> = {}) => taskRow({
+    repoId: repo.id,
+    repo,
+    runs: [priorRun({ repoId: repo.id, branch: priorHead, targetBranch: "main" })],
+    ...overrides,
+  });
+  const sourceRetry = {
+    sourceRunId: "run-3",
+    sourceMaxRunsPerTask: 5,
+    sourceBudgetGrants: 1,
+  } as const;
+  const cases: Array<{
+    name: string;
+    task: ReturnType<typeof taskRow>;
+    intent: OpenRunIntent;
+    branch: string;
+    targetBranch: string | null;
+  }> = [
+    {
+      name: "enqueue",
+      task: taskRow({ repoId: repo.id, repo }),
+      intent: { kind: "enqueue", readyAt: now },
+      branch: runOwnedHead("task-1", 1),
+      targetBranch: "main",
+    },
+    {
+      name: "merge-tail-requeue",
+      task: taskRow({ repoId: repo.id, repo }),
+      intent: { kind: "merge-tail-requeue", readyAt: now, budgetGrant: 1 },
+      branch: runOwnedHead("task-1", 1),
+      targetBranch: "main",
+    },
+    {
+      name: "task-created",
+      task: taskRow({ repoId: repo.id, repo }),
+      intent: { kind: "task-created", readyAt: now },
+      branch: runOwnedHead("task-1", 1),
+      targetBranch: "main",
+    },
+    {
+      // The repair card is chain-detached and publishes onto the chain head it
+      // was created to repair, which is its own targetBranch.
+      name: "merge-tail-repair",
+      task: taskRow({ repoId: repo.id, repo, targetBranch: chainHead }),
+      intent: { kind: "merge-tail-repair", readyAt: now },
+      branch: chainHead,
+      targetBranch: chainHead,
+    },
+    {
+      // An operator retry continues the head its predecessor was told to
+      // publish; provisioning recreates the ref when the remote lacks it.
+      name: "retry",
+      task: withPrior(),
+      intent: { kind: "retry", readyAt: now },
+      branch: priorHead,
+      targetBranch: "main",
+    },
+    {
+      name: "integrator-authorized",
+      task: withPrior({
+        assigneeAgent: agent({ name: "merge-integrator" }),
+        templateStepId: integratorStep.id,
+        templateStep: integratorStep,
+        runs: [priorRun({ repoId: repo.id, branch: chainHead, targetBranch: "release/1.2" })],
+      }),
+      intent: { kind: "integrator-authorized", readyAt: now },
+      branch: chainHead,
+      targetBranch: "release/1.2",
+    },
+    {
+      // The ref the previous Run owned is not carried forward: this one
+      // receives its own.
+      name: "retry-after-completion",
+      task: withPrior(),
+      intent: { kind: "retry-after-completion", readyAt: now, budgetGrant: 1, ...sourceRetry },
+      branch: runOwnedHead("task-1", 4),
+      targetBranch: "main",
+    },
+    {
+      // A lost lease reported nothing terminal about the head, so the
+      // replacement continues it.
+      name: "retry-after-lease-loss",
+      task: withPrior(),
+      intent: { kind: "retry-after-lease-loss", readyAt: now, ...sourceRetry },
+      branch: priorHead,
+      targetBranch: "main",
+    },
+  ];
+  assert.deepEqual(
+    cases.map((fixture) => fixture.name).sort(),
+    intents().map((intent) => intent.kind).sort(),
+    "every birth intent states its publish target here",
+  );
+
+  for (const fixture of cases) {
+    const options = fixture.name === "integrator-authorized"
+      ? { lockedAgent: agent({ name: "merge-integrator" }) }
+      : {};
+    const { tx, creates } = fakeTx(fixture.task, options);
+    const opened = await openRun(tx, fixture.task.id, fixture.intent);
+    assert.equal(opened.ok, true, fixture.name);
+    assert.equal(creates[0]?.branch, fixture.branch, fixture.name);
+    assert.equal(creates[0]?.targetBranch, fixture.targetBranch, fixture.name);
+  }
+});
+
+test("a Task without a Repo is born with no publish head at all", async () => {
+  const { tx, creates } = fakeTx(taskRow({ runs: [priorRun({ branch: null })] }));
+  const opened = await openRun(tx, "task-1", { kind: "retry", readyAt: now });
+  assert.equal(opened.ok, true);
+  assert.equal(creates[0]?.branch, null);
 });
 
 test("a pinned base follows the template Step when conditional tasks use dense chain ordinals", async () => {

--- a/packages/db/src/run-head.ts
+++ b/packages/db/src/run-head.ts
@@ -1,0 +1,23 @@
+/**
+ * The one ref a single Run owns: `agentos/<taskId>/run-<n>`.
+ *
+ * Two facts are spelled with this name and they must stay the same string, so
+ * it is derived here and nowhere else:
+ *
+ *   - the head a Run publishes when nothing else declares one, written to
+ *     `Run.branch` at Run birth by `resolveRunBranches` (`run-open.ts`);
+ *   - the WIP salvage ref a *failed* Run pushes instead of its declared head
+ *     (`packages/runner/src/delivery.ts`), which the control plane authorizes
+ *     by recomputing it (`packages/api/src/run-fence.ts` and
+ *     `packages/api/src/workspace-reclaim.ts`).
+ *
+ * Uniqueness comes from the pair: `taskId` is a database id and `runNumber` is
+ * unique within a Task, so no two Runs can be handed the same ref and a plain
+ * `git push` is enough to publish it. That is what lets salvage refuse to force:
+ * a rejection means something else is there.
+ *
+ * It is deliberately not the shared chain branch (`chain-branch.ts`): a failed
+ * run's half-finished tree must never reach the ref every later step clones.
+ */
+export const runOwnedHead = (taskId: string, runNumber: number): string =>
+  `agentos/${taskId}/run-${runNumber}`;

--- a/packages/db/src/run-open.ts
+++ b/packages/db/src/run-open.ts
@@ -26,6 +26,7 @@ import {
   stopStateFor,
 } from "./merge-integrator-db.js";
 import { runnerFor } from "./model-routing.js";
+import { runOwnedHead } from "./run-head.js";
 import { stepRole } from "./step-role.js";
 
 type Tx = Prisma.TransactionClient;
@@ -300,9 +301,9 @@ export const pinnedImplementationRange = async (
   return implementationRangeFromOutput(task.id, baseFromStepIndex, source);
 };
 
-/** The shape `resolveRunBranches` needs. Structural rather than a Prisma payload
- *  type so `openRun` can pass each intent's branch facts without coupling the
- *  resolver to its full Task query. */
+/** The shape the branch rules need once a Repo is known. Structural rather than
+ *  a Prisma payload type so `openRun` can pass each intent's branch facts
+ *  without coupling the resolver to its full Task query. */
 export type RunBranchTask = {
   id: string;
   projectId: string;
@@ -313,6 +314,17 @@ export type RunBranchTask = {
   templateStep?: { baseFromStepIndex: number | null } | null;
   targetBranch: string | null;
   repo: { defaultBranch: string };
+};
+
+/** A Task at Run birth, whose Repo may still be absent. */
+export type RunBirthTask = Omit<RunBranchTask, "repo"> & { repo: { defaultBranch: string } | null };
+
+/** The Run being born, as `resolveRunBranches` needs to see it: which rule
+ *  applies, which ref this Run would own, and what its predecessor carried. */
+export type RunBirth = {
+  intent: OpenRunIntent["kind"];
+  runNumber: number;
+  prior: { branch: string | null; targetBranch: string | null; runNumber: number } | null;
 };
 
 /**
@@ -425,25 +437,33 @@ export const resolveRequeueBase = async (
   return run.targetBranch;
 };
 
-const retryPublishHead = (
+/**
+ * The head a retry keeps because the *Task* owns it — a shared chain head, or
+ * the ref a merge-tail repair card was created to land on. A head this module
+ * minted for the previous Run belongs to that Run alone and is never carried
+ * forward: the retry receives its own.
+ *
+ * The comparison is against `runOwnedHead`, which this module is the only
+ * producer of, so it reads back a decision made here rather than recognising
+ * another package's naming convention.
+ */
+const taskOwnedHead = (
   taskId: string,
   prior: { branch: string | null; runNumber: number } | null | undefined,
 ): string | null => {
   if (!prior?.branch) return null;
-  const runnerFallback = `agentos/${taskId}/run-${prior.runNumber}`;
-  return prior.branch === runnerFallback ? null : prior.branch;
+  return prior.branch === runOwnedHead(taskId, prior.runNumber) ? null : prior.branch;
 };
 
 /**
- * Decides a new Run's head (`branch`) and base (`targetBranch`). `openRun` is
- * its only Run-birth caller; keeping the branch rule behind that seam prevents
- * one intent from putting a Step on a different branch from the rest of its
- * Chain.
+ * The head a Chain or Template Step publishes on, and the base it clones. Null
+ * head means no Chain, Template or repair rule names one, and the Run receives
+ * the ref it owns (`resolveRunBranches`).
  *
  * Writes at most one TaskActivity row (see the chain branch below), so it takes
  * the caller's transaction.
  */
-export const resolveRunBranches = async (
+const chainDeclaredBranches = async (
   tx: Tx,
   task: RunBranchTask,
   prior: { branch: string | null } | null,
@@ -531,11 +551,103 @@ export const resolveRunBranches = async (
   return { branch: shared, targetBranch };
 };
 
+/**
+ * Decides the publish target of a Run: the head it publishes (`branch`) and the
+ * base it clones (`targetBranch`).
+ *
+ * This is the only place either is decided. Every `openRun` intent goes through
+ * it, `repairReplacementAfterSalvage` re-runs it for a queued replacement whose
+ * clone base moved, and nothing else writes `Run.branch`. A caller that needs a
+ * different head adds its intent here; patching the row after birth would put
+ * the decision back in two places, which is how one Step ended up on a
+ * different branch from the rest of its Chain.
+ *
+ * A Run whose Task has a Repo always leaves here with a head, so the runner
+ * never invents one and `Run.branch` carries exactly one fact: the head the
+ * control plane declared. When no Chain, Template or repair rule names a head,
+ * it is the ref this Run owns (`runOwnedHead`).
+ *
+ * Writes at most one TaskActivity row (see `chainDeclaredBranches`), so it takes
+ * the caller's transaction.
+ */
+export const resolveRunBranches = async (
+  tx: Tx,
+  task: RunBirthTask,
+  birth: RunBirth,
+): Promise<{ branch: string | null; targetBranch: string | null }> => {
+  const { intent, prior } = birth;
+  // A Task with no Repo publishes nothing, so there is no head to declare; it
+  // carries its predecessor's columns forward untouched.
+  if (!task.repo) {
+    return { branch: prior?.branch ?? null, targetBranch: prior?.targetBranch ?? task.targetBranch };
+  }
+  const repoTask = { ...task, repo: task.repo };
+  const declared = await declaredPublishTarget(tx, repoTask, intent, prior);
+  return {
+    branch: declared.branch ?? runOwnedHead(task.id, birth.runNumber),
+    targetBranch: declared.targetBranch,
+  };
+};
+
+/** The head each birth intent names, before the Run's own ref fills a null. */
+const declaredPublishTarget = async (
+  tx: Tx,
+  task: RunBranchTask,
+  intent: OpenRunIntent["kind"],
+  prior: RunBirth["prior"],
+): Promise<{ branch: string | null; targetBranch: string | null }> => {
+  const requeueBase = async (): Promise<string | null> => (prior
+    ? resolveRequeueBase(tx, task, prior)
+    : task.targetBranch ?? task.repo.defaultBranch);
+  switch (intent) {
+    // A recovered human authorization renews the mechanical Run of a Step that
+    // already sits on its Chain's head against the base it was authorized on.
+    // It moves neither.
+    case "integrator-authorized":
+      return { branch: prior?.branch ?? null, targetBranch: prior?.targetBranch ?? task.targetBranch };
+    // A merge-tail repair card is chain-detached on purpose, but its commits
+    // have to land on the ref the tail is trying to merge. That ref is the
+    // Task's own targetBranch, written when the card was created from the
+    // source Run's head, so the card publishes onto its base.
+    case "merge-tail-repair":
+      return { branch: task.targetBranch, targetBranch: task.targetBranch };
+    case "retry-after-completion":
+      // A Chain or Template step's head belongs to the chain, so the chain rule
+      // answers. A Template retry may carry a head its runner published under;
+      // an indexed non-template sibling must not.
+      if (task.chainId && (task.templateId || task.chainIndex !== null)) {
+        return chainDeclaredBranches(tx, task, task.templateId ? { branch: prior?.branch ?? null } : null);
+      }
+      // Publication evidence answers the base. Only a head the Task owns
+      // answers the publish target; the ref the previous Run owned does not,
+      // so this Run receives its own.
+      return { branch: taskOwnedHead(task.id, prior), targetBranch: await requeueBase() };
+    case "retry-after-lease-loss":
+      // A pinned Step keeps its immutable range; an indexed non-template
+      // sibling re-derives the shared head from publication evidence alone.
+      if (task.templateStep?.baseFromStepIndex != null) {
+        return chainDeclaredBranches(tx, task, { branch: prior?.branch ?? null });
+      }
+      if (task.chainId && task.chainIndex !== null && !task.templateId) {
+        return chainDeclaredBranches(tx, task, null);
+      }
+      // Unlike a completion retry, the replacement for a lost lease continues
+      // the head its predecessor was told to publish: the lost Run may already
+      // have pushed it, and nothing terminal was reported about it.
+      return { branch: prior?.branch ?? null, targetBranch: await requeueBase() };
+    default:
+      return chainDeclaredBranches(tx, task, prior ? { branch: prior.branch } : null);
+  }
+};
+
 export type IntegratorStopBypass = { integratorTaskId: string; sourceStopId: string };
 
 export type OpenRunIntent =
   | { kind: "enqueue"; readyAt: Date; stopBypass?: IntegratorStopBypass | null }
   | { kind: "merge-tail-requeue"; readyAt: Date; budgetGrant: 1 }
+  /** The first Run of an automatic merge-tail repair card, which publishes onto
+   *  the chain head it was created to repair rather than onto a ref of its own. */
+  | { kind: "merge-tail-repair"; readyAt: Date }
   | { kind: "task-created"; readyAt: Date }
   | { kind: "retry"; readyAt: Date }
   | { kind: "integrator-authorized"; readyAt: Date }
@@ -689,6 +801,7 @@ export const openRun = async (
   }
   if (!task.repo && (intent.kind === "enqueue"
     || intent.kind === "merge-tail-requeue"
+    || intent.kind === "merge-tail-repair"
     || intent.kind === "task-created"
     || intent.kind === "integrator-authorized")) {
     return openRunRefusal("repo-required", "invalid-request", `Task ${task.id} cannot open a ${intent.kind} Run without a Repo`);
@@ -841,38 +954,13 @@ export const openRun = async (
     }
   }
 
-  const branches = intent.kind === "integrator-authorized"
-    ? { branch: prior?.branch ?? null, targetBranch: prior?.targetBranch ?? task.targetBranch }
-    : !task.repo
-      ? { branch: prior?.branch ?? null, targetBranch: prior?.targetBranch ?? task.targetBranch }
-      : intent.kind === "retry-after-completion"
-        ? task.chainId && (task.templateId || task.chainIndex !== null)
-          ? await resolveRunBranches(
-            tx,
-            { ...task, repo: task.repo },
-            task.templateId ? { branch: prior?.branch ?? null } : null,
-          )
-          : {
-            // Publication evidence answers the base. A head the task declared
-            // answers the publish target; a runner per-Run fallback does not,
-            // so it resets to null and lets this Run receive its own fallback.
-            branch: retryPublishHead(task.id, prior),
-            targetBranch: prior
-              ? await resolveRequeueBase(tx, { ...task, repo: task.repo }, prior)
-              : task.targetBranch ?? task.repo.defaultBranch,
-          }
-        : intent.kind === "retry-after-lease-loss"
-          ? task.templateStep?.baseFromStepIndex != null
-            ? await resolveRunBranches(tx, { ...task, repo: task.repo }, { branch: prior?.branch ?? null })
-            : task.chainId && task.chainIndex !== null && !task.templateId
-              ? await resolveRunBranches(tx, { ...task, repo: task.repo }, null)
-              : {
-                branch: prior?.branch ?? null,
-                targetBranch: prior
-                  ? await resolveRequeueBase(tx, { ...task, repo: task.repo }, prior)
-                  : task.targetBranch ?? task.repo.defaultBranch,
-              }
-          : await resolveRunBranches(tx, { ...task, repo: task.repo }, prior ?? null);
+  // Every intent asks the same module, so no arm can put a Step on a different
+  // branch from the rest of its Chain, and no caller has to fill in a head.
+  const branches = await resolveRunBranches(tx, task, {
+    intent: intent.kind,
+    runNumber,
+    prior: prior ?? null,
+  });
 
   // A salvaged publication can sit behind an intermediate cancelled Run, so
   // the latest Run alone is not the ownership proof. Bind the relaxation to

--- a/packages/db/src/run-open.ts
+++ b/packages/db/src/run-open.ts
@@ -439,9 +439,11 @@ export const resolveRequeueBase = async (
 
 /**
  * The head a retry keeps because the *Task* owns it — a shared chain head, or
- * the ref a merge-tail repair card was created to land on. A head this module
- * minted for the previous Run belongs to that Run alone and is never carried
- * forward: the retry receives its own.
+ * the ref a merge-tail repair card was created to land on. Under this rule a
+ * head minted for the previous Run belongs to that Run alone and is not carried
+ * forward: the retry receives its own. Only the completion retry asks; the
+ * lost-lease and ordinary-birth rules deliberately continue the predecessor's
+ * declared head, and each says why where it does so.
  *
  * The comparison is against `runOwnedHead`, which this module is the only
  * producer of, so it reads back a decision made here rather than recognising
@@ -556,9 +558,11 @@ const chainDeclaredBranches = async (
  * base it clones (`targetBranch`).
  *
  * This is the only place either is decided. Every `openRun` intent goes through
- * it, `repairReplacementAfterSalvage` re-runs it for a queued replacement whose
- * clone base moved, and nothing else writes `Run.branch`. A caller that needs a
- * different head adds its intent here; patching the row after birth would put
+ * it, and a Run's head is written once, at its birth: nothing else writes
+ * `Run.branch`. `repairReplacementAfterSalvage` re-runs it for a queued
+ * replacement whose clone base moved and takes the base alone from the answer.
+ * A caller that needs a different head adds its intent here; patching the row
+ * after birth would put
  * the decision back in two places, which is how one Step ended up on a
  * different branch from the rest of its Chain.
  *
@@ -635,8 +639,19 @@ const declaredPublishTarget = async (
       // the head its predecessor was told to publish: the lost Run may already
       // have pushed it, and nothing terminal was reported about it.
       return { branch: prior?.branch ?? null, targetBranch: await requeueBase() };
-    default:
+    // Every remaining intent is an ordinary birth with no snapshot of its own:
+    // the Chain rule answers, and a Run outside a Chain receives the ref it
+    // owns. Listed rather than defaulted so a new intent kind fails to compile
+    // here instead of inheriting this rule by accident.
+    case "enqueue":
+    case "merge-tail-requeue":
+    case "task-created":
+    case "retry":
       return chainDeclaredBranches(tx, task, prior ? { branch: prior.branch } : null);
+    default: {
+      const unhandled: never = intent;
+      throw new Error(`Unhandled Run birth intent: ${String(unhandled)}`);
+    }
   }
 };
 

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import test from "node:test";
 
-import { agentExecutionSucceeded, isCodexReconnectStatus, runOwnedHead } from "@anneal/db";
+import { agentExecutionSucceeded, isCodexReconnectStatus } from "@anneal/db";
 
 import {
   adapters, argsForRunner, buildChildEnvironment, buildPrompt, createAdapterState, failureReasonFromEvidence,
@@ -74,7 +74,7 @@ const claim: ClaimedTask = {
     implementationHeadSha: null,
     promptHash: "hash",
     workspacePath: null,
-    branch: runOwnedHead("task-1", 1),
+    branch: null,
     baseSha: null,
   },
   session: { id: "session-1" },

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import test from "node:test";
 
-import { agentExecutionSucceeded, isCodexReconnectStatus } from "@anneal/db";
+import { agentExecutionSucceeded, isCodexReconnectStatus, runOwnedHead } from "@anneal/db";
 
 import {
   adapters, argsForRunner, buildChildEnvironment, buildPrompt, createAdapterState, failureReasonFromEvidence,
@@ -74,7 +74,7 @@ const claim: ClaimedTask = {
     implementationHeadSha: null,
     promptHash: "hash",
     workspacePath: null,
-    branch: null,
+    branch: runOwnedHead("task-1", 1),
     baseSha: null,
   },
   session: { id: "session-1" },

--- a/packages/runner/src/delivery.ts
+++ b/packages/runner/src/delivery.ts
@@ -1,5 +1,5 @@
 import { confirmedWrite, isDeterministicRefusal, isLostResponse } from "@anneal/github-client";
-import { canonicalOutputSchema, PR_TEMPLATE_NAME, type PrHandoffKind, type PrHandoffOutput } from "@anneal/db";
+import { canonicalOutputSchema, PR_TEMPLATE_NAME, type PrHandoffKind, type PrHandoffOutput, runOwnedHead } from "@anneal/db";
 
 import type { ClaimedTask, FailureClass } from "./api.js";
 import type { RunnerConfig } from "./config.js";
@@ -875,9 +875,9 @@ export const deliverWorkspace = async (
  * run branch as WIP so the work survives workspace cleanup. Never opens a PR,
  * and never reports a failureClass — the run already has one from CLI evidence.
  *
- * The per-run branch here is deliberate and is now load-bearing: a failed run's
- * half-finished tree must never enter the chain's shared branch, which every
- * later step of the chain clones. Never change this to workspace.branch.
+ * The ref this pushes is the one the Run owns (`runOwnedHead` in @anneal/db),
+ * never `workspace.branch`: a failed run's half-finished tree must never enter
+ * the chain's shared branch, which every later step of the chain clones.
  *
  * Note what this function does *not* control: the completion payload still
  * reports `Run.branch` as the workspace branch (runner.ts spreads the workspace
@@ -897,7 +897,7 @@ export const salvageWorkspace = async (
     ?? bindCommandRunner(config.runAsPrefix, workspace.path, workspaceEnvironment(config));
   const retryOptions = dependencies.retryOptions ?? {};
   const remote = identity.remoteUrl ?? "origin";
-  const branch = `agentos/${identity.taskId}/run-${identity.runNumber}`;
+  const branch = runOwnedHead(identity.taskId, identity.runNumber);
   try {
     // Respect .gitignore while including tracked deletions and untracked files.
     await command("git", ["add", "-A"]);

--- a/packages/runner/src/provision-failure.test.ts
+++ b/packages/runner/src/provision-failure.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { test } from "node:test";
 
+import { runOwnedHead } from "@anneal/db";
+
 import type { ClaimedTask } from "./api.js";
 import type { RunnerConfig } from "./config.js";
 import { RUNNER_EXCEPTION_REASON, runnerExceptionEnvelope } from "./envelope.js";
@@ -104,7 +106,7 @@ const claim = (remoteUrl: string): ClaimedTask => ({
     implementationHeadSha: null,
     promptHash: "hash",
     workspacePath: null,
-    branch: null,
+    branch: runOwnedHead("task-113", 1),
     baseSha: null,
   },
   session: { id: "session-113" },

--- a/packages/runner/src/run-output.test.ts
+++ b/packages/runner/src/run-output.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { PR_TEMPLATE_NAME, type RunOutputEvidence, type RunOutputSatisfaction } from "@anneal/db";
+import { PR_TEMPLATE_NAME, runOwnedHead, type RunOutputEvidence, type RunOutputSatisfaction } from "@anneal/db";
 
 import { ControlPlaneError, type ClaimedTask } from "./api.js";
 import { adapters, type CliAdapter, type ExitEvidence, type RuntimeHandle } from "./adapters.js";
@@ -217,7 +217,7 @@ const claim = (remoteUrl: string): ClaimedTask => ({
     implementationHeadSha: null,
     promptHash: "hash",
     workspacePath: null,
-    branch: null,
+    branch: runOwnedHead("task-114", 1),
     baseSha: null,
   },
   session: { id: "session-114" },

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -7,7 +7,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 
-import type { RunOutcome, RunOutputEvidence } from "@anneal/db";
+import { type RunOutcome, type RunOutputEvidence, runOwnedHead } from "@anneal/db";
 
 import {
   adapters, buildPrompt, RUNNER_KINDS, type AdapterEvent, type CliAdapter, type ExitEvidence, type RuntimeHandle,
@@ -119,7 +119,9 @@ const mechanicalClaim: ClaimedTask = {
     implementationHeadSha: null,
     promptHash: "hash",
     workspacePath: null,
-    branch: null,
+    // The control plane declares the head at Run birth; provisioning refuses a
+    // claim without one, so no fixture may leave it null.
+    branch: runOwnedHead("task-10", 1),
     baseSha: null,
   },
   session: { id: "session-10" },

--- a/packages/runner/src/workspace.test.ts
+++ b/packages/runner/src/workspace.test.ts
@@ -210,6 +210,34 @@ test("an explicit true template step keeps the repository dependency policy path
   }
 });
 
+test("provisioning refuses a claim that carries no publish head", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agentos-workspace-no-head-"));
+  try {
+    const config = {
+      workspaceRoot: join(root, "workspaces"),
+      runAsPrefix: [],
+      path: process.env.PATH ?? "/usr/bin:/bin",
+      home: root,
+      gitIdentity: { name: "Runner Test", email: "runner@example.invalid" },
+    } as unknown as RunnerConfig;
+    // The head is decided once, at Run birth, by @anneal/db. A runner that
+    // filled a missing one in was the second decider this seam removed, so its
+    // absence is a fault to report rather than a name to invent.
+    const claim = workspaceClaim({
+      task: { id: "task-no-head" },
+      repo: { remoteUrl: join(root, "origin.git"), defaultBranch: "main" },
+      run: { id: "run-no-head", runNumber: 1, targetBranch: "main", branch: null },
+    });
+
+    await assert.rejects(
+      provisionWorkspace(config, claim, NO_DEPENDENCIES),
+      /carries no publish head/u,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("a workspace cloned from its own published head still resolves the target branch", async () => {
   const root = await mkdtemp(join(tmpdir(), "agentos-workspace-target-refspec-"));
   try {

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -430,7 +430,12 @@ export const provisionWorkspace = async (
   try {
     const identity = await resolveRunnerGitIdentity(config, run);
     const target = claim.run.targetBranch ?? claim.repo.defaultBranch;
-    const branch = claim.run.branch ?? `agentos/${claim.task.id}/run-${claim.run.runNumber}`;
+    // The control plane declares the head at Run birth (`resolveRunBranches` in
+    // @anneal/db). A claim without one is a Run that cannot publish, and
+    // inventing a name here is what let two processes disagree about which ref
+    // a retry owns.
+    const branch = claim.run.branch;
+    if (branch === null) throw new Error(`Claimed run ${claim.run.id} carries no publish head`);
     const pinnedBaseSha = claim.run.pinnedBaseSha;
     // Dependencies are materialised after the mirror lock is released: `npm ci`
     // is bounded in half-hours, and holding a machine-wide lock across it would


### PR DESCRIPTION
## What changed

`resolveRunBranches` in `packages/db/src/run-open.ts` documented itself as the
seam for the branch rule while four of `openRun`'s five ternary arms did not
call it, and the head a Run publishes was recovered afterwards by rebuilding
the runner's per-Run ref as a string at five production sites across two
packages. `Run.branch` held two facts at once: the head the control plane
declared at birth, and the head the runner filled in and reported back.

One module now decides the publish target of every Run, and the column carries
one fact.

- **The interface moved from "the chain rule" to "the publish target".**
  `resolveRunBranches(tx, task, birth)` takes the birth intent, the Run number
  and the prior Run, and answers the head (`branch`) and the base
  (`targetBranch`) for every intent. `openRun`'s five-arm nested ternary is one
  call; the intent-specific rules are an exhaustive switch inside the module,
  each arm stating why it differs, and a new intent kind fails to compile
  rather than inheriting the chain rule. `repairReplacementAfterSalvage` re-runs
  the same module for the base a moved salvage changed and leaves the
  replacement's head alone, so `Run.branch` is written once, at Run birth.
- **A Run whose Task has a Repo always leaves the module with a head.** When no
  Chain, Template or repair rule names one, it is the ref the Run owns. The
  runner therefore reads the head from the claim and refuses a claim that
  carries none, rather than inventing a name; `Run.branch` is no longer two
  facts that only a string match could tell apart.
- **`agentos/<taskId>/run-<n>` is derived in one place**, the new
  `packages/db/src/run-head.ts` (`runOwnedHead`). The five production sites are
  one: `runner/workspace.ts` no longer derives at all, and
  `runner/delivery.ts`, `api/run-fence.ts`, `api/workspace-reclaim.ts` and
  `merge-tail-repair.dbtest.ts` call the module.
- **`retryPublishHead` is gone.** Its replacement, `taskOwnedHead`, asks whether
  a prior head is the ref that Run owned by comparing against the name this
  module minted for it — reading back its own decision, not recognising another
  package's convention.
- **The merge-tail repair card has a birth intent.** `openAutomaticRepair` opens
  its Run with `{ kind: "merge-tail-repair" }`; the module reads the chain head
  off the Task's `targetBranch`. The post-enqueue `tx.run.update` that
  overwrote the module's answer is deleted.

Which dbtest proves each intent's observable behaviour (gate evidence; there is
no local PostgreSQL):

| intent | dbtest |
| --- | --- |
| enqueue / task-created, non-chain | `chain-branch.dbtest.ts` T9 |
| enqueue, chain step | `chain-branch.dbtest.ts` T1, T2 (`runs.map(run => run.branch)` is the shared head) |
| enqueue, template chain and deferred first start | `chain-branch.dbtest.ts` T6, T6b (`custom/branch`, `custom/deferred`) |
| enqueue, pinned blind-review step | `chain.dbtest.ts:1249` |
| retry (operator), non-chain | `chain-branch.dbtest.ts` T12a, T12b |
| retry (operator), chain and template | `chain-branch.dbtest.ts` T10, "an operator-retried template step publishes its declared head from the latest salvage base", T13b |
| retry-after-completion, chain | `chain-branch.dbtest.ts` T13 |
| retry-after-completion, non-chain | `chain-branch.dbtest.ts` T14a, T14 |
| retry-after-lease-loss, chain | `chain-branch.dbtest.ts` T11 (`requeued.branch === shared`) |
| retry-after-lease-loss, non-chain | `chain-branch.dbtest.ts` T12, T12c |
| merge-tail-requeue | `merge-tail-readiness.dbtest.ts`, `merge-tail-stop-notice.dbtest.ts` |
| merge-tail-repair | `merge-tail-repair.dbtest.ts` ("retryable repairs retain the shared publish head while retrying from salvage") |
| integrator-authorized | `merge-authorization-production.dbtest.ts`, `merge-base-drift-recovery.dbtest.ts` |
| late-salvage replacement repair | `workspace-reclaim.dbtest.ts`, `chain-branch.dbtest.ts` "late salvage revokes and repairs a replacement claimed before start" |

Five dbtest assertions that pinned `Run.branch === null` for a Repo-bearing Run
now assert the declared head (`chain-branch.dbtest.ts` T9 x2, T12, T14a, T14);
three runner claim fixtures that left `run.branch` null now carry the head the
control plane would have declared, which is the same string the runner used to
derive, so those tests exercise the same refs as before.

## Evidence

Run in the worktree after the final commit (`4f419fa0`, the disposition
commit; the same sequence was green at `9dd7af51` before it), with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh `mktemp -d`:

- `npm run lint` — pass (biome 772 files, then eslint; both clean).
- `npm run typecheck` — pass, all workspaces.
- `npm run test -w @anneal/db` — 427 tests, 427 pass, 0 fail.
- `npm run test -w @anneal/api` — 895 tests, 894 pass, 1 skipped, 0 fail.
- `npm run test -w @anneal/runner` — 560 tests, 558 pass, 2 skipped, 0 fail.
- `npm run test:snapshot-scan` — 21 tests, 21 pass (a file was added).

One earlier `@anneal/runner` invocation on this same tree failed a single
assertion and two immediate re-runs of the identical command were green
(exit 0, 558 pass); it did not reproduce and the suite above is the state after
the final commit.

Database tests are not runnable here and are merge-gate evidence; every
`*.dbtest.ts` touched typechecks.

## Decisions taken

**The brief asked for a shape where "`retryPublishHead` no longer needs to
recognise anything by name: the module knows whether a prior Run's declared
head was its own per-Run head or the shared chain branch because it decided
it." Fully eliminating the comparison needs the ownership of a head persisted
on the row, which is a schema change the brief permits only when the runner
must choose a head the control plane cannot know — and after this change it
never does. So the comparison survives, in one place, as `taskOwnedHead`: the
module recomputes the name it minted for the prior Run and treats equality as
"that head belonged to that Run". The pathology the finding names — one
package's naming convention respelled at five production sites in another — is
gone, because `runOwnedHead` has exactly one producer and every consumer
imports it. I judged a nullable `Run.publishTargetKind` column to be a worse
trade: a second source of truth for a fact the name already carries, and a
migration on the retry path.**

The decision function stays in `run-open.ts` rather than moving to a new
module. It needs `inheritedBase`, `resolveRequeueBase`, `pinnedImplementationRange`
and `templateChainBranch`, and `pinnedImplementationRange` is imported by
`run-claim.ts`, which the brief puts out of bounds; moving the cluster would
have edited that file for an import line alone. The new module is the naming
authority the three packages share, which is what had to be shared.

The head rule stays asymmetric between the two automatic retries, because both
asymmetries are load-bearing and this change preserves observable behaviour: a
completion retry takes its own ref (the fix in `f3805617`), a lease-loss
replacement continues the head its predecessor was told to publish, because
that Run may already have pushed it and nothing terminal was reported. One
sub-case does change: a lease lost before `POST /start` used to leave
`Run.branch` null and let the replacement derive its own ref; it now inherits
the head the lost Run was declared with. A Run that never started has no
workspace and nothing to salvage, so no push can collide on that ref, and the
post-start case — which is what a lost lease overwhelmingly is — keeps exactly
the behaviour it had.

The deploy is sequenced against a quiet queue. A Run that is already QUEUED or
CLAIMED with `Run.branch = null` on a Repo-bearing Task fails provisioning
after this deploy (`workspace.ts`, "carries no publish head") instead of
deriving the identical name, because the runner-side derivation is gone. The
failure is loud, not silent, and the next Run of that Task is born with a
declared head, so it self-heals after one wasted Run — but each affected
in-flight ad-hoc Task burns a Run and may land in REVIEW. A compatibility
fallback in the runner is exactly the second derivation this lane removes, and
a data migration to backfill the column is a migration the brief does not
permit, so the mitigation is procedural: deploy when no Run is queued or
claimed against a Repo-bearing Task with a null `branch`.

`resolveRunBranches` keeps its name. Renaming it would have staled the comments
that name it in `run-completion.ts`, `merge-evidence-worker.ts`,
`chain-branch.ts` and `delivery.ts`, and the brief forbids editing
`run-completion.ts`.

## Fence widened

Files that belong to no lane in `QUEUE.md`:

- `packages/db/src/index.ts` — two export lines: `run-head.js`, and
  `errorForOpenRunRefusal`, which `merge-tail-actions.ts` needs to raise the
  same error `enqueueTaskRun` raised.
- `packages/api/src/run-lifecycle.ts` — one line. `repairReplacementAfterSalvage`
  now takes the prior Run's `targetBranch` as part of an honest `prior`, and
  this is its other caller.
- `packages/api/src/chain-branch.dbtest.ts`, `packages/api/src/run-fence.test.ts`,
  `packages/api/src/run-lifecycle.test.ts`, `packages/api/src/workflow.test.ts`,
  `packages/runner/src/run-output.test.ts`,
  `packages/runner/src/provision-failure.test.ts` — tests whose fixtures pinned
  `run.branch === null` and whose claims reach `provisionWorkspace`, which now
  refuses a claim with no head. Inside the fence by the common rule, but PR #464
  (lane r1) also changes `run-output.test.ts` and `provision-failure.test.ts`:
  **a merge train must not carry #464 and #465 together.**

Files owned by lane r1, whose state is `dispatched`:

- `packages/runner/src/runner.test.ts` — one fixture line. `mechanicalClaim.run`
  is spread by tests that call `provisionWorkspace`, which now throws on a null
  head, so the edit is forced by the shape change rather than chosen. It is
  inside the fence by the common rule's "any test file whose assertions your
  change necessarily breaks", but the file is r1's and PR #464 changes it too;
  the same train exclusion applies.
- `packages/runner/src/adapters.test.ts` — **not edited.** The implementation
  stage changed its `branch` fixture; nothing in that file reads `run.branch`
  and it never calls `provisionWorkspace`, so the edit was cosmetic and has
  been reverted to the base value.

## Reported but unfixed

- `packages/api/src/run-completion.ts:894` writes `branch: body.branch ?? run.branch`
  and `packages/api/src/run-lifecycle.ts:142` writes `branch: input.body.branch ?? null`
  on `POST /runs/:id/start`. After this change the runner reports the head it
  was given, so both write the value the control plane already decided and the
  column no longer holds two facts — but the writes are now redundant, and
  removing them means removing `branch` from the start and completion request
  bodies, which is a claim/completion contract change. `run-completion.ts` is
  out of bounds for this lane and the contract belongs to k2/k3.
- `packages/api/src/run-terminal.ts:238` backfills `Run.branch` where
  `branch: null` on a cancellation acknowledgement. That predicate can now only
  match a Run whose Task has no Repo, which has no workspace and reports no
  branch, so the write is dead. It is one statement in a file no lane owns; I
  left it rather than widen the fence for a deletion that is not this brief.
- `pullRequestBase` is still re-derived in `run-claim.ts:1131` by a
  `chainFirstRun` query rather than read from the Run. It is a fourth notion of
  "which line does this Run belong to" and it does belong with the publish
  target, but `run-claim.ts` is fenced to k2 and t3.

## Disposition

Blind review returned `changes-required` with four findings. Every one is ruled
on below; nothing was dropped.

1. **Blocking — fence: four runner test files owned by lane r1 were edited and
   the body called them unowned (`packages/runner/src/adapters.test.ts:77`).**
   Fixed. `adapters.test.ts` is reverted to its base value — the reviewer is
   right that no assertion in it reads `run.branch` and it never reaches
   `provisionWorkspace`, so the edit bought nothing and only added a file
   overlap with an in-flight PR. `runner.test.ts` stays: `mechanicalClaim.run`
   is spread by tests that do call `provisionWorkspace`, which now refuses a
   claim with no head, so reverting it would fail the suite. `## Fence widened`
   above now names lane r1 as the owner of `runner.test.ts` and
   `adapters.test.ts`, and flags that PR #464 also changes `run-output.test.ts`
   and `provision-failure.test.ts`, so no merge train carries #464 and #465
   together.

2. **Advisory — Runs already QUEUED or CLAIMED with `Run.branch = null` fail
   provisioning after this deploy, and the transition was not recorded.**
   Fixed as documentation, which is what the finding asked for: the third
   paragraph of `## Decisions taken` states the transition, why a runner-side
   fallback and a backfill migration are both refused, and that the deploy is
   sequenced against a quiet queue.

3. **Advisory — `repairReplacementAfterSalvage` re-decided the replacement's
   head under a hard-coded `intent: "enqueue"`, rewriting a non-chain
   replacement's own ref back to the previous Run's ref.**
   Fixed, by a narrower route than the finding suggests. The replacement's birth
   intent is not persisted, so it cannot be passed; but it does not need to be.
   A late salvage moves only the publication evidence the *base* resolves
   against, so the repair now writes `targetBranch` alone and the head stays the
   one this module decided at the replacement's own birth. That removes the
   second writer of `Run.branch` outright — the invariant the lane exists to
   establish — instead of making a second writer agree with the first. The
   `enqueue` arm is still what answers the base, and the comment now says why:
   it is the rule that re-derives from current evidence rather than from the
   replacement's birth snapshot, which is exactly what a moved base means. The
   base rule cannot be replaced by `resolveRequeueBase` here, because a pinned
   implementation Step's base is an immutable SHA that only the chain rule
   returns. `taskOwnedHead`'s docstring is corrected to scope its "never carried
   forward" claim to its own rule; the lease-loss and ordinary-birth rules
   deliberately continue the predecessor's declared head and say so.

4. **Advisory — `declaredPublishTarget`'s `default:` arm let a future intent
   kind inherit the chain rule silently.**
   Fixed. The switch now names `enqueue`, `merge-tail-requeue`, `task-created`
   and `retry` explicitly and the `default:` arm is a `never` check that throws,
   so adding a kind to `OpenRunIntent` fails to compile until its rule is
   written. This is a compile-time guarantee, not generality for a hypothetical
   caller.

Generated with Claude Code (deepening round 6 lane k1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1KMxWcjsX23QvAQdGhWyC

