### PR TITLE
refactor(deploy): derive the sudoers grant from the control verbs

### DIFF
--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -263,11 +263,12 @@ the system-owned staged files to `/etc/systemd/system` as `root:root` with
 mode 0644, independently validates the rendered units and generated
 `/etc/sudoers.d/anneal-service-control` with `visudo -c`, runs
 `systemctl daemon-reload`, and then enables the generated inventory. The
-sudoers grant names only the generated unit names and only the verbs
-`restart`, `show`, and `is-active`. It does not grant `enable`, `disable`, or
-`daemon-reload`; those operations remain in the root install stage. A
-non-root control call uses `sudo -n`, and a denied command is a deployment
-failure rather than a successful no-op.
+sudoers grant is rendered from the control adapter's own description of its
+verbs, so it names only the generated unit names, only `/bin/systemctl`, and
+only the verbs `restart`, `is-active`, and `show -p ExecStart --value`. It
+does not grant `enable`, `disable`, or `daemon-reload`; those operations
+remain in the root install stage. A non-root control call uses `sudo -n`, and
+a denied command is a deployment failure rather than a successful no-op.
 
 Before replacing an existing system file, stage two records its bytes,
 ownership, mode, and enabled/active state in a root-owned mode-0600 transaction
@@ -317,9 +318,9 @@ pointer is activated, the Linux control adapter performs the following checks
 for each generated service label, in inventory order:
 
 ```sh
-sudo -n systemctl restart <label>.service
-sudo -n systemctl is-active <label>.service
-sudo -n systemctl show -p ExecStart --value <label>.service
+sudo -n /bin/systemctl restart <label>.service
+sudo -n /bin/systemctl is-active <label>.service
+sudo -n /bin/systemctl show -p ExecStart --value <label>.service
 ```
 
 `is-active` must return `active`, and the `ExecStart` value must contain both

--- a/scripts/deploy/install-launchd.mjs
+++ b/scripts/deploy/install-launchd.mjs
@@ -26,6 +26,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { resolveServicePlatform } from "./service-platform.mjs";
+import { SYSTEMCTL_PATH, SYSTEMD_CONTROL_VERBS, systemdControlArgv } from "./service-control.mjs";
 import { DEFAULT_DEPLOY_ROLE, resolveDeployRole } from "./deploy-role.mjs";
 
 export { DEFAULT_DEPLOY_ROLE, resolveDeployRole };
@@ -866,23 +867,22 @@ const systemdCommandPath = (name, configured, execute = execFileSync) => {
   }
 };
 
-export const renderSystemdSudoers = ({
-  serviceUser,
-  inventory,
-  systemctlPath = "/bin/systemctl",
-} = {}) => {
+/**
+ * Grant the service user exactly the commands `service-control.mjs` issues:
+ * one line per unit and control verb, rendered from that module's description
+ * of the verbs. Nothing else is granted, and a verb the deployment issues
+ * cannot be missing from the grant.
+ */
+export const renderSystemdSudoers = ({ serviceUser, inventory } = {}) => {
   if (!validAccountName(serviceUser) || serviceUser === "root") throw new Error("systemd-service-user-invalid");
   if (!isGeneratedServiceInventory(inventory) || inventory.entries.length === 0) {
     throw new Error("systemd-service-inventory-invalid");
   }
-  if (typeof systemctlPath !== "string" || systemctlPath === "" || !systemctlPath.startsWith("/")) {
-    throw new Error("systemd-command-not-absolute:systemctl");
-  }
   const rules = [];
   for (const { unitName } of inventory.entries) {
-    rules.push(`${systemctlPath} restart ${unitName}`);
-    rules.push(`${systemctlPath} show -p ExecStart --value ${unitName}`);
-    rules.push(`${systemctlPath} is-active ${unitName}`);
+    for (const verb of SYSTEMD_CONTROL_VERBS) {
+      rules.push([SYSTEMCTL_PATH, ...systemdControlArgv(verb, unitName)].join(" "));
+    }
   }
   return `${serviceUser} ALL=(root) NOPASSWD: ${rules.join(", ")}\n`;
 };
@@ -1119,7 +1119,7 @@ const readStageEntries = ({
   if (manifest.schemaVersion !== 1 || manifest.platform !== "linux"
       || manifest.repositoryRoot !== resolve(root) || manifest.stagingRoot !== stageRoot
       || manifest.unitDirectory !== unitDirectory || manifest.sudoersPath !== sudoersPath
-      || manifest.systemctlPath !== "/bin/systemctl"
+      || manifest.systemctlPath !== SYSTEMCTL_PATH
       || (manifest.reloadPending !== undefined && manifest.reloadPending !== true)
       || manifest.entries.length !== inventory.entries.length + 1) {
     invalidManifest(reason, manifestPath);
@@ -1237,11 +1237,9 @@ const readStageEntries = ({
     }
   }
   const sudoersEntry = manifest.auxiliaryEntries.find((entry) => entry.kind === "sudoers");
-  if (readFileSync(sudoersEntry.stagedPath, "utf8") !== renderSystemdSudoers({
-    serviceUser: account,
-    inventory,
-    systemctlPath: manifest.systemctlPath,
-  })) throw new Error("systemd-staged-sudoers-invalid");
+  if (readFileSync(sudoersEntry.stagedPath, "utf8") !== renderSystemdSudoers({ serviceUser: account, inventory })) {
+    throw new Error("systemd-staged-sudoers-invalid");
+  }
   for (const entry of manifest.auxiliaryEntries.filter((candidate) => candidate.kind === "drop-in")) validateDropIn(entry, inventory);
   const retiredEntries = manifest.retiredEntries ?? [];
   if (!Array.isArray(retiredEntries)) throw new Error("systemd-service-manifest-invalid");
@@ -1690,7 +1688,7 @@ const systemdStagePlan = ({
       && fileDigest(wrapper) !== wrapperManifestEntry.installedSha256 && !replaceExisting) {
     throw new Error(`launchd-service-wrapper-conflict:${wrapper}`);
   }
-  const sudoers = renderSystemdSudoers({ serviceUser: account, inventory, systemctlPath: "/bin/systemctl" });
+  const sudoers = renderSystemdSudoers({ serviceUser: account, inventory });
   const sudoersStaged = stageSystemdDefinition({
     stagingRoot: stageRoot,
     relativePath: "sudoers/anneal-service-control",
@@ -1730,7 +1728,7 @@ const systemdStagePlan = ({
     stagingRoot: stageRoot,
     unitDirectory: resolvedUnitDirectory,
     sudoersPath: resolvedSudoersPath,
-    systemctlPath: "/bin/systemctl",
+    systemctlPath: SYSTEMCTL_PATH,
     renderInputs: {
       nodeBinary: resolvedNode,
       path: controlledPath,

--- a/scripts/deploy/service-control.mjs
+++ b/scripts/deploy/service-control.mjs
@@ -15,6 +15,40 @@ export const serviceUnitName = (label, inventory) => {
   return entry.unitName;
 };
 
+/**
+ * The systemd program every control command runs. The installer pins the same
+ * path into the service manifest, and `renderSystemdSudoers` grants exactly
+ * this program, so the granted command and the issued command are one string.
+ */
+export const SYSTEMCTL_PATH = "/bin/systemctl";
+
+/**
+ * The complete systemd control vocabulary of this deployment: for each verb,
+ * the systemctl arguments that precede the unit name. Both derivations of the
+ * command read this description - `invoke` below issues
+ * `systemdControlArgv(verb, unit)`, and `renderSystemdSudoers` renders the
+ * service user's `sudo -n` grant from the same call. 6da5abd3 had to repair a
+ * grant that allowed `systemctl show <unit>` while `describe` issued
+ * `systemctl show -p ExecStart --value <unit>`; that mismatch is now
+ * unrepresentable.
+ */
+const SYSTEMD_CONTROL_ARGUMENTS = Object.freeze({
+  restart: Object.freeze(["restart"]),
+  "is-active": Object.freeze(["is-active"]),
+  show: Object.freeze(["show", "-p", "ExecStart", "--value"]),
+});
+
+/** The control verbs in the order the deployment issues them. */
+export const SYSTEMD_CONTROL_VERBS = Object.freeze(Object.keys(SYSTEMD_CONTROL_ARGUMENTS));
+
+/** The exact systemctl argv a verb produces for one unit. */
+export const systemdControlArgv = (verb, unitName) => {
+  if (!Object.hasOwn(SYSTEMD_CONTROL_ARGUMENTS, verb)) {
+    throw new DeployFailure("service-control-verb-unknown", String(verb));
+  }
+  return [...SYSTEMD_CONTROL_ARGUMENTS[verb], unitName];
+};
+
 const uidOf = () => {
   if (typeof process.getuid === "function") return process.getuid();
   return 0;
@@ -79,7 +113,6 @@ export const createServiceControl = ({
   wrapperPath = "",
   uid = uidOf(),
   euid = euidOf(),
-  systemctlBinary = "systemctl",
   sudoBinary = "sudo",
   launchctlBinary = "/bin/launchctl",
   timeoutMs = Object.freeze({
@@ -102,7 +135,7 @@ export const createServiceControl = ({
   const invoke = async ({
     label,
     verb,
-    args,
+    launchctlArgs,
     options = {},
     inactiveExit = false,
     failureReason = "service-control-failed",
@@ -111,12 +144,12 @@ export const createServiceControl = ({
     const unit = serviceUnitName(label, inventory);
     const program = platform === "darwin"
       ? launchctlBinary
-      : euid === 0 ? systemctlBinary : sudoBinary;
+      : euid === 0 ? SYSTEMCTL_PATH : sudoBinary;
     const commandArgs = platform === "darwin"
-      ? args
+      ? launchctlArgs
       : euid === 0
-        ? args
-        : ["-n", systemctlBinary, ...args];
+        ? systemdControlArgv(verb, unit)
+        : ["-n", SYSTEMCTL_PATH, ...systemdControlArgv(verb, unit)];
     const binaryName = platform === "darwin" ? "launchctl" : euid === 0 ? "systemctl" : "sudo";
     let result;
     try {
@@ -175,9 +208,7 @@ export const createServiceControl = ({
       verb: "restart",
       failureReason: reason,
       useChecked: platform === "darwin",
-      args: platform === "darwin"
-        ? ["kickstart", "-k", `gui/${uid}/${label}`]
-        : ["restart", serviceUnitName(label, inventory)],
+      launchctlArgs: ["kickstart", "-k", `gui/${uid}/${label}`],
       options: {
         timeoutMs: timeout,
         timeoutReason: timeoutReason ?? `${reason}-timeout`,
@@ -191,9 +222,7 @@ export const createServiceControl = ({
       label,
       verb: "is-active",
       inactiveExit: true,
-      args: platform === "darwin"
-        ? ["print", `gui/${uid}/${label}`]
-        : ["is-active", serviceUnitName(label, inventory)],
+      launchctlArgs: ["print", `gui/${uid}/${label}`],
       options: {
         ...options,
         timeoutMs: options.timeoutMs ?? inspectTimeoutMs,
@@ -209,9 +238,7 @@ export const createServiceControl = ({
       label,
       verb: "show",
       inactiveExit: platform === "darwin",
-      args: platform === "darwin"
-        ? ["print", `gui/${uid}/${label}`]
-        : ["show", "-p", "ExecStart", "--value", serviceUnitName(label, inventory)],
+      launchctlArgs: ["print", `gui/${uid}/${label}`],
       options: {
         ...options,
         timeoutMs: options.timeoutMs ?? inspectTimeoutMs,

--- a/scripts/deploy/service-control.test.mjs
+++ b/scripts/deploy/service-control.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { renderSystemdSudoers } from "./install-launchd.mjs";
 import { DeployFailure } from "./quiet-window-lib.mjs";
 import { generateServiceInventory, resolveServiceInventory } from "./service-inventory.mjs";
 import {
@@ -55,15 +56,15 @@ test("runner role service control accepts only the local runner inventory", asyn
   });
   await control.restart("com.agentos.runner-2");
   assert.deepEqual(recorder.calls.map(({ program, args }) => [program, args]), [
-    ["systemctl", ["restart", "com.agentos.runner-2.service"]],
+    ["/bin/systemctl", ["restart", "com.agentos.runner-2.service"]],
   ]);
-  assert.throws(() => control.restart("com.agentos.api"), /service-control-label-invalid/u);
+  await assert.rejects(control.restart("com.agentos.api"), /service-control-label-invalid/u);
 });
 
-test("Linux root control uses bare systemctl verbs and the stable ExecStart query", async () => {
+test("Linux root control runs the granted systemctl program and the stable ExecStart query", async () => {
   const recorder = runRecorder({
-    "systemctl is-active com.agentos.api.service": { code: 0, stdout: "active\n", stderr: "" },
-    "systemctl show -p ExecStart --value com.agentos.api.service": {
+    "/bin/systemctl is-active com.agentos.api.service": { code: 0, stdout: "active\n", stderr: "" },
+    "/bin/systemctl show -p ExecStart --value com.agentos.api.service": {
       code: 0,
       stdout: "/usr/bin/node /srv/shared/bin/agentos-service-wrapper.mjs com.agentos.api\n",
       stderr: "",
@@ -75,26 +76,26 @@ test("Linux root control uses bare systemctl verbs and the stable ExecStart quer
   assert.equal(await control.isRunning("com.agentos.api"), true);
   assert.match(await control.describe("com.agentos.api"), /agentos-service-wrapper\.mjs/u);
   assert.deepEqual(recorder.calls.map(({ program, args }) => [program, args]), [
-    ["systemctl", ["restart", "com.agentos.api.service"]],
-    ["systemctl", ["is-active", "com.agentos.api.service"]],
-    ["systemctl", ["show", "-p", "ExecStart", "--value", "com.agentos.api.service"]],
+    ["/bin/systemctl", ["restart", "com.agentos.api.service"]],
+    ["/bin/systemctl", ["is-active", "com.agentos.api.service"]],
+    ["/bin/systemctl", ["show", "-p", "ExecStart", "--value", "com.agentos.api.service"]],
   ]);
 });
 test("Linux non-root control prefixes sudo -n and an inactive unit is not running", async () => {
   const recorder = runRecorder({
-    "sudo -n systemctl is-active com.agentos.web.service": { code: 3, stdout: "inactive\n", stderr: "" },
+    "sudo -n /bin/systemctl is-active com.agentos.web.service": { code: 3, stdout: "inactive\n", stderr: "" },
   });
   const control = createServiceControl({ inventory: DEFAULT_INVENTORY, platform: "linux", euid: 1000, run: recorder.run });
 
   assert.equal(await control.isRunning("com.agentos.web"), false);
   assert.deepEqual(recorder.calls.map(({ program, args }) => [program, args]), [
-    ["sudo", ["-n", "systemctl", "is-active", "com.agentos.web.service"]],
+    ["sudo", ["-n", "/bin/systemctl", "is-active", "com.agentos.web.service"]],
   ]);
 });
 
 test("a denied Linux control command fails with the unit named", async () => {
   const recorder = runRecorder({
-    "sudo -n systemctl restart com.agentos.api.service": {
+    "sudo -n /bin/systemctl restart com.agentos.api.service": {
       code: 1,
       stdout: "",
       stderr: "sudo: a password is required\n",
@@ -113,7 +114,7 @@ test("a denied Linux control command fails with the unit named", async () => {
 
 test("a systemctl failure is distinct from sudo denial and retains diagnostics", async () => {
   const recorder = runRecorder({
-    "sudo -n systemctl restart com.agentos.api.service": {
+    "sudo -n /bin/systemctl restart com.agentos.api.service": {
       code: 1,
       stdout: "",
       stderr: "Job for com.agentos.api.service failed; inspect the journal\n",
@@ -170,9 +171,9 @@ test("every Linux inventory label uses the restart, liveness, and boundary argv"
   }
 
   assert.deepEqual(calls.map(({ program, args }) => [program, args]), SERVICE_LABELS.flatMap((label) => [
-    ["systemctl", ["restart", `${label}.service`]],
-    ["systemctl", ["is-active", `${label}.service`]],
-    ["systemctl", ["show", "-p", "ExecStart", "--value", `${label}.service`]],
+    ["/bin/systemctl", ["restart", `${label}.service`]],
+    ["/bin/systemctl", ["is-active", `${label}.service`]],
+    ["/bin/systemctl", ["show", "-p", "ExecStart", "--value", `${label}.service`]],
   ]));
 });
 
@@ -203,6 +204,39 @@ test("every Darwin inventory label keeps the launchctl command sequence", async 
     ["/bin/launchctl", ["print", `gui/501/${label}`]],
     ["/bin/launchctl", ["print", `gui/501/${label}`]],
   ]));
+});
+
+test("the sudoers grant is exactly the set of commands service control can issue", async () => {
+  const serviceUser = "anneal-test";
+  const issueEveryCommand = async (euid) => {
+    const issued = [];
+    const run = async (program, args) => {
+      issued.push([program, ...args].join(" "));
+      return { code: 0, stdout: "active\n", stderr: "" };
+    };
+    const control = createServiceControl({ inventory: DEFAULT_INVENTORY, platform: "linux", euid, run });
+    for (const label of SERVICE_LABELS) {
+      await control.restart(label);
+      assert.equal(await control.isRunning(label), true);
+      await control.describe(label);
+    }
+    return issued;
+  };
+
+  const asRoot = await issueEveryCommand(0);
+  const asServiceUser = (await issueEveryCommand(1000)).map((command) => {
+    assert.equal(command.startsWith("sudo -n "), true, command);
+    return command.slice("sudo -n ".length);
+  });
+  assert.deepEqual(asServiceUser, asRoot);
+  assert.equal(asRoot.length, SERVICE_LABELS.length * 3);
+
+  const prefix = `${serviceUser} ALL=(root) NOPASSWD: `;
+  const grant = renderSystemdSudoers({ serviceUser, inventory: DEFAULT_INVENTORY }).trim();
+  assert.equal(grant.startsWith(prefix), true, grant);
+  const granted = grant.slice(prefix.length).split(", ");
+  assert.equal(granted.length, new Set(granted).size, "the grant repeats a command");
+  assert.deepEqual([...new Set(granted)].sort(), [...new Set(asServiceUser)].sort());
 });
 
 test("wrapper-boundary proof requires both the stable wrapper and label", () => {

--- a/scripts/deploy/systemd-installer.test.mjs
+++ b/scripts/deploy/systemd-installer.test.mjs
@@ -686,11 +686,7 @@ test("the real service CLI enforces the Linux root boundary and sudo -n policy",
         assert.equal(ownership.some((change) => change.path === entry.path && change.uid === 0 && change.gid === 0), true, entry.path);
       }
       const sudoers = readFileSync(sudoersPath, "utf8");
-      assert.equal(sudoers, renderSystemdSudoers({
-        serviceUser: "anneal-test",
-        inventory: DEFAULT_INVENTORY,
-        systemctlPath: "/bin/systemctl",
-      }));
+      assert.equal(sudoers, renderSystemdSudoers({ serviceUser: "anneal-test", inventory: DEFAULT_INVENTORY }));
       assert.match(sudoers, /systemctl show -p ExecStart --value com\.agentos\.api\.service/u);
       assert.doesNotMatch(sudoers, /\b(?:enable|disable|daemon-reload)\b/u);
       const sudo = writeSudoPolicyStub(root);


### PR DESCRIPTION
## What changed

The systemd control commands had two independent derivations: `renderSystemdSudoers`
in `scripts/deploy/install-launchd.mjs` hand-wrote the commands the service user may
run under `sudo -n`, and `invoke` in `scripts/deploy/service-control.mjs` hand-wrote
the argv it issues. `6da5abd3` repaired exactly that mismatch (the grant allowed
`systemctl show <unit>` while `describe` issued
`systemctl show -p ExecStart --value <unit>`), which fails a production restart
silently under `sudo -n`.

`service-control.mjs` now carries one description of the systemd control vocabulary:
the systemctl program (`SYSTEMCTL_PATH`) and, per verb, the arguments that precede the
unit name (`SYSTEMD_CONTROL_ARGUMENTS`, exposed as `SYSTEMD_CONTROL_VERBS` and
`systemdControlArgv`). `invoke` builds its systemd argv from `systemdControlArgv`;
`renderSystemdSudoers` renders one grant line per unit and verb from the same call.
Neither restates the other, and the granted command and the issued command are now the
same string, program included.

Two options that could only reintroduce the drift are gone rather than left in place:
`createServiceControl`'s `systemctlBinary` (no caller passed it; its default `systemctl`
made the issued program differ from the granted `/bin/systemctl` and relied on sudo's
PATH resolution and inode comparison to match) and `renderSystemdSudoers`'s
`systemctlPath` (both callers passed the pinned path, which the manifest invariant at
`install-launchd.mjs` already required). The manifest's `systemctlPath` field and its
check now read the constant.

The `createServiceControl` interface is unchanged: `{platform, wrapperPath, restart,
isRunning, describe}` with `run` injected. The launchd adapter keeps its own argv and
gains no grant.

New test in `service-control.test.mjs`: drive `restart`, `isRunning` and `describe`
over every inventory label, once as root and once as the unprivileged service user,
and assert the set of issued commands equals the set of rendered grant lines exactly
(the sudo prefix stripped, no duplicates, nothing granted that is not issued). The
existing tests continue to pin the argv text itself, so a change to the description is
still caught by an assertion that spells the argv out.

## Evidence

Base `467f37f604f27a65eaaa9a673484531422beed6b`, head `cafbc72dc42f0a8bb0234766e29e9143fd4f2d78`.
All commands run in the lane worktree after the final commit, with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh temporary directory.

- `npm run lint` - pass (biome 776 files, eslint clean).
- `npm run typecheck` - pass.
- `npm run test:auto-deploy` - 222 tests, 219 pass, 1 skipped, 2 fail. Both failures are
  pre-existing on the base and are host-environment artifacts of running the darwin
  installer suite on an operator Mac: `default Darwin render, manifest entries, and plan
  stdout match 9a52c6ad bytes` stops on
  `launchd-service-definition-conflict:~/Library/LaunchAgents/com.agentos.api.plist`
  (this host has the real agents installed), and `runner auto-deploy stage one prints a
  stage-two command carrying the role` fails with
  `systemd-command-unavailable:systemctl` (macOS has no systemctl). Verified on the base
  with the change stashed: `node --test scripts/deploy/systemd-installer.test.mjs` gives
  43 tests, 40 pass, the same 2 failures; with the change it gives the same numbers.
- `npm run test:snapshot-scan` - 21 tests, 21 pass (the runbook was edited).
- Mutation check: shortening the `show` verb's arguments in the description makes the
  two argv-pinning tests fail, so the description is load-bearing.

## Decisions taken

- The description lives in `service-control.mjs`, beside the systemd adapter, and
  `install-launchd.mjs` imports it. The reverse direction would have pulled the whole
  installer into the control adapter's import graph; there is no cycle in this direction
  (`service-control.mjs` imports only `quiet-window-lib.mjs` and `service-platform.mjs`).
- The description owns the program path as well as the arguments, so the issued command
  changes from `sudo -n systemctl ...` to `sudo -n /bin/systemctl ...`. Matching a bare
  name against an absolute sudoers command works only through sudo's PATH resolution and
  its device/inode fallback; the installer already pins `/bin/systemctl` into the service
  manifest and refuses any other value, so naming it directly is the same fact stated
  once. If `/bin/systemctl` is absent the control call now fails loudly with
  `service-control-systemctl-unavailable` instead of silently running a different binary.
- Errors from `restart`/`isRunning`/`describe` are now uniformly asynchronous. Building
  the systemd argv inside `invoke` means an unknown label no longer throws synchronously
  out of `restart`; the corresponding assertion moved from `assert.throws` to
  `assert.rejects`. Every caller in `quiet-window-deploy.mjs` already awaits.
- The grant's line order follows the description (restart, is-active, show) rather than
  the previous restart, show, is-active. sudoers command lists are unordered and the
  installer re-renders and re-validates the file, so the only effect is one changed byte
  sequence in `/etc/sudoers.d/anneal-service-control` at the next install.

## Fence widened

- `docs/runbooks/quiet-window-auto-deploy.md` (no lane owns it): the runbook printed the
  operator reproduction commands as `sudo -n systemctl ...` and described the grant's
  verbs in prose. Both are statements about the commands this change now derives, so they
  were updated to `/bin/systemctl` and to the exact verb list.
- `scripts/deploy/systemd-installer.test.mjs` is named by lane d34's owned paths, which is
  dispatched. The only edit is dropping the removed `systemctlPath` argument from one
  `renderSystemdSudoers` call, which is a test whose assertion this change necessarily
  breaks. `scripts/deploy/install-launchd.mjs` is shared with d34 by the queue; the edits
  outside `renderSystemdSudoers` are the two call sites of the removed argument, the
  manifest field and its check, and the import line.

## Reported but unfixed

- The installer's own root-level systemctl calls (`daemon-reload`, `enable --now`,
  `is-enabled`/`is-active` state capture in `install-launchd.mjs`) are a separate,
  ungranted vocabulary that is still spelled inline at each call site. They run as root
  during the privileged install stage, so no grant covers them and no mismatch is
  possible; folding them into the description would mean granting them, which the runbook
  explicitly refuses.
- `scripts/os-isolation/verify.sh` issues `"$SYSTEMCTL" is-active "$unit"` from shell with
  its own binary resolution; the shell side still restates the verb. Lane d1 owns that
  file and the shell-side inventory question.

Generated with Claude Code (deepening round 6 lane d2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zzbyE3vWTRrDacwLEoA3v
