### PR TITLE
feat(db): make the published prompt generation a checked-in fact

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -11,6 +11,34 @@ and full-tail readiness contract are maintained in the
 [Tier 0 / Tier 1 onboarding runbook](../docs/runbooks/add-a-project.md).
 Follow its Tier 1 checklist when onboarding another Project.
 
+## Changing a canonical prompt
+
+Editing any file under `templates/` retires the prompt generation every
+deployment is running. Canonical sync installs the source tree's prompts, and
+the rows it finds carry whatever generation the last deploy installed; it can
+only replace them when the registry says which retired generation they are.
+Three edits belong in the same change.
+
+1. Edit the Markdown.
+2. Re-pin the source generation. `npm run db:template-digest` prints one digest
+   per template; copy the changed one into
+   `CANONICAL_SOURCE_PROMPT_GENERATIONS` in
+   `packages/db/src/canonical-template-transition.ts`.
+3. Publish the new generation and register the one it replaces. Append the new
+   digest to `PUBLISHED_PROMPT_GENERATIONS` in
+   `packages/db/src/canonical-published-generations.ts` — append, never rewrite
+   the last element, which names a generation already deployed — and add an
+   entry to the retired-generation registry in
+   `canonical-template-transition.ts` carrying a marker that names what
+   changed, the shape those rows hold, and `promptDigest` set to the digest the
+   published list held before this change. A change that also changes the shape
+   is identified by its shape instead: register it without a `promptDigest` and
+   name its marker as `retiredByShape` on the published entry.
+
+`packages/db/src/canonical-published-generations.test.ts` refuses in the merge
+gate until all three are done, so a generation nothing can transition from
+stops the change rather than the deploy that installs it.
+
 ## Layout
 
 - `foundational.md` — the shared foundational prompt. Body maps to `Agent.foundationalPrompt` for every agent.

--- a/packages/db/src/canonical-published-generations.test.ts
+++ b/packages/db/src/canonical-published-generations.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PUBLISHED_PROMPT_GENERATIONS,
+  publishedGenerationDrift,
+  type PublishedPromptGeneration,
+} from "./canonical-published-generations.js";
+import {
+  CANONICAL_SOURCE_PROMPT_GENERATIONS,
+  LEGACY_TEMPLATE_GENERATIONS,
+  templatePromptGenerationDigest,
+  type CanonicalTemplateRegistryName,
+  type LegacyTemplateGeneration,
+} from "./canonical-template-transition.js";
+import { loadAllTemplateStepSources } from "./template-sources.js";
+
+const canonicalNames = Object.keys(PUBLISHED_PROMPT_GENERATIONS) as CanonicalTemplateRegistryName[];
+
+const registered = (marker: string, promptDigest?: string): LegacyTemplateGeneration => (
+  promptDigest === undefined ? { marker, shape: [] } : { marker, shape: [], promptDigest }
+);
+
+const published = (...entries: PublishedPromptGeneration[]): readonly PublishedPromptGeneration[] => entries;
+
+const OUTGOING = "a".repeat(64);
+const CURRENT = "b".repeat(64);
+
+test("every published prompt generation is one the registry can transition from", () => {
+  for (const templateName of canonicalNames) {
+    assert.equal(
+      publishedGenerationDrift(
+        templateName,
+        PUBLISHED_PROMPT_GENERATIONS[templateName],
+        LEGACY_TEMPLATE_GENERATIONS[templateName],
+        CANONICAL_SOURCE_PROMPT_GENERATIONS[templateName],
+      ),
+      null,
+    );
+  }
+});
+
+test("the last published generation is the one agents/templates holds", async () => {
+  // The published history stands on its own rather than restating the pin: a
+  // prompt edit that re-pins the source generation leaves this stale, and that
+  // is the whole tripwire.
+  const sources = await loadAllTemplateStepSources();
+  for (const templateName of canonicalNames) {
+    const steps = sources.get(templateName);
+    assert.ok(steps, `${templateName} must load from source`);
+    assert.equal(
+      PUBLISHED_PROMPT_GENERATIONS[templateName].at(-1)?.digest,
+      templatePromptGenerationDigest(steps),
+      `${templateName} published history does not end at the source tree's generation`,
+    );
+  }
+  assert.deepEqual(
+    canonicalNames.slice().sort((left, right) => left.localeCompare(right)),
+    Object.keys(LEGACY_TEMPLATE_GENERATIONS).sort((left, right) => left.localeCompare(right)),
+  );
+});
+
+test("a prompt edit that only re-pins the source generation is refused", () => {
+  // 2a558a72 exactly: the source moved on and the generation production still
+  // runs was never recorded, let alone registered.
+  const refusal = publishedGenerationDrift("direct", published({ digest: OUTGOING }), [], CURRENT);
+  assert.ok(refusal);
+  assert.match(refusal, /last published prompt generation a{64}, but the source tree now holds b{64}/u);
+  assert.match(refusal, /canonical-published-generations\.ts/u);
+  assert.match(refusal, /canonical-template-transition\.ts/u);
+});
+
+test("publishing the successor without registering its predecessor is refused", () => {
+  const refusal = publishedGenerationDrift(
+    "direct",
+    published({ digest: OUTGOING }, { digest: CURRENT }),
+    [registered("pre-something-older", "c".repeat(64))],
+    CURRENT,
+  );
+  assert.ok(refusal);
+  assert.match(refusal, /which no registered generation retires/u);
+  assert.match(refusal, /promptDigest a{64}/u);
+});
+
+test("a registered predecessor closes the transition", () => {
+  assert.equal(
+    publishedGenerationDrift(
+      "direct",
+      published({ digest: OUTGOING }, { digest: CURRENT }),
+      [registered("pre-something", OUTGOING)],
+      CURRENT,
+    ),
+    null,
+  );
+});
+
+test("a structural retirement is named, because no entry states its digest", () => {
+  assert.equal(
+    publishedGenerationDrift(
+      "direct",
+      published({ digest: OUTGOING, retiredByShape: "pre-revalidate-step" }, { digest: CURRENT }),
+      [registered("pre-revalidate-step")],
+      CURRENT,
+    ),
+    null,
+  );
+  const unknown = publishedGenerationDrift(
+    "direct",
+    published({ digest: OUTGOING, retiredByShape: "pre-invented" }, { digest: CURRENT }),
+    [registered("pre-revalidate-step")],
+    CURRENT,
+  );
+  assert.ok(unknown);
+  assert.match(unknown, /names structural retirement pre-invented/u);
+
+  const promptOnly = publishedGenerationDrift(
+    "direct",
+    published({ digest: OUTGOING, retiredByShape: "pre-something" }, { digest: CURRENT }),
+    [registered("pre-something", OUTGOING)],
+    CURRENT,
+  );
+  assert.ok(promptOnly);
+  assert.match(promptOnly, /drop retiredByShape/u);
+});
+
+test("the generation the source tree holds cannot already be retired", () => {
+  const refusal = publishedGenerationDrift(
+    "direct",
+    published({ digest: CURRENT, retiredByShape: "pre-something" }),
+    [registered("pre-something")],
+    CURRENT,
+  );
+  assert.ok(refusal);
+  assert.match(refusal, /which the source tree still holds/u);
+});
+
+test("a generation is published once and the history is never empty", () => {
+  const duplicate = publishedGenerationDrift(
+    "direct",
+    published({ digest: OUTGOING }, { digest: CURRENT }, { digest: OUTGOING }),
+    [registered("pre-something", OUTGOING)],
+    OUTGOING,
+  );
+  assert.ok(duplicate);
+  assert.match(duplicate, /twice/u);
+
+  const empty = publishedGenerationDrift("direct", published(), [], CURRENT);
+  assert.ok(empty);
+  assert.match(empty, /publishes no prompt generation at all/u);
+});

--- a/packages/db/src/canonical-published-generations.ts
+++ b/packages/db/src/canonical-published-generations.ts
@@ -1,0 +1,124 @@
+import { PR_TEMPLATE_NAME } from "./agent-contract.js";
+import type {
+  CanonicalTemplateRegistryName,
+  LegacyTemplateGeneration,
+} from "./canonical-template-transition.js";
+
+/**
+ * One prompt generation this repository has published, as the digest
+ * `templatePromptGenerationDigest` computes over a template's ordered step
+ * prompts.
+ */
+export type PublishedPromptGeneration = Readonly<{
+  digest: string;
+  /**
+   * The marker of the structural transition that retired this generation, when
+   * the retirement changed the graph's shape. A structural retirement is
+   * identified by the shape alone, so no registered entry states this digest
+   * and there is nothing else to point at. Absent on a prompt-only retirement,
+   * whose registered entry carries this exact digest as its `promptDigest`.
+   */
+  retiredByShape?: string;
+}>;
+
+/**
+ * Every prompt generation this repository has published, per canonical
+ * template, oldest first. The last element is the generation the source tree
+ * holds now; every earlier element is a generation an installation may still
+ * be running, and must therefore be one the transition registry can roll over.
+ *
+ * This is the fact `2a558a72` was missing. Canonical sync installs the source
+ * tree's prompts; the rows it finds carry whatever generation the last deploy
+ * installed. A prompt-only edit that re-pins the source generation without
+ * registering the outgoing one leaves those rows matching no registered
+ * generation, so the sync cannot roll them over and refuses at the first step
+ * an instantiated task references. Nothing in the tree could notice, because
+ * the outgoing generation existed only in the previous state of the tree and
+ * in production.
+ *
+ * Recorded here, it survives the edit. Appending the new generation makes the
+ * outgoing one an earlier element, and `publishedGenerationDrift` then refuses
+ * until the registry registers it -- in the merge gate, on the change that
+ * edits the prompt, instead of on the deploy that installs it.
+ *
+ * The list starts at the generation each template held on 2026-09-04.
+ * Generations published before that are covered by the registry entries that
+ * already retire them; nothing in the tree records what they were, and
+ * inventing digests for them would state facts this repository cannot check.
+ *
+ * Append -- never rewrite the last element. Rewriting it in place asserts that
+ * the generation it named was never published, which for anything already on
+ * main is false.
+ */
+export const PUBLISHED_PROMPT_GENERATIONS = {
+  "direct-engineer-workflow": [
+    { digest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543" },
+  ],
+  "compound-engineer-workflow": [
+    { digest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9" },
+  ],
+  [PR_TEMPLATE_NAME]: [
+    { digest: "1c1169bf0586f6bb71f4ed34b3eb6b166828802a9b24c6b07844b2f526b5f8a8" },
+  ],
+} as const satisfies Readonly<Record<CanonicalTemplateRegistryName, readonly PublishedPromptGeneration[]>>;
+
+const REGISTRY_FILE = "packages/db/src/canonical-template-transition.ts";
+const PUBLISHED_FILE = "packages/db/src/canonical-published-generations.ts";
+
+const retirementRefusal = (
+  templateName: string,
+  entry: PublishedPromptGeneration,
+  registered: readonly LegacyTemplateGeneration[],
+): string | null => {
+  if (entry.retiredByShape !== undefined) {
+    const structural = registered.find((generation) => generation.marker === entry.retiredByShape);
+    if (!structural) {
+      return `${templateName} published prompt generation ${entry.digest} names structural retirement ${entry.retiredByShape}, which ${REGISTRY_FILE} does not register`;
+    }
+    if (structural.promptDigest !== undefined) {
+      return `${templateName} published prompt generation ${entry.digest} names ${entry.retiredByShape} as a structural retirement, but that entry registers prompt generation ${structural.promptDigest}; drop retiredByShape`;
+    }
+    return null;
+  }
+  const registration = registered.find((generation) => generation.promptDigest === entry.digest);
+  if (!registration) {
+    return `${templateName} published prompt generation ${entry.digest}, which no registered generation retires: add an entry to ${REGISTRY_FILE} carrying promptDigest ${entry.digest} and the shape those rows hold, or, when the retirement changed the shape, name that entry's marker as retiredByShape in ${PUBLISHED_FILE}`;
+  }
+  return null;
+};
+
+/**
+ * The first reason this template's published generations are not a history the
+ * transition registry can transition from, or null when they are.
+ *
+ * Pure in all four arguments so the invariant can be exercised against
+ * fixtures rather than only against the canonical constants.
+ */
+export const publishedGenerationDrift = (
+  templateName: string,
+  published: readonly PublishedPromptGeneration[],
+  registered: readonly LegacyTemplateGeneration[],
+  sourceGeneration: string,
+): string | null => {
+  const current = published.at(-1);
+  if (!current) {
+    return `${templateName} publishes no prompt generation at all; ${PUBLISHED_FILE} must name the generation the source tree holds`;
+  }
+  const duplicate = published.find((entry, index) => (
+    published.findIndex((candidate) => candidate.digest === entry.digest) !== index
+  ));
+  if (duplicate) {
+    return `${templateName} publishes prompt generation ${duplicate.digest} twice; a generation is published once`;
+  }
+  if (current.retiredByShape !== undefined) {
+    return `${templateName} names a retirement for prompt generation ${current.digest}, which the source tree still holds`;
+  }
+  if (current.digest !== sourceGeneration) {
+    return `${templateName} last published prompt generation ${current.digest}, but the source tree now holds ${sourceGeneration}: append { digest: "${sourceGeneration}" } in ${PUBLISHED_FILE}, then register ${current.digest} as a retired generation in ${REGISTRY_FILE}`;
+  }
+  for (const entry of published.slice(0, -1)) {
+    const refusal = retirementRefusal(templateName, entry, registered);
+    if (refusal !== null) return refusal;
+  }
+  return null;
+};


### PR DESCRIPTION
## What changed

The repository now records which prompt generation each canonical template has
published, and refuses in the merge gate when one of them is a generation the
transition registry cannot transition from.

`packages/db/src/canonical-published-generations.ts` is the new module. Its
interface is one fact and one pure function:

- `PUBLISHED_PROMPT_GENERATIONS`: per canonical template, every prompt
  generation this repository has published, oldest first. The last element is
  the generation the source tree holds; every earlier element is a generation
  an installation may still be running.
- `publishedGenerationDrift(templateName, published, registered, sourceGeneration)`:
  the first reason that history is not one the registry can transition from, or
  null. It is pure in all four arguments, so the invariant is exercised against
  fixtures as well as against the canonical constants.

Why this closes `2a558a72`. Canonical sync installs the source tree's prompts,
and the rows it finds carry whatever generation the last deploy installed. A
prompt-only edit that re-pins `CANONICAL_SOURCE_PROMPT_GENERATIONS` without
registering the outgoing generation leaves those rows matching no registered
generation, so `matchedLegacyGeneration` returns null, no rollover is planned,
and the sync refuses at the first step an instantiated task references. Nothing
in the tree could notice, because the outgoing generation existed only in the
previous state of the tree and in production.

Recorded, it survives the edit, and the leverage is that the same three edits
are now forced in sequence by three failing assertions rather than by an
operator remembering them:

1. Editing a prompt makes the source pin stale; the existing transition test
   says so.
2. Re-pinning makes the published history's last element stale; the new test
   says to append the new digest.
3. Appending makes the outgoing digest an earlier element, which must be a
   generation the registry retires; the new refusal names the digest, the entry
   to add, and the file to add it to.

The history starts at the generation each template holds today. Generations
published earlier are already retired by registry entries, and inventing
digests for them would state facts this repository cannot check.

`agents/README.md` gains "Changing a canonical prompt", the three edits in
order. `grep` for `promptDigest`, `db:template-digest` or `rollover` across
`agents/`, `CONTRIBUTING.md` and `docs/` returned nothing before this change:
the registration step was undocumented.

## Evidence

Base `467f37f604f27a65eaaa9a673484531422beed6b`, run in
`worktrees/anneal-deepen-20260904/t4` after the final commit, with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh temporary directory.

- `npm run lint` — pass (biome 778 files, then eslint).
- `npm run typecheck` — pass, all workspaces.
- `npm run test -w @anneal/db` — 437 pass, 0 fail, including the 8 new tests.
- `npm run test:snapshot-scan` — 21 pass (a file was added).
- `npm run snapshot:scan` — exit 0.
- `npm run test:frozen-docs` — 28 pass (`docs/` untouched, `agents/` changed).
- `npm run test:release-docs` — 14 pass; `agents/README.md` is on that test's
  reduced-canonical-sync list, which forbids naming
  `db:sync-canonical-prompts`, `db:verify-agent-template` or `--install-full`
  in it. The new section names only `db:template-digest`.

End-to-end proof of the tripwire, run on a scratch tree and reverted before the
commit: appending a line to
`agents/templates/pr-engineer-workflow/01-implementation.md` moved that
template's digest to `c7ce1ab5…`, and

- with the pin and the published history untouched, the new suite failed with
  `pr-engineer-workflow published history does not end at the source tree's
  generation`;
- with the pin re-pinned and the new digest appended but nothing registered, it
  failed with `pr-engineer-workflow published prompt generation 1c1169bf…,
  which no registered generation retires: add an entry to
  packages/db/src/canonical-template-transition.ts carrying promptDigest
  1c1169bf… and the shape those rows hold, …`.

That is the `2a558a72` failure mode, failing in the gate.

Not run: `test:db`. There is no local PostgreSQL; the merge gate owns it. No
dbtest was changed.

## Decisions taken

**The brief's fact is "what production runs"; the fact delivered is "what this
repository has published".** "What production runs" has a freshness problem
that defeats the check: if the recorded value is not advanced after each
deploy, it keeps naming an old generation that is still registered, passes, and
misses the newer generation production actually installed — the original hole,
reopened by bookkeeping. "What this repository has published" needs no
freshness: production runs one of the published generations, every published
generation must be transitionable, and the record advances in the same change
that publishes a generation. It is also strictly stronger, and it covers a
deployment several generations behind.

**Rejected: deriving the outgoing generation from git.** The exact fact wanted
is the source generation at the merge-base with `main`, which needs no
transcription at all and is self-maintaining. It is not available: the gate
worker's mirror "has no remote to fetch"
(`packages/runner/runtime-tools/gate-worker/run-gate.sh`), `origin/main` does
not resolve there, and the authoritative master oid reaches
`check-frozen-docs.sh` as a `--master` argument from `merge-gate.sh` and is not
in a Node test's environment. A test that resolved it would fail in the gate
for the wrong reason. Making it a gate step of its own would mean editing
`scripts/merge-gate.sh`, which no lane owns and which I cannot exercise from
here.

**The published history duplicates one digest per template on purpose.** The
last element restates the source pin, and that restatement is the tripwire: it
is the only value that goes stale when a prompt changes and that still knows
what the outgoing generation was. Retired elements are not fresh transcriptions
— they are values that were already in the file and stopped being edited. This
is one checked copy per template, not the fifteen unchecked copies the audit
found.

**No `retiredBy` marker on prompt-only entries.** A prompt-only retirement is
found by matching the digest against the registry's `promptDigest`, so a marker
there would be a second guess at the same fact and could be wrong in a way
nothing detects. Only a structural retirement needs `retiredByShape`, because a
structural entry deliberately carries no digest and there is nothing to match.

**No refusal added to `verify-agent-template.ts`,** although the brief offers it
as a site. The check is tree-only, so the gate already proves it and a second
site would prove nothing; and the deploy does not run
`db:verify-agent-template` at all (`scripts/deploy/quiet-window-deploy.mjs`
runs `sync-canonical-prompts.ts`), so a refusal there would not have stopped
`2a558a72`.

**No plan-time prompt refusal in `planCanonicalInstallation`.** Refusing before
any write when a persisted row's prompts differ from source would also refuse
the legitimate case the sync self-heals today: an unreferenced canonical step
whose prompt drifted is rewritten from source. The two are indistinguishable at
that site, the change would be a behaviour change with dbtest fallout I cannot
run here, and the gate check makes the production refusal unreachable for the
failure mode this lane owns.

**No release-tooling change under `scripts/deploy`.** Nothing in the deploy
needs to state the published generation once the gate proves it, and the
release artifact is built from the same tree the gate checked.

## Fence widened

`agents/README.md` — belongs to no lane; the brief routes the procedure
documentation through it (`CLAUDE.md` sends every agent there before changing a
canonical template). Recorded per rule 1.

`packages/db/src/canonical-published-generations.ts` and its test are new files
belonging to no lane. Lane t4's fence lists no "one new module" clause, unlike
the other lanes'; taken under rule 1. `packages/db/src/**/*.ts` is already
classified in `public-snapshot.json`, so no closed list needed an edit.

`packages/db/src/canonical-template-transition.ts` was **not** edited, so lane
t2 (in flight, owning `shapeMatches` and `LegacyStepRecord` in that file) has
no conflict with this branch.

## Reported but unfixed

- The refusal an unregistered generation still produces in production, if one
  ever gets past the gate, is `Template … step N (…) is referenced by
  instantiated tasks; canonical sync will not mutate its prompt`
  (`packages/db/prisma/sync-canonical-prompts.ts`). It names neither the
  generation the rows hold nor the registry. Naming it would mean computing the
  installed digest per template row in the sync and threading it into that
  message; the file is t1's (merged) and the change is diagnosis only, so it is
  reported rather than taken.
- `legacyTemplateShapeRefusal` in `canonical-template-transition.ts` is dead
  code with zero callers outside `dist` (audit section 6). Inside lane t2's
  region of that file, so not touched.
- The published history grows one entry per prompt change and nothing prunes
  it. Pruning would need to know the oldest generation any installation still
  runs, which is exactly the production fact this lane declined to depend on.

Generated with Claude Code (deepening round 6 lane t4)
