### PR TITLE
refactor(runner): one verdict over one exit record

### DIFF
--- a/packages/db/src/run-outcome.test.ts
+++ b/packages/db/src/run-outcome.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { agentExitVerdict, type AgentExitEvidence, type AgentExitVerdict } from "./run-outcome.js";
+
+const exit = (overrides: Partial<AgentExitEvidence> = {}): AgentExitEvidence => ({
+  exitCode: 0,
+  signal: null,
+  terminalEventSeen: false,
+  terminalSuccess: false,
+  terminationReason: null,
+  ...overrides,
+});
+
+// One row per case, plus the record shapes that used to be read field by field
+// at each of the four call sites this verdict replaced.
+const rows: Array<{ name: string; evidence: AgentExitEvidence; verdict: AgentExitVerdict }> = [
+  {
+    name: "an agent that reported success and exited cleanly",
+    evidence: exit({ terminalEventSeen: true, terminalSuccess: true }),
+    verdict: { case: "succeeded" },
+  },
+  {
+    name: "an agent that reported failure",
+    evidence: exit({ terminalEventSeen: true, exitCode: 1 }),
+    verdict: { case: "refused" },
+  },
+  {
+    name: "an agent that reported failure and still exited zero",
+    evidence: exit({ terminalEventSeen: true }),
+    verdict: { case: "refused" },
+  },
+  {
+    name: "a rejection the runner then stopped",
+    evidence: exit({ terminalEventSeen: true, signal: "SIGKILL" }),
+    verdict: { case: "refused" },
+  },
+  {
+    name: "a success claim its process contradicted with a non-zero exit",
+    evidence: exit({ terminalEventSeen: true, terminalSuccess: true, exitCode: 1 }),
+    verdict: { case: "contradicted" },
+  },
+  {
+    name: "a success claim the runner stopped anyway",
+    evidence: exit({ terminalEventSeen: true, terminalSuccess: true, terminationReason: "stall budget" }),
+    verdict: { case: "contradicted" },
+  },
+  {
+    name: "a success claim a signal cut short",
+    evidence: exit({ terminalEventSeen: true, terminalSuccess: true, signal: "SIGTERM" }),
+    verdict: { case: "contradicted" },
+  },
+  {
+    name: "a child the runner killed before it said anything",
+    evidence: exit({ terminationReason: "stall budget" }),
+    verdict: { case: "stopped" },
+  },
+  {
+    name: "a child a signal killed before it said anything",
+    evidence: exit({ signal: "SIGKILL", exitCode: null }),
+    verdict: { case: "stopped" },
+  },
+  {
+    name: "a stream that dropped after the CLI shut itself down in order",
+    evidence: exit(),
+    verdict: { case: "dropped", cleanExit: true },
+  },
+  {
+    name: "a stream that dropped with the CLI itself failing",
+    evidence: exit({ exitCode: 1 }),
+    verdict: { case: "dropped", cleanExit: false },
+  },
+  {
+    name: "a stream that dropped without the process reporting an exit at all",
+    evidence: exit({ exitCode: null }),
+    verdict: { case: "dropped", cleanExit: false },
+  },
+];
+
+for (const row of rows) {
+  test(`the exit verdict for ${row.name}`, () => {
+    assert.deepEqual(agentExitVerdict(row.evidence), row.verdict);
+  });
+}
+
+test("the optional exit fields are absent, not null, on evidence that omits them", () => {
+  assert.deepEqual(
+    agentExitVerdict({ exitCode: 0, terminalEventSeen: true, terminalSuccess: true }),
+    { case: "succeeded" },
+  );
+  assert.deepEqual(agentExitVerdict({ exitCode: 0, terminalEventSeen: false, terminalSuccess: false }), {
+    case: "dropped",
+    cleanExit: true,
+  });
+});

--- a/packages/db/src/run-outcome.ts
+++ b/packages/db/src/run-outcome.ts
@@ -82,20 +82,62 @@ export type AgentExitEvidence = {
 };
 
 /**
- * Did the agent process itself finish its work successfully?
+ * How the agent process itself ended, decided once from its own exit record.
  *
- * The one copy of what used to be `adapterExecutionSucceeded` in the runner and
- * `completionSucceeded` in the API. Only the runner asks it now — the control
- * plane reads the outcome instead — but it lives here because it is the
- * predicate whose duplication the outcome exists to end, and a second copy
- * appearing anywhere is the regression to catch.
+ * This is the extension of the outcome above to the record the outcome is
+ * derived from. It replaces `agentExecutionSucceeded` — itself the one copy of
+ * what used to be `adapterExecutionSucceeded` in the runner and
+ * `completionSucceeded` in the API — because that predicate was only the first
+ * of four readings of the same five fields. The others were written
+ * independently, in three modules: the Codex adapter's in-Run resume
+ * qualification, the runner's post-delivery disconnect tolerance, and the
+ * runner's "did the provider explicitly reject this session" test. One repair
+ * to the shared question reached one of them at a time — a regex tightened in
+ * the adapter, a field typed in the runner, clauses reordered at a call site —
+ * for one question about one record.
+ *
+ * The cases partition the record, so each reading is one case and no reader
+ * restates a field. Only the runner asks; the control plane reads the outcome
+ * instead. It lives here because it is the predicate whose duplication the
+ * outcome exists to end, and a second copy appearing anywhere is the
+ * regression to catch.
  */
-export const agentExecutionSucceeded = (evidence: AgentExitEvidence): boolean =>
-  evidence.exitCode === 0
-  && !evidence.signal
-  && !evidence.terminationReason
-  && evidence.terminalEventSeen
-  && evidence.terminalSuccess;
+export type AgentExitVerdict =
+  /**
+   * The agent emitted a terminal event reporting failure. That rejection is
+   * the agent's own and stands whatever the process then did.
+   */
+  | { case: "refused" }
+  /** The agent reported success, nothing stopped the child, and it exited 0. */
+  | { case: "succeeded" }
+  /**
+   * The agent reported success and its process disagreed: a signal, a
+   * runner-ordered termination, or a non-zero exit. No caller reads this case;
+   * it exists so that `succeeded` needs no further qualification from the
+   * readers, which is the duplication this verdict ends.
+   */
+  | { case: "contradicted" }
+  /** The runner or the OS ended the child before the agent said anything. */
+  | { case: "stopped" }
+  /**
+   * The child ended without a terminal event and without being stopped: the
+   * provider stream is simply gone. `cleanExit` is the process having exited
+   * 0 — the shape a dropped connection takes when the CLI still shut itself
+   * down in order. Whether such a drop can be continued is a judgement about
+   * the provider, not about this record, and stays with the adapter that owns
+   * the provider.
+   */
+  | { case: "dropped"; cleanExit: boolean };
+
+export const agentExitVerdict = (evidence: AgentExitEvidence): AgentExitVerdict => {
+  const stopped = Boolean(evidence.signal) || Boolean(evidence.terminationReason);
+  if (evidence.terminalEventSeen) {
+    if (!evidence.terminalSuccess) return { case: "refused" };
+    return stopped || evidence.exitCode !== 0 ? { case: "contradicted" } : { case: "succeeded" };
+  }
+  if (stopped) return { case: "stopped" };
+  return { case: "dropped", cleanExit: evidence.exitCode === 0 };
+};
 
 export type RunOutcomeVerdict = {
   succeeded: boolean;

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import test from "node:test";
 
-import { agentExecutionSucceeded, isCodexReconnectStatus } from "@anneal/db";
+import { agentExitVerdict, isCodexReconnectStatus } from "@anneal/db";
 
 import {
   adapters, argsForRunner, buildChildEnvironment, buildPrompt, createAdapterState, failureReasonFromEvidence,
@@ -18,7 +18,7 @@ import { parseClaudeTranscript } from "./adapters/claude.js";
 import {
   CODEX_STARTER_MODEL,
   initialCodexState,
-  isCodexInRunResumeCandidate,
+  isCodexProviderDisconnect,
   parseCodexEvent,
   parseCodexTranscript,
   type CodexProviderState,
@@ -1545,8 +1545,8 @@ test("exit code zero without a provider terminal event is failure", () => {
     stdout: "",
     stderr: "",
   };
-  assert.equal(agentExecutionSucceeded(evidence), false);
-  assert.equal(agentExecutionSucceeded({ ...evidence, terminalEventSeen: true, terminalSuccess: true }), true);
+  assert.deepEqual(agentExitVerdict(evidence), { case: "dropped", cleanExit: true });
+  assert.equal(agentExitVerdict({ ...evidence, terminalEventSeen: true, terminalSuccess: true }).case, "succeeded");
 });
 
 const codexStateOf = (state: AdapterState): CodexProviderState => state.providerState as CodexProviderState;
@@ -1582,7 +1582,7 @@ test("Codex treats recovered reconnect evidence as provisional after terminal co
   assert.equal(evidence.terminalEventSeen, true);
   assert.equal(evidence.terminalSuccess, true);
   assert.equal(evidence.providerError, "Reconnecting... 2/5");
-  assert.equal(agentExecutionSucceeded(evidence), true);
+  assert.equal(agentExitVerdict(evidence).case, "succeeded");
 });
 
 test("Codex emits an observed-child signal only after a spawn returns a child thread", () => {
@@ -1641,7 +1641,7 @@ test("Codex reconnect progress stays provisional when the counter carries its ca
   const evidence = evidenceFromState(state);
 
   assert.equal(evidence.terminalSuccess, true);
-  assert.equal(agentExecutionSucceeded(evidence), true);
+  assert.equal(agentExitVerdict(evidence).case, "succeeded");
 });
 
 test("Codex latches a real provider error that only resembles reconnect progress", () => {
@@ -1655,7 +1655,7 @@ test("Codex latches a real provider error that only resembles reconnect progress
   for (const message of cases) {
     const state = parseCodexTranscript([{ type: "error", message }, { type: "turn.completed" }]);
     assert.equal(state.terminalSuccess, false, message);
-    assert.equal(agentExecutionSucceeded(evidenceFromState(state)), false, message);
+    assert.equal(agentExitVerdict(evidenceFromState(state)).case, "refused", message);
   }
 });
 
@@ -1666,11 +1666,11 @@ test("Codex preserves reconnect evidence when the stream ends before completion"
 
   assert.equal(evidence.terminalEventSeen, false);
   assert.equal(evidence.terminalSuccess, false);
-  assert.equal(agentExecutionSucceeded(evidence), false);
+  assert.deepEqual(agentExitVerdict(evidence), { case: "dropped", cleanExit: false });
   assert.equal(failureReasonFromEvidence(evidence), reconnectMessage);
 });
 
-test("Codex in-Run resume predicate covers reconnect, network, and disqualifying exits", () => {
+test("Codex provider-disconnect predicate covers reconnect, network, and disqualifying exits", () => {
   const reconnectMessage = "Reconnecting... 3/5 (stream disconnected before completion: tls handshake eof)";
   const bareDisconnectMessage = "stream disconnected before completion: tls handshake eof";
   const base: ExitEvidence = {
@@ -1689,36 +1689,26 @@ test("Codex in-Run resume predicate covers reconnect, network, and disqualifying
   // network retry pattern list; the Codex-owned status predicate recognizes it.
   assert.equal(isTransientNetworkError(reconnectMessage), false);
   const fresh = initialCodexState();
-  assert.equal(isCodexInRunResumeCandidate({ ...base, providerError: reconnectMessage }, "thread-1", fresh), true);
+  assert.equal(isCodexProviderDisconnect({ ...base, providerError: reconnectMessage }, fresh), true);
   assert.equal(isCodexReconnectStatus(bareDisconnectMessage), false);
   assert.equal(isTransientNetworkError(bareDisconnectMessage), false);
-  assert.equal(isCodexInRunResumeCandidate({
-    ...base,
-    providerError: bareDisconnectMessage,
-  }, "thread-1", fresh), true);
-  assert.equal(isCodexInRunResumeCandidate({ ...base, stderr: "fetch failed" }, "thread-1", fresh), true);
+  assert.equal(isCodexProviderDisconnect({ ...base, providerError: bareDisconnectMessage }, fresh), true);
+  assert.equal(isCodexProviderDisconnect({ ...base, stderr: "fetch failed" }, fresh), true);
 
-  const disqualified: Array<[string, Partial<ExitEvidence>, string | null, CodexProviderState]> = [
-    ["terminal event", { terminalEventSeen: true, providerError: reconnectMessage }, "thread-1", fresh],
-    ["signal", { signal: "SIGTERM", providerError: reconnectMessage }, "thread-1", fresh],
-    ["termination", { terminationReason: "cancelled", providerError: reconnectMessage }, "thread-1", fresh],
-    ["missing conversation", { providerError: reconnectMessage }, null, fresh],
-    ["binary missing", { exitCode: 127, providerError: "connection reset" }, "thread-1", fresh],
-    ["authentication", { providerError: "authentication_failed: connection reset" }, "thread-1", fresh],
-    ["rate limit", { providerError: "rate limit: connection reset" }, "thread-1", fresh],
+  // The exit record's own shape — a terminal event, a signal, a stamped
+  // termination — is `agentExitVerdict`'s question, and a missing conversation
+  // id is the relaunch gate's. What is left here is Codex-shaped.
+  const disqualified: Array<[string, Partial<ExitEvidence>, CodexProviderState]> = [
+    ["binary missing", { exitCode: 127, providerError: "connection reset" }, fresh],
+    ["authentication", { providerError: "authentication_failed: connection reset" }, fresh],
+    ["rate limit", { providerError: "rate limit: connection reset" }, fresh],
     ["tool failure", {
       providerError: '"isError":true stream disconnected before completion: tls handshake eof',
-    }, "thread-1", fresh],
-    ["prior provider error", { providerError: reconnectMessage }, "thread-1", {
-      sawNonReconnectProviderError: true,
-    }],
+    }, fresh],
+    ["prior provider error", { providerError: reconnectMessage }, { sawNonReconnectProviderError: true }],
   ];
-  for (const [name, overrides, conversationId, providerState] of disqualified) {
-    assert.equal(
-      isCodexInRunResumeCandidate({ ...base, ...overrides }, conversationId, providerState),
-      false,
-      name,
-    );
+  for (const [name, overrides, providerState] of disqualified) {
+    assert.equal(isCodexProviderDisconnect({ ...base, ...overrides }, providerState), false, name);
   }
 });
 
@@ -1732,7 +1722,7 @@ test("Codex preserves disqualifying provider-error history after reconnect statu
 
   assert.equal(evidence.providerError, reconnectMessage);
   assert.equal(codexStateOf(state).sawNonReconnectProviderError, true);
-  assert.equal(isCodexInRunResumeCandidate(evidence, "thread-1", state.providerState), false);
+  assert.equal(isCodexProviderDisconnect(evidence, state.providerState), false);
 });
 
 test("Codex bare disconnect evidence remains resumable provider history", () => {
@@ -1743,7 +1733,7 @@ test("Codex bare disconnect evidence remains resumable provider history", () => 
   const evidence = evidenceFromState(state);
 
   assert.equal(codexStateOf(state).sawNonReconnectProviderError, false);
-  assert.equal(isCodexInRunResumeCandidate(evidence, "thread-1", state.providerState), true);
+  assert.equal(isCodexProviderDisconnect(evidence, state.providerState), true);
 });
 
 test("Codex does not let augmented disconnect wording hide a provider error", () => {
@@ -1754,13 +1744,13 @@ test("Codex does not let augmented disconnect wording hide a provider error", ()
   const evidence = evidenceFromState(state);
 
   assert.equal(codexStateOf(state).sawNonReconnectProviderError, true);
-  assert.equal(isCodexInRunResumeCandidate(evidence, "thread-1", state.providerState), false);
+  assert.equal(isCodexProviderDisconnect(evidence, state.providerState), false);
 });
 
-test("only Codex declares the optional in-Run resume capability", () => {
-  assert.equal(typeof adapters.CODEX.isInRunResumeCandidate, "function");
-  assert.equal(adapters.CLAUDE.isInRunResumeCandidate, undefined);
-  assert.equal(adapters.PI.isInRunResumeCandidate, undefined);
+test("only Codex declares the optional provider-disconnect reading", () => {
+  assert.equal(typeof adapters.CODEX.isProviderDisconnect, "function");
+  assert.equal(adapters.CLAUDE.isProviderDisconnect, undefined);
+  assert.equal(adapters.PI.isProviderDisconnect, undefined);
 });
 
 test("PI terminal success follows the final provider attempt after an internal retry", () => {
@@ -1775,7 +1765,7 @@ test("PI terminal success follows the final provider attempt after an internal r
   assert.equal(evidence.terminalSuccess, true);
   assert.equal(evidence.providerError, null);
   assert.equal(evidence.finalOutput, "final PASS");
-  assert.equal(agentExecutionSucceeded(evidence), true);
+  assert.equal(agentExitVerdict(evidence).case, "succeeded");
 });
 
 test("PI exposes the exhausted provider error instead of a generic protocol failure", () => {

--- a/packages/runner/src/adapters/codex.ts
+++ b/packages/runner/src/adapters/codex.ts
@@ -59,23 +59,18 @@ export const initialCodexState = (): CodexProviderState => ({ sawNonReconnectPro
 const codexState = (providerState: unknown): CodexProviderState => providerState as CodexProviderState;
 
 /**
- * Decide whether a dead Codex child can be continued in the same Run.
+ * Is this dead Codex child's exit Codex's own transport dropping?
  *
- * Reconnect progress is reported through Codex's `error` event, but a plain
- * reconnect message is only provisional. The adapter's own state carries the
- * history of non-reconnect provider errors so a later reconnect status cannot
- * hide an earlier terminal provider error.
+ * Asked only about an exit the shared `agentExitVerdict` already classified as
+ * `dropped`, so nothing here re-reads whether the child was stopped or
+ * reported its own end. What is left is Codex-shaped. Reconnect progress is
+ * reported through Codex's `error` event, but a plain reconnect message is only
+ * provisional: the adapter's own state carries the history of non-reconnect
+ * provider errors so a later reconnect status cannot hide an earlier terminal
+ * provider error.
  */
-export const isCodexInRunResumeCandidate = (
-  evidence: ExitEvidence,
-  providerConversationId: string | null,
-  providerState: unknown,
-): boolean => {
-  if (evidence.terminalEventSeen
-    || evidence.signal !== null
-    || evidence.terminationReason !== null
-    || providerConversationId === null
-    || codexState(providerState).sawNonReconnectProviderError) return false;
+export const isCodexProviderDisconnect = (evidence: ExitEvidence, providerState: unknown): boolean => {
+  if (codexState(providerState).sawNonReconnectProviderError) return false;
 
   if (NON_RESUMABLE_FAILURE_CLASSES.has(classifyRuntimeError(evidence).failureClass)) return false;
 
@@ -334,5 +329,5 @@ export const codexDeclaration: AdapterDeclaration = Object.freeze({
   providerEventPersistence: () => true,
   parseEvent: parseCodexEvent,
   preflight,
-  isInRunResumeCandidate: isCodexInRunResumeCandidate,
+  isProviderDisconnect: isCodexProviderDisconnect,
 });

--- a/packages/runner/src/adapters/runtime.ts
+++ b/packages/runner/src/adapters/runtime.ts
@@ -111,15 +111,16 @@ export interface CliAdapter {
   heartbeat(handle: RuntimeHandle): Promise<HeartbeatSnapshot>;
   classifyError(evidence: ExitEvidence): ClassifiedFailure;
   /**
-   * Provider-owned qualification for an in-Run resume after a dead child. The
-   * verdict reads the adapter's own `providerState` from that child, so no
-   * provider-shaped history has to travel on the shared exit record.
+   * Is this dead child's exit a disconnect of the provider's own transport?
+   *
+   * Asked only about an exit the shared verdict already classified as
+   * `dropped`, so the fields that say a child was stopped or reported its own
+   * end are not this hook's business. What it adds is provider-shaped: the
+   * text a provider uses for a lost connection, and the adapter's own
+   * `providerState` from that child, so no provider-shaped history has to
+   * travel on the shared exit record.
    */
-  isInRunResumeCandidate?(
-    evidence: ExitEvidence,
-    providerConversationId: string | null,
-    providerState: unknown,
-  ): boolean;
+  isProviderDisconnect?(evidence: ExitEvidence, providerState: unknown): boolean;
 }
 
 export type AdapterEventParser = (
@@ -163,12 +164,8 @@ export type AdapterDeclaration = {
   providerEventPersistence: ProviderEventPersistencePredicate;
   parseEvent: AdapterEventParser;
   preflight(spec: PreflightSpec): Promise<PreflightResult>;
-  /** Optional provider-owned qualification for in-Run resume. */
-  isInRunResumeCandidate?(
-    evidence: ExitEvidence,
-    providerConversationId: string | null,
-    providerState: unknown,
-  ): boolean;
+  /** Optional provider-owned reading of a dropped exit, see `CliAdapter`. */
+  isProviderDisconnect?(evidence: ExitEvidence, providerState: unknown): boolean;
 };
 
 export const createAdapterState = (
@@ -555,8 +552,8 @@ export const createCliAdapter = (declaration: AdapterDeclaration): CliAdapter =>
   kill: (handle, reason) => killRuntime(handle, reason),
   heartbeat: (handle) => heartbeatRuntime(handle),
   classifyError: (evidence) => classifyRuntimeError(evidence),
-  ...(declaration.isInRunResumeCandidate
-    ? { isInRunResumeCandidate: declaration.isInRunResumeCandidate }
+  ...(declaration.isProviderDisconnect
+    ? { isProviderDisconnect: declaration.isProviderDisconnect }
     : {}),
 });
 

--- a/packages/runner/src/runner.test.ts
+++ b/packages/runner/src/runner.test.ts
@@ -1625,7 +1625,7 @@ test("three Codex resume attempts exhaust on the fourth disconnect and preserve 
 
     // The fourth evidence is classified independently of whether the optional
     // Codex capability is exposed; the resume loop must not alter the verdict.
-    const { isInRunResumeCandidate: _capability, ...withoutCapability } = adapters.CODEX;
+    const { isProviderDisconnect: _capability, ...withoutCapability } = adapters.CODEX;
     assert.equal(withoutCapability.classifyError(fourthEvidence).failureClass, expectedClass);
     assert.equal(outputStatusReads, 2, "the terminal-product probe runs once, followed by the settling-path read");
   } finally {
@@ -1641,9 +1641,12 @@ type NoResumeCase = {
   withoutCapability?: boolean;
 };
 
-// The exit shapes a Codex disconnect is disqualified by are the adapter's own
-// question, proven in adapters.test.ts. These two cases prove the wiring: a
-// refusal from the relaunch gate stops the loop before any second child.
+// The provider-shaped wording a Codex disconnect is disqualified by is the
+// adapter's own question, proven in adapters.test.ts, and the exit record's
+// own shape is `agentExitVerdict`'s, proven in run-outcome.test.ts. These
+// three cases prove the wiring: the loop starts no second child when the
+// verdict is not a drop, when the adapter offers no reading, or when the
+// relaunch gate refuses.
 const noResumeCases: NoResumeCase[] = [
   {
     name: "a missing provider conversation id",
@@ -1654,6 +1657,12 @@ const noResumeCases: NoResumeCase[] = [
     name: "an adapter without the optional capability",
     evidence: reconnectEvidence(),
     withoutCapability: true,
+  },
+  {
+    // Codex disconnect wording on an exit the runner itself ended: the shared
+    // verdict calls it `stopped`, so the adapter is never consulted.
+    name: "an exit the shared verdict does not call a drop",
+    evidence: reconnectEvidence({ terminationReason: "cancelled" }),
   },
 ];
 
@@ -1671,7 +1680,7 @@ for (const noResumeCase of noResumeCases) {
         providerResumeBackoff: async () => assert.fail("a disqualified exit must not wait before resuming"),
         ...(noResumeCase.withoutCapability ? {
           adapter: (claim, calls) => {
-            const { isInRunResumeCandidate: _capability, ...adapter } = fakeCodexAdapter(claim, [{
+            const { isProviderDisconnect: _capability, ...adapter } = fakeCodexAdapter(claim, [{
               evidence: noResumeCase.evidence,
               providerConversationId: noResumeCase.providerConversationId === undefined
                 ? "thread-resume"

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 
 import {
-  agentExecutionSucceeded,
+  agentExitVerdict,
   PR_TEMPLATE_NAME,
   type BudgetGate,
   type PersistedRunOutput,
@@ -598,11 +598,10 @@ export const executeClaim = async (
       const relaunch = await decideProviderRelaunch({
         purpose: "resume-disconnect",
         providerConversationId: deadProviderConversationId,
-        exitResumable: adapter.isInRunResumeCandidate?.(
-          evidence,
-          deadProviderConversationId,
-          deadHandle.providerState,
-        ) ?? false,
+        // The shared verdict owns the exit record; the adapter adds only the
+        // provider-shaped reading of a drop it already classified.
+        exitResumable: agentExitVerdict(evidence).case === "dropped"
+          && (adapter.isProviderDisconnect?.(evidence, deadHandle.providerState) ?? false),
         attempts: providerResumeAttempts,
         authorityHeld: () => runLease.authority.held,
         budgetRefused: () => budget.refusal !== null,
@@ -654,6 +653,10 @@ export const executeClaim = async (
       evidence = await resumedHandle.exit;
       producedOutput = outputTail(evidence);
     }
+    // The dead child is classified once here, from the evidence the Run ends
+    // on. Every question the rest of this function asks about how the agent
+    // process ended is one case of this verdict.
+    const exitVerdict = agentExitVerdict(evidence);
     let regressionHandoffPersisted = false;
     if (runLease.held) {
       try {
@@ -685,7 +688,7 @@ export const executeClaim = async (
         });
       }
     }
-    if (agentExecutionSucceeded(evidence)
+    if (exitVerdict.case === "succeeded"
       && claim.task.templateStep?.outputKind
       && runLease.held
       && terminalFailureReason === null) {
@@ -797,7 +800,7 @@ export const executeClaim = async (
                 payload: {
                   outputKind,
                   outputPersisted: remediated,
-                  terminalSuccess: agentExecutionSucceeded(remediationEvidence),
+                  terminalSuccess: agentExitVerdict(remediationEvidence).case === "succeeded",
                   evidence: exitEvidencePayload(remediationEvidence),
                   workspaceChanged,
                   ...(workspaceChanged ? {
@@ -852,14 +855,14 @@ export const executeClaim = async (
       });
     }
     let postDeliveryDisconnectTolerated = false;
-    const disconnectCandidate = evidence.exitCode === 0
-      && evidence.signal === null
-      && evidence.terminationReason === null
-      && evidence.terminalEventSeen === false
+    // A clean drop is the exit half; the rest is this Run's own state, which
+    // no reading of the exit record can supply.
+    const postDeliveryDisconnect = exitVerdict.case === "dropped"
+      && exitVerdict.cleanExit
       && terminalFailureReason === null
       && budget.refusal === null
       && runLease.held;
-    if (disconnectCandidate) {
+    if (postDeliveryDisconnect) {
       try {
         const outputEvidence = await session.outputStatus();
         const satisfaction = outputEvidence?.satisfaction;
@@ -947,15 +950,14 @@ export const executeClaim = async (
       });
       return;
     }
-    // A validated, fenced Regression handoff is the step's terminal product
-    // only when the provider did not explicitly reject the session. Transport
-    // loss remains recoverable, but a terminal failure keeps its authority.
-    const explicitTerminalFailure = evidence.terminalEventSeen && !evidence.terminalSuccess;
     const regressionMechanicallySettled = regressionHandoffPersisted
-      && !explicitTerminalFailure
+      // A validated, fenced Regression handoff is the step's terminal product
+      // only when the provider did not explicitly reject the session. Transport
+      // loss remains recoverable, but a terminal failure keeps its authority.
+      && exitVerdict.case !== "refused"
       && terminalFailureReason === null
       && budget.refusal === null;
-    const executionSucceeded = (agentExecutionSucceeded(evidence)
+    const executionSucceeded = (exitVerdict.case === "succeeded"
       || regressionMechanicallySettled
       || postDeliveryDisconnectTolerated)
       && terminalFailureReason === null
@@ -1054,7 +1056,7 @@ export const executeClaim = async (
     // value is what used to be spelled by overwriting `exitCode`,
     // `terminalEventSeen` and `terminalSuccess` so the control plane's copy of
     // the success predicate would agree with the verdict already reached here.
-    const successOutcome: RunOutcome = agentExecutionSucceeded(evidence)
+    const successOutcome: RunOutcome = exitVerdict.case === "succeeded"
       ? { case: "succeeded" }
       : regressionMechanicallySettled
         ? { case: "regression-mechanically-settled" }


### PR DESCRIPTION
## What changed

`agentExitVerdict` in `packages/db/src/run-outcome.ts` classifies a dead
provider child's exit record once. It extends the delivered run-outcome module
to the record that module's outcome is derived from, and it partitions that
record, so each reading is one case and no reader restates a field:

- `succeeded` replaces `agentExecutionSucceeded`, which is deleted.
- `refused` replaces the inline `evidence.terminalEventSeen &&
  !evidence.terminalSuccess` that gated `regressionMechanicallySettled`.
- `dropped` with `cleanExit` replaces `disconnectCandidate`'s four-field half
  in the post-delivery tolerance (the remaining conjuncts are this Run's own
  state, which no reading of the exit record can supply).
- `dropped` alone is what the Codex adapter is now asked about.
- `contradicted` and `stopped` complete the partition; no caller reads them,
  and they exist so `succeeded` and `dropped` need no further qualification
  from their readers.

The Codex adapter keeps only its provider-shaped contribution. Its predicate is
renamed `isCodexProviderDisconnect`, loses the `terminalEventSeen` / `signal` /
`terminationReason` / `providerConversationId` clauses, and the optional
adapter hook is renamed `isInRunResumeCandidate` -> `isProviderDisconnect` with
the conversation-id parameter dropped. The resume loop composes the two:
`agentExitVerdict(evidence).case === "dropped" && adapter.isProviderDisconnect(...)`.
`executeClaim` computes the verdict once, after the resume loop, and its five
later questions read that one value.

`probeDurableTerminalProduct` is untouched: it is not a reading of the exit
record but a probe of the workspace and the server, and lane r1 already made it
an input to `decideProviderRelaunch`.

Behaviour is unchanged. Each of the four replaced readings is exactly one case
of the partition, including the edges that made the partition awkward: a
rejection that a signal followed is still `refused` (the agent's rejection
stands whatever the process then did), and a success claim with a non-zero exit
is still not a success.

## Evidence

Run in the worktree after the final commit `558295c5`, with
`export RUNNER_WORKSPACE_ROOT=$(mktemp -d)`:

- `npm run lint` (root): pass, 777 files checked, biome and eslint clean.
- `npm run typecheck` (root): pass, all workspaces.
- `npm run test -w @anneal/runner`: 574 tests, 572 pass, 0 fail, 2 skipped
  (root-only uid tests).
- `npm run test -w @anneal/db`: 442 tests, 442 pass, 0 fail.
- `npm run test:snapshot-scan`: 21 tests, 21 pass (a file was added).

`test:db` not run: no local PostgreSQL, and no `*.dbtest.ts` was changed.

New tests: `packages/db/src/run-outcome.test.ts`, table-driven, one row per
case plus the record shapes each replaced call site used to read field by
field. `packages/runner/src/runner.test.ts` gains a third no-resume wiring case
proving the loop consults no adapter when the shared verdict is not a drop.

## Decisions taken

**The a1 seam is `packages/db/src/run-outcome.ts`, not
`packages/runner/src/envelope.ts`.** The brief names `envelope.ts` as the home
of the delivered outcome module. On the base, `envelope.ts` is a
fact-reporter whose own interface doc states that it "does not decide
anything"; round 5 lane a1 delivered run outcome classification as `RunOutcome`
/ `runOutcomeVerdict` / `agentExecutionSucceeded` in `packages/db/src/run-outcome.ts`,
whose doc says `agentExecutionSucceeded` "is the predicate whose duplication
the outcome exists to end, and a second copy appearing anywhere is the
regression to catch". That predicate reads the same five fields as the three
sites the brief names, so it is the fourth reading of the same record and the
verdict's only non-competing home. Putting the verdict in the runner would have
opened exactly the competing seam the brief forbids. `envelope.ts` is therefore
unchanged.

**Deletion test.** With the verdict, `agentExecutionSucceeded`, the Codex
predicate's four record clauses, `disconnectCandidate`'s four clauses, and
`explicitTerminalFailure` all disappear; without it, five sites restate the
fields and a repair to any one of them reaches only that one. The verdict
extends the a1 seam cleanly, so this is delivered rather than reported as
`already-delivered`.

**The composition stays at the call site, not inside the relaunch gate.** The
brief forbids touching the relaunch module's refusal reasons beyond feeding it
the verdict. Feeding `decideProviderRelaunch` a verdict plus a separate
provider fact would have required it to distinguish "not a drop" from "the
provider does not call this a disconnect" in its refusal vocabulary. The
`exitResumable` boolean it already takes is the composition, so `provider-relaunch.ts`
is unchanged.

**`agentExecutionSucceeded` was deleted rather than kept as a one-line reading
of `succeeded`.** A named synonym for one case is the second name whose
divergence this change exists to prevent; readers now spell the case.

**No adapter version bump.** `isProviderDisconnect` is an optional in-process
hook, not part of the launch manifest that `ADAPTER_VERSION` stamps.

## Fence widened

- `packages/db/src/run-outcome.ts` and the new
  `packages/db/src/run-outcome.test.ts`: owned by no lane in `QUEUE.md`. Taken
  because it is the a1 seam the brief requires the verdict to extend.
- `packages/runner/src/adapters/runtime.ts` and
  `packages/runner/src/runner.test.ts`: owned by lane r1, state `merged`. Taken
  for the hook rename and its test wiring.

Nothing was taken from a lane in state `dispatched` or `ready`. The `RunOutcome`
type and `runOutcomeVerdict` are untouched, so lane k3's
`packages/api/src/run-completion.ts` is unaffected.

## Reported but unfixed

- `packages/runner/src/adapters/runtime.ts`: `CodexProviderState` is still the
  only `providerState` any adapter supplies, and `isProviderDisconnect` is
  still declared by one adapter. That is candidate C4 in the findings, judged
  not worth a lane there, and this change does not make it worse.
- `packages/runner/src/runner.ts`: `executeClaim` remains a ~965-line function
  with one try block spanning most of it. Candidates C1 and C2 took the
  relaunch gate and the lease headroom out of it; the phase sequencing after
  the resume loop is still inline. Out of this brief's scope.
- `scripts/deploy/systemd-installer.test.mjs:591`: the systemd-analyze check
  asserts `doesNotMatch(/Unknown|Failed to parse/u)` over the whole command
  output, which includes systemd's diagnostics about the host's own units, not
  only the rendered unit. It fails on any Linux host whose systemd is older
  than a key used by an installed system unit. It should filter the output to
  the lines naming the file under test. Not fixed here: that file is a test of
  `scripts/deploy/install-launchd.mjs`, owned by lanes d2 and d34, both
  `dispatched` in `QUEUE.md`, so the fence forbids taking it.

## Disposition

**Blind review: nothing to dispose.** The reviewer returned verdict `approve`
with an empty findings list. No blocking or advisory finding was raised, so
none is fixed and none is rejected.

**Merge gate round 1 FAIL at head `558295c5` (fixed by re-dispatch, no code
change).** The failing check was
`scripts/deploy/systemd-installer.test.mjs:539`, "rendered unit syntax is
verified by systemd-analyze when available", asserting that
`systemd-analyze verify` printed nothing matching `/Unknown|Failed to parse/u`.
The three lines it actually saw name `netplan-ovs-cleanup.service`,
`tat_agent.service` and `/lib/systemd/system/snapd.service` — host units, not
the rendered unit. The cause is the worker host, not this branch: the fallback
worker `agentos-gate` runs systemd 249 while its installed `snapd.service`
declares `RestartMode=`, a key systemd 249 does not know. Reproduced with a
four-line probe unit containing no repository code:

- `agentos-gate`: `systemd 249 (249.11-0ubuntu3.17)`, prints
  `/lib/systemd/system/snapd.service:23: Unknown key name 'RestartMode' ...`
  for a unit that only declares `ExecStart=/bin/true`.
- `ci-desktop-worker`: `systemd 255 (255.4-1ubuntu8.17)`, prints nothing.

This branch changes only `packages/db` and `packages/runner`. Decision:
re-dispatched with `AGENTOS_GATE_FALLBACK_SERVER=''` — the mechanism the
program's common rules give for a known-broken fallback worker — rather than
editing the test, because `scripts/deploy/systemd-installer.test.mjs` is a test
of lanes d2 and d34, both `dispatched`, and the fence forbids taking a
dispatched lane's file. The over-broad assertion is recorded under
`## Reported but unfixed` for the lane that owns it.

**Verification re-run at the unchanged head `558295c5`** (`origin/main` is
still `467f37f6`; no commit was needed, so nothing was rebased or merged), with
`export RUNNER_WORKSPACE_ROOT=$(mktemp -d)`:

- `npm run lint` (root): pass, 777 files checked, biome and eslint clean.
- `npm run typecheck` (root): pass, all workspaces.
- `npm run test -w @anneal/runner`: 574 tests, 572 pass, 0 fail, 2 skipped.
- `npm run test -w @anneal/db`: 442 tests, 442 pass, 0 fail.
- `npm run test:snapshot-scan`: 21 tests, 21 pass.
- Merge gate, second dispatch on the primary worker `ci-desktop-worker`:
  `MERGE GATE: PASS 558295c50d108e93200e67751eb132572e4e32b2`.

Generated with Claude Code (deepening round 6 lane r2)
