### PR TITLE
refactor(db): one module decides mechanical contract compatibility

### DIFF
--- a/packages/api/src/routes/runner.test.ts
+++ b/packages/api/src/routes/runner.test.ts
@@ -10,9 +10,8 @@ import {
   type PrismaClient,
 } from "@anneal/db";
 import {
-  MECHANICAL_CONTRACT_MISMATCH_ALERT_BODY_PREFIX,
-  MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX,
   RUN_COMPLETION_CONTRACT_VERSION,
+  mechanicalContractMismatch,
 } from "@anneal/db/claim-contract";
 
 import { createApp } from "../test-app.js";
@@ -216,36 +215,35 @@ for (const contractVersion of [undefined, RUN_COMPLETION_CONTRACT_VERSION + 1]) 
             }),
           });
 
+        // The decision the route must reach, composed by the module that owns
+        // it. The route may serialise it and nothing else.
+        const decided = (received: number | null) => {
+          const mismatch = mechanicalContractMismatch({ receivedVersion: received, taskId: "task-mechanical", now: new Date() });
+          assert.ok(mismatch);
+          return mismatch;
+        };
+        const expected = decided(contractVersion ?? null);
+
         const response = await request();
         assert.equal(response.status, 409);
-        const refusal = await response.json() as Record<string, unknown>;
-        assert.equal(refusal.code, "mechanical_contract_mismatch");
-        assert.equal(refusal.expectedVersion, RUN_COMPLETION_CONTRACT_VERSION);
-        assert.equal(refusal.receivedVersion, contractVersion ?? null);
-        assert.match(String(refusal.error), new RegExp(`executor version ${contractVersion ?? "missing"}`, "u"));
-        assert.match(String(refusal.error), new RegExp(`API version ${RUN_COMPLETION_CONTRACT_VERSION}`, "u"));
+        assert.deepEqual(await response.json(), expected.refusal);
         assert.equal(runMutations, 0);
         assert.equal(activities.length, 1);
         assert.equal(activities[0]?.taskId, "task-mechanical");
-        assert.match(String(activities[0]?.body), new RegExp(`executor version ${contractVersion ?? "missing"}`, "u"));
-        assert.match(String(activities[0]?.body), new RegExp(`API version ${RUN_COMPLETION_CONTRACT_VERSION}`, "u"));
+        assert.equal(activities[0]?.body, expected.activity.body);
+        assert.deepEqual(activities[0]?.metadata, expected.activity.metadata);
         assert.equal((await request()).status, 409);
         assert.equal(activities.length, 1);
         assert.equal(inboxMessages.length, 1);
         assert.equal(inboxMessages[0]?.status, InboxStatus.OPEN);
-        assert.match(String(inboxMessages[0]?.dedupeKey), new RegExp(`^${MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX}`, "u"));
-        assert.ok(String(inboxMessages[0]?.body).startsWith(MECHANICAL_CONTRACT_MISMATCH_ALERT_BODY_PREFIX));
-        assert.match(String(inboxMessages[0]?.body), new RegExp(`executor version ${contractVersion ?? "missing"}; API version ${RUN_COMPLETION_CONTRACT_VERSION}`, "u"));
-        assert.match(String(inboxMessages[0]?.body), /task task-mechanical/u);
+        assert.equal(inboxMessages[0]?.body, expected.alert.body);
+        assert.ok(String(inboxMessages[0]?.dedupeKey).startsWith(expected.alert.dedupeKeyPrefix));
         if (contractVersion === undefined) {
           const differentVersion = RUN_COMPLETION_CONTRACT_VERSION + 1;
           assert.equal((await request(differentVersion)).status, 409);
           assert.equal(inboxMessages.length, 2);
           assert.equal(inboxMessages.filter(({ status }) => status === InboxStatus.OPEN).length, 2);
-          assert.match(
-            String(inboxMessages[1]?.dedupeKey),
-            new RegExp(`^${MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX}${RUN_COMPLETION_CONTRACT_VERSION}:${differentVersion}:`, "u"),
-          );
+          assert.ok(String(inboxMessages[1]?.dedupeKey).startsWith(decided(differentVersion).alert.dedupeKeyPrefix));
           assert.equal(activities.length, 2);
         }
       } finally {

--- a/packages/api/src/routes/runner.ts
+++ b/packages/api/src/routes/runner.ts
@@ -1,5 +1,4 @@
 import { RunnerKind } from "@anneal/db";
-import { MECHANICAL_CONTRACT_MISMATCH_CODE } from "@anneal/db/claim-contract";
 import { z } from "zod";
 
 import { fence, id, readJson, refusal, refusalJson } from "./support.js";
@@ -196,18 +195,11 @@ export const registerRunnerRoutes = (
       signal: context.req.raw.signal,
     });
     if (claimed && "error" in claimed) {
-      if (typeof claimed.error !== "string") throw new TypeError("Run claim refusal has no message");
-      if (typeof claimed.reason !== "string") throw new TypeError("Run claim refusal has no reason");
-      return refusalJson(context, refusal("conflict", claimed.error, {
-        reason: claimed.reason,
-        ...(claimed.reason === MECHANICAL_CONTRACT_MISMATCH_CODE
-          ? {
-            code: claimed.reason,
-            expectedVersion: claimed.expectedVersion,
-            receivedVersion: claimed.receivedVersion,
-          }
-          : {}),
-      }));
+      // The refusal value is the response body. Whatever evidence a refusal
+      // carries — a contract mismatch carries four fields — was decided where
+      // the refusal was composed, so this route adds none of its own.
+      const { error, ...detail } = claimed;
+      return refusalJson(context, refusal("conflict", error, detail));
     }
     return claimed ? context.json(claimed) : context.body(null, 204);
   });

--- a/packages/api/src/run-claim.ts
+++ b/packages/api/src/run-claim.ts
@@ -31,10 +31,8 @@ import {
 import { heldPredicate, heldSql, heldWhere } from "@anneal/db/chain-hold";
 import type { ClaimContract, ClaimRefusal } from "@anneal/db/claim-contract";
 import {
-  MECHANICAL_CONTRACT_MISMATCH_ALERT_BODY_PREFIX,
-  MECHANICAL_CONTRACT_MISMATCH_CODE,
   MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX,
-  RUN_COMPLETION_CONTRACT_VERSION,
+  mechanicalContractMismatch,
 } from "@anneal/db/claim-contract";
 import { z } from "zod";
 
@@ -623,22 +621,26 @@ export const claimRun = async (
       // empty — the shipped default — or with `MERGE_EXECUTOR_TOKEN` unset or
       // aliased onto the runner token, no integrator run is claimable at all.
       if (!claimantMayTake(executionMode, claimantClass, body.runnerId, executorRunnerIds)) return SKIP;
-      if (executionMode === "mechanical" && body.contractVersion !== RUN_COMPLETION_CONTRACT_VERSION) {
-        const receivedVersion = body.contractVersion ?? null;
-        const displayedVersion = receivedVersion ?? "missing";
-        const message = `Mechanical completion contract mismatch: executor version ${displayedVersion}; API version ${RUN_COMPLETION_CONTRACT_VERSION}`;
-        const alertKeyPrefix = `${MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX}${RUN_COMPLETION_CONTRACT_VERSION}:${displayedVersion}:`;
+      // Compatibility with the independently released merge executor is one
+      // decision, and `mechanicalContractMismatch` is all of it: the
+      // comparison, the refusal on the wire, this record and the alert. What
+      // is left here is the writing.
+      const mismatch = executionMode === "mechanical"
+        ? mechanicalContractMismatch({ receivedVersion: body.contractVersion ?? null, taskId: candidate.task.id, now })
+        : null;
+      if (mismatch) {
+        const { code, apiVersion, executorVersion } = mismatch.activity.metadata;
         const existingActivity = await tx.taskActivity.findFirst({
           where: {
             taskId: candidate.task.id,
             actorType: "control-plane",
             AND: [
-              { metadata: { path: ["code"], equals: MECHANICAL_CONTRACT_MISMATCH_CODE } },
-              { metadata: { path: ["apiVersion"], equals: RUN_COMPLETION_CONTRACT_VERSION } },
+              { metadata: { path: ["code"], equals: code } },
+              { metadata: { path: ["apiVersion"], equals: apiVersion } },
               {
                 metadata: {
                   path: ["executorVersion"],
-                  equals: receivedVersion === null ? Prisma.JsonNull : receivedVersion,
+                  equals: executorVersion === null ? Prisma.JsonNull : executorVersion,
                 },
               },
             ],
@@ -650,26 +652,13 @@ export const claimRun = async (
             data: {
               taskId: candidate.task.id,
               actorType: "control-plane",
-              body: message,
-              metadata: {
-                code: MECHANICAL_CONTRACT_MISMATCH_CODE,
-                executorVersion: receivedVersion,
-                apiVersion: RUN_COMPLETION_CONTRACT_VERSION,
-              },
+              body: mismatch.activity.body,
+              metadata: mismatch.activity.metadata,
             },
           });
         }
-        await openMechanicalContractMismatchAlert(tx, {
-          body: `${MECHANICAL_CONTRACT_MISMATCH_ALERT_BODY_PREFIX} executor version ${displayedVersion}; API version ${RUN_COMPLETION_CONTRACT_VERSION}; task ${candidate.task.id}`,
-          dedupeKey: `${alertKeyPrefix}${now.toISOString()}`,
-          dedupeKeyPrefix: alertKeyPrefix,
-        });
-        return {
-          error: message,
-          reason: MECHANICAL_CONTRACT_MISMATCH_CODE,
-          expectedVersion: RUN_COMPLETION_CONTRACT_VERSION,
-          receivedVersion,
-        };
+        await openMechanicalContractMismatchAlert(tx, mismatch.alert);
+        return mismatch.refusal;
       }
       // The backend circuit breaker tracks model-CLI health. A mechanical run
       // spawns no CLI, so an open CLI circuit is not evidence about it; the

--- a/packages/db/src/claim-contract.test.ts
+++ b/packages/db/src/claim-contract.test.ts
@@ -3,12 +3,76 @@ import test from "node:test";
 
 import {
   MECHANICAL_CONTRACT_MISMATCH_CODE,
+  MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX,
   RUN_COMPLETION_CONTRACT_VERSION,
+  mechanicalContractMismatch,
 } from "./claim-contract.js";
+
+const NOW = new Date("2026-09-04T12:00:00.000Z");
 
 test("exports one completion contract version for independently built processes", () => {
   assert.equal(RUN_COMPLETION_CONTRACT_VERSION, 1);
   assert.equal(Number.isInteger(RUN_COMPLETION_CONTRACT_VERSION), true);
   assert.equal(RUN_COMPLETION_CONTRACT_VERSION > 0, true);
   assert.equal(MECHANICAL_CONTRACT_MISMATCH_CODE, "mechanical_contract_mismatch");
+});
+
+test("the executor's own version is compatible", () => {
+  assert.equal(
+    mechanicalContractMismatch({ receivedVersion: RUN_COMPLETION_CONTRACT_VERSION, taskId: "task-1", now: NOW }),
+    null,
+  );
+});
+
+test("an incompatible claim gets a refusal, a record and an alert naming both versions", () => {
+  const mismatch = mechanicalContractMismatch({
+    receivedVersion: RUN_COMPLETION_CONTRACT_VERSION + 1,
+    taskId: "task-1",
+    now: NOW,
+  });
+  assert.ok(mismatch);
+  assert.deepEqual(mismatch.refusal, {
+    error: `Mechanical completion contract mismatch: executor version ${RUN_COMPLETION_CONTRACT_VERSION + 1}; API version ${RUN_COMPLETION_CONTRACT_VERSION}`,
+    reason: MECHANICAL_CONTRACT_MISMATCH_CODE,
+    code: MECHANICAL_CONTRACT_MISMATCH_CODE,
+    expectedVersion: RUN_COMPLETION_CONTRACT_VERSION,
+    receivedVersion: RUN_COMPLETION_CONTRACT_VERSION + 1,
+  });
+  assert.equal(mismatch.activity.body, mismatch.refusal.error);
+  assert.deepEqual(mismatch.activity.metadata, {
+    code: MECHANICAL_CONTRACT_MISMATCH_CODE,
+    executorVersion: RUN_COMPLETION_CONTRACT_VERSION + 1,
+    apiVersion: RUN_COMPLETION_CONTRACT_VERSION,
+  });
+  assert.equal(
+    mismatch.alert.body,
+    `merge executor completion contract mismatch: executor version ${RUN_COMPLETION_CONTRACT_VERSION + 1}; API version ${RUN_COMPLETION_CONTRACT_VERSION}; task task-1`,
+  );
+  assert.ok(mismatch.alert.dedupeKeyPrefix.startsWith(MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX));
+  assert.equal(mismatch.alert.dedupeKey, `${mismatch.alert.dedupeKeyPrefix}${NOW.toISOString()}`);
+});
+
+test("an omitted version is reported as missing, not as a compatible claim", () => {
+  const mismatch = mechanicalContractMismatch({ receivedVersion: null, taskId: "task-1", now: NOW });
+  assert.ok(mismatch);
+  assert.equal(mismatch.refusal.receivedVersion, null);
+  assert.match(mismatch.refusal.error, /executor version missing/u);
+  assert.equal(mismatch.activity.metadata.executorVersion, null);
+  assert.match(mismatch.alert.body, /executor version missing/u);
+});
+
+test("each version pair takes its own alert dedupe prefix", () => {
+  const pair = (receivedVersion: number | null): string => {
+    const mismatch = mechanicalContractMismatch({ receivedVersion, taskId: "task-1", now: NOW });
+    assert.ok(mismatch);
+    return mismatch.alert.dedupeKeyPrefix;
+  };
+  assert.notEqual(pair(null), pair(RUN_COMPLETION_CONTRACT_VERSION + 1));
+  assert.equal(pair(RUN_COMPLETION_CONTRACT_VERSION + 1), pair(RUN_COMPLETION_CONTRACT_VERSION + 1));
+});
+
+test("the alert body and dedupe key do not share a prefix, so one is not the other", () => {
+  const mismatch = mechanicalContractMismatch({ receivedVersion: null, taskId: "task-1", now: NOW });
+  assert.ok(mismatch);
+  assert.equal(mismatch.alert.body.startsWith(MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX), false);
 });

--- a/packages/db/src/claim-contract.ts
+++ b/packages/db/src/claim-contract.ts
@@ -10,6 +10,13 @@
  * aliases it, so a consumer that reads a field the server never sends fails
  * to compile too.
  *
+ * It also owns the one decision the same two processes make about each other:
+ * whether a mechanical claim's build is compatible with this one, and what the
+ * control plane answers, records and alerts when it is not. That decision's
+ * strings used to be constants here while its comparison, its wire shape and
+ * its dedupe keys were assembled in three other files across two packages; a
+ * version bump now changes this file alone.
+ *
  * Prisma is imported as types only: persisted enum widening becomes a
  * compile-time change at this seam without pulling generated client code into
  * a consumer. Unlike `wire-contract.ts` and `board-contract.ts` this contract
@@ -40,13 +47,20 @@ export const RUN_COMPLETION_CONTRACT_VERSION = 1;
 /** Stable refusal discriminator shared by the API and mechanical executor. */
 export const MECHANICAL_CONTRACT_MISMATCH_CODE = "mechanical_contract_mismatch";
 
-/** Stable Inbox body prefix for mechanical completion contract mismatch alerts. */
-export const MECHANICAL_CONTRACT_MISMATCH_ALERT_BODY_PREFIX =
-  "merge executor completion contract mismatch:";
-
-/** Stable Inbox dedupe-key prefix for mechanical completion contract mismatch alerts. */
+/**
+ * Stable Inbox dedupe-key prefix for every mechanical contract mismatch alert.
+ *
+ * Exported because the claim transaction takes its advisory lock on this
+ * prefix and closes every OPEN alert under it once a compatible executor
+ * claims. The per-version-pair prefix that decides whether a *new* alert is
+ * opened is built by `mechanicalContractMismatch` below.
+ */
 export const MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX =
   "merge-executor-completion-contract-mismatch:";
+
+/** Stable Inbox body prefix for mechanical completion contract mismatch alerts. */
+const MECHANICAL_CONTRACT_MISMATCH_ALERT_BODY_PREFIX =
+  "merge executor completion contract mismatch:";
 
 /** The step identity a runner needs: title the delivery, and decide provisioning. */
 export type ClaimTemplateStep = {
@@ -234,11 +248,111 @@ export type ClaimContract = {
 };
 
 /** The refusal `claimRun` reports instead of a claim, rendered as a 409. */
-export type ClaimRefusal = {
+export type ClaimRefusal = ClaimRefused | MechanicalContractMismatchRefusal;
+
+/** A refusal that carries no evidence beyond its reason. */
+export type ClaimRefused = {
   error: string;
   reason: string;
-  /** Present only for a mechanical completion-contract mismatch. */
-  expectedVersion?: number;
-  /** Null means the mechanical executor omitted its version. */
-  receivedVersion?: number | null;
 };
+
+/**
+ * The refusal a mechanical claim gets when the two independently released
+ * processes disagree about the completion contract.
+ *
+ * Every field here is on the wire: the route answers 409 with `{ error,
+ * ...rest }` of this value and adds nothing, so this type *is* the response
+ * body the merge executor decodes. `code` repeats `reason` because the
+ * released executor branches on `code`; changing which field carries the
+ * discriminator would go unrecognised by exactly the build this refusal
+ * exists to stop.
+ */
+export type MechanicalContractMismatchRefusal = {
+  error: string;
+  reason: typeof MECHANICAL_CONTRACT_MISMATCH_CODE;
+  code: typeof MECHANICAL_CONTRACT_MISMATCH_CODE;
+  expectedVersion: number;
+  /** Null means the mechanical executor omitted its version. */
+  receivedVersion: number | null;
+};
+
+/**
+ * Everything the control plane says and records about one incompatible
+ * mechanical claim: what it answers, what it writes on the Task, and what it
+ * raises for an operator. The caller performs the writes; it composes no
+ * string of its own.
+ */
+export type MechanicalContractMismatch = {
+  refusal: MechanicalContractMismatchRefusal;
+  /**
+   * The Task record. `metadata` is also the dedupe predicate: one record per
+   * (code, apiVersion, executorVersion) triple, so a poll every few seconds
+   * does not fill the Task feed.
+   */
+  activity: {
+    body: string;
+    metadata: {
+      code: typeof MECHANICAL_CONTRACT_MISMATCH_CODE;
+      executorVersion: number | null;
+      apiVersion: number;
+    };
+  };
+  /**
+   * The operator alert. A new one is opened only when no OPEN alert starts
+   * with `dedupeKeyPrefix`, which names this exact version pair; `dedupeKey`
+   * makes the row itself unique.
+   */
+  alert: { body: string; dedupeKey: string; dedupeKeyPrefix: string };
+};
+
+/**
+ * Decide whether a mechanical claim is compatible with this build.
+ *
+ * Null means compatible. Anything else — the version comparison, the refusal
+ * on the wire, the recorded fact, the alert text and both dedupe keys — is
+ * this module's, so a version bump changes one file rather than four.
+ */
+export const mechanicalContractMismatch = (input: {
+  /** The version the executor sent; null when it sent none. */
+  receivedVersion: number | null;
+  taskId: string;
+  now: Date;
+}): MechanicalContractMismatch | null => {
+  if (input.receivedVersion === RUN_COMPLETION_CONTRACT_VERSION) return null;
+  const displayedVersion = input.receivedVersion ?? "missing";
+  const versions = `executor version ${displayedVersion}; API version ${RUN_COMPLETION_CONTRACT_VERSION}`;
+  const message = `Mechanical completion contract mismatch: ${versions}`;
+  const dedupeKeyPrefix =
+    `${MECHANICAL_CONTRACT_MISMATCH_DEDUPE_KEY_PREFIX}${RUN_COMPLETION_CONTRACT_VERSION}:${displayedVersion}:`;
+  return {
+    refusal: {
+      error: message,
+      reason: MECHANICAL_CONTRACT_MISMATCH_CODE,
+      code: MECHANICAL_CONTRACT_MISMATCH_CODE,
+      expectedVersion: RUN_COMPLETION_CONTRACT_VERSION,
+      receivedVersion: input.receivedVersion,
+    },
+    activity: {
+      body: message,
+      metadata: {
+        code: MECHANICAL_CONTRACT_MISMATCH_CODE,
+        executorVersion: input.receivedVersion,
+        apiVersion: RUN_COMPLETION_CONTRACT_VERSION,
+      },
+    },
+    alert: {
+      body: `${MECHANICAL_CONTRACT_MISMATCH_ALERT_BODY_PREFIX} ${versions}; task ${input.taskId}`,
+      dedupeKey: `${dedupeKeyPrefix}${input.now.toISOString()}`,
+      dedupeKeyPrefix,
+    },
+  };
+};
+
+/**
+ * The claim fields the merge executor reads, projected from `ClaimContract`
+ * rather than restated: a projection that stops producing one of them fails to
+ * compile in the executor instead of arriving there as `undefined`.
+ */
+export type MechanicalClaim =
+  & Pick<ClaimContract, "executionMode" | "fencingToken" | "sessionToken">
+  & { task: Pick<ClaimTask, "chainIndex">; run: Pick<ClaimRun, "id"> };

--- a/packages/merge-executor/src/agentos.test.ts
+++ b/packages/merge-executor/src/agentos.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The control plane composes a refusal; this process decodes it. Both sides
+ * are here, so a change to one that the other cannot read fails in this file
+ * rather than in production, where the two builds are released separately.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { RUN_COMPLETION_CONTRACT_VERSION, mechanicalContractMismatch } from "@anneal/db/claim-contract";
+
+import { decodeContractMismatchRefusal } from "./agentos.js";
+
+const NOW = new Date("2026-09-04T12:00:00.000Z");
+
+test("the executor decodes exactly the refusal the control plane composes", () => {
+  for (const receivedVersion of [null, RUN_COMPLETION_CONTRACT_VERSION - 1, RUN_COMPLETION_CONTRACT_VERSION + 1]) {
+    const mismatch = mechanicalContractMismatch({ receivedVersion, taskId: "task-1", now: NOW });
+    assert.ok(mismatch);
+    // Exactly what the route sends: the refusal's `error` plus the rest of it.
+    const { error, ...detail } = mismatch.refusal;
+    assert.deepEqual(decodeContractMismatchRefusal(JSON.stringify({ error, ...detail })), mismatch.refusal);
+  }
+});
+
+test("a refusal that is not a contract mismatch is not decoded as one", () => {
+  assert.equal(decodeContractMismatchRefusal(JSON.stringify({ error: "no", reason: "prior-output-missing" })), null);
+  assert.equal(decodeContractMismatchRefusal(JSON.stringify({ error: "no", code: "other", expectedVersion: 1, receivedVersion: 0 })), null);
+});
+
+test("a mismatch refusal missing its version evidence is not decoded", () => {
+  const mismatch = mechanicalContractMismatch({ receivedVersion: null, taskId: "task-1", now: NOW });
+  assert.ok(mismatch);
+  const { expectedVersion, ...withoutExpected } = mismatch.refusal;
+  assert.equal(decodeContractMismatchRefusal(JSON.stringify(withoutExpected)), null);
+  assert.equal(decodeContractMismatchRefusal(JSON.stringify({ ...mismatch.refusal, error: 7 })), null);
+});
+
+test("a body that is not a JSON object is not decoded", () => {
+  assert.equal(decodeContractMismatchRefusal("<html>502</html>"), null);
+  assert.equal(decodeContractMismatchRefusal("[]"), null);
+  assert.equal(decodeContractMismatchRefusal("null"), null);
+});

--- a/packages/merge-executor/src/agentos.ts
+++ b/packages/merge-executor/src/agentos.ts
@@ -14,19 +14,12 @@ import type { MergeOutcome } from "@anneal/db/merge-integrator";
 import {
   MECHANICAL_CONTRACT_MISMATCH_CODE,
   RUN_COMPLETION_CONTRACT_VERSION,
+  type MechanicalClaim,
+  type MechanicalContractMismatchRefusal,
 } from "@anneal/db/claim-contract";
 
 import type { ExecutorConfig } from "./config.js";
 import type { ChainEnvelope, IntentRecord } from "./decision-table.js";
-
-export type MechanicalClaim = {
-  executionMode: "mechanical" | "agent";
-  task: { id: string; name: string; chainIndex?: number | null };
-  run: { id: string; runNumber: number; maxRunsPerTask: number };
-  session: { id: string };
-  fencingToken: string;
-  sessionToken: string;
-};
 
 export type MechanicalCancellation = {
   requestId: string;
@@ -92,6 +85,40 @@ export class CompletionTransportError extends Error {
   }
 }
 
+/**
+ * Read a 409 body as the contract-mismatch refusal the control plane composes,
+ * or null when it is any other refusal.
+ *
+ * Every field name checked here belongs to the declared refusal, so this
+ * process recognises the mismatch by the same value the API produced rather
+ * than by a shape restated on this side. A body that is not that refusal — a
+ * different reason, or a malformed one — is not the named compatibility
+ * result, and the caller surfaces the original response error through the
+ * ordinary claim-loop path.
+ */
+export const decodeContractMismatchRefusal = (
+  responseBody: string,
+): MechanicalContractMismatchRefusal | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(responseBody) as unknown;
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+  const refusal = parsed as Record<string, unknown>;
+  if (refusal.code !== MECHANICAL_CONTRACT_MISMATCH_CODE) return null;
+  if (typeof refusal.error !== "string" || typeof refusal.expectedVersion !== "number") return null;
+  if (typeof refusal.receivedVersion !== "number" && refusal.receivedVersion !== null) return null;
+  return {
+    error: refusal.error,
+    reason: MECHANICAL_CONTRACT_MISMATCH_CODE,
+    code: MECHANICAL_CONTRACT_MISMATCH_CODE,
+    expectedVersion: refusal.expectedVersion,
+    receivedVersion: refusal.receivedVersion,
+  };
+};
+
 const jsonHeaders = (token: string): Record<string, string> => ({
   Authorization: `Bearer ${token}`,
   "Content-Type": "application/json",
@@ -137,22 +164,9 @@ export const makeAgentOsClient = (config: ExecutorConfig, fetchImpl: typeof fetc
       });
     } catch (error: unknown) {
       if (error instanceof AgentOsResponseError && error.status === 409) {
-        let refusal: Record<string, unknown> | null = null;
-        try {
-          const parsed = JSON.parse(error.responseBody) as unknown;
-          if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) refusal = parsed as Record<string, unknown>;
-        } catch {
-          // A malformed refusal is not the named compatibility result; surface
-          // the original response error through the ordinary claim-loop path.
-        }
-        if (refusal?.code === MECHANICAL_CONTRACT_MISMATCH_CODE
-          && typeof refusal.expectedVersion === "number"
-          && (typeof refusal.receivedVersion === "number" || refusal.receivedVersion === null)) {
-          throw new MechanicalContractMismatchError(
-            refusal.receivedVersion,
-            refusal.expectedVersion,
-            typeof refusal.error === "string" ? refusal.error : error.message,
-          );
+        const refusal = decodeContractMismatchRefusal(error.responseBody);
+        if (refusal) {
+          throw new MechanicalContractMismatchError(refusal.receivedVersion, refusal.expectedVersion, refusal.error);
         }
       }
       throw error;

--- a/packages/merge-executor/src/index.test.ts
+++ b/packages/merge-executor/src/index.test.ts
@@ -8,9 +8,9 @@ import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import type { RunOutcome } from "@anneal/db";
-import { RUN_COMPLETION_CONTRACT_VERSION } from "@anneal/db/claim-contract";
+import { RUN_COMPLETION_CONTRACT_VERSION, type MechanicalClaim } from "@anneal/db/claim-contract";
 
-import { makeAgentOsClient, type MechanicalClaim } from "./agentos.js";
+import { makeAgentOsClient } from "./agentos.js";
 import type { ExecutorConfig } from "./config.js";
 import { mintInstallationToken } from "./github-app-auth.js";
 import { claimOnce, pollClaims, runClaim } from "./index.js";
@@ -37,9 +37,8 @@ const config: ExecutorConfig = {
 
 const claimed = (id: string): MechanicalClaim => ({
   executionMode: "mechanical",
-  task: { id: `task-${id}`, name: "merge", chainIndex: 7 },
-  run: { id, runNumber: 1, maxRunsPerTask: 3 },
-  session: { id: `session-${id}` },
+  task: { chainIndex: 7 },
+  run: { id },
   fencingToken: `fence-${id}`,
   sessionToken: `session-token-${id}`,
 });

--- a/packages/merge-executor/src/index.ts
+++ b/packages/merge-executor/src/index.ts
@@ -15,6 +15,7 @@ import "dotenv/config";
 import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
+import type { MechanicalClaim } from "@anneal/db/claim-contract";
 import { INTEGRATOR_OUTPUT_KIND, MERGE_INTEGRATOR_KIND, MERGE_INTEGRATOR_SCHEMA_VERSION, serializeMergeResult } from "@anneal/db/merge-integrator";
 
 import {
@@ -23,7 +24,6 @@ import {
   makeAgentOsClient,
   MechanicalContractMismatchError,
   type MechanicalCancellation,
-  type MechanicalClaim,
 } from "./agentos.js";
 import { loadExecutorConfig, type ExecutorConfig } from "./config.js";
 import { execute, type Deps } from "./decision-table.js";
@@ -85,7 +85,7 @@ export const runClaim = async (
       return false;
     }
   };
-  const chainIndex = claimed.task.chainIndex ?? null;
+  const chainIndex = claimed.task.chainIndex;
   if (chainIndex === null) {
     // Fail closed and loudly: a mechanical run outside a chain has no
     // predecessor to read an authorization from, so there is nothing to execute.


### PR DESCRIPTION
## What changed

"Is this merge executor's build compatible with this control plane, and what do
we say when it is not" is now one module's decision. `mechanicalContractMismatch`
in `packages/db/src/claim-contract.ts` returns null for a compatible claim and
otherwise the whole answer: the refusal exactly as it goes on the wire, the Task
record with the metadata that dedupes it, and the operator alert with its body,
its dedupe key and the per-version-pair prefix that decides whether a new alert
opens.

- `run-claim.ts` asks the module and performs the writes; it composes no string
  and repeats no version comparison.
- `routes/runner.ts` sends the refusal value as the response body
  (`{ error, ...rest }`) and adds nothing. The hand-assembled `code` branch and
  the two unreachable `TypeError` guards are deleted.
- `ClaimRefusal` is now a union of an ordinary refusal and
  `MechanicalContractMismatchRefusal`, which declares every field on the wire
  including the `code` its only consumer reads. The declaration was previously
  missing that field.
- `packages/merge-executor/src/agentos.ts` decodes that declared type in
  `decodeContractMismatchRefusal`, replacing the inline shape check, and its
  `MechanicalClaim` is projected from `ClaimContract` instead of being an
  independent structural mirror.

Depth: the leverage per unit of interface goes up because a version bump is now
one edit in one file, and the executor's decoder and the control plane's
composer are checked against each other by a test rather than by review.

## Evidence

Base: `467f37f604f27a65eaaa9a673484531422beed6b` (`origin/main`). Head:
`62b5027c859affcd54d4b0de8946568c90cd6509`. All commands run in the lane
worktree after the final commit, with `RUNNER_WORKSPACE_ROOT` pointed at a fresh
`mktemp -d`.

- `npm run lint` — pass (biome 777 files, eslint clean).
- `npm run typecheck` — pass (all workspaces).
- `npm run test -w @anneal/db` — 434 pass, 0 fail.
- `npm run test -w @anneal/api` — 894 pass, 0 fail, 1 skipped (pre-existing).
- `npm run test -w @anneal/merge-executor` — 107 pass, 0 fail, 1 skipped (the
  GraphQL schema gate, which needs a token and is not part of this suite). The
  four new round-trip assertions in `agentos.test.ts` ran and passed.
- `npm run test:snapshot-scan` — 21 pass (one file added;
  `packages/merge-executor/src/**/*.ts` already classifies it).
- `test:db` not run: no local PostgreSQL, so the dbtests are merge gate
  evidence. They were typechecked by `npm run typecheck`; none needed editing
  because the wire is unchanged.

Anchors re-verified on the base before editing: `claim-contract.ts:38-49`
(version, code, two alert prefixes), `run-claim.ts:626-673` (comparison,
activity, alert, refusal), `routes/runner.ts:198-211` (the added `code` field),
`agentos.ts:22` and `:126-161` (the mirror and the inline decoder). All were
still present at `467f37f6`; nothing was already fixed.

## Decisions taken

**The module is `claim-contract.ts`, not a new file.** The brief allows one new
module under `packages/db/src`. A new module would have had to own
`RUN_COMPLETION_CONTRACT_VERSION` to be the single owner of the decision, but
nine files outside this lane's fence import that constant from
`@anneal/db/claim-contract` — including `run-completion.ts`, owned by lane k3,
which is dispatched. Moving it would either widen the fence into a live lane or
leave a re-export shim, both of which this program forbids. `claim-contract.ts`
already held the version and all three strings, is already the one module both
processes import, and needs no new package export entry, so the logic moved to
the strings rather than the reverse.

**`code` stays on the wire and now duplicates `reason` by declaration.** Sending
only `reason` would be one field cleaner, but the released merge executor
branches on `code`, and the exact situation this refusal exists for is the one
where the executor is an older build. Dropping `code` would make that build fail
to recognise the refusal it was written to obey. Both fields are now produced in
one place, and the type says so.

**`MechanicalClaim` is narrowed to what the executor reads.** It was declared
with `task.id`, `task.name`, `run.runNumber`, `run.maxRunsPerTask` and
`session.id`; no code in the package reads any of them. The projected type
declares `executionMode`, `task.chainIndex`, `run.id`, `fencingToken` and
`sessionToken`, so a projection that stops sending one of those is a compile
error in the executor. Extra fields on the wire are simply ignored, as before.

**The claim payload gets no separate hash guard.** The brief asks whether the
guard that hashes the completion input schema per version should extend to the
claim payload. It cannot in the same form: `completionInput` is a Zod schema
with a runtime representation to hash, while the claim payload is a TypeScript
type with none. The equivalent guard for the claim payload is the compile-time
one, and this change strengthens it by deriving `MechanicalClaim` from
`ClaimContract` instead of restating it. Nothing was added.

**The `decodeContractMismatchRefusal` shape check now requires `error` to be a
string.** The old code fell back to the HTTP error message when `error` was
absent or non-string. The API's refusal serialiser always sets `error` to the
refusal message, so the fallback covered nothing that can occur; a body without
it is not this refusal and now surfaces as the ordinary response error.

## Fence widened

- `packages/merge-executor/src/index.ts` — belongs to no lane in `QUEUE.md`.
  Two lines: `MechanicalClaim` is imported from `@anneal/db/claim-contract`
  rather than re-exported through `agentos.ts`, and `claimed.task.chainIndex ??
  null` loses a coalesce the declared type makes dead.
- `packages/merge-executor/src/index.test.ts` — belongs to no lane; its
  `claimed()` fixture pinned the old mirror's fields and had to follow the
  narrowed type.

## Reported but unfixed

- `packages/merge-executor/src/isolation.test.ts:103` says "The one permitted
  `@anneal/db` entry point is its PURE record-convention subpath". That comment
  was already false before this change: `agentos.ts` has imported
  `@anneal/db/claim-contract` since the contract-version guard landed, and the
  assertion only rejects the bare `@anneal/db` specifier. The comment, not the
  assertion, is stale. Outside this lane's fence and unrelated to the
  compatibility decision.
- `packages/db/src/claim-contract.ts:4` describes the claim as "the widest
  cross-process boundary in the system". "Boundary" is banned vocabulary for
  this program; the sentence predates the lane and rewriting it is not part of
  this deepening.

Generated with Claude Code (deepening round 6 lane k2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zzbyE3vWTRrDacwLEoA3v
