### PR TITLE
refactor(db): one field table behind both template step comparators

### DIFF
--- a/packages/db/src/canonical-template-transition.test.ts
+++ b/packages/db/src/canonical-template-transition.test.ts
@@ -16,7 +16,12 @@ import {
   type CanonicalTemplateRegistryName,
   type PersistedTransitionStep,
 } from "./canonical-template-transition.js";
-import { loadAllTemplateStepSources, type TemplateStepSource } from "./template-sources.js";
+import { retiredStepShapeDifferences, type LegacyStepRecord } from "./template-step-fields.js";
+import {
+  LEGACY_ALL_PRIOR_OUTPUTS,
+  loadAllTemplateStepSources,
+  type TemplateStepSource,
+} from "./template-sources.js";
 
 test("parked and not-yet-started legacy chains may roll over intact", () => {
   assert.equal(templateRolloverBlockerCount([
@@ -79,12 +84,29 @@ const persistedGeneration = (
   attachmentsFromPrevious: step.attachmentsFromPrevious,
   priorOutputKinds: [],
   opensPullRequest: step.opensPullRequest,
-  requiresCommit: step.outputKind === "plan" || step.outputKind === "implementation",
+  requiresCommit: step.requiresCommit ?? false,
   provisionDependencies,
   baseFromStepIndex: step.baseFromStepIndex,
   spawnPolicy: step.spawnPolicy,
   prompt: "retired",
 })) as unknown as PersistedTransitionStep[];
+
+/** One source step as the registry would record it: every field stated as data. */
+const asLegacyRecord = (step: TemplateStepSource): LegacyStepRecord => ({
+  name: step.name,
+  agentName: step.agentName,
+  assigneeType: (step.agentName === null ? "HUMAN" : "AGENT") as LegacyStepRecord["assigneeType"],
+  layer: step.layer,
+  approvalGate: step.approvalGate,
+  optional: step.optional,
+  outputKind: step.outputKind,
+  attachmentsFromPrevious: step.attachmentsFromPrevious,
+  opensPullRequest: step.opensPullRequest,
+  requiresCommit: step.requiresCommit,
+  provisionDependencies: step.provisionDependencies,
+  baseFromStepIndex: step.baseFromStepIndex,
+  spawnPolicy: step.spawnPolicy as LegacyStepRecord["spawnPolicy"],
+});
 
 const PROMPT_ROLLOVER_TEMPLATES = ["direct-engineer-workflow", "compound-engineer-workflow"] as const;
 
@@ -190,6 +212,7 @@ test("a structure-identical generation is decided by its prompt digest alone", (
     outputKind: "implementation",
     attachmentsFromPrevious: false,
     opensPullRequest: true,
+    requiresCommit: true,
     baseFromStepIndex: null,
     layer: 1,
     spawnPolicy: null,
@@ -360,7 +383,7 @@ test("bound direct revalidation is a registered structural rollover", async () =
       outputKind: step.outputKind,
       attachmentsFromPrevious: step.attachmentsFromPrevious,
       opensPullRequest: step.opensPullRequest,
-      requiresCommit: step.outputKind === "plan" || step.outputKind === "implementation",
+      requiresCommit: step.requiresCommit ?? false,
       provisionDependencies: true,
       baseFromStepIndex: step.baseFromStepIndex,
       spawnPolicy: step.spawnPolicy,
@@ -379,20 +402,12 @@ test("the pull-request workflow has a registered prompt-only generation and curr
   const generation = generationOf(PR_TEMPLATE_NAME, "pre-pr-handover-quality");
   assert.equal(generation.promptDigest, "93a72d354876a6c26020e8638b6c365fb15e4ca4a400a2d6ca80084994f249d6");
   assert.equal(generation.shape.length, 4);
+  // The retired graph against the current one, field by field through the
+  // shared table: identical except that its review steps predate opting out of
+  // dependency provisioning, which is what tells the two shapes apart.
   assert.deepEqual(
-    generation.shape,
-    current.map(({ name, agentName, approvalGate, outputKind, attachmentsFromPrevious, opensPullRequest, baseFromStepIndex, layer, spawnPolicy }) => ({
-      name,
-      agentName,
-      assigneeType: agentName === null ? "HUMAN" : "AGENT",
-      approvalGate,
-      outputKind,
-      attachmentsFromPrevious,
-      opensPullRequest,
-      baseFromStepIndex,
-      layer,
-      spawnPolicy,
-    })),
+    asPersisted(current).map((step, index) => retiredStepShapeDifferences(step, generation.shape[index]!)),
+    [[], ["provisionDependencies"], ["provisionDependencies"], []],
   );
   assert.equal(templatePromptGenerationDigest(current), CANONICAL_SOURCE_PROMPT_GENERATIONS[PR_TEMPLATE_NAME]);
   assert.equal(matchedLegacyGeneration(PR_TEMPLATE_NAME, asPersisted(current)), null);
@@ -496,4 +511,45 @@ test("every registered generation, structural ones included, rolls straight to t
     assert.ok(current, `${templateName} must load from source`);
     assert.equal(sourcePromptGenerationDrift(templateName, current), null, templateName);
   }
+});
+
+test("the next prompt-only rollover of the optional-review graphs is registrable", async () => {
+  // The block the optional column left behind: the deployed direct and compound
+  // graphs carry an optional blind review, so a prompt-only successor could not
+  // be registered while the comparator asserted a fixed value for that field.
+  // Registered here in test data only; the real registry is untouched.
+  const sources = await loadAllTemplateStepSources();
+  for (const templateName of PROMPT_ROLLOVER_TEMPLATES) {
+    const current = sources.get(templateName);
+    assert.ok(current, `${templateName} must load from source`);
+    assert.ok(
+      current.some((step) => step.outputKind === "blind-findings" && step.optional),
+      `${templateName} must still carry an optional blind review`,
+    );
+    const rows = asPersisted(current);
+    const registered = {
+      marker: "synthetic-prompt-only-successor",
+      shape: current.map(asLegacyRecord),
+      promptDigest: templatePromptGenerationDigest(rows),
+    };
+
+    assert.equal(legacyGenerationMatches(registered, rows), true, templateName);
+    const successor = rows.map((step) => ({ ...step, prompt: `${step.prompt}\n\nthe replacement instruction` }));
+    assert.equal(legacyGenerationMatches(registered, successor), false, templateName);
+  }
+});
+
+test("a retired generation is identified without its prior-output whitelist", () => {
+  // The whitelist migration rewrites this column on rows of every generation,
+  // so reading it would refuse the rollover of any row it has not reached.
+  const generation = generationOf("direct-engineer-workflow", "pre-adjudication");
+  const rows = persistedGeneration(generation, true);
+  assert.equal(legacyGenerationMatches(generation, rows), true);
+  assert.equal(
+    legacyGenerationMatches(
+      generation,
+      rows.map((step) => ({ ...step, priorOutputKinds: [LEGACY_ALL_PRIOR_OUTPUTS] })),
+    ),
+    true,
+  );
 });

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -1,33 +1,11 @@
 import { createHash } from "node:crypto";
-import { isDeepStrictEqual } from "node:util";
 
-import { AssigneeType, Prisma, RunStatus } from "@prisma/client";
+import { AssigneeType, RunStatus } from "@prisma/client";
 
 import { PR_TEMPLATE_NAME } from "./agent-contract.js";
 import { stepRole, type StepRole } from "./step-role.js";
-
-export type LegacyStepRecord = Readonly<{
-  name: string;
-  agentName: string | null;
-  assigneeType: AssigneeType;
-  approvalGate: boolean;
-  /**
-   * Defaults to false: generations registered before optional steps existed
-   * have no optional step, and their deployed rows are all optional = false.
-   */
-  optional?: boolean;
-  outputKind: string;
-  attachmentsFromPrevious: boolean;
-  opensPullRequest: boolean;
-  baseFromStepIndex: number | null;
-  layer: number;
-  spawnPolicy: Prisma.JsonValue;
-  /**
-   * Defaults to true: generations registered before this field existed
-   * predate steps that opt out of dependency provisioning.
-   */
-  provisionDependencies?: boolean;
-}>;
+import { retiredStepShapeDifferences, type LegacyStepRecord } from "./template-step-fields.js";
+import type { PersistedTemplateStepStructure } from "./template-sources.js";
 
 /**
  * Every retired canonical graph, keyed by the marker its renamed rows carry.
@@ -104,7 +82,7 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-narrow-regression-lease",
       shape: [
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
@@ -116,7 +94,7 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-adjudication",
       shape: [
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Opus adjudication", agentName: "review-adjudicator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "must-fix", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 3, spawnPolicy: null },
@@ -132,7 +110,7 @@ const legacyTemplateGenerations = {
       // changed prompts only. `promptDigest` is what tells the two apart.
       promptDigest: "1b2447559a77e28added3509a6f6b17bce8a8cd7db9113bdaaa17d581d874165",
       shape: [
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
@@ -145,7 +123,7 @@ const legacyTemplateGenerations = {
       marker: "pre-platform-spec-materialization",
       promptDigest: "c1a9ec1f8e783c3c814c0d0f5f4a9b91d5759b9dc39473dc200447aeb96677c5",
       shape: [
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
@@ -160,7 +138,7 @@ const legacyTemplateGenerations = {
       marker: "pre-regression-step-split",
       promptDigest: "a760a6ca04bc047b47831fc4a4064cf2157487142f32a480223d6b5d8187c4a1",
       shape: [
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
@@ -173,7 +151,7 @@ const legacyTemplateGenerations = {
       marker: "pre-internal-npm-scope-rename",
       promptDigest: "3b50afcdd5aef2d0f06b00b7644cc67fac3ffbd29414e44564dc6aeb9757580d",
       shape: [
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
@@ -199,7 +177,7 @@ const legacyTemplateGenerations = {
         integrator: 8,
       },
       shape: [
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
@@ -217,7 +195,7 @@ const legacyTemplateGenerations = {
       promptDigest: "0aa379a51d722ec9b8b5d91bc6158d9dd9a1f5d380b50695613d5aece9afda46",
       shape: [
         { name: "Revalidate specification", agentName: "spec-revalidator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
@@ -231,7 +209,7 @@ const legacyTemplateGenerations = {
       promptDigest: "c0ec5acb70b82b85bc3f3aff5840029a303d31e6098b7171a2bef35f105f3371",
       shape: [
         { name: "Revalidate specification", agentName: "spec-revalidator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
@@ -245,7 +223,7 @@ const legacyTemplateGenerations = {
       promptDigest: "e8fdf5533275e85e33b0cf812db9474b00214de2401e4c97bb6eb0732f864df8",
       shape: [
         { name: "Revalidate specification", agentName: "spec-revalidator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
@@ -260,10 +238,10 @@ const legacyTemplateGenerations = {
       marker: "pre-narrow-regression-lease",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
-        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
@@ -277,10 +255,10 @@ const legacyTemplateGenerations = {
       marker: "pre-adjudication",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: true, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: true, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
-        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Opus adjudication", agentName: "review-adjudicator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "must-fix", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 7, spawnPolicy: null },
@@ -295,10 +273,10 @@ const legacyTemplateGenerations = {
       marker: "pre-zero-gate",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: true, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: true, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
-        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
@@ -315,10 +293,10 @@ const legacyTemplateGenerations = {
       promptDigest: "a9994d131d1cf2667c6d61cc7161f5653cf9903a6aae77ed55c18b1db6fb3cf2",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
-        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
@@ -335,10 +313,10 @@ const legacyTemplateGenerations = {
       promptDigest: "74fe9add0789494efce82d477ea472ce2a16132fe105e6f12c87223c18dbabf8",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
-        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
@@ -353,10 +331,10 @@ const legacyTemplateGenerations = {
       promptDigest: "79845a3badc75200d30ac22cb4fb10c6efa38308c31156e7b15f4c8475e9f7ff",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
-        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
@@ -371,10 +349,10 @@ const legacyTemplateGenerations = {
       promptDigest: "606f9b5a667781cde3400d114cc7f2ebf00bada6995eee07a7019b63e7dd8424",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
-        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
@@ -389,10 +367,10 @@ const legacyTemplateGenerations = {
       promptDigest: "27d552a220439bc091956173bc5ee12e5e7158b160fb015443a68f2e744e85d8",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
-        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
@@ -407,10 +385,10 @@ const legacyTemplateGenerations = {
       promptDigest: "c3b3bb4692bda266e5afd81bb6ad258f58bd1eed14240f272338e0f44fa5e97e",
       shape: [
         { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
-        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
         { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
         { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
-        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null, provisionDependencies: false },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null, provisionDependencies: false },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
@@ -430,7 +408,7 @@ const legacyTemplateGenerations = {
       marker: "pre-pr-handover-quality",
       promptDigest: "93a72d354876a6c26020e8638b6c365fb15e4ca4a400a2d6ca80084994f249d6",
       shape: [
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
@@ -442,7 +420,7 @@ const legacyTemplateGenerations = {
       marker: "pre-pr-head-tree-check",
       promptDigest: "805b9e911be94c84e451cdbf4d1cdb93ab10031c031c6854947f56d306fb1906",
       shape: [
-        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
@@ -623,28 +601,26 @@ export const templateRolloverBlockerCount = (
 export const legacyAdjudicationTemplateName = (templateName: string, templateId: string): string =>
   legacyTemplateName(templateName, "pre-adjudication", templateId);
 
-export type PersistedTransitionStep = {
+/**
+ * A persisted step as a transition reads it: the structural columns every
+ * row-vs-spec comparison uses, plus the identity, prompt and task count a
+ * rollover decision needs. `optional` is required here because every row a
+ * transition sees carries the column.
+ */
+export type PersistedTransitionStep = PersistedTemplateStepStructure & {
   id: string;
   taskTemplateId: string;
   stepIndex: number;
-  name: string;
-  assigneeAgent: { name: string } | null;
-  assigneeType: string;
-  layer?: number | null;
-  approvalGate: boolean;
   optional: boolean;
-  outputKind: string;
-  attachmentsFromPrevious: boolean;
-  priorOutputKinds: string[];
-  opensPullRequest: boolean;
-  requiresCommit: boolean;
-  provisionDependencies: boolean;
-  baseFromStepIndex: number | null;
-  spawnPolicy: Prisma.JsonValue;
   prompt: string;
   _count?: { tasks: number };
 };
 
+/**
+ * Whether a persisted graph is exactly the graph a generation registered:
+ * contiguous step indexes from 1, and every structural field of every step
+ * equal to what the record states.
+ */
 const shapeMatches = (
   steps: readonly PersistedTransitionStep[],
   expected: readonly LegacyStepRecord[],
@@ -652,25 +628,7 @@ const shapeMatches = (
   if (steps.length !== expected.length) return false;
   const ordered = [...steps].sort((left, right) => left.stepIndex - right.stepIndex);
   if (ordered.some((step, index) => step.stepIndex !== index + 1)) return false;
-  for (const [index, step] of ordered.entries()) {
-    const expectedStep = expected[index]!;
-    if (step.name !== expectedStep.name
-      || (step.assigneeAgent?.name ?? null) !== expectedStep.agentName
-      || step.assigneeType !== expectedStep.assigneeType
-      || step.approvalGate !== expectedStep.approvalGate
-      || step.optional !== (expectedStep.optional ?? false)
-      || step.outputKind !== expectedStep.outputKind
-      || step.attachmentsFromPrevious !== expectedStep.attachmentsFromPrevious
-      || step.opensPullRequest !== expectedStep.opensPullRequest
-      || step.requiresCommit !== (expectedStep.outputKind === "plan" || expectedStep.outputKind === "implementation")
-      || step.provisionDependencies !== (expectedStep.provisionDependencies ?? true)
-      || step.baseFromStepIndex !== expectedStep.baseFromStepIndex
-      || step.layer !== expectedStep.layer
-      || !isDeepStrictEqual(step.spawnPolicy, expectedStep.spawnPolicy)) {
-      return false;
-    }
-  }
-  return true;
+  return ordered.every((step, index) => retiredStepShapeDifferences(step, expected[index]!).length === 0);
 };
 
 /**

--- a/packages/db/src/template-sources.test.ts
+++ b/packages/db/src/template-sources.test.ts
@@ -12,6 +12,10 @@ import { DIRECT_TEMPLATE_NAME, PR_TEMPLATE_NAME } from "./agent-contract.js";
 import { canonicalOutputSchema, canonicalOutputSchemas } from "./canonical-output-schema.js";
 import { INTEGRATOR_TEMPLATE_NAME } from "./merge-integrator.js";
 import {
+  retiredStepShapeDifferences,
+  type LegacyStepRecord,
+} from "./template-step-fields.js";
+import {
   loadAllTemplateStepSources,
   loadTemplateStepSources,
   templateStepStructureDifferences,
@@ -598,5 +602,96 @@ test("layer, requiresCommit, and dependency provisioning are structural fields i
   assert.deepEqual(
     templateStepStructureDifferences({ ...persisted, provisionDependencies: !expected.provisionDependencies }, expected),
     ["provisionDependencies"],
+  );
+});
+
+test("one field table decides both row-vs-spec comparisons", async () => {
+  // The roster, pinned: a structural column added to a step shape without an
+  // entry in the field table cannot make either comparator report it.
+  const expected = (await loadTemplateStepSources(DIRECT_TEMPLATE_NAME))[2]!;
+  const persisted: PersistedTemplateStepStructure = {
+    name: expected.name,
+    assigneeAgent: { name: expected.agentName! },
+    assigneeType: "AGENT",
+    layer: expected.layer,
+    approvalGate: expected.approvalGate,
+    optional: expected.optional,
+    outputKind: expected.outputKind,
+    attachmentsFromPrevious: expected.attachmentsFromPrevious,
+    priorOutputKinds: expected.priorOutputKinds,
+    opensPullRequest: expected.opensPullRequest,
+    requiresCommit: expected.requiresCommit,
+    provisionDependencies: expected.provisionDependencies,
+    baseFromStepIndex: expected.baseFromStepIndex,
+    spawnPolicy: expected.spawnPolicy as PersistedTemplateStepStructure["spawnPolicy"],
+  };
+  const changed: PersistedTemplateStepStructure = {
+    name: `${expected.name} (renamed)`,
+    assigneeAgent: null,
+    assigneeType: "HUMAN",
+    layer: expected.layer + 1,
+    approvalGate: !expected.approvalGate,
+    optional: !expected.optional,
+    outputKind: `${expected.outputKind}-v2`,
+    attachmentsFromPrevious: !expected.attachmentsFromPrevious,
+    priorOutputKinds: [...expected.priorOutputKinds, "spec"],
+    opensPullRequest: !expected.opensPullRequest,
+    requiresCommit: !expected.requiresCommit,
+    provisionDependencies: !expected.provisionDependencies,
+    baseFromStepIndex: (expected.baseFromStepIndex ?? 0) + 1,
+    spawnPolicy: { changed: true },
+  };
+  assert.deepEqual(templateStepStructureDifferences(changed, expected), [
+    "name", "agent", "assigneeType", "layer", "approvalGate", "optional", "outputKind",
+    "attachmentsFromPrevious", "priorOutputKinds", "opensPullRequest", "requiresCommit",
+    "provisionDependencies", "baseFromStepIndex", "spawnPolicy",
+  ]);
+
+  // The retired-shape reading of the same table: every field is data on the
+  // record, and the prior-output whitelist is deliberately not read, because
+  // its migration is independent of any graph transition.
+  const record: LegacyStepRecord = {
+    name: expected.name,
+    agentName: expected.agentName,
+    assigneeType: "AGENT" as LegacyStepRecord["assigneeType"],
+    layer: expected.layer,
+    approvalGate: expected.approvalGate,
+    optional: expected.optional,
+    outputKind: expected.outputKind,
+    attachmentsFromPrevious: expected.attachmentsFromPrevious,
+    opensPullRequest: expected.opensPullRequest,
+    requiresCommit: expected.requiresCommit,
+    provisionDependencies: expected.provisionDependencies,
+    baseFromStepIndex: expected.baseFromStepIndex,
+    spawnPolicy: expected.spawnPolicy as LegacyStepRecord["spawnPolicy"],
+  };
+  assert.deepEqual(retiredStepShapeDifferences(persisted, record), []);
+  assert.deepEqual(retiredStepShapeDifferences({ ...persisted, priorOutputKinds: ["anything"] }, record), []);
+  assert.deepEqual(retiredStepShapeDifferences(changed, record), [
+    "name", "agent", "assigneeType", "layer", "approvalGate", "optional", "outputKind",
+    "attachmentsFromPrevious", "opensPullRequest", "requiresCommit",
+    "provisionDependencies", "baseFromStepIndex", "spawnPolicy",
+  ]);
+
+  // An omitted field is the documented default, not an unconstrained one.
+  const omitted: LegacyStepRecord = {
+    name: record.name,
+    agentName: record.agentName,
+    assigneeType: record.assigneeType,
+    layer: record.layer,
+    approvalGate: record.approvalGate,
+    outputKind: record.outputKind,
+    attachmentsFromPrevious: record.attachmentsFromPrevious,
+    opensPullRequest: record.opensPullRequest,
+    baseFromStepIndex: record.baseFromStepIndex,
+    spawnPolicy: record.spawnPolicy,
+  };
+  assert.deepEqual(
+    retiredStepShapeDifferences({ ...persisted, optional: false, requiresCommit: false, provisionDependencies: true }, omitted),
+    [],
+  );
+  assert.deepEqual(
+    retiredStepShapeDifferences({ ...persisted, optional: true, requiresCommit: false, provisionDependencies: true }, omitted),
+    ["optional"],
   );
 });

--- a/packages/db/src/template-sources.ts
+++ b/packages/db/src/template-sources.ts
@@ -9,6 +9,13 @@ import { DIRECT_TEMPLATE_NAME, PR_TEMPLATE_NAME } from "./agent-contract.js";
 import { gateSlotOf } from "./gate-slot.js";
 import { INTEGRATOR_TEMPLATE_NAME } from "./merge-integrator.js";
 import { parseInlineList, parsePromptDocument, requiredFrontmatter } from "./prompt-document.js";
+import { TEMPLATE_STEP_FRONTMATTER_KEYS } from "./template-step-fields.js";
+
+/**
+ * The row-vs-source comparator this module presents, built from the one field
+ * table `template-step-fields.ts` holds.
+ */
+export { templateStepStructureDifferences } from "./template-step-fields.js";
 
 const templatesRoot = fileURLToPath(new URL("../../../agents/templates/", import.meta.url));
 /** Migration-only marker: pre-whitelist template rows retain the old all-output handoff. */
@@ -52,21 +59,6 @@ export const canonicalTemplateSourceSpec = (name: CanonicalTemplateName) => {
   if (!spec) throw new Error(`Unknown canonical template source ${name}`);
   return spec;
 };
-const STRUCTURAL_FIELDS = [
-  "stepIndex",
-  "layer",
-  "agent",
-  "approvalGate",
-  "optional",
-  "outputKind",
-  "attachmentsFromPrevious",
-  "priorOutputKinds",
-  "opensPullRequest",
-  "requiresCommit",
-  "provisionDependencies",
-  "baseFromStepIndex",
-  "spawnPolicy",
-] as const;
 
 export type TemplateStepSource = {
   stepIndex: number;
@@ -129,32 +121,6 @@ export const templateMetadataDifferences = (
     .map(([field]) => field);
 };
 
-export const templateStepStructureDifferences = (
-  actual: PersistedTemplateStepStructure,
-  expected: TemplateStepSource,
-): string[] => {
-  const expectedAssigneeType = expected.agentName === null ? "HUMAN" : "AGENT";
-  const fields = [
-    ["name", actual.name, expected.name],
-    ["agent", actual.assigneeAgent?.name ?? null, expected.agentName],
-    ["assigneeType", actual.assigneeType, expectedAssigneeType],
-    ["layer", actual.layer, expected.layer],
-    ["approvalGate", actual.approvalGate, expected.approvalGate],
-    ["optional", actual.optional, expected.optional],
-    ["outputKind", actual.outputKind, expected.outputKind],
-    ["attachmentsFromPrevious", actual.attachmentsFromPrevious, expected.attachmentsFromPrevious],
-    ["priorOutputKinds", actual.priorOutputKinds, expected.priorOutputKinds],
-    ["opensPullRequest", actual.opensPullRequest, expected.opensPullRequest],
-    ["requiresCommit", actual.requiresCommit, expected.requiresCommit],
-    ["provisionDependencies", actual.provisionDependencies, expected.provisionDependencies],
-    ["baseFromStepIndex", actual.baseFromStepIndex, expected.baseFromStepIndex],
-    ["spawnPolicy", actual.spawnPolicy, expected.spawnPolicy],
-  ] as const;
-  return fields
-    .filter(([, actualValue, expectedValue]) => !isDeepStrictEqual(actualValue, expectedValue))
-    .map(([field]) => field);
-};
-
 const parseBoolean = (value: string, filePath: string, key: string): boolean => {
   if (value !== "true" && value !== "false") throw new Error(`${filePath} ${key} must be true or false`);
   return value === "true";
@@ -207,9 +173,9 @@ export const loadTemplateStepSources = async (
     const filePath = join(templateRoot, filename);
     const document = parsePromptDocument(await readFile(filePath, "utf8"), filePath);
     const keys = Object.keys(document.attributes).sort();
-    const expectedKeys = [...STRUCTURAL_FIELDS].sort();
+    const expectedKeys = [...TEMPLATE_STEP_FRONTMATTER_KEYS].sort();
     if (JSON.stringify(keys) !== JSON.stringify(expectedKeys)) {
-      throw new Error(`${filePath} frontmatter must contain exactly ${STRUCTURAL_FIELDS.join(", ")}`);
+      throw new Error(`${filePath} frontmatter must contain exactly ${TEMPLATE_STEP_FRONTMATTER_KEYS.join(", ")}`);
     }
     const stepIndex = parseStepIndex(requiredFrontmatter(document, "stepIndex", filePath), filePath);
     if (Number(filename.slice(0, 2)) !== stepIndex) throw new Error(`${filePath} prefix does not match stepIndex ${stepIndex}`);

--- a/packages/db/src/template-step-fields.ts
+++ b/packages/db/src/template-step-fields.ts
@@ -1,0 +1,220 @@
+/**
+ * The one description of a template step's structural fields.
+ *
+ * `template-sources.ts` presents the row-vs-source comparison and
+ * `canonical-template-transition.ts` matches retired generations; both read the
+ * same table from here, so a structural column is described once. This module
+ * imports nothing at run time on purpose: `template-sources.ts` evaluates the
+ * canonical source specs during module initialization, and a run-time edge back
+ * into it from the transition registry deadlocks that initialization.
+ */
+import { isDeepStrictEqual } from "node:util";
+
+import type { AssigneeType, Prisma } from "@prisma/client";
+
+import type { PersistedTemplateStepStructure, TemplateStepSource } from "./template-sources.js";
+
+/**
+ * One step of a retired canonical graph, as `canonical-template-transition.ts`
+ * registers it. A generation states what its deployed rows carried; a field it
+ * omits takes the default documented on that field and nothing else. No value
+ * is derived from another field inside a comparator.
+ */
+export type LegacyStepRecord = Readonly<{
+  name: string;
+  agentName: string | null;
+  assigneeType: AssigneeType;
+  layer: number;
+  approvalGate: boolean;
+  /**
+   * Defaults to false: generations registered before optional steps existed
+   * have no optional step, and their deployed rows are all optional = false.
+   */
+  optional?: boolean;
+  outputKind: string;
+  attachmentsFromPrevious: boolean;
+  opensPullRequest: boolean;
+  /** Defaults to false: a generation states this at the steps that committed. */
+  requiresCommit?: boolean;
+  /**
+   * Defaults to true: generations registered before this field existed
+   * predate steps that opt out of dependency provisioning.
+   */
+  provisionDependencies?: boolean;
+  baseFromStepIndex: number | null;
+  spawnPolicy: Prisma.JsonValue;
+}>;
+
+/**
+ * One structural field of a template step. Three shapes describe the same
+ * step -- the persisted row, the Markdown source, and the record a retired
+ * generation registers -- and this table says once how each of them states the
+ * field.
+ */
+type TemplateStepField = Readonly<{
+  /** The difference name callers report and `canonical-step-adoption.ts` keys on. */
+  field: string;
+  /** The frontmatter key that authors this field, or null when the source derives it. */
+  frontmatterKey: string | null;
+  persisted: (actual: PersistedTemplateStepStructure) => unknown;
+  fromSource: (expected: TemplateStepSource) => unknown;
+  /**
+   * The value a retired generation's record states, or null when the field
+   * cannot identify a generation. `priorOutputKinds` is the only such field:
+   * the whitelist migration rewrote it independently of any graph transition,
+   * so rows of one retired generation legitimately carry either the whitelist
+   * or the retired all-outputs marker that `canonical-step-adoption.ts`
+   * forgives at every step, and matching it exactly would refuse the rollover
+   * of every row the migration has not reached.
+   */
+  fromRetiredShape: ((expected: LegacyStepRecord) => unknown) | null;
+}>;
+
+/**
+ * The structural fields of a template step, stated once.
+ *
+ * Both row-vs-spec comparators are built from this table:
+ * `templateStepStructureDifferences` compares a row with its Markdown source,
+ * and `retiredStepShapeDifferences` compares a row with the record of a retired
+ * generation. A new structural column is one entry here plus one field on each
+ * shape it belongs to; it is never a branch inside a comparator.
+ *
+ * The table is shared, the tolerance is not. Source drift is forgiven per step
+ * by `canonical-step-adoption.ts`; a retired shape is exact historical identity
+ * and forgives nothing.
+ */
+const TEMPLATE_STEP_FIELDS: readonly TemplateStepField[] = [
+  {
+    field: "name",
+    frontmatterKey: null,
+    persisted: (actual) => actual.name,
+    fromSource: (expected) => expected.name,
+    fromRetiredShape: (expected) => expected.name,
+  },
+  {
+    field: "agent",
+    frontmatterKey: "agent",
+    persisted: (actual) => actual.assigneeAgent?.name ?? null,
+    fromSource: (expected) => expected.agentName,
+    fromRetiredShape: (expected) => expected.agentName,
+  },
+  {
+    field: "assigneeType",
+    frontmatterKey: null,
+    persisted: (actual) => actual.assigneeType,
+    fromSource: (expected) => (expected.agentName === null ? "HUMAN" : "AGENT"),
+    fromRetiredShape: (expected) => expected.assigneeType,
+  },
+  {
+    field: "layer",
+    frontmatterKey: "layer",
+    persisted: (actual) => actual.layer,
+    fromSource: (expected) => expected.layer,
+    fromRetiredShape: (expected) => expected.layer,
+  },
+  {
+    field: "approvalGate",
+    frontmatterKey: "approvalGate",
+    persisted: (actual) => actual.approvalGate,
+    fromSource: (expected) => expected.approvalGate,
+    fromRetiredShape: (expected) => expected.approvalGate,
+  },
+  {
+    field: "optional",
+    frontmatterKey: "optional",
+    persisted: (actual) => actual.optional,
+    fromSource: (expected) => expected.optional,
+    fromRetiredShape: (expected) => expected.optional ?? false,
+  },
+  {
+    field: "outputKind",
+    frontmatterKey: "outputKind",
+    persisted: (actual) => actual.outputKind,
+    fromSource: (expected) => expected.outputKind,
+    fromRetiredShape: (expected) => expected.outputKind,
+  },
+  {
+    field: "attachmentsFromPrevious",
+    frontmatterKey: "attachmentsFromPrevious",
+    persisted: (actual) => actual.attachmentsFromPrevious,
+    fromSource: (expected) => expected.attachmentsFromPrevious,
+    fromRetiredShape: (expected) => expected.attachmentsFromPrevious,
+  },
+  {
+    field: "priorOutputKinds",
+    frontmatterKey: "priorOutputKinds",
+    persisted: (actual) => actual.priorOutputKinds,
+    fromSource: (expected) => expected.priorOutputKinds,
+    fromRetiredShape: null,
+  },
+  {
+    field: "opensPullRequest",
+    frontmatterKey: "opensPullRequest",
+    persisted: (actual) => actual.opensPullRequest,
+    fromSource: (expected) => expected.opensPullRequest,
+    fromRetiredShape: (expected) => expected.opensPullRequest,
+  },
+  {
+    field: "requiresCommit",
+    frontmatterKey: "requiresCommit",
+    persisted: (actual) => actual.requiresCommit,
+    fromSource: (expected) => expected.requiresCommit,
+    fromRetiredShape: (expected) => expected.requiresCommit ?? false,
+  },
+  {
+    field: "provisionDependencies",
+    frontmatterKey: "provisionDependencies",
+    persisted: (actual) => actual.provisionDependencies,
+    fromSource: (expected) => expected.provisionDependencies,
+    fromRetiredShape: (expected) => expected.provisionDependencies ?? true,
+  },
+  {
+    field: "baseFromStepIndex",
+    frontmatterKey: "baseFromStepIndex",
+    persisted: (actual) => actual.baseFromStepIndex,
+    fromSource: (expected) => expected.baseFromStepIndex,
+    fromRetiredShape: (expected) => expected.baseFromStepIndex,
+  },
+  {
+    field: "spawnPolicy",
+    frontmatterKey: "spawnPolicy",
+    persisted: (actual) => actual.spawnPolicy,
+    fromSource: (expected) => expected.spawnPolicy,
+    fromRetiredShape: (expected) => expected.spawnPolicy,
+  },
+];
+
+/**
+ * The exact frontmatter contract of a step prompt: its own index plus every
+ * structural field the table says the author writes.
+ */
+export const TEMPLATE_STEP_FRONTMATTER_KEYS: readonly string[] = [
+  "stepIndex",
+  ...TEMPLATE_STEP_FIELDS.flatMap(({ frontmatterKey }) => (frontmatterKey === null ? [] : [frontmatterKey])),
+];
+
+/**
+ * The fields in which a persisted step differs from its Markdown source.
+ * Callers decide what to do with each name: `canonical-step-adoption.ts` says
+ * which are forgiven at which step, and every other difference is drift.
+ */
+export const templateStepStructureDifferences = (
+  actual: PersistedTemplateStepStructure,
+  expected: TemplateStepSource,
+): string[] => TEMPLATE_STEP_FIELDS
+  .filter((entry) => !isDeepStrictEqual(entry.persisted(actual), entry.fromSource(expected)))
+  .map((entry) => entry.field);
+
+/**
+ * The fields in which a persisted step differs from the record of the retired
+ * generation it is claimed to be. Empty means exact historical identity: this
+ * comparison forgives nothing, so a rollover renames only a row that really is
+ * the registered graph.
+ */
+export const retiredStepShapeDifferences = (
+  actual: PersistedTemplateStepStructure,
+  expected: LegacyStepRecord,
+): string[] => TEMPLATE_STEP_FIELDS
+  .filter((entry) => entry.fromRetiredShape !== null
+    && !isDeepStrictEqual(entry.persisted(actual), entry.fromRetiredShape(expected)))
+  .map((entry) => entry.field);


### PR DESCRIPTION
## What changed

A template step's structural fields are described once, in the new module
`packages/db/src/template-step-fields.ts`, and both row-vs-spec comparators are
built from that table:

- `templateStepStructureDifferences` (a persisted row against its Markdown
  source), which `template-sources.ts` still presents to its callers.
- `retiredStepShapeDifferences` (a persisted row against the record a retired
  generation registers), which `shapeMatches` in
  `canonical-template-transition.ts` now consumes.

The table is shared; the tolerance is not. Source drift stays forgiving through
`canonical-step-adoption.ts`; retired-shape matching stays exact historical
identity and forgives nothing.

Each table entry says how one field is read from the persisted row, from the
Markdown source, and from the retired record, so the two comparators can no
longer drift apart in either direction. Three consequences:

- Every field a retired generation states is data on `LegacyStepRecord`.
  `requiresCommit` was derived inside the comparator from `outputKind`; it is
  now recorded at the 30 registered steps that committed, with the same values
  the derivation produced.
- The frontmatter contract of a step prompt is derived from the same table
  (`TEMPLATE_STEP_FRONTMATTER_KEYS`) instead of a second hand-kept list in
  `template-sources.ts`.
- `PersistedTransitionStep` extends `PersistedTemplateStepStructure` instead of
  restating the same fourteen columns.

The latent block the audit named is gone and is now pinned by a test: a
prompt-only rollover of the direct and compound graphs, whose blind-review step
is `optional: true`, registers and matches in test data with no change to the
comparator. No registered generation was added, removed or re-pinned, and the
digest computation lane t1 delivered is untouched.

## Evidence

Run in the lane worktree after the final commit `8625f424`, with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh temporary directory:

- `npm run lint` -- pass (biome 777 files, then eslint; exit 0).
- `npm run typecheck` -- pass, exit 0, every workspace.
- `npm run test -w @anneal/db` -- 432 tests, 432 pass, 0 fail.
- `npm run test:snapshot-scan` (a file was added) -- 21 tests, 21 pass, 0 fail.
  The new module needs no `public-snapshot.json` entry: the db source surface is
  published by glob, and the scan is green with the file tracked.

Not run: `test:db`. There is no local PostgreSQL; database tests are merge gate
evidence. No `*.dbtest.ts` file was changed.

## Decisions taken

**`priorOutputKinds` stays out of the retired-shape comparison, as a stated
entry in the table rather than a silent omission.** The brief listed it among
the shared fields because `shapeMatches` compares it nowhere. Reading it would
be wrong, not just stricter: `canonical-step-adoption.ts` forgives
`[LEGACY_ALL_PRIOR_OUTPUTS]` at *every* step because the whitelist migration
rewrites that column independently of any graph transition, so two rows of the
same retired generation legitimately differ in it depending on whether the
migration has reached them. Comparing it exactly would make
`matchedLegacyGeneration` return null for every un-migrated row, which turns a
registered rollover into a refused deploy. The table therefore carries a
`fromRetiredShape: null` entry for it with the reason written down, so the next
person adding a column decides consciously instead of forgetting. A unit test
pins it: a retired generation is still identified when its rows carry the
pre-whitelist marker.

**The table lives in its own module, not in `template-sources.ts`.** That was
the first shape I built, and it deadlocks module initialization:
`template-sources.ts` evaluates `CANONICAL_TEMPLATE_SOURCE_SPECS` at load time
from `merge-integrator.js`, which imports `canonical-template-transition.js`, so
a run-time edge from the transition registry back into `template-sources.ts`
closes a cycle and throws `Cannot access 'INTEGRATOR_TEMPLATE_NAME' before
initialization` (observed: `src/merge-integrator.test.ts`,
`prisma/agent-contract.test.ts` and two more suites failed on it).
`template-step-fields.ts` imports nothing at run time, which is why it is a
separate module; the reason is recorded in its header so it is not merged back.
`template-sources.ts` re-exports `templateStepStructureDifferences`, so its
interface and every existing import site are unchanged.

**`optional`, `requiresCommit` and `provisionDependencies` keep a documented
default on the record rather than being restated on all 191 registered steps.**
An omitted field means exactly the default written on it, which is data about
what those generations carried, not a branch: the defaults live in the table's
readers and are pinned by a unit test that a record omitting them matches only
rows carrying the default values.

**The two shape assertions that pinned the old projection were rewritten in the
table's vocabulary rather than extended by hand.** The pull-request generation
assertion now states the exact per-step difference from the current graph
(`[[], ["provisionDependencies"], ["provisionDependencies"], []]`), which is
both stronger and true; the previous literal projection silently omitted
`provisionDependencies` and would have kept omitting any future column.

## Fence widened

- Added `packages/db/src/template-step-fields.ts`. Lane t2's owned paths in
  `QUEUE.md` name no new module, and a new file belongs to no lane; it is taken
  under rule 1. It holds only the shared table and the two comparators, and the
  cycle above forces it to be its own module.
- `packages/db/src/canonical-template-transition.ts`: besides `shapeMatches` and
  `LegacyStepRecord`, `PersistedTransitionStep` in the same file now extends
  `PersistedTemplateStepStructure`. No other lane owns that type; lane t4's slice
  of this file (the registration check) is untouched.
- `canonical-step-adoption.ts` and everything under `agents/` are untouched, as
  the brief requires.

## Reported but unfixed

- `legacyTemplateShapeRefusal` is named in the findings as dead code with zero
  callers. It is not in this change's scope and was left alone; grep still shows
  no caller outside `dist`.
- `merge-integrator.ts` mints `legacy-10`, `legacy-9`, `legacy-human-12` and
  `legacy-regression-first-13` names through `legacyTemplateName` for markers the
  registry does not register, so `canonicalTemplateIdentity` returns null for
  those rows. Confirmed present at `merge-integrator.ts:64-73`. The file is
  outside this lane's fence.
- `template-sources.ts` still parses each frontmatter key with a hand-written
  parser per field, so adding a column still edits the loader as well as the
  table. Deriving the parse from the table was not attempted here.

Generated with Claude Code (deepening round 6 lane t2)
