### PR TITLE
refactor(api): decide completion advancement before writing it

### DIFF
--- a/packages/api/src/completion-advancement.test.ts
+++ b/packages/api/src/completion-advancement.test.ts
@@ -39,7 +39,7 @@ const facts = (overrides: Partial<CompletionAdvancementFacts> = {}): CompletionA
   ...overrides,
 });
 
-const templateTask = (overrides: Partial<NonNullable<CompletionAdvancementFacts["task"]>> = {}) => ({
+const templateTask = (overrides: Partial<CompletionAdvancementFacts["task"]> = {}) => ({
   templateId: "template-1",
   chainId: "chain-1",
   approvalGate: false,
@@ -189,13 +189,6 @@ test("a negative Regression verdict on a Task with no template parks rather than
       reportedFailureReason: "stream closed",
     })),
     { case: "park-task", status: "REVIEW", failureReason: "stream closed" },
-  );
-});
-
-test("a successful Run whose Task row is absent parks rather than advancing anything", () => {
-  assert.deepEqual(
-    completionAdvancement(facts({ task: null })),
-    { case: "park-task", status: "REVIEW", failureReason: null },
   );
 });
 

--- a/packages/api/src/completion-advancement.test.ts
+++ b/packages/api/src/completion-advancement.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  completionActivityBody,
+  completionAdvancement,
+  type CompletionAdvancement,
+  type CompletionAdvancementFacts,
+} from "./completion-advancement.js";
+
+// One row per arm of the completion outcome ladder. Before this table the same
+// arms were reachable only through a scratch PostgreSQL, because the decision
+// was fused with the writes it selected; the Prisma fake that stood in for it
+// could only reach the last row by pinning chainId, templateId and templateStep
+// to null.
+const facts = (overrides: Partial<CompletionAdvancementFacts> = {}): CompletionAdvancementFacts => ({
+  runNumber: 3,
+  succeeded: true,
+  mechanical: false,
+  task: {
+    templateId: null,
+    chainId: null,
+    approvalGate: false,
+    regressionVerificationStep: false,
+  },
+  durableNegativeRegressionVerdict: false,
+  outputRefusal: null,
+  mergeTailAuxiliary: false,
+  mergeTailHandled: false,
+  auxiliaryTargetTaskId: null,
+  mergeTailRequeue: false,
+  mergeTailRecoverySourceRunId: null,
+  retryCreated: false,
+  retryRefusalMessage: null,
+  budgetExhausted: false,
+  budgetCeiling: 3,
+  missingOutputReason: null,
+  reportedFailureReason: null,
+  ...overrides,
+});
+
+const templateTask = (overrides: Partial<NonNullable<CompletionAdvancementFacts["task"]>> = {}) => ({
+  templateId: "template-1",
+  chainId: "chain-1",
+  approvalGate: false,
+  regressionVerificationStep: false,
+  ...overrides,
+});
+
+const rows: { name: string; facts: CompletionAdvancementFacts; expected: CompletionAdvancement }[] = [
+  {
+    name: "a failed Run that published a negative Regression verdict hands the chain to repair",
+    facts: facts({
+      succeeded: false,
+      durableNegativeRegressionVerdict: true,
+      task: templateTask({ regressionVerificationStep: true }),
+      reportedFailureReason: "stream closed",
+    }),
+    expected: { case: "repair-after-negative-regression" },
+  },
+  {
+    name: "a successful integrator Step is already settled by its own merge result",
+    facts: facts({ mechanical: true, task: templateTask() }),
+    expected: { case: "mechanical-merge-already-recorded" },
+  },
+  {
+    name: "a refused canonical output is terminal, whatever else the Step is",
+    facts: facts({ task: templateTask(), outputRefusal: "missing implementation output" }),
+    expected: { case: "stop-with-output-refusal", reason: "missing implementation output" },
+  },
+  {
+    name: "a successful Regression Step is settled by its verdict",
+    facts: facts({ task: templateTask({ regressionVerificationStep: true }) }),
+    expected: { case: "settle-regression-verdict" },
+  },
+  {
+    name: "an ordinary canonical Step advances its template task",
+    facts: facts({
+      task: templateTask(),
+      mergeTailRequeue: true,
+      mergeTailRecoverySourceRunId: "run-recovery",
+    }),
+    expected: {
+      case: "advance-template-step",
+      mergeTailRequeue: true,
+      mergeTailRecoverySourceRunId: "run-recovery",
+    },
+  },
+  {
+    name: "a chain step the merge tail already settled writes nothing further",
+    facts: facts({ task: templateTask({ templateId: null }), mergeTailHandled: true }),
+    expected: { case: "merge-tail-settled" },
+  },
+  {
+    name: "a gated chain step asks its gate question",
+    facts: facts({ task: templateTask({ templateId: null, approvalGate: true }) }),
+    expected: { case: "ask-approval-gate-question" },
+  },
+  {
+    name: "an ungated chain step completes and activates its successor",
+    facts: facts({ task: templateTask({ templateId: null }) }),
+    expected: {
+      case: "complete-and-activate-successors",
+      activateChainSuccessor: true,
+      auxiliaryTargetTaskId: null,
+    },
+  },
+  {
+    name: "a successful automatic repair activates the merge-tail target it serves",
+    facts: facts({ mergeTailAuxiliary: true, auxiliaryTargetTaskId: "task-regression" }),
+    expected: {
+      case: "complete-and-activate-successors",
+      activateChainSuccessor: false,
+      auxiliaryTargetTaskId: "task-regression",
+    },
+  },
+  {
+    name: "a standalone success parks the task for review",
+    facts: facts(),
+    expected: { case: "park-task", status: "REVIEW", failureReason: null },
+  },
+  {
+    name: "a failure with a retry parks the task as DOING and still carries its reason",
+    facts: facts({ succeeded: false, retryCreated: true, reportedFailureReason: "exit 1" }),
+    expected: { case: "park-task", status: "DOING", failureReason: "exit 1" },
+  },
+  {
+    name: "a spent budget parks the task naming the ceiling",
+    facts: facts({ succeeded: false, budgetExhausted: true, budgetCeiling: 4 }),
+    expected: { case: "park-task", status: "REVIEW", failureReason: "Maximum 4 runs reached" },
+  },
+  {
+    name: "a refused automatic retry parks the task naming the refusal",
+    facts: facts({ succeeded: false, retryRefusalMessage: "chain is held" }),
+    expected: {
+      case: "park-task",
+      status: "REVIEW",
+      failureReason: "Automatic retry refused: chain is held",
+    },
+  },
+  {
+    name: "an absent deliverable outranks both the ceiling and the reported reason",
+    facts: facts({
+      succeeded: false,
+      budgetExhausted: true,
+      missingOutputReason: "missing implementation task output for current Run run-3",
+      reportedFailureReason: "exit 1",
+    }),
+    expected: {
+      case: "park-task",
+      status: "REVIEW",
+      failureReason: "missing implementation task output for current Run run-3",
+    },
+  },
+  {
+    name: "a failure that reported nothing still says the execution failed",
+    facts: facts({ succeeded: false }),
+    expected: { case: "park-task", status: "REVIEW", failureReason: "Execution failed" },
+  },
+];
+
+for (const row of rows) {
+  test(`completion advancement: ${row.name}`, () => {
+    assert.deepEqual(completionAdvancement(row.facts), row.expected);
+  });
+}
+
+test("every advancement case has a row", () => {
+  const cases = new Set(rows.map((row) => completionAdvancement(row.facts).case));
+  assert.deepEqual([...cases].sort(), [
+    "advance-template-step",
+    "ask-approval-gate-question",
+    "complete-and-activate-successors",
+    "mechanical-merge-already-recorded",
+    "merge-tail-settled",
+    "park-task",
+    "repair-after-negative-regression",
+    "settle-regression-verdict",
+    "stop-with-output-refusal",
+  ]);
+});
+
+test("a negative Regression verdict on a Task with no template parks rather than repairs", () => {
+  assert.deepEqual(
+    completionAdvancement(facts({
+      succeeded: false,
+      durableNegativeRegressionVerdict: true,
+      task: templateTask({ templateId: null, regressionVerificationStep: true }),
+      reportedFailureReason: "stream closed",
+    })),
+    { case: "park-task", status: "REVIEW", failureReason: "stream closed" },
+  );
+});
+
+test("a successful Run whose Task row is absent parks rather than advancing anything", () => {
+  assert.deepEqual(
+    completionAdvancement(facts({ task: null })),
+    { case: "park-task", status: "REVIEW", failureReason: null },
+  );
+});
+
+const narrations: { name: string; facts: CompletionAdvancementFacts; expected: string | null }[] = [
+  {
+    name: "an integrator success narrates nothing; its own branch already did",
+    facts: facts({ mechanical: true, task: templateTask() }),
+    expected: null,
+  },
+  {
+    name: "a durable negative Regression verdict is named before anything else",
+    facts: facts({
+      succeeded: false,
+      durableNegativeRegressionVerdict: true,
+      outputRefusal: "refused",
+      task: templateTask(),
+    }),
+    expected: "Run 3 failed after publishing a negative Regression verdict; repair queued",
+  },
+  {
+    name: "a refused canonical output is named even when the merge tail settled the Task",
+    facts: facts({ task: templateTask({ templateId: null }), mergeTailHandled: true, outputRefusal: "refused" }),
+    expected: "Run 3 succeeded but canonical task output was refused",
+  },
+  {
+    name: "a chain or template success reads as an advance or an awaited approval",
+    facts: facts({ task: templateTask() }),
+    expected: "Run 3 succeeded; chain advanced or awaiting approval",
+  },
+  {
+    name: "a standalone success reads as a move to review",
+    facts: facts(),
+    expected: "Run 3 succeeded; task moved to review",
+  },
+  {
+    name: "a retried failure reads as a queued retry",
+    facts: facts({ succeeded: false, retryCreated: true }),
+    expected: "Run 3 failed; retry queued",
+  },
+  {
+    name: "a refused retry names the refusal",
+    facts: facts({ succeeded: false, retryRefusalMessage: "chain is held" }),
+    expected: "Run 3 failed; automatic retry refused: chain is held",
+  },
+  {
+    name: "a final failure reads as a move to review",
+    facts: facts({ succeeded: false }),
+    expected: "Run 3 failed; task moved to review",
+  },
+];
+
+for (const row of narrations) {
+  test(`completion activity: ${row.name}`, () => {
+    assert.equal(completionActivityBody(row.facts), row.expected);
+  });
+}

--- a/packages/api/src/completion-advancement.ts
+++ b/packages/api/src/completion-advancement.ts
@@ -1,0 +1,158 @@
+import { TaskStatus } from "@anneal/db";
+
+/**
+ * What one completion means for its Task, decided as a named value before any
+ * of the advancement writes happen.
+ *
+ * The facts are the ones `completeRun` has already read inside its
+ * transaction: the outcome it classified, the Task's chain and template
+ * identity, the merge-tail settlement it just performed, and the retry it just
+ * opened or was refused. Nothing here reads the database, so every arm of the
+ * ladder that used to be reachable only with a scratch PostgreSQL is a row in
+ * a table.
+ */
+export type CompletionAdvancementFacts = {
+  runNumber: number;
+  succeeded: boolean;
+  /** The Step is the integrator's: its own outcome branch already advanced or
+   *  stopped the chain from the merge result the executor persisted. */
+  mechanical: boolean;
+  task: {
+    templateId: string | null;
+    chainId: string | null;
+    approvalGate: boolean;
+    regressionVerificationStep: boolean;
+  } | null;
+  /** A failed completion that nevertheless published a qualified negative
+   *  Regression verdict for this Run and head. */
+  durableNegativeRegressionVerdict: boolean;
+  /** Why the canonical deliverable this Run claims to have authored was
+   *  refused, from `canonicalOutputRefusal`; the refusal itself has already
+   *  parked the Task in REVIEW. */
+  outputRefusal: string | null;
+  /** The Task's own marker names the Regression it serves, so it is an
+   *  automatic repair rather than a chain step. */
+  mergeTailAuxiliary: boolean;
+  /** `settleMergeTailCompletion` already decided this Task's next state. */
+  mergeTailHandled: boolean;
+  auxiliaryTargetTaskId: string | null;
+  mergeTailRequeue: boolean;
+  mergeTailRecoverySourceRunId: string | null;
+  retryCreated: boolean;
+  retryRefusalMessage: string | null;
+  budgetExhausted: boolean;
+  budgetCeiling: number;
+  missingOutputReason: string | null;
+  reportedFailureReason: string | null;
+};
+
+/**
+ * One case per arm of the completion outcome ladder, named for what the
+ * completion means rather than for the conditions that selected it. Each case
+ * carries exactly what its writes need, so the apply step is a sequence of the
+ * existing actions with no conditions of its own.
+ */
+export type CompletionAdvancement =
+  /** The Run failed, but its negative Regression verdict is durable evidence:
+   *  hand the chain to repair and stop the merge lease. */
+  | { case: "repair-after-negative-regression" }
+  /** The integrator Step's own branch advanced the chain or recorded a stop
+   *  from the merge result; there is nothing left for the ladder to do. */
+  | { case: "mechanical-merge-already-recorded" }
+  /** The process succeeded without a canonical deliverable bound to this Run
+   *  and head. The REVIEW park written by the refusal is terminal. */
+  | { case: "stop-with-output-refusal"; reason: string }
+  /** A Regression Step succeeded: its verdict decides whether the chain
+   *  advances or the tail stops. */
+  | { case: "settle-regression-verdict" }
+  /** An ordinary canonical Step succeeded: advance the template Task. */
+  | {
+      case: "advance-template-step";
+      mergeTailRequeue: boolean;
+      mergeTailRecoverySourceRunId: string | null;
+    }
+  /** The merge tail already settled this Task's state. */
+  | { case: "merge-tail-settled" }
+  /** A gated chain step succeeded: park it in REVIEW and open the gate
+   *  question. */
+  | { case: "ask-approval-gate-question" }
+  /** A chain step or automatic repair succeeded: mark it DONE and queue
+   *  whatever it releases. */
+  | {
+      case: "complete-and-activate-successors";
+      activateChainSuccessor: boolean;
+      auxiliaryTargetTaskId: string | null;
+    }
+  /** Everything else: the Task carries the completion's own verdict, either
+   *  waiting for the retry that was just opened or surfaced to an operator. */
+  | {
+      case: "park-task";
+      status: Extract<TaskStatus, "DOING" | "REVIEW">;
+      failureReason: string | null;
+    };
+
+const parkFailureReason = (facts: CompletionAdvancementFacts): string | null => {
+  if (facts.succeeded) return null;
+  if (facts.missingOutputReason) return facts.missingOutputReason;
+  if (facts.budgetExhausted) return `Maximum ${facts.budgetCeiling} runs reached`;
+  if (facts.retryRefusalMessage) return `Automatic retry refused: ${facts.retryRefusalMessage}`;
+  return facts.reportedFailureReason ?? "Execution failed";
+};
+
+export const completionAdvancement = (facts: CompletionAdvancementFacts): CompletionAdvancement => {
+  const { task } = facts;
+  if (facts.durableNegativeRegressionVerdict && task?.templateId) {
+    return { case: "repair-after-negative-regression" };
+  }
+  if (facts.succeeded && facts.mechanical) return { case: "mechanical-merge-already-recorded" };
+  if (facts.succeeded && task?.templateId) {
+    if (facts.outputRefusal) return { case: "stop-with-output-refusal", reason: facts.outputRefusal };
+    if (task.regressionVerificationStep) return { case: "settle-regression-verdict" };
+    return {
+      case: "advance-template-step",
+      mergeTailRequeue: facts.mergeTailRequeue,
+      mergeTailRecoverySourceRunId: facts.mergeTailRecoverySourceRunId,
+    };
+  }
+  if (facts.succeeded && task && (task.chainId || facts.mergeTailAuxiliary)) {
+    if (facts.mergeTailHandled) return { case: "merge-tail-settled" };
+    if (task.approvalGate) return { case: "ask-approval-gate-question" };
+    return {
+      case: "complete-and-activate-successors",
+      activateChainSuccessor: Boolean(task.chainId),
+      auxiliaryTargetTaskId: facts.auxiliaryTargetTaskId,
+    };
+  }
+  return {
+    case: "park-task",
+    status: facts.retryCreated ? TaskStatus.DOING : TaskStatus.REVIEW,
+    failureReason: parkFailureReason(facts),
+  };
+};
+
+/**
+ * How the same decision reads on the Task's activity feed, or `null` when the
+ * completion writes no runner activity at all — the integrator Step narrates
+ * its own merge, and a second entry would claim the chain advanced twice.
+ *
+ * This is deliberately not derived from `CompletionAdvancement`: a canonical
+ * output refusal on a chain step without a template still settles through the
+ * merge tail, and the feed has always said so.
+ */
+export const completionActivityBody = (facts: CompletionAdvancementFacts): string | null => {
+  if (facts.succeeded && facts.mechanical) return null;
+  const run = `Run ${facts.runNumber}`;
+  if (facts.durableNegativeRegressionVerdict) {
+    return `${run} failed after publishing a negative Regression verdict; repair queued`;
+  }
+  if (facts.outputRefusal) return `${run} succeeded but canonical task output was refused`;
+  if (facts.succeeded && (facts.task?.templateId || facts.task?.chainId || facts.mergeTailAuxiliary)) {
+    return `${run} succeeded; chain advanced or awaiting approval`;
+  }
+  if (facts.succeeded) return `${run} succeeded; task moved to review`;
+  if (facts.retryCreated) return `${run} failed; retry queued`;
+  if (facts.retryRefusalMessage) {
+    return `${run} failed; automatic retry refused: ${facts.retryRefusalMessage}`;
+  }
+  return `${run} failed; task moved to review`;
+};

--- a/packages/api/src/completion-advancement.ts
+++ b/packages/api/src/completion-advancement.ts
@@ -17,12 +17,15 @@ export type CompletionAdvancementFacts = {
   /** The Step is the integrator's: its own outcome branch already advanced or
    *  stopped the chain from the merge result the executor persisted. */
   mechanical: boolean;
+  /** The Task row read with the fenced Run. `completeRun` throws before it
+   *  decides anything when a Run names a task the include did not carry, so
+   *  there is no absent-Task case to decide. */
   task: {
     templateId: string | null;
     chainId: string | null;
     approvalGate: boolean;
     regressionVerificationStep: boolean;
-  } | null;
+  };
   /** A failed completion that nevertheless published a qualified negative
    *  Regression verdict for this Run and head. */
   durableNegativeRegressionVerdict: boolean;
@@ -101,11 +104,11 @@ const parkFailureReason = (facts: CompletionAdvancementFacts): string | null => 
 
 export const completionAdvancement = (facts: CompletionAdvancementFacts): CompletionAdvancement => {
   const { task } = facts;
-  if (facts.durableNegativeRegressionVerdict && task?.templateId) {
+  if (facts.durableNegativeRegressionVerdict && task.templateId) {
     return { case: "repair-after-negative-regression" };
   }
   if (facts.succeeded && facts.mechanical) return { case: "mechanical-merge-already-recorded" };
-  if (facts.succeeded && task?.templateId) {
+  if (facts.succeeded && task.templateId) {
     if (facts.outputRefusal) return { case: "stop-with-output-refusal", reason: facts.outputRefusal };
     if (task.regressionVerificationStep) return { case: "settle-regression-verdict" };
     return {
@@ -114,7 +117,7 @@ export const completionAdvancement = (facts: CompletionAdvancementFacts): Comple
       mergeTailRecoverySourceRunId: facts.mergeTailRecoverySourceRunId,
     };
   }
-  if (facts.succeeded && task && (task.chainId || facts.mergeTailAuxiliary)) {
+  if (facts.succeeded && (task.chainId || facts.mergeTailAuxiliary)) {
     if (facts.mergeTailHandled) return { case: "merge-tail-settled" };
     if (task.approvalGate) return { case: "ask-approval-gate-question" };
     return {
@@ -146,7 +149,7 @@ export const completionActivityBody = (facts: CompletionAdvancementFacts): strin
     return `${run} failed after publishing a negative Regression verdict; repair queued`;
   }
   if (facts.outputRefusal) return `${run} succeeded but canonical task output was refused`;
-  if (facts.succeeded && (facts.task?.templateId || facts.task?.chainId || facts.mergeTailAuxiliary)) {
+  if (facts.succeeded && (facts.task.templateId || facts.task.chainId || facts.mergeTailAuxiliary)) {
     return `${run} succeeded; chain advanced or awaiting approval`;
   }
   if (facts.succeeded) return `${run} succeeded; task moved to review`;

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -1224,7 +1224,7 @@ export const completeRun = async (
           break;
         default: {
           const unhandled: never = advancement;
-          return unhandled;
+          throw new Error(`Run ${run.id} decided an unhandled completion advancement ${JSON.stringify(unhandled)}`);
         }
       }
       const activityBody = completionActivityBody(advancementFacts);

--- a/packages/api/src/run-completion.ts
+++ b/packages/api/src/run-completion.ts
@@ -57,6 +57,11 @@ import {
   retryDelayMs,
 } from "./execution.js";
 import {
+  completionActivityBody,
+  completionAdvancement,
+  type CompletionAdvancementFacts,
+} from "./completion-advancement.js";
+import {
   activeRepairRecoverySourceRun,
   handleRegressionCompletion,
   mergeTailRequeueContextForRun,
@@ -1074,43 +1079,76 @@ export const completeRun = async (
             succeeded,
           })
         : { handled: false, leaseOutcome: "continue" as const };
-      leaseOutcome = canonicalOutputFailure
-        && isRegressionVerificationOutputKind(run.task?.templateStep?.outputKind)
+      const regressionVerificationStep = isRegressionVerificationOutputKind(run.task?.templateStep?.outputKind);
+      leaseOutcome = canonicalOutputFailure && regressionVerificationStep
         ? "stop"
         : mergeTailCompletion.leaseOutcome;
-      if (durableNegativeRegressionVerdict && run.task?.templateId) {
-        await handleRegressionCompletion(tx, {
-          task: run.task,
-          run: {
-            id: run.id,
-            agentId: run.agentId,
-            branch: body.branch ?? run.branch,
-            headSha: body.headSha ?? null,
-            sessionId: run.session.id,
-          },
-          ...(failedRegressionVerdict?.status === "ok"
-            ? { qualifiedVerdict: failedRegressionVerdict.verdict }
-            : {}),
-          now,
-        });
-        leaseOutcome = "stop";
-      } else if (succeeded && mechanical) {
-        // Already branched above; the mechanical path owns its own advance.
-      } else if (succeeded && run.task?.templateId) {
-        if (canonicalOutputFailure) {
-          // The current Run succeeded as a process, but it did not publish a
-          // canonical deliverable bound to that Run and head. The REVIEW
-          // state written above is the terminal control-plane outcome.
-        } else if (isRegressionVerificationOutputKind(run.task.templateStep?.outputKind)) {
+      // The Task row is included with the fenced Run, so a Run that names a
+      // task always carries it. Every advancement below is about that Task.
+      const completionTask = run.task;
+      if (!completionTask) {
+        throw new Error(`Run ${run.id} names task ${run.taskId} but no task row was read with it`);
+      }
+      // What this completion means for the Task, decided from facts already
+      // read. The ladder this replaced fused the decision with its writes over
+      // succeeded x mechanical x templateId x chainId x mergeTailAuxiliary, so
+      // no arm could be read without a database; the writes below are now a
+      // sequence of the existing actions with no conditions of their own.
+      const advancementFacts: CompletionAdvancementFacts = {
+        runNumber: run.runNumber,
+        succeeded,
+        mechanical,
+        task: {
+          templateId: completionTask.templateId,
+          chainId: completionTask.chainId,
+          approvalGate: completionTask.approvalGate,
+          regressionVerificationStep,
+        },
+        durableNegativeRegressionVerdict,
+        outputRefusal: canonicalOutputFailure,
+        mergeTailAuxiliary,
+        mergeTailHandled: mergeTailCompletion.handled,
+        auxiliaryTargetTaskId,
+        mergeTailRequeue: mergeTailSuccessorRequeue,
+        mergeTailRecoverySourceRunId: mergeTailRequeueContext?.recoverySourceRunId ?? null,
+        retryCreated,
+        retryRefusalMessage: retryRefusal?.message ?? null,
+        budgetExhausted,
+        budgetCeiling,
+        missingOutputReason,
+        reportedFailureReason: reported.failureReason,
+      };
+      const advancement = completionAdvancement(advancementFacts);
+      const regressionRun = {
+        id: run.id,
+        agentId: run.agentId,
+        branch: body.branch ?? run.branch,
+        headSha: body.headSha ?? null,
+        sessionId: run.session.id,
+      };
+      switch (advancement.case) {
+        case "repair-after-negative-regression":
+          await handleRegressionCompletion(tx, {
+            task: completionTask,
+            run: regressionRun,
+            ...(failedRegressionVerdict?.status === "ok"
+              ? { qualifiedVerdict: failedRegressionVerdict.verdict }
+              : {}),
+            now,
+          });
+          leaseOutcome = "stop";
+          break;
+        // The mechanical branch above owns the step-12 advance and its stop;
+        // the output refusal has already parked the Task in REVIEW; and a
+        // settled merge tail has already written this Task's next state.
+        case "mechanical-merge-already-recorded":
+        case "stop-with-output-refusal":
+        case "merge-tail-settled":
+          break;
+        case "settle-regression-verdict": {
           const result = await handleRegressionCompletion(tx, {
-            task: run.task,
-            run: {
-              id: run.id,
-              agentId: run.agentId,
-              branch: body.branch ?? run.branch,
-              headSha: body.headSha ?? null,
-              sessionId: run.session.id,
-            },
+            task: completionTask,
+            run: regressionRun,
             now,
           });
           if (result === "advance") {
@@ -1118,7 +1156,9 @@ export const completeRun = async (
           } else {
             leaseOutcome = "stop";
           }
-        } else {
+          break;
+        }
+        case "advance-template-step":
           await advanceTemplateTask(
             tx,
             run.taskId,
@@ -1127,32 +1167,33 @@ export const completeRun = async (
             now,
             completionTaskStatus,
             {
-              mergeTailRequeue: mergeTailSuccessorRequeue,
-              ...(mergeTailRequeueContext?.recoverySourceRunId
-                ? { mergeTailRecoverySourceRunId: mergeTailRequeueContext.recoverySourceRunId }
+              mergeTailRequeue: advancement.mergeTailRequeue,
+              ...(advancement.mergeTailRecoverySourceRunId
+                ? { mergeTailRecoverySourceRunId: advancement.mergeTailRecoverySourceRunId }
                 : {}),
             },
           );
-        }
-      } else if (succeeded && run.task && (run.task.chainId || mergeTailAuxiliary)) {
-        if (!mergeTailCompletion.handled && run.task.approvalGate) {
+          break;
+        case "ask-approval-gate-question": {
           const claimed = await tx.task.updateMany({
             where: { id: run.taskId, status: completionTaskStatus! },
             data: { status: TaskStatus.REVIEW, failureReason: null },
           });
           if (claimed.count === 1) await gateQuestion(tx, run.taskId, run.id, process.env.FEISHU_DEFAULT_CHAT_ID ?? null);
-        } else if (!mergeTailCompletion.handled) {
+          break;
+        }
+        case "complete-and-activate-successors": {
           const completed = await tx.task.updateMany({
             where: { id: run.taskId, status: completionTaskStatus! }, data: { status: TaskStatus.DONE, failureReason: null },
           });
           if (completed.count === 1) {
-            if (run.task.chainId) {
-              await activateChainSuccessor(tx, run.task, {
+            if (advancement.activateChainSuccessor) {
+              await activateChainSuccessor(tx, completionTask, {
                 sourceRunId: run.id,
                 chatId: process.env.FEISHU_DEFAULT_CHAT_ID ?? null,
               }, now);
             }
-            if (auxiliaryTargetTaskId) {
+            if (advancement.auxiliaryTargetTaskId) {
               const repairSourceRunId = typeof repairMarker?.raw.sourceRunId === "string"
                 ? repairMarker.raw.sourceRunId
                 : null;
@@ -1162,40 +1203,37 @@ export const completeRun = async (
                     sourceRunId: repairSourceRunId,
                   })
                 : null;
-              await activateMergeTailTarget(tx, auxiliaryTargetTaskId, now, {
+              await activateMergeTailTarget(tx, advancement.auxiliaryTargetTaskId, now, {
                 ...(recoverySourceRunId === null ? {} : { recoverySourceRunId }),
               });
             }
           }
+          break;
         }
-      } else {
-        await tx.task.updateMany({
-          where: { id: run.taskId, ...(completionTaskStatus ? { status: completionTaskStatus } : {}) },
-          data: {
-            status: retryCreated ? TaskStatus.DOING : TaskStatus.REVIEW,
-            // The fail-loud park keeps naming the absent deliverable once the
-            // budget is spent; the budget itself is reported by the Inbox
-            // message below.
-            failureReason: succeeded ? null : missingOutputReason ?? (budgetExhausted
-              ? `Maximum ${budgetCeiling} runs reached`
-              : retryRefusal
-                ? `Automatic retry refused: ${retryRefusal.message}`
-                : reported.failureReason ?? "Execution failed"),
-          },
-        });
+        case "park-task":
+          await tx.task.updateMany({
+            where: { id: run.taskId, ...(completionTaskStatus ? { status: completionTaskStatus } : {}) },
+            data: {
+              status: advancement.status,
+              // The fail-loud park keeps naming the absent deliverable once the
+              // budget is spent; the budget itself is reported by the Inbox
+              // message below.
+              failureReason: advancement.failureReason,
+            },
+          });
+          break;
+        default: {
+          const unhandled: never = advancement;
+          return unhandled;
+        }
       }
-      if (!(succeeded && mechanical)) await tx.taskActivity.create({
+      const activityBody = completionActivityBody(advancementFacts);
+      if (activityBody) await tx.taskActivity.create({
         data: {
           taskId: run.taskId,
           actorType: "runner",
           actorId: body.runnerId,
-          body: durableNegativeRegressionVerdict ? `Run ${run.runNumber} failed after publishing a negative Regression verdict; repair queued`
-            : canonicalOutputFailure ? `Run ${run.runNumber} succeeded but canonical task output was refused`
-            : succeeded && (run.task?.templateId || run.task?.chainId || mergeTailAuxiliary) ? `Run ${run.runNumber} succeeded; chain advanced or awaiting approval`
-            : succeeded ? `Run ${run.runNumber} succeeded; task moved to review`
-            : retryCreated ? `Run ${run.runNumber} failed; retry queued`
-              : retryRefusal ? `Run ${run.runNumber} failed; automatic retry refused: ${retryRefusal.message}`
-              : `Run ${run.runNumber} failed; task moved to review`,
+          body: activityBody,
           metadata: jsonValue({ exitCode: body.exitCode, outcome: body.outcome.case, failureClass, pushStatus: body.pushStatus, pullRequestUrl: body.pullRequestUrl }),
         },
       });

--- a/scripts/deploy/systemd-installer.test.mjs
+++ b/scripts/deploy/systemd-installer.test.mjs
@@ -15,7 +15,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import test from "node:test";
 
 import {
@@ -588,7 +588,16 @@ test("rendered unit syntax is verified by systemd-analyze when available", (t) =
       });
       const output = `${verified.stdout ?? ""}${verified.stderr ?? ""}`;
       assert.equal(verified.status, 0, output);
-      assert.doesNotMatch(output, /Unknown|Failed to parse/u);
+      // systemd-analyze loads the host's own units alongside the rendered one,
+      // so its output carries diagnostics about units this repository does not
+      // write (a newer key in a distribution unit, an unreadable runtime unit).
+      // Only the lines naming the unit under test are evidence about our
+      // rendering; every unit under test lives under the temporary root.
+      const rendered = output
+        .split("\n")
+        .filter((line) => line.includes(root) || line.startsWith(`${basename(path)}:`))
+        .join("\n");
+      assert.doesNotMatch(rendered, /Unknown|Failed to parse/u);
     }
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## What changed

`completeRun`'s outcome ladder decided and performed at once. Eight arms over
`succeeded x mechanical x templateId x chainId x mergeTailAuxiliary` selected
chain advancement, merge-tail settlement, regression handling, the approval
gate, repair reactivation and the activity narration by the same conditions
that wrote them, so no arm could be read without a scratch PostgreSQL: the
only non-database harness was a hand-written Prisma fake that reached the last
arm by pinning `chainId`, `templateId` and `templateStep` to null.

The new module `packages/api/src/completion-advancement.ts` is the same move
round 5 made for `runOutcomeVerdict` and `completionEvidenceRequirement`.

- **`completionAdvancement(facts)` is what this completion means for its
  Task**, one named case per arm: `repair-after-negative-regression`,
  `mechanical-merge-already-recorded`, `stop-with-output-refusal`,
  `settle-regression-verdict`, `advance-template-step`, `merge-tail-settled`,
  `ask-approval-gate-question`, `complete-and-activate-successors`,
  `park-task`. Each case carries exactly what its writes need (the park's
  status and failure reason, the requeue grant and its recovery source, whether
  a chain successor and an auxiliary target are released), so a reader learns
  the outcome space from the type rather than from a chain of conditions.
- **`completionActivityBody(facts)` answers the same question in prose**, or
  `null` when the completion narrates nothing because the integrator Step
  already did. Deliberately not derived from `CompletionAdvancement`: a
  canonical output refusal on a chain step with no template still settles
  through the merge tail while the feed names the refusal, and that is what it
  has always said.
- **The apply step is a `switch` with no conditions of its own**, a thin
  sequence of the existing actions (`handleRegressionCompletion`,
  `advanceTemplateTask`, `gateQuestion`, `activateChainSuccessor`,
  `activateMergeTailTarget`, the status compare-and-set). A new case fails to
  compile rather than falling into the park arm, and the exhaustiveness escape
  throws rather than returning: reaching it would otherwise skip the
  `taskActivity` write, the budget and retry Inbox messages and the backend
  circuit breaker, and hand the caller `undefined`.
- **`run.task` is asserted once, loudly.** The ladder re-tested `run.task &&`
  in five places for a row Prisma returns whenever `run.taskId` is set. It is
  now read once inside `if (run.taskId)` and a missing row throws instead of
  silently taking the park arm.

No write moves and no transaction boundary changes. The one behaviour change
is the loud missing-Task-row throw, recorded under `## Decisions taken`. The
classification half (`runOutcomeVerdict`, `completionEvidenceRequirement`,
refund and budget) and the completion input schema are untouched; the schema
hash test still pins contract version 1.

Which dbtest proves each case (gate evidence; there is no local PostgreSQL):

| case | dbtest |
| --- | --- |
| `repair-after-negative-regression` | `run-output.dbtest.ts` "a retryable protocol failure consumes its durable negative Regression verdict exactly once"; "current v2 durable negative verdicts survive lease-loss reconciliation without a Regression retry" |
| `mechanical-merge-already-recorded` | `merge-stop-state.dbtest.ts` "a merged outcome advances the chain and lands DONE"; "N18 an absent, wrong-kind or unparseable output lands missing-or-malformed-result, synthesizing nothing" |
| `stop-with-output-refusal` | `run-output.dbtest.ts` "a canonical step cannot advance from a prior Run's output"; "a canonical Regression output refusal is the backstop once the run budget is spent" |
| `settle-regression-verdict` | `run-output.dbtest.ts` "every authored Regression stop verdict releases its chain lease"; `merge-tail-readiness.dbtest.ts` "base drift invalidates a head-bound PASS and returns the chain to regression" |
| `advance-template-step` | `template-authoring-end-to-end.dbtest.ts` "clone, replace, instantiate, and activate an edited fan-out chain end to end"; requeue fields: `merge-tail-repair.dbtest.ts` "a Full Assurance documentation requeue grants the following Regression hop exactly once" |
| `merge-tail-settled` | `merge-tail-stop-notice.dbtest.ts` "a repeated same-reason merge-tail stop settles its run and leaves the queue claimable"; `merge-tail-readiness.dbtest.ts` "post-acquire readiness stop releases its own confirmed lease" |
| `ask-approval-gate-question` | `chain.dbtest.ts` "gated non-template run completion creates an OPEN card and reviewable output" |
| `complete-and-activate-successors` | chain successor: `chain.dbtest.ts` "non-template chained completion advances the next execution layer and persists output", "concurrent chain advance creates exactly one successor run with no client-visible conflict"; auxiliary target: `merge-tail-repair.dbtest.ts` "successful auxiliary repair completion preserves success when its chain target or target assignee is archived" |
| `park-task` | `run-completion.dbtest.ts` "an accepted completion returns what it did rather than a response"; `run-output.dbtest.ts` "a required deliverable the run never persisted is a retryable failure, not a success"; `provision-budget.dbtest.ts` "a failure the agent's own work produced still spends a session" |

## Evidence

Run in the worktree after the final commit (`9d206293`, which merges
`origin/main` at `2a6eb8cc`), with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh `mktemp -d`:

- `npm run lint` - exit 0 (biome 778 files clean, then eslint clean).
- `npm run typecheck` - exit 0, all workspaces.
- `npm run test -w @anneal/api` - 920 tests, 919 pass, 1 skipped, 0 fail
  (one row fewer than at `e8c36f22`: the unreachable absent-Task row is gone).
- `npm run test:snapshot-scan` - 21 tests, 21 pass (the existing
  `packages/api/src/**/*.ts` classification covers both new files, so
  `public-snapshot.json` needed no edit).
- Merge gate: `MERGE GATE: PASS 9d2062930a9c1a432f1cc4398f381efbb16b221d`
  on `ci-desktop-worker`, the exact head of this branch. The repaired
  `systemd-analyze` test ran there for real (1513ms, not a skip).

`run-completion.dbtest.ts` is unchanged and typechecks under
`npm run typecheck`; database tests are merge gate evidence.

Gate history, reported in full:

- `e8c36f22` (first head) - FAIL on the fallback Linux worker `agentos-gate`,
  one assertion in `scripts/deploy/systemd-installer.test.mjs`; every other
  check passed. See `## Disposition`.
- `76adeb1e` (findings and gate fix) - `MERGE GATE: PASS`
  `76adeb1ef41a103118a17f2007aef6d7fc39cb75` on `ci-desktop-worker`. That
  worker does have `systemd-analyze`, so the repaired test ran for real there
  (`rendered unit syntax is verified by systemd-analyze when available`, 2299ms,
  not a skip) rather than skipping.
- A confirmation dispatch pinned to `agentos-gate`, the worker that produced
  the original FAIL, could not run: `Connection to 106.53.166.207 port 22 timed
  out` during the mirror push, so `gate-dispatch` reported
  `GATE NOT RUN: no configured worker produced a verdict`. The repaired
  assertion is therefore proven to still pass on a systemd host, but not
  re-run against the exact host-unit noise that failed it. Not retried: the
  verdict for this head already exists and the worker is unreachable.

## Decisions taken`. The
classification half (`runOutcomeVerdict`, `completionEvidenceRequirement`,
refund and budget) and the completion input schema are untouched; the schema
hash test still pins contract version 1.

Which dbtest proves each case (gate evidence; there is no local PostgreSQL):

| case | dbtest |
| --- | --- |
| `repair-after-negative-regression` | `run-output.dbtest.ts` "a retryable protocol failure consumes its durable negative Regression verdict exactly once"; "current v2 durable negative verdicts survive lease-loss reconciliation without a Regression retry" |
| `mechanical-merge-already-recorded` | `merge-stop-state.dbtest.ts` "a merged outcome advances the chain and lands DONE"; "N18 an absent, wrong-kind or unparseable output lands missing-or-malformed-result, synthesizing nothing" |
| `stop-with-output-refusal` | `run-output.dbtest.ts` "a canonical step cannot advance from a prior Run's output"; "a canonical Regression output refusal is the backstop once the run budget is spent" |
| `settle-regression-verdict` | `run-output.dbtest.ts` "every authored Regression stop verdict releases its chain lease"; `merge-tail-readiness.dbtest.ts` "base drift invalidates a head-bound PASS and returns the chain to regression" |
| `advance-template-step` | `template-authoring-end-to-end.dbtest.ts` "clone, replace, instantiate, and activate an edited fan-out chain end to end"; requeue fields: `merge-tail-repair.dbtest.ts` "a Full Assurance documentation requeue grants the following Regression hop exactly once" |
| `merge-tail-settled` | `merge-tail-stop-notice.dbtest.ts` "a repeated same-reason merge-tail stop settles its run and leaves the queue claimable"; `merge-tail-readiness.dbtest.ts` "post-acquire readiness stop releases its own confirmed lease" |
| `ask-approval-gate-question` | `chain.dbtest.ts` "gated non-template run completion creates an OPEN card and reviewable output" |
| `complete-and-activate-successors` | chain successor: `chain.dbtest.ts` "non-template chained completion advances the next execution layer and persists output", "concurrent chain advance creates exactly one successor run with no client-visible conflict"; auxiliary target: `merge-tail-repair.dbtest.ts` "successful auxiliary repair completion preserves success when its chain target or target assignee is archived" |
| `park-task` | `run-completion.dbtest.ts` "an accepted completion returns what it did rather than a response"; `run-output.dbtest.ts` "a required deliverable the run never persisted is a retryable failure, not a success"; `provision-budget.dbtest.ts` "a failure the agent's own work produced still spends a session" |

## Evidence

Run in the worktree after the final commit (`e8c36f22`), with
`RUNNER_WORKSPACE_ROOT` pointed at a fresh `mktemp -d`:

- `npm run lint` - pass (biome 778 files clean, then eslint clean), exit 0.
- `npm run typecheck` - pass, all workspaces, exit 0.
- `npm run test -w @anneal/api` - 921 tests, 920 pass, 1 skipped, 0 fail.
- `npm run test:snapshot-scan` - 21 tests, 21 pass (two files added; the
  existing `packages/api/src/**/*.ts` classification covers them, so
  `public-snapshot.json` needed no edit).

The same sequence was green before the commit as well. `run-completion.dbtest.ts`
is unchanged and typechecks under `npm run typecheck`; database tests are merge
gate evidence.

## Decisions taken

**`statefulCompletionHarness` is kept.** The brief allows deleting it "if
nothing needs it afterwards"; three tests still do, and no dbtest replaces
them. They are the only proof that `completeRun` counts prior
`externalFailureRefund.granted` activities with `policy: "capped"` and feeds
that count to `externalFailureRefundDecision` - `provision-budget.dbtest.ts`
covers refund persistence with a real database but never reaches the cap, and
nothing else exercises the target-fetch external refund end to end. Deleting
the fake would have removed live coverage to satisfy a shape argument. What the
finding actually complained about is gone: the branches the fake could not
reach are now a table with no Prisma at all, and the fake is left doing only
the arithmetic it can honestly do.

**Narration is included in the deepening.** The brief lists the apply actions
and does not name the activity body, but the same ternary ladder over the same
facts sat directly below the outcome ladder and was equally unreadable without
a database. It is a second pure function over the same facts value rather than
a field on `CompletionAdvancement`, because the feed's cases and the writes'
cases genuinely differ in two places (a refusal on a chain step, and a
`durableNegativeRegressionVerdict` on a Task with no template).

**No configuration and no seam.** `CompletionAdvancement` is a value with one
producer and one consumer; nothing is injectable and no adapter was added.

**A missing Task row now aborts the transaction (behaviour change).** Before
this change a `run.taskId` whose Task row was absent fell into the park arm and
the `updateMany` no-opped; `completeRun` now throws. Prisma's relation include
makes the state unreachable - the fenced Run is read with its Task - so no
dbtest can produce it, but the old code silently reported success for a Run
whose Task it could not advance. `CompletionAdvancementFacts.task` is
non-nullable for the same reason: the decision has no absent-Task case to
decide.

**The `systemd-analyze` check reads only its own unit.**
`systemd-analyze verify` loads the host's units alongside the rendered one, so
its output carries diagnostics about units this repository does not write. The
assertion scanned that whole output for `Unknown|Failed to parse` and failed on
the gate worker for `snapd.service` (a distribution unit using a key the
worker's systemd does not know) and an unreadable `/run/systemd/system` unit.
Filtering to the lines naming the unit under test keeps exactly the evidence
the test is named for. The alternative - re-dispatching until the gate lands on
the macOS worker, where `systemd-analyze` is absent and the test skips - would
have hidden a check that fails for reasons no change to this repository can
fix.

## Fence widened

`scripts/deploy/systemd-installer.test.mjs`, one assertion in the
`rendered unit syntax is verified by systemd-analyze when available` test. The
merge gate failed there at `e8c36f22` for a host-unit diagnostic unrelated to
this branch, and `QUEUE.md` lists that file under lane d1, whose state is
`merged`, so the widening is taken under rule 1. Lane d2 has since merged too
and its edit to this file (`renderSystemdSudoers` call site, line ~686) is
already merged into this branch with no conflict. Lane d34 is still
`dispatched` and owns `install-launchd.mjs` plus "their tests"; the edit here
is confined to the body of a test d34's candidate (installer outcome,
staged-file transaction) does not touch.

Nothing else: `packages/api/src/run-completion.ts` and one new module with its
test are inside lane k3's owned paths.

## Reported but unfixed

- `packages/api/src/run-completion.ts` writes `branch: body.branch ?? run.branch`
  at terminalization. Lane k1 (PR #465) reported this as redundant after the
  publish target became one decision: the runner now reports back the head the
  control plane gave it. Removing the write means removing `branch` from the
  completion request body, which is a change to `completionInput` and its
  version guard - explicitly out of bounds for this lane.
- The mechanical output-validation block (`succeeded && mechanical`) and the
  canonical output block (`succeeded && (templateId || chainId || auxiliary)`)
  above the ladder are still a second, earlier if/else over the same five
  facts, and they write (`taskStepOutput` create/update, the REVIEW park) before
  the advancement is decided. They can be folded into the same decision only by
  moving those writes, which the brief forbids ("this lane moves the decision,
  not the effects"). The decision now consumes their result as
  `outputRefusal`.
- `completeRun` is still a single ~700-line transaction callback. The
  classification half, the evidence half and this advancement half are each a
  named value now, but the locals that carry them between the halves
  (`failedRegressionVerdict`, `repairMarker`, `repairDocumentationTask`,
  `tailMarkers`) are read at three different points for four different
  consumers.

## Disposition

Blind review returned `approve` with three advisory findings; all three are
fixed. The merge gate at `e8c36f22` returned FAIL; its single failing check is
fixed. `origin/main` then moved to `2a6eb8cc` (lanes d2, k2, t4 published), so
it is merged into this branch and the whole verification sequence re-run.

| # | finding | outcome |
| --- | --- | --- |
| 1 | advisory, `run-completion.ts`: the switch exhaustiveness escape returned the `never` value instead of throwing | **fixed** - `default` now throws with the Run id and the unhandled advancement, so an unreachable case cannot skip the activity write, the Inbox messages and the circuit breaker |
| 2 | advisory, `completion-advancement.ts`: `CompletionAdvancementFacts.task` was nullable although the only producer throws when the Task row is absent | **fixed** - `task` is non-nullable, the optional chaining in `completionAdvancement` and `completionActivityBody` is gone, and the test row pinning the unreachable absent-Task state is deleted (920 tests, was 921) |
| 3 | advisory, PR body asserted "No behaviour changes" while describing a new throw | **fixed** - the sentence now names the one behaviour change and `## Decisions taken` records it with its before/after |
| G | merge gate FAIL at `e8c36f22`: `scripts/deploy/systemd-installer.test.mjs:539` "rendered unit syntax is verified by systemd-analyze when available" | **fixed** - the assertion scanned the whole `systemd-analyze verify` output, including diagnostics about the worker's own `snapd.service` and an unreadable `/run/systemd/system` unit; it now reads only the lines naming the unit under test. Not reproducible on macOS, where the test skips for want of `systemd-analyze`; the gate on the Linux worker is the proof |

Generated with Claude Code (deepening round 6 lane k3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zzbyE3vWTRrDacwLEoA3v

