### PR TITLE
docs(agents): clarify verification and deployment boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,14 @@ in a host window. Read "Everyone", then only the section for your kind.
 - Design simply: implement the simplest design that fully meets the current
   requirement; add an abstraction, configuration option, or compatibility path
   only when a current acceptance criterion or caller requires it.
-- Verify narrowly: build, lint, typecheck, and test only the workspace(s) your
-  change touches (`npm run <script> -w <workspace>`). Database tests need a
-  scratch PostgreSQL that a Run is never granted, so `test:db` is merge gate
-  evidence: do not attempt it inside a Run, and do not report its absence as a
-  gap. Never run a whole database suite or a repository-wide root script by
-  hand; the merge gate owns repository-wide proof.
+- Verify narrowly: use affected workspace checks
+  (`npm run <script> -w <workspace>`) and named checks relevant to the change,
+  including checks defined at the repository root. The merge gate owns
+  repository-wide proof: do not run whole-repository build, lint, typecheck,
+  or test aggregates, or whole database suites, independently of the gate.
+  Database tests need a scratch PostgreSQL that a Run is never granted, so
+  `test:db` is merge gate evidence: do not attempt it inside a Run, and do not
+  report its absence as a gap.
 - Before tests outside the merge gate, point `RUNNER_WORKSPACE_ROOT` at a new
   temporary directory; a hand-built `RunnerConfig` also pins `home` to one.
   Runner tests provision real workspaces.
@@ -27,6 +29,8 @@ in a host window. Read "Everyone", then only the section for your kind.
 - Before changing canonical Agents, roles, or task templates, read
   [`agents/README.md`](agents/README.md); it and the contract files it names own
   canonical defaults.
+- When adding, removing, or changing an HTTP route, update the
+  [operator API handbook](docs/operator-api.md) in the same change.
 
 ## Inside an Anneal run
 
@@ -35,10 +39,11 @@ any worktree you need inside your own run workspace (a relative path such as
 `./worktrees/<name>`), never outside it. Commit your work; the platform pushes,
 opens the pull request, and runs the Regression step and merge tail. Never run
 `scripts/merge-gate.sh`, the gate-worker scripts under `scripts/gate-worker/*`
-and `packages/runner/runtime-tools/gate-worker/*`, or a repository-wide root
-script inside a run: the merge gate and the root scripts refuse from inside a
-run, the gate-worker scripts carry no such refusal and rely on this rule alone,
-and the Regression step runs the gate on the gate worker. Never operate on a production or appliance checkout.
+and `packages/runner/runtime-tools/gate-worker/*`, or repository-wide
+verification aggregates inside a run. The merge gate and guarded root
+verification scripts refuse inside a run; gate-worker scripts carry no such
+refusal and rely on this rule. The Regression step runs the gate on the gate
+worker. Never operate on a production or appliance checkout.
 
 ## In a host window
 
@@ -54,10 +59,11 @@ and the Regression step runs the gate on the gate worker. Never operate on a pro
   applicable section before acting on one of those surfaces. Never switch
   branches or commit feature work in the shared checkout: deliver from an
   isolated worktree on your own branch, and remove the worktree once merged.
-- Appliance checkout: before changing files or branches in a checkout named by
-  a loaded `com.agentos.*` service, read
+- Before changing a deployment directory, runtime artifact, or service
+  configuration, read
   [`docs/runbooks/quiet-window-auto-deploy.md`](docs/runbooks/quiet-window-auto-deploy.md).
-  Leave that checkout on clean `main`; work in a separate worktree.
+  Follow its ownership and activation contract; develop in a separate clone
+  or worktree.
 
 ## Editing these instructions
 
@@ -70,5 +76,3 @@ literal is an instruction to every reader whose section contains it: the only
 commands written into "Everyone" or "Inside an Anneal run" are ones a run may
 execute; host-workflow commands live in host-facing documents, reached from "In
 a host window" by pointer.
-
-For the operator-facing HTTP route handbook, see [docs/operator-api.md](docs/operator-api.md). A change that adds, removes, or alters an HTTP route updates the handbook in the same change.


### PR DESCRIPTION
Repository instructions could hide the HTTP handbook update rule from Run readers, overgeneralize restrictions on root-level checks, and trigger deployment guidance only for service-backed source checkouts.

Move the HTTP rule into Everyone, distinguish relevant named checks from gate-owned aggregate verification, and trigger the deployment runbook for deployment directories, runtime artifacts, and service configuration. Preserve Run database and gate prohibitions, test isolation, and shared-checkout protection.

Validation: `MERGE GATE: PASS 2a6eb8cc30e71bca7701d6722e7486bd802a3a02` against baseline `d0383f015a2a748b452904d93cf9b414e271d0b0`. The gate automatically selected `docs-only`; frozen records, profile fixtures, diff hygiene, public snapshot scope, and final commit/worktree drift checks passed.
