### PR TITLE
refactor(api): state the template step omission fact once

### DIFF
--- a/packages/api/src/canonical-task-output.test.ts
+++ b/packages/api/src/canonical-task-output.test.ts
@@ -385,7 +385,7 @@ test("a present blind review sibling without output keeps its exact refusal", as
   );
 });
 
-test("a review step this chain instantiated is owed at the review boundary", async () => {
+test("a review step this chain instantiated is owed in the predecessor layer", async () => {
   const result = await persistFixedOutput({
     reviewTasks: [reviewTask("sol-task", "sol-findings")],
     chainReviewSteps: [

--- a/packages/api/src/canonical-task-output.test.ts
+++ b/packages/api/src/canonical-task-output.test.ts
@@ -85,6 +85,11 @@ const persistFixedOutput = async (input: {
   reviewTasks: ReviewTask[];
   successfulSiblingRuns?: Array<{ taskId: string; headSha: string }>;
   body?: string;
+  /**
+   * The chain's own witness of which review steps it instantiated. Defaults to
+   * exactly the steps the review layer carries, which is the ordinary chain.
+   */
+  chainReviewSteps?: Array<{ outputKind: ReviewKind; instantiated: boolean }>;
 }) => {
   const fixTask = {
     id: "fix-task",
@@ -96,9 +101,16 @@ const persistFixedOutput = async (input: {
     templateStep: {
       stepIndex: 5,
       outputKind: "fixed-implementation",
+      taskTemplateId: "direct-template",
       taskTemplate: { name: "direct-engineer-workflow" },
     },
   };
+  const chainReviewSteps = input.chainReviewSteps ?? (["sol-findings", "blind-findings"] as const).map(
+    (outputKind) => ({
+      outputKind,
+      instantiated: input.reviewTasks.some((task) => task.templateStep.outputKind === outputKind),
+    }),
+  );
   const tx = {
     $queryRaw: async () => [{ id: "locked" }],
     run: {
@@ -115,6 +127,12 @@ const persistFixedOutput = async (input: {
     task: {
       findFirst: async () => ({ chainLayer: 2 }),
       findMany: async () => input.reviewTasks,
+    },
+    taskTemplateStep: {
+      findMany: async () => chainReviewSteps.map(({ outputKind, instantiated }) => ({
+        outputKind,
+        tasks: instantiated ? [{ id: `${outputKind}-task` }] : [],
+      })),
     },
     taskStepOutput: {
       findUnique: async () => null,
@@ -358,6 +376,21 @@ test("a present blind review sibling without output keeps its exact refusal", as
     reviewTasks: [
       reviewTask("sol-task", "sol-findings"),
       reviewTask("blind-task", "blind-findings", null),
+    ],
+  });
+
+  assert.equal(
+    persistenceRefusal(result),
+    "fixed-implementation requires exactly one immutable blind-findings sibling output",
+  );
+});
+
+test("a review step this chain instantiated is owed at the review boundary", async () => {
+  const result = await persistFixedOutput({
+    reviewTasks: [reviewTask("sol-task", "sol-findings")],
+    chainReviewSteps: [
+      { outputKind: "sol-findings", instantiated: true },
+      { outputKind: "blind-findings", instantiated: true },
     ],
   });
 

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -19,6 +19,7 @@ import {
 } from "@anneal/db";
 import type { ClaimPreviousRunHandoff } from "@anneal/db/claim-contract";
 
+import { chainStepPresence, type ChainStepPresenceIndex } from "./chain-step-omission.js";
 import {
   fenceRefusalResponse,
   type FenceRefusalResponse,
@@ -172,6 +173,7 @@ type FixStepTask = {
   projectId: string;
   chainId: string | null;
   chainLayer: number | null;
+  templateStep: { taskTemplateId: string };
 };
 
 /**
@@ -242,13 +244,27 @@ const fixedImplementationPersistenceRefusal = async (
     successfulSiblingHeads.set(run.taskId, heads);
   }
   const reports: ReviewArtifact[] = [];
+  let presence: ChainStepPresenceIndex | null = null;
   for (const kind of ["sol-findings", "blind-findings"] as const) {
     const matches = reviewTasks.filter((candidate) => (
       kind === "sol-findings"
         ? isCanonicalSolFindingsStep(candidate.templateStep)
         : isCanonicalBlindFindingsStep(candidate.templateStep)
     ));
-    if (matches.length === 0) continue;
+    if (matches.length === 0) {
+      // Absence of the sibling excuses the fix only when the producing step is
+      // absent from the whole chain. A step this chain did instantiate is
+      // owed at the review boundary.
+      presence ??= await chainStepPresence(tx, {
+        projectId: task.projectId,
+        chainId: task.chainId,
+        taskTemplateId: task.templateStep.taskTemplateId,
+      });
+      if (presence.ofRole(kind) === "instantiated") {
+        return `fixed-implementation requires exactly one immutable ${kind} sibling output`;
+      }
+      continue;
+    }
     if (matches.length !== 1 || !matches[0]!.stepOutput || matches[0]!.stepOutput!.kind !== kind) {
       return `fixed-implementation requires exactly one immutable ${kind} sibling output`;
     }
@@ -441,6 +457,7 @@ export const persistSessionTaskOutput = async (
     templateStep: { select: {
       stepIndex: true,
       outputKind: true,
+      taskTemplateId: true,
       taskTemplate: { select: { name: true } },
     } },
   } },
@@ -463,8 +480,8 @@ export const persistSessionTaskOutput = async (
     const bodyRefusal = canonicalBodyRefusal(step, input.body, input.commitSha, phase);
     if (bodyRefusal) return { ok: false, reason: bodyRefusal };
   }
-  if (isCanonicalFixStep(step)) {
-    const refusal = await fixedImplementationPersistenceRefusal(tx, task, input.body);
+  if (step && isCanonicalFixStep(step)) {
+    const refusal = await fixedImplementationPersistenceRefusal(tx, { ...task, templateStep: step }, input.body);
     if (refusal) return { ok: false, reason: refusal };
   }
   // The retired must-fix role remains only on already-instantiated Chains.

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -254,7 +254,7 @@ const fixedImplementationPersistenceRefusal = async (
     if (matches.length === 0) {
       // Absence of the sibling excuses the fix only when the producing step is
       // absent from the whole chain. A step this chain did instantiate is
-      // owed at the review boundary.
+      // owed in the fix step's predecessor layer.
       presence ??= await chainStepPresence(tx, {
         projectId: task.projectId,
         chainId: task.chainId,

--- a/packages/api/src/chain-step-omission.test.ts
+++ b/packages/api/src/chain-step-omission.test.ts
@@ -50,6 +50,23 @@ test("instantiation omits the conditional revalidation step only when the chain 
   assert.deepEqual(kinds(otherFamily.instantiated), kinds(directSteps));
 });
 
+test("the conditional rule drops exactly one ordinal", () => {
+  // The caller shifts every retained ordinal down by one, so a template that
+  // declared a second revalidation-role step must not lose two steps here.
+  const twoRevalidations = [
+    { outputKind: "revalidation", optional: false },
+    { outputKind: "revalidation-v2", optional: false },
+    { outputKind: "implementation", optional: false },
+  ];
+  const instantiation = templateStepInstantiation(twoRevalidations, {
+    routesImplementation: true,
+    boundToPredecessor: false,
+    skipOptionalSteps: false,
+  });
+  assert.equal(instantiation.omittedConditionalRevalidation, true);
+  assert.deepEqual(kinds(instantiation.instantiated), ["revalidation-v2", "implementation"]);
+});
+
 test("instantiation omits optional steps independently of the conditional rule", () => {
   const both = templateStepInstantiation(directSteps, {
     routesImplementation: true,

--- a/packages/api/src/chain-step-omission.test.ts
+++ b/packages/api/src/chain-step-omission.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { Prisma } from "@anneal/db";
+
+import { chainStepPresence, templateStepInstantiation } from "./chain-step-omission.js";
+
+const directSteps = [
+  { outputKind: "revalidation", optional: false },
+  { outputKind: "implementation", optional: false },
+  { outputKind: "sol-findings", optional: false },
+  { outputKind: "blind-findings", optional: true },
+  { outputKind: "fixed-implementation", optional: false },
+  { outputKind: "regression-verification-v2", optional: false },
+];
+
+const kinds = (steps: Array<{ outputKind: string }>): string[] => steps.map((step) => step.outputKind);
+
+test("instantiation omits the conditional revalidation step only when the chain is unbound", () => {
+  const unbound = templateStepInstantiation(directSteps, {
+    routesImplementation: true,
+    boundToPredecessor: false,
+    skipOptionalSteps: false,
+  });
+  assert.equal(unbound.omittedConditionalRevalidation, true);
+  assert.deepEqual(kinds(unbound.instantiated), [
+    "implementation",
+    "sol-findings",
+    "blind-findings",
+    "fixed-implementation",
+    "regression-verification-v2",
+  ]);
+
+  const bound = templateStepInstantiation(directSteps, {
+    routesImplementation: true,
+    boundToPredecessor: true,
+    skipOptionalSteps: false,
+  });
+  assert.equal(bound.omittedConditionalRevalidation, false);
+  assert.deepEqual(kinds(bound.instantiated), kinds(directSteps));
+
+  // A template that does not route implementation keeps a revalidation-shaped
+  // step: the conditional rule belongs to the routing family, not to the kind.
+  const otherFamily = templateStepInstantiation(directSteps, {
+    routesImplementation: false,
+    boundToPredecessor: false,
+    skipOptionalSteps: false,
+  });
+  assert.equal(otherFamily.omittedConditionalRevalidation, false);
+  assert.deepEqual(kinds(otherFamily.instantiated), kinds(directSteps));
+});
+
+test("instantiation omits optional steps independently of the conditional rule", () => {
+  const both = templateStepInstantiation(directSteps, {
+    routesImplementation: true,
+    boundToPredecessor: false,
+    skipOptionalSteps: true,
+  });
+  assert.equal(both.omittedConditionalRevalidation, true);
+  assert.deepEqual(kinds(both.instantiated), [
+    "implementation",
+    "sol-findings",
+    "fixed-implementation",
+    "regression-verification-v2",
+  ]);
+
+  const optionalOnly = templateStepInstantiation(directSteps, {
+    routesImplementation: true,
+    boundToPredecessor: true,
+    skipOptionalSteps: true,
+  });
+  assert.equal(optionalOnly.omittedConditionalRevalidation, false);
+  assert.deepEqual(kinds(optionalOnly.instantiated), [
+    "revalidation",
+    "implementation",
+    "sol-findings",
+    "fixed-implementation",
+    "regression-verification-v2",
+  ]);
+});
+
+const presenceFor = async (steps: Array<{ outputKind: string; instantiated: boolean }>) => {
+  const queries: Array<Record<string, unknown>> = [];
+  const tx = {
+    taskTemplateStep: {
+      findMany: async (query: Record<string, unknown>) => {
+        queries.push(query);
+        return steps.map(({ outputKind, instantiated }) => ({
+          outputKind,
+          tasks: instantiated ? [{ id: `task-${outputKind}` }] : [],
+        }));
+      },
+    },
+  } as unknown as Prisma.TransactionClient;
+  const presence = await chainStepPresence(tx, {
+    projectId: "project-1",
+    chainId: "chain-1",
+    taskTemplateId: "template-1",
+  });
+  return { presence, queries };
+};
+
+test("chain presence separates an omitted producer from an undeclared one", async () => {
+  const { presence, queries } = await presenceFor([
+    { outputKind: "implementation", instantiated: true },
+    { outputKind: "sol-findings", instantiated: true },
+    { outputKind: "blind-findings", instantiated: false },
+  ]);
+  assert.equal(presence.ofKind("implementation"), "instantiated");
+  assert.equal(presence.ofKind("blind-findings"), "omitted");
+  assert.equal(presence.ofKind("documentation"), "undeclared");
+  assert.equal(presence.ofRole("blind-findings"), "omitted");
+  assert.equal(presence.ofRole("sol-findings"), "instantiated");
+  assert.equal(presence.ofRole("documentation"), "undeclared");
+  // One read answers every kind and every role the callers ask about.
+  assert.equal(queries.length, 1);
+  assert.deepEqual(queries[0]!.where, { taskTemplateId: "template-1" });
+});
+
+test("chain presence answers a versioned output kind through its role", async () => {
+  const { presence } = await presenceFor([
+    { outputKind: "blind-findings-v2", instantiated: false },
+    { outputKind: "regression-verification-v2", instantiated: true },
+  ]);
+  assert.equal(presence.ofKind("blind-findings"), "undeclared");
+  assert.equal(presence.ofRole("blind-findings"), "omitted");
+  assert.equal(presence.ofKind("regression-verification-v2"), "instantiated");
+  assert.equal(presence.ofRole("regression"), "instantiated");
+});
+
+test("a kind produced by two steps is omitted only when neither has a task", async () => {
+  const partial = await presenceFor([
+    { outputKind: "sol-findings", instantiated: false },
+    { outputKind: "sol-findings", instantiated: true },
+  ]);
+  assert.equal(partial.presence.ofKind("sol-findings"), "instantiated");
+
+  const neither = await presenceFor([
+    { outputKind: "sol-findings", instantiated: false },
+    { outputKind: "sol-findings", instantiated: false },
+  ]);
+  assert.equal(neither.presence.ofKind("sol-findings"), "omitted");
+});

--- a/packages/api/src/chain-step-omission.ts
+++ b/packages/api/src/chain-step-omission.ts
@@ -84,15 +84,18 @@ export const templateStepInstantiation = <Step extends { outputKind: string; opt
   steps: readonly Step[],
   rules: TemplateStepOmissionRules,
 ): TemplateStepInstantiation<Step> => {
-  const omittedConditionalRevalidation = rules.routesImplementation
-    && !rules.boundToPredecessor
-    && steps.some((step) => stepRole(step) === "revalidation");
+  // Exactly one step is conditional, so exactly one ordinal can be dropped:
+  // the offset the caller applies to every retained ordinal is one, and a
+  // template that declared a second revalidation step would need its own rule.
+  const conditionalRevalidation = rules.routesImplementation && !rules.boundToPredecessor
+    ? steps.find((step) => stepRole(step) === "revalidation") ?? null
+    : null;
   return {
     instantiated: steps.filter((step) => {
-      if (omittedConditionalRevalidation && stepRole(step) === "revalidation") return false;
+      if (step === conditionalRevalidation) return false;
       if (rules.skipOptionalSteps && step.optional) return false;
       return true;
     }),
-    omittedConditionalRevalidation,
+    omittedConditionalRevalidation: conditionalRevalidation !== null,
   };
 };

--- a/packages/api/src/chain-step-omission.ts
+++ b/packages/api/src/chain-step-omission.ts
@@ -1,0 +1,98 @@
+import { Prisma, stepRole, type StepRole } from "@anneal/db";
+
+type DbTx = Prisma.TransactionClient;
+
+/**
+ * Instantiation omits template steps for two unrelated reasons and stores
+ * neither: the conditional revalidation step applies only to a Chain bound to
+ * a predecessor task, and a project may skip every step the template marks
+ * optional. An omitted step is the absence of a Task row, so the Chain's own
+ * task rows are the only witness of it.
+ *
+ * This module owns both sides of that one fact. `templateStepInstantiation`
+ * decides the omission; `chainStepPresence` reads it back. Absence stays the
+ * truth deliberately: nothing can make a stored omission list disagree with
+ * the tasks that actually exist.
+ */
+
+/** How a Chain stands with respect to one template step. */
+export type ChainStepPresence =
+  /** The template declares such a step and this Chain has a task for it. */
+  | "instantiated"
+  /** The template declares such a step and this Chain instantiated none. */
+  | "omitted"
+  /** The template declares no such step, so the Chain never could have one. */
+  | "undeclared";
+
+/**
+ * The presence answer for one Chain, in the two vocabularies its readers hold:
+ * a declared prior output kind, and a canonical step role. Readers decide
+ * their own tolerance; `omitted` and `undeclared` are not interchangeable.
+ */
+export type ChainStepPresenceIndex = {
+  ofKind(outputKind: string): ChainStepPresence;
+  ofRole(role: StepRole): ChainStepPresence;
+};
+
+export const chainStepPresence = async (
+  tx: DbTx,
+  chain: { projectId: string; chainId: string; taskTemplateId: string },
+): Promise<ChainStepPresenceIndex> => {
+  const steps = await tx.taskTemplateStep.findMany({
+    where: { taskTemplateId: chain.taskTemplateId },
+    select: {
+      outputKind: true,
+      tasks: {
+        where: { projectId: chain.projectId, chainId: chain.chainId },
+        select: { id: true },
+        take: 1,
+      },
+    },
+  });
+  const presenceOf = (declaring: typeof steps): ChainStepPresence => {
+    if (declaring.length === 0) return "undeclared";
+    return declaring.some(({ tasks }) => tasks.length > 0) ? "instantiated" : "omitted";
+  };
+  return {
+    ofKind: (outputKind) => presenceOf(steps.filter((step) => step.outputKind === outputKind)),
+    ofRole: (role) => presenceOf(steps.filter((step) => stepRole(step) === role)),
+  };
+};
+
+/** What instantiation knows that decides whether a step is omitted. */
+export type TemplateStepOmissionRules = {
+  /** The template routes implementation; only that family carries the conditional revalidation step. */
+  routesImplementation: boolean;
+  /** The Chain dispatches on an existing task's completion (`afterTaskId`). */
+  boundToPredecessor: boolean;
+  /** The project skips every step its template marks optional. */
+  skipOptionalSteps: boolean;
+};
+
+export type TemplateStepInstantiation<Step> = {
+  /** The steps that get a Task row, in the template order they arrived in. */
+  instantiated: Step[];
+  /**
+   * True when the conditional revalidation step was omitted. It is the first
+   * ordinal of its template, so every retained step's chain ordinal shifts
+   * down by one.
+   */
+  omittedConditionalRevalidation: boolean;
+};
+
+export const templateStepInstantiation = <Step extends { outputKind: string; optional: boolean }>(
+  steps: readonly Step[],
+  rules: TemplateStepOmissionRules,
+): TemplateStepInstantiation<Step> => {
+  const omittedConditionalRevalidation = rules.routesImplementation
+    && !rules.boundToPredecessor
+    && steps.some((step) => stepRole(step) === "revalidation");
+  return {
+    instantiated: steps.filter((step) => {
+      if (omittedConditionalRevalidation && stepRole(step) === "revalidation") return false;
+      if (rules.skipOptionalSteps && step.optional) return false;
+      return true;
+    }),
+    omittedConditionalRevalidation,
+  };
+};

--- a/packages/api/src/parallel-review-fixture.ts
+++ b/packages/api/src/parallel-review-fixture.ts
@@ -192,6 +192,34 @@ const createParallelReviewHarness = ({
     };
   };
 
+  /**
+   * Chain tasks are addressed by the output kind their template step produces.
+   * A chain that omitted an optional or conditional step renumbers every later
+   * ordinal, so a hardcoded chainIndex silently names a different node.
+   */
+  const chainTasks = async <ChainTask extends { id: string; templateStepId: string | null }>(
+    taskTemplateId: string,
+    tasks: ChainTask[],
+  ) => {
+    const steps = await getDb().taskTemplateStep.findMany({
+      where: { taskTemplateId },
+      select: { id: true, outputKind: true },
+    });
+    const outputKindOf = new Map(steps.map(({ id, outputKind }) => [id, outputKind]));
+    const byOutputKind = new Map(tasks.map((task) => [
+      task.templateStepId === null ? null : outputKindOf.get(task.templateStepId) ?? null,
+      task,
+    ]));
+    return {
+      taskFor: (outputKind: string): ChainTask => {
+        const task = byOutputKind.get(outputKind);
+        assert.ok(task, `chain has no ${outputKind} task`);
+        return task;
+      },
+      omits: (outputKind: string): boolean => !byOutputKind.has(outputKind),
+    };
+  };
+
   const instantiateDirect = async (brief = SPECIFICATION_BRIEF): Promise<DirectFixture> => {
     const installation = await canonicalInstallation();
     const branchName = `parallel/direct-${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`;
@@ -202,15 +230,15 @@ const createParallelReviewHarness = ({
       description: brief,
       autoStart: true,
     });
-    const byIndex = new Map(chain.tasks.map((task) => [task.chainIndex, task]));
+    const { taskFor } = await chainTasks(installation.directTemplateId, chain.tasks);
     return {
       ...installation,
       chainId: chain.chainId,
       branchName,
-      implementationTaskId: byIndex.get(1)!.id,
-      solTaskId: byIndex.get(2)!.id,
-      blindTaskId: byIndex.get(3)!.id,
-      fixTaskId: byIndex.get(4)!.id,
+      implementationTaskId: taskFor("implementation").id,
+      solTaskId: taskFor("sol-findings").id,
+      blindTaskId: taskFor("blind-findings").id,
+      fixTaskId: taskFor("fixed-implementation").id,
     };
   };
 
@@ -238,18 +266,18 @@ const createParallelReviewHarness = ({
       afterTaskId: predecessor.id,
     });
     assert.equal(chain.tasks.length, 8);
-    const byIndex = new Map(chain.tasks.map((task) => [task.chainIndex, task]));
+    const { taskFor } = await chainTasks(installation.directTemplateId, chain.tasks);
     const dispatched = await operatorRequest(`/tasks/${predecessor.id}`, "PATCH", { status: TaskStatus.DONE });
     assert.equal(dispatched.status, 200, JSON.stringify(dispatched.body));
     return {
       ...installation,
       chainId: chain.chainId,
       branchName,
-      revalidationTaskId: byIndex.get(1)!.id,
-      implementationTaskId: byIndex.get(2)!.id,
-      solTaskId: byIndex.get(3)!.id,
-      blindTaskId: byIndex.get(4)!.id,
-      fixTaskId: byIndex.get(5)!.id,
+      revalidationTaskId: taskFor("revalidation").id,
+      implementationTaskId: taskFor("implementation").id,
+      solTaskId: taskFor("sol-findings").id,
+      blindTaskId: taskFor("blind-findings").id,
+      fixTaskId: taskFor("fixed-implementation").id,
     };
   };
 
@@ -267,19 +295,9 @@ const createParallelReviewHarness = ({
       description: brief,
       autoStart: true,
     });
-    const byKind = new Map(chain.tasks.map((task) => [task.templateStepId, task]));
-    const steps = await getDb().taskTemplateStep.findMany({
-      where: { taskTemplateId: installation.directTemplateId },
-      select: { id: true, outputKind: true },
-    });
-    const taskFor = (kind: string) => {
-      const step = steps.find((candidate) => candidate.outputKind === kind)!;
-      return byKind.get(step.id)!;
-    };
+    const { taskFor, omits } = await chainTasks(installation.directTemplateId, chain.tasks);
     assert.equal(chain.tasks.length, 6);
-    assert.equal(chain.tasks.some((task) => (
-      steps.find((step) => step.id === task.templateStepId)?.outputKind === "blind-findings"
-    )), false);
+    assert.equal(omits("blind-findings"), true);
     return {
       ...installation,
       chainId: chain.chainId,
@@ -306,13 +324,16 @@ const createParallelReviewHarness = ({
       description: SPECIFICATION_BRIEF,
       autoStart: false,
     });
-    const byIndex = new Map(chain.tasks.map((task) => [task.chainIndex, task]));
-    const priorIds = chain.tasks.filter((task) => (task.chainIndex ?? 0) < 5).map((task) => task.id);
+    const { taskFor } = await chainTasks(installation.fullTemplateId, chain.tasks);
+    const implementation = taskFor("implementation");
+    const priorIds = chain.tasks
+      .filter((task) => (task.chainIndex ?? 0) < (implementation.chainIndex ?? 0))
+      .map((task) => task.id);
     await getDb().task.updateMany({
       where: { id: { in: priorIds } },
       data: { status: TaskStatus.DONE },
     });
-    const specificationTask = byIndex.get(1)!;
+    const specificationTask = taskFor("spec");
     await getDb().taskStepOutput.create({
       data: {
         taskId: specificationTask.id,
@@ -325,7 +346,7 @@ const createParallelReviewHarness = ({
         commitSha: IMPLEMENTATION_BASE,
       },
     });
-    const revisedPlanTask = byIndex.get(4)!;
+    const revisedPlanTask = taskFor("revised-plan");
     await getDb().taskStepOutput.create({
       data: {
         taskId: revisedPlanTask.id,
@@ -340,15 +361,14 @@ const createParallelReviewHarness = ({
         commitSha: IMPLEMENTATION_BASE,
       },
     });
-    const implementation = byIndex.get(5)!;
     await getDb().$transaction((tx) => enqueueTaskRun(tx, implementation.id));
     return {
       ...installation,
       chainId: chain.chainId,
       branchName,
       implementationTaskId: implementation.id,
-      solTaskId: byIndex.get(6)!.id,
-      blindTaskId: byIndex.get(7)!.id,
+      solTaskId: taskFor("sol-findings").id,
+      blindTaskId: taskFor("blind-findings").id,
     };
   };
 

--- a/packages/api/src/parallel-review-fixture.ts
+++ b/packages/api/src/parallel-review-fixture.ts
@@ -206,10 +206,13 @@ const createParallelReviewHarness = ({
       select: { id: true, outputKind: true },
     });
     const outputKindOf = new Map(steps.map(({ id, outputKind }) => [id, outputKind]));
-    const byOutputKind = new Map(tasks.map((task) => [
-      task.templateStepId === null ? null : outputKindOf.get(task.templateStepId) ?? null,
-      task,
-    ]));
+    const byOutputKind = new Map<string, ChainTask>();
+    for (const task of tasks) {
+      const outputKind = task.templateStepId === null ? null : outputKindOf.get(task.templateStepId) ?? null;
+      assert.ok(outputKind, `chain task ${task.id} names no step of template ${taskTemplateId}`);
+      assert.ok(!byOutputKind.has(outputKind), `template ${taskTemplateId} declares ${outputKind} twice`);
+      byOutputKind.set(outputKind, task);
+    }
     return {
       taskFor: (outputKind: string): ChainTask => {
         const task = byOutputKind.get(outputKind);

--- a/packages/api/src/run-claim.ts
+++ b/packages/api/src/run-claim.ts
@@ -38,6 +38,7 @@ import { z } from "zod";
 
 import { issueSessionToken } from "./auth.js";
 import { isCanonicalBlindFindingsStep, previousRunHandoffForClaim } from "./canonical-task-output.js";
+import { chainStepPresence } from "./chain-step-omission.js";
 import { makeFencingToken } from "./execution.js";
 import { openMergeTailStopNotice } from "./merge-tail-actions.js";
 import { hasOpenOperatorAlert, openOperatorAlert } from "./operator-alert.js";
@@ -810,35 +811,18 @@ export const claimRun = async (
           : declaredPriorOutputKinds.filter((kind) => !presentKinds.has(kind));
         // A retained step may still declare an output whose producer was
         // omitted when this chain was instantiated. Only that narrow case is
-        // satisfied by absence: an unknown kind, or any template step
-        // producing the kind that has a task in this chain, remains a claim
-        // refusal.
-        const producerSteps = missingKinds.length > 0
+        // satisfied by absence: an undeclared kind, or a producer that does
+        // have a task in this chain, remains a claim refusal.
+        const presence = missingKinds.length > 0
           && candidate.task.templateStep !== null
           && candidate.task.chainId !== null
-          && candidate.task.chainIndex !== null
-          ? await tx.taskTemplateStep.findMany({
-            where: {
-              taskTemplateId: candidate.task.templateStep.taskTemplateId,
-              outputKind: { in: missingKinds },
-            },
-            select: {
-              outputKind: true,
-              tasks: {
-                where: {
-                  projectId: candidate.task.projectId,
-                  chainId: candidate.task.chainId,
-                },
-                select: { id: true },
-              },
-            },
+          ? await chainStepPresence(tx, {
+            projectId: candidate.task.projectId,
+            chainId: candidate.task.chainId,
+            taskTemplateId: candidate.task.templateStep.taskTemplateId,
           })
-          : [];
-        const producerHasTask = new Map<string, boolean>();
-        for (const { outputKind, tasks } of producerSteps) {
-          producerHasTask.set(outputKind, (producerHasTask.get(outputKind) ?? false) || tasks.length > 0);
-        }
-        const unresolvedMissingKinds = missingKinds.filter((kind) => producerHasTask.get(kind) !== false);
+          : null;
+        const unresolvedMissingKinds = missingKinds.filter((kind) => presence?.ofKind(kind) !== "omitted");
         if (unresolvedMissingKinds.length > 0) {
           const reason = `Prior output claim refused: missing declared output kind${unresolvedMissingKinds.length === 1 ? "" : "s"}: ${unresolvedMissingKinds.join(", ")}`;
           await parkQueuedCandidate(candidate, {

--- a/packages/api/src/templates.ts
+++ b/packages/api/src/templates.ts
@@ -22,6 +22,7 @@ import {
 import { layerOf } from "@anneal/db/chain-order";
 
 import { isValidBranchName } from "./branch-name.js";
+import { templateStepInstantiation } from "./chain-step-omission.js";
 import { composeBrief } from "./task-brief.js";
 import {
   TemplateInstantiationRefusal,
@@ -371,16 +372,12 @@ export const instantiateTemplate = async (
       }
       assertValidBaseReferences(template.steps);
 
-      const conditionalRevalidation = consumesImplementationRoute
-        ? template.steps.find((step) => step.outputKind === "revalidation") ?? null
-        : null;
-      const omitRevalidation = conditionalRevalidation !== null && !input.afterTaskId;
-      const instantiatedTemplateSteps = omitRevalidation || projectInstantiationDefaults.skipOptionalSteps
-        ? template.steps.filter((step) => (
-          (!omitRevalidation || step.id !== conditionalRevalidation?.id)
-          && (!projectInstantiationDefaults.skipOptionalSteps || !step.optional)
-        ))
-        : template.steps;
+      const instantiation = templateStepInstantiation(template.steps, {
+        routesImplementation: consumesImplementationRoute,
+        boundToPredecessor: Boolean(input.afterTaskId),
+        skipOptionalSteps: projectInstantiationDefaults.skipOptionalSteps,
+      });
+      const instantiatedTemplateSteps = instantiation.instantiated;
       if (instantiatedTemplateSteps.length === 0) {
         throw templateRefusal("template_has_no_instantiable_steps", "Template has no instantiable steps");
       }
@@ -648,7 +645,7 @@ export const instantiateTemplate = async (
         const promptVariables = { ...input.variables, chainId };
         for (const [index, effective] of effectiveSteps.entries()) {
           const { step } = effective;
-          const conditionalOrdinalOffset = omitRevalidation ? 1 : 0;
+          const conditionalOrdinalOffset = instantiation.omittedConditionalRevalidation ? 1 : 0;
           const context = composeTemplateTaskDescription({
             prompt: interpolate(step.prompt, promptVariables),
             featureBrief: input.description,


### PR DESCRIPTION
## What changed

Instantiation omits a template step for two unrelated reasons — the conditional
revalidation step of an unbound Chain, and every optional step when the project
skips them — and stores neither. An omitted step is the absence of a Task row.
That absence was inferred again at each reader, with a different query, and
`instantiateTemplate` fused both omission rules into one filter expression.

`packages/api/src/chain-step-omission.ts` is one module owning both sides of
that single fact:

- `templateStepInstantiation` states the two omission rules and returns the
  steps that get a Task row, plus whether the conditional revalidation ordinal
  was dropped (the ordinal shift `instantiateTemplate` already applied).
- `chainStepPresence` reads the absence back in one query and answers
  `instantiated | omitted | undeclared`, in both vocabularies its readers hold:
  a declared prior output kind, and a canonical step role.

Leverage: `templates.ts`, `run-claim.ts` and `canonical-task-output.ts` all ask
this module; the two inference queries are deleted. Locality: the omission rule
and the inference that reads it back are edited in one place.

`parallel-review-fixture.ts` addressed tasks three ways (hardcoded chainIndex
twice, an ad-hoc step lookup once). It now addresses every chain task by the
output kind its template step produces, through one `chainTasks` helper, so no
fixture depends on an ordinal that omission shifts.

## Evidence

Worktree `worktrees/anneal-deepen-20260904/t3`, branch `deepen6/t3`, base
`62b5027c` (lane k2's delivered head). `origin/main` moved twice under the
branch and was merged both times: `d0383f01` as `21c37919`, then `0d8d4bc3`
(AGENTS.md only) as `b092ee1a`. All commands below were run in the worktree
after the final commit `b092ee1a`, with `RUNNER_WORKSPACE_ROOT` pointed at a
fresh `mktemp -d`:

- `npm run lint` — pass (biome 781 files, eslint clean).
- `npm run typecheck` — pass, all workspaces.
- `npm run test -w @anneal/api` — 902 tests, 901 pass, 1 skipped, 0 fail.
- `npm run test:snapshot-scan` — 21 tests, 0 fail (the two added files need no
  new `public-snapshot.json` entry; the existing globs classify them).
- `packages/api/src/prior-outputs-whitelist.dbtest.ts` and
  `optional-blind-review-flow.dbtest.ts` typecheck under the root typecheck and
  are unchanged; they are merge gate evidence, not run locally.
- Merge gate: `MERGE GATE: PASS b092ee1a26432b5819ab4de06ef2307aee7850da`
  (primary worker `ci-desktop-worker`, baseline `cd5e7fb0`).

## Decisions taken

**Absence stays the truth; the brief's recorded-fact shape is not delivered.**
Two pieces of evidence decided it. First, there is no chain-scoped row to carry
the record without a migration, which the brief forbids: a Chain is not a
table. `chainId` is a column on `Task`, and the only chain-scoped model,
`ChainControl`, is created lazily by an operator hold, so a stored omission list
would be absent for almost every Chain and would have to be reconstructed from
absence anyway. Second, the cost the recording was meant to remove is smaller
than it looked: `canonical-task-output.ts` inferred the omission from a query it
already needed for the review outputs, so only `run-claim.ts` paid a dedicated
round trip, and that round trip still exists (one per claim that finds a missing
declared kind) — it is now shared, not doubled. The deletion test the brief asks
for: with the module removed, `run-claim` would have to re-query
`TaskTemplateStep`, and `canonical-task-output` would have to decide again what
a zero-match review layer means; both blocks were load-bearing before and are
load-bearing now, but they are stated once instead of twice.

**Three-valued answer instead of a boolean.** The two readers do not tolerate
the same thing. `run-claim` must refuse a declared prior output kind that no
template step produces (a broken declaration) while excusing one whose producer
was omitted; `canonical-task-output` must excuse both, because a retired graph
carries the combined `must-fix` role and declares no `blind-findings` step at
all. Collapsing `omitted` and `undeclared` into one boolean would have broken
one of the two. Each caller maps the three values to its own rule.

**`canonical-task-output` is tightened, not just re-pointed.** It used to treat
"no review sibling at the predecessor layer" as an omission unconditionally.
It now asks the Chain: a review step this Chain did instantiate is owed in the fix
step's predecessor layer, and only an `omitted` or `undeclared` producer
excuses the missing sibling. A new unit test pins that case. This is a behaviour change on
one path — a Chain that instantiated a review step but placed it outside the
fix step's predecessor layer now refuses instead of silently accepting a
one-sided fix. No canonical or retired graph has that shape.

**The vestigial `chainIndex !== null` guard on the producer query is dropped.**
The old inference query never used `chainIndex`; it guarded on it because the
sibling prior-output query does. The presence query needs only `projectId` and
`chainId`.

**Revalidation is matched by step role, not by a literal `outputKind`.** The old
filter compared `outputKind === "revalidation"`, which a versioned successor
kind (`revalidation-v2`) would silently escape while every other reader in the
repository identifies that step through `stepRole`. The module uses `stepRole`.

**The new module is not added to the merge-tail defense list.** It is
instantiation and claim machinery; the list names merge-tail machinery, and no
closed-list test requires the entry.

## Disposition

Blind review returned `approve` with three advisory findings, and the first gate
dispatch returned FAIL. Every one is answered here.

1. **Vocabulary drift (`canonical-task-output.ts:257`, `canonical-task-output.test.ts:388`)
   — fixed.** The new comment and the new test name now say "predecessor layer";
   the pre-existing refusal string at line 201 keeps its wording because it is a
   stable operator-facing message this brief does not own.
2. **`templateStepInstantiation` omitted every revalidation-role step while
   `conditionalOrdinalOffset` stays `1` — fixed.** The rule resolves one step
   again, exactly as the code it replaced did (`find`, then identity
   comparison), so the omitted count and the applied ordinal offset cannot
   disagree. A unit test pins it with a template declaring `revalidation` and
   `revalidation-v2`: only the first is dropped. The hardcoded offset itself
   stays under Reported but unfixed.
3. **`parallel-review-fixture.chainTasks` collapsed duplicate output kinds and
   mapped a foreign `templateStepId` to a null key — fixed.** Building the index
   now asserts that every chain task names a step of the queried template and
   that no output kind appears twice, so `omits(kind)` can no longer report a
   task that exists, and a duplicate kind fails loudly instead of the later task
   winning.
4. **Merge gate FAIL on `21c37919` — rejected as a worker-environment failure,
   re-dispatched on the primary worker.** The single failing assertion was
   `scripts/deploy/systemd-installer.test.mjs:539`, which asserts that
   `systemd-analyze verify` prints no `Unknown|Failed to parse`. The actual
   output names only that worker's own system unit files
   (`/lib/systemd/system/snapd.service:23: Unknown key name 'RestartMode'`,
   `netplan-ovs-cleanup.service: Permission denied`), not any unit this
   repository renders; the log line `gate-dispatch: running on fallback
   (agentos-gate)` shows the run landed on the fallback worker, which produced
   the same class of false FAIL for lanes r2 and k3 in this round. That file is
   also owned by lane `d34`, whose state is `dispatched`, so the fence forbids
   editing it. The re-dispatch pins the primary worker with
   `AGENTOS_GATE_FALLBACK_SERVER=''`.

## Fence widened

`packages/api/src/chain-step-omission.ts` and its test are new files under
`packages/api/src`, a path lane t3's row does not name explicitly (lane k3's row
reserves "one new module under packages/api/src" for a different module, with a
different name; no file is shared). No file owned by a `dispatched` or `ready`
lane was edited. `packages/api/src/canonical-task-output.test.ts` is inside the
fence as a test the change necessarily breaks: its fake transaction had to grow
a `taskTemplateStep` reader and its fix task a `taskTemplateId`.

## Reported but unfixed

- `packages/api/src/templates.ts` still derives the omitted step's ordinal shift
  from a single hardcoded assumption — `conditionalOrdinalOffset` is `1`, which
  is only correct because the conditional revalidation step is `stepIndex` 1 of
  its template. `templateStepInstantiation` reports that the step was omitted;
  turning the offset into a derived value is a chain-ordinal change outside this
  brief.
- `scripts/deploy/systemd-installer.test.mjs:539` asserts on the gate worker's
  whole `systemd-analyze verify` output, so unrelated system unit files on the
  host can fail it. Owned by lane `d34` (`dispatched`), so it is reported, not
  edited.
- `packages/api/src/chain.ts` (`chainProgress` / `positions`) still infers
  omission from `templateStep: null` fixtures; the brief rules it out of scope
  and it earns its keep.

Generated with Claude Code (deepening round 6 lane t3)

