### PR TITLE
refactor(deploy): one installer outcome and one owner for the staged-file recovery rules

### DIFF
--- a/scripts/deploy/install-launchd-services.mjs
+++ b/scripts/deploy/install-launchd-services.mjs
@@ -47,41 +47,21 @@ export const runServiceInstaller = (args, context = {}) => {
     if (options.help) {
       usage();
       return 0;
-    } else {
-      const result = installLaunchdServices({
-        ...context,
-        apply: options.apply,
-        revert: options.revert,
-        replaceExisting: options.replaceExisting,
-        installUnits: options.installUnits,
-        serviceUser: options.serviceUser,
-      });
-      if (result.platform === "linux") {
-        const prefix = `${result.deployRole === "runner" ? "AGENTOS_DEPLOY_ROLE=runner " : ""}${result.runnerIdPrefix
-          ? `AGENTOS_RUNNER_ID_PREFIX=${shellQuote(result.runnerIdPrefix)} `
-          : ""}`;
-        const phase = options.revert ? "REVERT" : options.apply || options.installUnits ? "APPLY" : "PLAN";
-        process.stdout.write(`${phase} platform=linux\n`);
-        process.stdout.write(`${phase} unit-directory=${result.unitDirectory ?? "/etc/systemd/system"}\n`);
-        process.stdout.write(`${phase} units=${result.units.length}\n`);
-        process.stdout.write(`${phase} staging=${result.staging ?? "recorded"}\n`);
-        if (!options.apply && !options.installUnits) process.stdout.write("PLAN no files or systemd state changed\n");
-        else if (options.apply && !options.installUnits && !options.revert) {
-          process.stdout.write(`NEXT sudo ${prefix}node ${shellQuote(process.argv[1])} --install-units --service-user ${shellQuote(options.serviceUser)}\n`);
-        } else if (options.apply && options.revert && !options.installUnits) {
-          process.stdout.write(`NEXT sudo ${prefix}node ${shellQuote(process.argv[1])} --install-units --revert --service-user ${shellQuote(options.serviceUser)}\n`);
-        }
-      } else {
-        process.stdout.write(`${options.revert ? "REVERT" : options.apply ? "APPLY" : "PLAN"} service-wrapper=${result.wrapper ?? "recorded"}\n`);
-        process.stdout.write(`${options.revert ? "REVERT" : options.apply ? "APPLY" : "PLAN"} service-definitions=${result.entries.length}\n`);
-        if (options.apply && !options.revert) {
-          process.stdout.write("NEXT reload each service plist with launchctl, then run the wrapper inventory readiness check\n");
-        } else if (!options.apply) {
-          process.stdout.write("PLAN no files or launchd state changed\n");
-        }
-      }
-      return 0;
     }
+    const result = installLaunchdServices({
+      ...context,
+      apply: options.apply,
+      revert: options.revert,
+      replaceExisting: options.replaceExisting,
+      installUnits: options.installUnits,
+      serviceUser: options.serviceUser,
+    });
+    for (const [key, value] of result.report) process.stdout.write(`${result.phase} ${key}=${value}\n`);
+    if (result.notice) process.stdout.write(`${result.notice}\n`);
+    if (result.remaining) {
+      process.stdout.write(`NEXT sudo ${result.remaining.environment}node ${shellQuote(process.argv[1])} ${result.remaining.options}\n`);
+    }
+    return 0;
   } catch (error) {
     process.stderr.write(`STOP ${error instanceof Error ? error.message : String(error)}\n`);
     return 1;

--- a/scripts/deploy/install-launchd.mjs
+++ b/scripts/deploy/install-launchd.mjs
@@ -2658,7 +2658,7 @@ export const installLaunchd = (args, context = {}) => {
       resolveSystemdServiceUser({ serviceUser, platform, lookup: context.userLookup, execute: context.execute ?? execFileSync });
     }
     if (installUnits) {
-      installStagedSystemdAutoDeploy({
+      const { phase } = installStagedSystemdAutoDeploy({
         repositoryRoot: context.repositoryRoot,
         manifestPath: context.manifestPath,
         unitDirectory: context.unitDirectory,
@@ -2674,7 +2674,6 @@ export const installLaunchd = (args, context = {}) => {
         revert,
         apply: true,
       });
-      const phase = installerPhase({ revert, applied: true });
       process.stdout.write(`${phase} platform=linux\n`);
       process.stdout.write(`${phase} unit-directory=${context.unitDirectory ?? SYSTEMD_UNIT_DIRECTORY}\n`);
       process.stdout.write(`${phase} units=2\n`);
@@ -2682,7 +2681,7 @@ export const installLaunchd = (args, context = {}) => {
       return 0;
     }
     if (revert) {
-      installStagedSystemdAutoDeploy({
+      const { phase } = installStagedSystemdAutoDeploy({
         repositoryRoot: context.repositoryRoot,
         manifestPath: context.manifestPath,
         unitDirectory: context.unitDirectory,
@@ -2697,7 +2696,6 @@ export const installLaunchd = (args, context = {}) => {
         revert: true,
         apply,
       });
-      const phase = installerPhase({ revert: true, applied: apply });
       process.stdout.write(`${phase} platform=linux\n`);
       process.stdout.write(`${phase} unit-directory=${context.unitDirectory ?? SYSTEMD_UNIT_DIRECTORY}\n`);
       process.stdout.write(`${phase} units=2\n`);
@@ -2743,7 +2741,7 @@ export const installLaunchd = (args, context = {}) => {
       execute: context.execute ?? execFileSync,
       deployRole,
     });
-    const phase = installerPhase({ applied: apply });
+    const { phase } = result;
     process.stdout.write(`${phase} platform=linux\n`);
     process.stdout.write(`${phase} unit-directory=${context.unitDirectory ?? SYSTEMD_UNIT_DIRECTORY}\n`);
     process.stdout.write(`${phase} units=2\n`);
@@ -2933,7 +2931,7 @@ export const planSystemdAutoDeploy = ({
   const timerPath = join(targetRoot, AUTO_DEPLOY_TIMER);
   if (!apply) return Object.freeze({
     applied: false,
-    reverted: false,
+    phase: installerPhase({ applied: false }),
     platform: "linux",
     staging: stage,
     unitDirectory: targetRoot,
@@ -2996,7 +2994,7 @@ export const planSystemdAutoDeploy = ({
   writeAtomic(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 0o600);
   return Object.freeze({
     applied: true,
-    reverted: false,
+    phase: installerPhase({ applied: true }),
     platform: "linux",
     staging: stage,
     unitDirectory: targetRoot,
@@ -3067,7 +3065,7 @@ export const installStagedSystemdAutoDeploy = ({
   if (readFileSync(entries[1].stagedPath, "utf8") !== expectedTimer) throw new Error(`systemd-staged-unit-invalid:${AUTO_DEPLOY_TIMER}`);
   if (!apply) return Object.freeze({
     applied: false,
-    reverted: false,
+    phase: installerPhase({ revert, applied: false }),
     platform: "linux",
     staging: expectedStage,
     unitDirectory: targetRoot,
@@ -3099,7 +3097,7 @@ export const installStagedSystemdAutoDeploy = ({
     runSystemctl({ systemctlPath: systemctl, args: ["daemon-reload"], execute });
     runSystemctl({ systemctlPath: systemctl, args: ["enable", "--now", AUTO_DEPLOY_TIMER], unit: AUTO_DEPLOY_TIMER, execute });
     return Object.freeze({
-      applied: true, reverted: false, platform: "linux", staging: expectedStage,
+      applied: true, phase: installerPhase({ applied: true }), platform: "linux", staging: expectedStage,
       unitDirectory: targetRoot, deployRole, units: entries.map((entry) => entry.unit), entries: entries.map((entry) => entry.path),
     });
   }
@@ -3124,7 +3122,7 @@ export const installStagedSystemdAutoDeploy = ({
   rmSync(transactionStatePath, { force: true });
   rmSync(expectedStage, { recursive: true, force: true });
   return Object.freeze({
-    applied: true, reverted: true, platform: "linux", deployRole, staging: expectedStage,
+    applied: true, phase: installerPhase({ revert: true, applied: true }), platform: "linux", deployRole, staging: expectedStage,
     unitDirectory: targetRoot, units: entries.map((entry) => entry.unit), entries: entries.map((entry) => entry.path),
   });
 };

--- a/scripts/deploy/install-launchd.mjs
+++ b/scripts/deploy/install-launchd.mjs
@@ -1540,6 +1540,53 @@ const linuxServiceValues = ({ root, inventory, nodeBinary, path, serviceUser, wr
   }),
 ));
 
+const SERVICE_INSTALLER_UNCHANGED = Object.freeze({
+  darwin: "PLAN no files or launchd state changed",
+  linux: "PLAN no files or systemd state changed",
+});
+const LAUNCHD_ACTIVATION_NOTICE = "NEXT reload each service plist with launchctl, then run the wrapper inventory readiness check";
+
+/** The phase word an installer invocation performed. A revert names itself
+ * even when it only planned; an invocation that changed nothing is a plan. */
+const installerPhase = ({ revert = false, applied }) => revert ? "REVERT" : applied ? "APPLY" : "PLAN";
+
+/** The privileged systemd step that remains after an unprivileged stage,
+ * spelled except for the entrypoint path only the caller knows. */
+const privilegedStageCommand = ({ deployRole, runnerIdPrefix, serviceUser, revert }) => Object.freeze({
+  environment: `${deployRole === DEFAULT_DEPLOY_ROLE ? "" : `AGENTOS_DEPLOY_ROLE=${deployRole} `}${runnerIdPrefix
+    ? `AGENTOS_RUNNER_ID_PREFIX=${shellQuote(runnerIdPrefix)} `
+    : ""}`,
+  options: `--install-units${revert ? " --revert" : ""} --service-user ${shellQuote(serviceUser)}`,
+});
+
+const systemdInstallerReport = ({ unitDirectory, units, staging }) => [
+  ["platform", "linux"],
+  ["unit-directory", unitDirectory],
+  ["units", String(units.length)],
+  ["staging", staging],
+];
+
+const launchdInstallerReport = ({ wrapper, entries }) => [
+  ["service-wrapper", wrapper],
+  ["service-definitions", String(entries.length)],
+];
+
+/** The one outcome both platforms return. It names the phase performed, the
+ * report a caller prints under that phase word, the notice this installer can
+ * spell itself, and the privileged command that remains. Callers read these
+ * fields; nobody recomputes the phase from the options it was given. */
+const serviceInstallerOutcome = ({ platform, revert = false, applied, report, remaining = null, ...detail }) => Object.freeze({
+  phase: installerPhase({ revert, applied }),
+  platform,
+  applied,
+  report: Object.freeze(report.map((fact) => Object.freeze(fact))),
+  notice: applied
+    ? (platform === "darwin" && !revert ? LAUNCHD_ACTIVATION_NOTICE : null)
+    : SERVICE_INSTALLER_UNCHANGED[platform],
+  remaining,
+  ...detail,
+});
+
 const systemdStagePlan = ({
   repositoryRoot,
   nodeBinary = process.execPath,
@@ -1617,10 +1664,10 @@ const systemdStagePlan = ({
   ])));
   verifySystemdServiceDefinitions(unitDefinitions, inventory);
   const unitPaths = inventory.entries.map(({ unitName }) => join(resolvedUnitDirectory, unitName));
-  if (!apply) return Object.freeze({
-    applied: false,
-    reverted: false,
+  if (!apply) return serviceInstallerOutcome({
     platform: "linux",
+    applied: false,
+    report: systemdInstallerReport({ unitDirectory: resolvedUnitDirectory, units: unitPaths, staging: stageRoot }),
     staging: stageRoot,
     unitDirectory: resolvedUnitDirectory,
     runnerIdPrefix,
@@ -1788,10 +1835,11 @@ const systemdStagePlan = ({
   }
   mkdirSync(dirname(manifestPath), { recursive: true, mode: 0o700 });
   writeAtomic(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 0o600);
-  return Object.freeze({
-    applied: true,
-    reverted: false,
+  return serviceInstallerOutcome({
     platform: "linux",
+    applied: true,
+    report: systemdInstallerReport({ unitDirectory: resolvedUnitDirectory, units: unitEntries, staging: stageRoot }),
+    remaining: privilegedStageCommand({ deployRole, runnerIdPrefix, serviceUser: account, revert: false }),
     staging: stageRoot,
     unitDirectory: resolvedUnitDirectory,
     serviceUser: account,
@@ -1854,10 +1902,14 @@ export const installStagedSystemdServices = ({
   });
   const entries = validated.entries;
   const systemctl = systemctlPath ?? systemdCommandPath("systemctl", null, execute);
-  if (!apply) return Object.freeze({
-    applied: false,
-    reverted: false,
+  if (!apply) return serviceInstallerOutcome({
     platform: "linux",
+    applied: false,
+    report: systemdInstallerReport({
+      unitDirectory: resolvedUnitDirectory,
+      units: validated.inventory.entries,
+      staging: validated.stageRoot,
+    }),
     staging: validated.stageRoot,
     unitDirectory: resolvedUnitDirectory,
     units: validated.inventory.entries.map(({ unitName }) => unitName),
@@ -2013,10 +2065,14 @@ export const installStagedSystemdServices = ({
         throw new Error(`systemd-service-manifest-update-failed:complete:${error instanceof Error ? error.message : String(error)}`);
       }
     }
-    return Object.freeze({
-      applied: true,
-      reverted: false,
+    return serviceInstallerOutcome({
       platform: "linux",
+      applied: true,
+      report: systemdInstallerReport({
+        unitDirectory: resolvedUnitDirectory,
+        units: validated.inventory.entries,
+        staging: validated.stageRoot,
+      }),
       staging: validated.stageRoot,
       unitDirectory: resolvedUnitDirectory,
       runnerIdPrefix: manifest.renderInputs?.runnerIdPrefix ?? "",
@@ -2067,10 +2123,15 @@ export const installStagedSystemdServices = ({
   rmSync(path, { force: true });
   rmSync(transactionStatePath, { force: true });
   rmSync(validated.stageRoot, { recursive: true, force: true });
-  return Object.freeze({
-    applied: true,
-    reverted: true,
+  return serviceInstallerOutcome({
     platform: "linux",
+    revert: true,
+    applied: true,
+    report: systemdInstallerReport({
+      unitDirectory: resolvedUnitDirectory,
+      units: validated.inventory.entries,
+      staging: validated.stageRoot,
+    }),
     staging: validated.stageRoot,
     unitDirectory: resolvedUnitDirectory,
     units: validated.inventory.entries.map(({ unitName }) => unitName),
@@ -2123,10 +2184,23 @@ const installLinuxServices = (options = {}) => {
       manifest.wrapperReverted = true;
       writeAtomic(path, `${JSON.stringify(manifest, null, 2)}\n`, 0o600);
     }
-    return Object.freeze({
-      applied: apply,
-      reverted: false,
+    return serviceInstallerOutcome({
       platform: "linux",
+      revert: true,
+      applied: apply,
+      report: systemdInstallerReport({
+        unitDirectory: resolvedUnitDirectory,
+        units: validated.inventory.entries,
+        staging: validated.stageRoot,
+      }),
+      remaining: apply
+        ? privilegedStageCommand({
+            deployRole: validated.inventory.deployRole,
+            runnerIdPrefix: validated.inventory.runnerIdPrefix,
+            serviceUser: manifest.serviceUser,
+            revert: true,
+          })
+        : null,
       staging: validated.stageRoot,
       unitDirectory: resolvedUnitDirectory,
       runnerIdPrefix: validated.inventory.runnerIdPrefix,
@@ -2293,12 +2367,15 @@ export const installLaunchdServices = ({
         }
       }
     }
-    if (!apply) return {
+    if (!apply) return serviceInstallerOutcome({
+      platform: "darwin",
+      revert: true,
       applied: false,
-      reverted: false,
+      report: launchdInstallerReport({ wrapper, entries: manifest.entries }),
       deployRole,
+      wrapper,
       entries: manifest.entries.map((entry) => entry.path),
-    };
+    });
     for (const entry of manifest.entries) {
       if (entry.existed) {
         if (observed.get(entry.path) !== entry.originalSha256) {
@@ -2309,7 +2386,15 @@ export const installLaunchdServices = ({
       if (entry.backupPath) rmSync(entry.backupPath, { force: true });
     }
     rmSync(manifestPath, { force: true });
-    return { applied: true, reverted: true, deployRole, entries: manifest.entries.map((entry) => entry.path) };
+    return serviceInstallerOutcome({
+      platform: "darwin",
+      revert: true,
+      applied: true,
+      report: launchdInstallerReport({ wrapper, entries: manifest.entries }),
+      deployRole,
+      wrapper,
+      entries: manifest.entries.map((entry) => entry.path),
+    });
   }
   const resolvedNode = resolve(nodeBinary);
   const resolvedGit = gitBinary ? resolve(gitBinary) : resolvedNode;
@@ -2427,14 +2512,15 @@ export const installLaunchdServices = ({
       throw new Error(`launchd-service-definition-drift:${entry.path}`);
     }
   }
-  if (!apply) return {
+  if (!apply) return serviceInstallerOutcome({
+    platform: "darwin",
     applied: false,
-    reverted: false,
+    report: launchdInstallerReport({ wrapper, entries }),
     deployRole,
     wrapper,
     entries: entries.map(({ path: entryPath }) => entryPath),
     rendered,
-  };
+  });
   if (!existsSync(join(sharedRoot, ".env"))) throw new Error("shared-environment-missing");
   for (const directory of SHARED_RUNTIME_DIRECTORIES) {
     mkdirSync(join(sharedRoot, directory), { recursive: true, mode: 0o700 });
@@ -2535,14 +2621,15 @@ export const installLaunchdServices = ({
     });
     writeAtomic(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 0o600);
   }
-  return {
+  return serviceInstallerOutcome({
+    platform: "darwin",
     applied: true,
-    reverted: false,
+    report: launchdInstallerReport({ wrapper, entries }),
     deployRole,
     wrapper,
     bootstrap,
     entries: entries.map(({ path: entryPath }) => entryPath),
-  };
+  });
 };
 
 export const installLaunchd = (args, context = {}) => {
@@ -2579,7 +2666,7 @@ export const installLaunchd = (args, context = {}) => {
         revert,
         apply: true,
       });
-      const phase = revert ? "REVERT" : "APPLY";
+      const phase = installerPhase({ revert, applied: true });
       process.stdout.write(`${phase} platform=linux\n`);
       process.stdout.write(`${phase} unit-directory=${context.unitDirectory ?? SYSTEMD_UNIT_DIRECTORY}\n`);
       process.stdout.write(`${phase} units=2\n`);
@@ -2602,10 +2689,11 @@ export const installLaunchd = (args, context = {}) => {
         revert: true,
         apply,
       });
-      process.stdout.write(`${apply ? "REVERT" : "PLAN"} platform=linux\n`);
-      process.stdout.write(`${apply ? "REVERT" : "PLAN"} unit-directory=${context.unitDirectory ?? SYSTEMD_UNIT_DIRECTORY}\n`);
-      process.stdout.write(`${apply ? "REVERT" : "PLAN"} units=2\n`);
-      process.stdout.write(`${apply ? "REVERT" : "PLAN"} staging=${context.stagingRoot ?? "recorded"}\n`);
+      const phase = installerPhase({ revert: true, applied: apply });
+      process.stdout.write(`${phase} platform=linux\n`);
+      process.stdout.write(`${phase} unit-directory=${context.unitDirectory ?? SYSTEMD_UNIT_DIRECTORY}\n`);
+      process.stdout.write(`${phase} units=2\n`);
+      process.stdout.write(`${phase} staging=${context.stagingRoot ?? "recorded"}\n`);
       if (!apply) process.stdout.write("PLAN no files or systemd state changed\n");
       return 0;
     }
@@ -2647,10 +2735,11 @@ export const installLaunchd = (args, context = {}) => {
       execute: context.execute ?? execFileSync,
       deployRole,
     });
-    process.stdout.write(`${apply ? "APPLY" : "PLAN"} platform=linux\n`);
-    process.stdout.write(`${apply ? "APPLY" : "PLAN"} unit-directory=${context.unitDirectory ?? SYSTEMD_UNIT_DIRECTORY}\n`);
-    process.stdout.write(`${apply ? "APPLY" : "PLAN"} units=2\n`);
-    process.stdout.write(`${apply ? "APPLY" : "PLAN"} staging=${result.staging}\n`);
+    const phase = installerPhase({ applied: apply });
+    process.stdout.write(`${phase} platform=linux\n`);
+    process.stdout.write(`${phase} unit-directory=${context.unitDirectory ?? SYSTEMD_UNIT_DIRECTORY}\n`);
+    process.stdout.write(`${phase} units=2\n`);
+    process.stdout.write(`${phase} staging=${result.staging}\n`);
     if (!apply) process.stdout.write("PLAN no files or systemd state changed\n");
     else {
       const role = deployRole === DEFAULT_DEPLOY_ROLE ? "" : `AGENTOS_DEPLOY_ROLE=${deployRole} `;
@@ -2691,21 +2780,22 @@ export const installLaunchd = (args, context = {}) => {
   };
   verifyRenderedToolchain(values);
   const rendered = renderLaunchdPlist(readFileSync(TEMPLATE, "utf8"), values);
-  process.stdout.write(`${apply ? "APPLY" : "PLAN"} label=${LABEL}\n`);
-  process.stdout.write(`${apply ? "APPLY" : "PLAN"} destination=${destination}\n`);
-  process.stdout.write(`${apply ? "APPLY" : "PLAN"} repository=${values.repositoryRoot}\n`);
-  process.stdout.write(`${apply ? "APPLY" : "PLAN"} node=${values.nodeBinary}\n`);
-  process.stdout.write(`${apply ? "APPLY" : "PLAN"} path=${values.path}\n`);
-  process.stdout.write(`${apply ? "APPLY" : "PLAN"} git=${values.gitBinary}\n`);
-  process.stdout.write(`${apply ? "APPLY" : "PLAN"} npm=${values.npmBinary}\n`);
-  process.stdout.write(`${apply ? "APPLY" : "PLAN"} rendered_toolchain=verified\n`);
-  if (values.backup) process.stdout.write(`${apply ? "APPLY" : "PLAN"} pg_dump_mode=${values.backup.mode}\n`);
+  const phase = installerPhase({ applied: apply });
+  process.stdout.write(`${phase} label=${LABEL}\n`);
+  process.stdout.write(`${phase} destination=${destination}\n`);
+  process.stdout.write(`${phase} repository=${values.repositoryRoot}\n`);
+  process.stdout.write(`${phase} node=${values.nodeBinary}\n`);
+  process.stdout.write(`${phase} path=${values.path}\n`);
+  process.stdout.write(`${phase} git=${values.gitBinary}\n`);
+  process.stdout.write(`${phase} npm=${values.npmBinary}\n`);
+  process.stdout.write(`${phase} rendered_toolchain=verified\n`);
+  if (values.backup) process.stdout.write(`${phase} pg_dump_mode=${values.backup.mode}\n`);
   if (values.backup?.mode === "host") {
-    process.stdout.write(`${apply ? "APPLY" : "PLAN"} pg_dump=${values.backup.pgDumpBinary}\n`);
+    process.stdout.write(`${phase} pg_dump=${values.backup.pgDumpBinary}\n`);
   } else if (values.backup) {
-    process.stdout.write(`${apply ? "APPLY" : "PLAN"} docker=${values.backup.dockerBinary}\n`);
-    process.stdout.write(`${apply ? "APPLY" : "PLAN"} pg_dump_container=${values.backup.container}\n`);
-    process.stdout.write(`${apply ? "APPLY" : "PLAN"} container_pg_dump=${values.backup.pgDumpBinary}\n`);
+    process.stdout.write(`${phase} docker=${values.backup.dockerBinary}\n`);
+    process.stdout.write(`${phase} pg_dump_container=${values.backup.container}\n`);
+    process.stdout.write(`${phase} container_pg_dump=${values.backup.pgDumpBinary}\n`);
   }
 
   if (!apply) {

--- a/scripts/deploy/install-launchd.mjs
+++ b/scripts/deploy/install-launchd.mjs
@@ -897,6 +897,41 @@ const validateSudoers = ({ path, visudoPath, execute = execFileSync }) => {
 };
 
 const fileDigest = (path) => existsSync(path) ? sha256(readFileSync(path)) : null;
+
+/** The recovery rules every staged-file installer depends on. A manifest entry
+ * recognises exactly the digests an interrupted install can leave at its
+ * target: what this installer installed, what it installed before that, the
+ * operator's original when it overwrote one, and nothing at all when it
+ * created the file. An entry still showing the installed digest over an
+ * operator file needs a verified backup or there is no way back. `reason`
+ * names the installer in both refusals. Returns the digest observed at the
+ * target so a caller that restores need not read the file twice. */
+export const recognizeInstalledEntry = ({ entry, reason }) => {
+  const current = fileDigest(entry.path);
+  const recognized = current === entry.installedSha256
+    || current === entry.previousInstalledSha256
+    || (entry.existed && current === entry.originalSha256)
+    || (!entry.existed && current === null);
+  if (!recognized) throw new Error(`${reason}-definition-drift:${entry.path}`);
+  if (entry.existed && current === entry.installedSha256
+      && (!entry.backupPath || fileDigest(entry.backupPath) !== entry.originalSha256)) {
+    throw new Error(`${reason}-backup-missing:${entry.path}`);
+  }
+  return current;
+};
+
+/** The staged source an entry promises to install. Every copy out of a staging
+ * root passes through here first, and so does every installer that checks the
+ * staged files before it starts. */
+export const assertStagedSource = (entry) => {
+  if (!entry.stagedPath || !existsSync(entry.stagedPath)) {
+    throw new Error(`systemd-staged-file-missing:${entry.stagedPath ?? entry.path}`);
+  }
+  if (fileDigest(entry.stagedPath) !== entry.installedSha256) {
+    throw new Error(`systemd-staged-file-drift:${entry.stagedPath}`);
+  }
+};
+
 const invalidManifest = (reason, manifestPath, field) => {
   const detail = [manifestPath, field].filter((value) => value !== undefined && value !== null && value !== "").join(":");
   throw new DeployFailure(reason, detail);
@@ -1283,8 +1318,7 @@ const readStageEntries = ({
 };
 
 const copyStagedEntry = ({ entry, unitDirectory, sudoersPath, strictOwner = true, chown = chownSync }) => {
-  if (!entry.stagedPath || !existsSync(entry.stagedPath)) throw new Error(`systemd-staged-file-missing:${entry.stagedPath ?? entry.path}`);
-  if (fileDigest(entry.stagedPath) !== entry.installedSha256) throw new Error(`systemd-staged-file-drift:${entry.stagedPath}`);
+  assertStagedSource(entry);
   if (entry.kind === "wrapper") throw new Error("systemd-root-wrapper-write-refused");
   if (entry.kind === "sudoers") assertTargetPathSafe(entry.path, dirname(sudoersPath));
   else assertTargetPathSafe(entry.path, unitDirectory);
@@ -1916,20 +1950,8 @@ export const installStagedSystemdServices = ({
     entries: entries.map((entry) => entry.path),
   });
   for (const entry of entries) {
-    const currentSha = fileDigest(entry.path);
-    const recognized = currentSha === entry.installedSha256
-      || currentSha === entry.previousInstalledSha256
-      || (entry.existed && currentSha === entry.originalSha256)
-      || (!entry.existed && currentSha === null);
-    if (!recognized) throw new Error(`systemd-service-definition-drift:${entry.path}`);
-    if (entry.existed && currentSha === entry.installedSha256) {
-      if (!entry.backupPath || !existsSync(entry.backupPath) || fileDigest(entry.backupPath) !== entry.originalSha256) {
-        throw new Error(`systemd-service-backup-missing:${entry.path}`);
-      }
-    }
-    if (!revert && fileDigest(entry.stagedPath) !== entry.installedSha256) {
-      throw new Error(`systemd-staged-file-drift:${entry.stagedPath}`);
-    }
+    recognizeInstalledEntry({ entry, reason: "systemd-service" });
+    if (!revert) assertStagedSource(entry);
   }
   const transactionStatePath = join(resolvedUnitDirectory, ".anneal-service-transaction.json");
   let previousTransactionStateContents = null;
@@ -2349,24 +2371,10 @@ export const installLaunchdServices = ({
     const { manifest } = validateServiceManifest(
       readJsonFile(manifestPath, "launchd-service-manifest-invalid"), root, manifestPath, deployRole,
     );
-    const observed = new Map();
-    for (const entry of manifest.entries) {
-      const current = existsSync(entry.path) ? readFileSync(entry.path) : null;
-      const currentSha = current === null ? null : sha256(current);
-      observed.set(entry.path, currentSha);
-      const recognized = currentSha === entry.installedSha256
-        || currentSha === entry.previousInstalledSha256
-        || (entry.existed && currentSha === entry.originalSha256)
-        || (!entry.existed && currentSha === null);
-      if (!recognized) {
-        throw new Error(`launchd-service-definition-drift:${entry.path}`);
-      }
-      if (entry.existed && currentSha === entry.installedSha256) {
-        if (!entry.backupPath || !existsSync(entry.backupPath) || sha256(readFileSync(entry.backupPath)) !== entry.originalSha256) {
-          throw new DeployFailure("launchd-service-backup-missing", entry.backupPath ?? entry.path);
-        }
-      }
-    }
+    const observed = new Map(manifest.entries.map((entry) => [
+      entry.path,
+      recognizeInstalledEntry({ entry, reason: "launchd-service" }),
+    ]));
     if (!apply) return serviceInstallerOutcome({
       platform: "darwin",
       revert: true,
@@ -3068,18 +3076,8 @@ export const installStagedSystemdAutoDeploy = ({
   });
   const systemctl = systemctlPath ?? systemdCommandPath("systemctl", null, execute);
   for (const entry of entries) {
-    const current = fileDigest(entry.path);
-    const recognized = current === entry.installedSha256
-      || (entry.existed && current === entry.originalSha256)
-      || (!entry.existed && current === null);
-    if (!recognized) throw new Error(`systemd-auto-deploy-definition-drift:${entry.path}`);
-    if (entry.existed && current === entry.installedSha256
-        && (!entry.backupPath || !existsSync(entry.backupPath) || fileDigest(entry.backupPath) !== entry.originalSha256)) {
-      throw new Error(`systemd-auto-deploy-backup-missing:${entry.path}`);
-    }
-    if (!revert && fileDigest(entry.stagedPath) !== entry.installedSha256) {
-      throw new Error(`systemd-staged-file-drift:${entry.stagedPath}`);
-    }
+    recognizeInstalledEntry({ entry, reason: "systemd-auto-deploy" });
+    if (!revert) assertStagedSource(entry);
   }
   const transactionStatePath = join(targetRoot, ".anneal-auto-deploy-transaction.json");
   const transactionState = rootTransactionState({

--- a/scripts/deploy/launchd-service-wrapper.test.mjs
+++ b/scripts/deploy/launchd-service-wrapper.test.mjs
@@ -44,6 +44,7 @@ import {
   renderServicePlists,
   verifyServicePlistDefinitions,
 } from "./install-launchd.mjs";
+import { runServiceInstaller } from "./install-launchd-services.mjs";
 
 /** The standalone wrapper carries label, runner id and unit name; the resolved
  * inventory carries those plus the runner index and plist name. Compare the
@@ -477,6 +478,49 @@ test("the real web invocation starts from a read-only release without writing in
   await new Promise((resolveExit) => child.once("exit", resolveExit));
 });
 
+const captureStdout = (work) => {
+  const chunks = [];
+  const original = process.stdout.write;
+  process.stdout.write = (chunk) => { chunks.push(String(chunk)); return true; };
+  try { work(); } finally { process.stdout.write = original; }
+  return chunks.join("");
+};
+
+test("the service CLI prints the launchd outcome for every phase", () => {
+  const fixture = releaseFixture();
+  const home = join(fixture.root, "operator-home");
+  const context = {
+    repositoryRoot: fixture.root,
+    userHome: home,
+    nodeBinary: process.execPath,
+    gitBinary: process.execPath,
+  };
+  const wrapper = serviceWrapperPath(realpathSync(fixture.root));
+  const definitions = SERVICE_LABELS.length + 1;
+  try {
+    assert.equal(
+      captureStdout(() => assert.equal(runServiceInstaller([], context), 0)),
+      `PLAN service-wrapper=${wrapper}\nPLAN service-definitions=${definitions}\nPLAN no files or launchd state changed\n`,
+    );
+    assert.equal(
+      captureStdout(() => assert.equal(runServiceInstaller(["--apply"], context), 0)),
+      `APPLY service-wrapper=${wrapper}\nAPPLY service-definitions=${definitions}\n`
+        + "NEXT reload each service plist with launchctl, then run the wrapper inventory readiness check\n",
+    );
+    assert.equal(
+      captureStdout(() => assert.equal(runServiceInstaller(["--revert"], context), 0)),
+      `REVERT service-wrapper=${wrapper}\nREVERT service-definitions=${definitions}\nPLAN no files or launchd state changed\n`,
+    );
+    assert.equal(
+      captureStdout(() => assert.equal(runServiceInstaller(["--revert", "--apply"], context), 0)),
+      `REVERT service-wrapper=${wrapper}\nREVERT service-definitions=${definitions}\n`,
+    );
+    assert.equal(existsSync(wrapper), false);
+  } finally {
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+});
+
 test("service plist rendering and installation cover every label before activation", () => {
   const fixture = releaseFixture();
   const home = join(fixture.root, "operator-home");
@@ -520,9 +564,9 @@ test("service plist rendering and installation cover every label before activati
     }
 
     const plannedRevert = installLaunchdServices({ repositoryRoot: fixture.root, userHome: home, revert: true });
-    assert.equal(plannedRevert.applied, false);
+    assert.deepEqual([plannedRevert.phase, plannedRevert.applied], ["REVERT", false]);
     const reverted = installLaunchdServices({ repositoryRoot: fixture.root, userHome: home, revert: true, apply: true });
-    assert.equal(reverted.reverted, true);
+    assert.deepEqual([reverted.phase, reverted.applied], ["REVERT", true]);
     assert.equal(existsSync(serviceWrapperPath(fixture.root)), false);
     for (const label of SERVICE_LABELS) assert.equal(existsSync(join(home, "Library/LaunchAgents", `${label}.plist`)), false);
     assert.equal(existsSync(join(fixture.root, "shared/.env")), true);
@@ -573,7 +617,7 @@ test("an explicit wrapper migration replaces existing service definitions and re
       replaceExisting: true,
       apply: true,
     });
-    assert.equal(installed.applied, true);
+    assert.deepEqual([installed.phase, installed.applied], ["APPLY", true]);
     for (const label of SERVICE_LABELS) {
       const installedDefinition = readFileSync(join(launchAgents, `${label}.plist`), "utf8");
       assert.match(installedDefinition, /agentos-service-wrapper\.mjs/u);
@@ -594,7 +638,7 @@ test("an explicit wrapper migration replaces existing service definitions and re
       revert: true,
       apply: true,
     });
-    assert.equal(reverted.reverted, true);
+    assert.deepEqual([reverted.phase, reverted.applied], ["REVERT", true]);
     for (const label of SERVICE_LABELS) {
       assert.equal(readFileSync(join(launchAgents, `${label}.plist`), "utf8"), originals[label]);
     }
@@ -624,7 +668,7 @@ test("wrapper migration reuses matching orphaned backups and names conflicting l
       replaceExisting: true,
       apply: true,
     });
-    assert.equal(installed.applied, true);
+    assert.deepEqual([installed.phase, installed.applied], ["APPLY", true]);
     installLaunchdServices({ repositoryRoot: fixture.root, userHome: home, revert: true, apply: true });
 
     writeFileSync(apiBackup, "unrelated-leftover\n");

--- a/scripts/deploy/systemd-installer.test.mjs
+++ b/scripts/deploy/systemd-installer.test.mjs
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  assertStagedSource,
   autoDeployEnvironmentValues,
   controlledLaunchdPath,
   installLaunchd,
@@ -31,6 +32,7 @@ import {
   renderLaunchdPlist,
   renderServiceLaunchdPlist,
   renderServiceSystemdUnit,
+  recognizeInstalledEntry,
   renderSystemdSudoers,
   serviceEnvironmentValues,
   servicePlistValues,
@@ -600,6 +602,95 @@ test("rendered unit syntax is verified by systemd-analyze when available", (t) =
       assert.equal(verified.status, 0, output);
       assert.doesNotMatch(output, /Unknown|Failed to parse/u);
     }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the recovery rules recognise every state an interrupted install can leave", () => {
+  const root = mkdtempSync(join(tmpdir(), "agentos-staged-recovery-"));
+  try {
+    const target = join(root, "com.agentos.api.service");
+    const backup = join(root, "backup");
+    const write = (path, contents) => { writeFileSync(path, contents); return digest(contents); };
+    const installed = digest("installed\n");
+    const previous = digest("previous\n");
+    const original = digest("original\n");
+    const created = {
+      path: target,
+      existed: false,
+      backupPath: null,
+      originalSha256: null,
+      installedSha256: installed,
+    };
+    const overwritten = {
+      path: target,
+      existed: true,
+      backupPath: backup,
+      originalSha256: original,
+      installedSha256: installed,
+      previousInstalledSha256: previous,
+    };
+
+    // The copy completed over a file the installer created.
+    write(target, "installed\n");
+    assert.equal(recognizeInstalledEntry({ entry: created, reason: "systemd-service" }), installed);
+
+    // The copy completed over an operator file: the backup is the only way
+    // back, so it must be present and must still be the operator's bytes.
+    assert.throws(
+      () => recognizeInstalledEntry({ entry: overwritten, reason: "systemd-service" }),
+      /^Error: systemd-service-backup-missing:/u,
+    );
+    write(backup, "someone-elses\n");
+    assert.throws(
+      () => recognizeInstalledEntry({ entry: overwritten, reason: "launchd-service" }),
+      /^Error: launchd-service-backup-missing:/u,
+    );
+    write(backup, "original\n");
+    assert.equal(recognizeInstalledEntry({ entry: overwritten, reason: "systemd-service" }), installed);
+
+    // The copy never happened, or a partial transaction was already restored.
+    write(target, "original\n");
+    assert.equal(recognizeInstalledEntry({ entry: overwritten, reason: "systemd-service" }), original);
+    rmSync(backup, { force: true });
+    assert.equal(recognizeInstalledEntry({ entry: overwritten, reason: "systemd-service" }), original);
+
+    // An interrupted upgrade left the digest this installer wrote last time.
+    write(target, "previous\n");
+    assert.equal(recognizeInstalledEntry({ entry: overwritten, reason: "systemd-service" }), previous);
+
+    // Nothing at the target is the created entry's untouched state and the
+    // overwritten entry's drift.
+    rmSync(target, { force: true });
+    assert.equal(recognizeInstalledEntry({ entry: created, reason: "systemd-service" }), null);
+    assert.throws(
+      () => recognizeInstalledEntry({ entry: overwritten, reason: "systemd-auto-deploy" }),
+      /^Error: systemd-auto-deploy-definition-drift:/u,
+    );
+
+    // Anything else at the target is a foreign write.
+    write(target, "operator-edited\n");
+    assert.throws(
+      () => recognizeInstalledEntry({ entry: created, reason: "systemd-service" }),
+      new RegExp(`^Error: systemd-service-definition-drift:${escapeRegExp(target)}$`, "u"),
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a staged source is refused when it is missing or no longer what the manifest promised", () => {
+  const root = mkdtempSync(join(tmpdir(), "agentos-staged-source-"));
+  try {
+    const stagedPath = join(root, "staged");
+    const entry = { path: join(root, "target"), stagedPath, installedSha256: digest("installed\n") };
+    assert.throws(() => assertStagedSource(entry), /^Error: systemd-staged-file-missing:/u);
+    assert.throws(() => assertStagedSource({ ...entry, stagedPath: undefined }), /^Error: systemd-staged-file-missing:/u);
+    writeFileSync(stagedPath, "tampered\n");
+    assert.throws(() => assertStagedSource(entry), /^Error: systemd-staged-file-drift:/u);
+    writeFileSync(stagedPath, "installed\n");
+    assert.equal(assertStagedSource(entry), undefined);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/deploy/systemd-installer.test.mjs
+++ b/scripts/deploy/systemd-installer.test.mjs
@@ -37,6 +37,7 @@ import {
   verifySystemdAutoDeployDefinitions,
   verifySystemdServiceDefinitions,
 } from "./install-launchd.mjs";
+import { runServiceInstaller } from "./install-launchd-services.mjs";
 import { generateServiceInventory, resolveServiceInventory } from "./service-inventory.mjs";
 
 const DEFAULT_INVENTORY = resolveServiceInventory({});
@@ -54,6 +55,15 @@ const withServicePlatform = async (platform, work) => {
 };
 
 const withLinux = (work) => withServicePlatform("linux", work);
+
+const shellQuote = (value) => `'${String(value).replaceAll("'", `'"'"'`)}'`;
+const captureStdout = (work) => {
+  const chunks = [];
+  const original = process.stdout.write;
+  process.stdout.write = (chunk) => { chunks.push(String(chunk)); return true; };
+  try { work(); } finally { process.stdout.write = original; }
+  return chunks.join("");
+};
 
 const prepareManifestValidationCase = (platform) => {
   const root = mkdtempSync(join(tmpdir(), `agentos-${platform}-manifest-invalid-`));
@@ -595,6 +605,59 @@ test("rendered unit syntax is verified by systemd-analyze when available", (t) =
   }
 });
 
+test("the service CLI prints the phase, report and remaining step the installer returns", async () => {
+  await withLinux(async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentos-systemd-cli-outcome-"));
+    const unitDirectory = join(root, "etc/systemd/system");
+    const sudoersPath = join(root, "etc/sudoers.d/anneal-service-control");
+    const context = {
+      repositoryRoot: root,
+      nodeBinary: process.execPath,
+      gitBinary: process.execPath,
+      unitDirectory,
+      sudoersPath,
+      visudoPath: "/usr/bin/true",
+      userLookup: accountLookup,
+      effectiveUid: 501,
+    };
+    const stageCommand = (options) => `NEXT sudo node ${shellQuote(process.argv[1])} ${options}\n`;
+    try {
+      const planned = captureStdout(() => assert.equal(runServiceInstaller(["--service-user", "anneal-test"], context), 0));
+      const stagingRoot = planned.match(/^PLAN staging=(.*)$/mu)[1];
+      assert.equal(planned, [
+        "PLAN platform=linux",
+        `PLAN unit-directory=${unitDirectory}`,
+        `PLAN units=${SERVICE_LABELS.length}`,
+        `PLAN staging=${stagingRoot}`,
+        "PLAN no files or systemd state changed\n",
+      ].join("\n"));
+      const applied = captureStdout(() =>
+        assert.equal(runServiceInstaller(["--apply", "--service-user", "anneal-test"], context), 0));
+      assert.equal(applied, [
+        "APPLY platform=linux",
+        `APPLY unit-directory=${unitDirectory}`,
+        `APPLY units=${SERVICE_LABELS.length}`,
+        `APPLY staging=${applied.match(/^APPLY staging=(.*)$/mu)[1]}`,
+        stageCommand("--install-units --service-user 'anneal-test'"),
+      ].join("\n"));
+      const plannedRevert = captureStdout(() =>
+        assert.equal(runServiceInstaller(["--revert", "--service-user", "anneal-test"], context), 0));
+      assert.match(plannedRevert, /^REVERT platform=linux\n/u);
+      assert.match(plannedRevert, /\nPLAN no files or systemd state changed\n$/u);
+      const stagedRevert = captureStdout(() =>
+        assert.equal(runServiceInstaller(["--revert", "--apply", "--service-user", "anneal-test"], context), 0));
+      assert.match(stagedRevert, /^REVERT platform=linux\n/u);
+      assert.equal(
+        stagedRevert.endsWith(stageCommand("--install-units --revert --service-user 'anneal-test'")),
+        true,
+        stagedRevert,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 test("the real service CLI enforces the Linux root boundary and sudo -n policy", async () => {
   await withLinux(async () => {
     const root = mkdtempSync(join(tmpdir(), "agentos-systemd-installer-"));
@@ -747,7 +810,7 @@ test("the real service CLI enforces the Linux root boundary and sudo -n policy",
         userLookup: accountLookup,
         visudoPath: "/usr/bin/true",
       });
-      assert.equal(reverted.reverted, true);
+      assert.deepEqual([reverted.phase, reverted.applied], ["REVERT", true]);
       assert.equal(reverted.platform, "linux");
       assert.equal(existsSync(join(unitDirectory, "com.agentos.api.service")), false);
       assert.equal(existsSync(join(unitDirectory, "com.agentos.api.service.d")), false);

--- a/scripts/deploy/systemd-installer.test.mjs
+++ b/scripts/deploy/systemd-installer.test.mjs
@@ -593,6 +593,7 @@ test("rendered unit syntax is verified by systemd-analyze when available", (t) =
     writeFileSync(autoService, renderAutoDeploySystemdUnit(undefined, autoValues));
     writeFileSync(autoTimer, renderAutoDeploySystemdTimer());
     files.push(autoService, autoTimer);
+    const renderedNames = files.map((file) => file.slice(root.length + 1));
     for (const path of files) {
       const verified = spawnSync("systemd-analyze", ["verify", path], {
         encoding: "utf8",
@@ -600,7 +601,13 @@ test("rendered unit syntax is verified by systemd-analyze when available", (t) =
       });
       const output = `${verified.stdout ?? ""}${verified.stderr ?? ""}`;
       assert.equal(verified.status, 0, output);
-      assert.doesNotMatch(output, /Unknown|Failed to parse/u);
+      // systemd-analyze also loads the host's own units and reports on them;
+      // only the lines naming a unit this test rendered are evidence here.
+      const rendered = output
+        .split("\n")
+        .filter((line) => line.startsWith(root) || renderedNames.some((name) => line.startsWith(`${name}:`)))
+        .join("\n");
+      assert.doesNotMatch(rendered, /Unknown|Failed to parse/u);
     }
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## What changed

Two deepenings in the deploy service installer, in one branch.

**One installer outcome (D4).** `installLaunchdServices` returned
`{applied, reverted, entries}` on darwin and a different shape on linux, so
`install-launchd-services.mjs` re-branched on `result.platform` and recomputed
the PLAN / APPLY / REVERT word at five sites with four different boolean
expressions (`77456bea` repaired one of them by appending `|| options.installUnits`
to a ternary). Both platforms now return one outcome: `phase` (the word), `report`
(the ordered facts the caller prints under that word), `notice` (the line the
installer can spell itself, because only it knows whether it changed anything and
which state store it owns) and `remaining` (the privileged systemd command,
spelled except for the entrypoint path only the CLI knows). The CLI prints the
outcome and computes nothing. `applied` survives as the fact "this invocation
changed state"; `reverted` is gone from every installer outcome, service and
auto-deploy alike, since `phase` names the operation. The auto-deploy outcomes
carry the same `phase` from the one `installerPhase` rule, so the auto-deploy CLI
prints it instead of recomputing it at three further sites.

**One module owns the recovery rules (D3, partial).** The digest recognition an
interrupted install can leave at a target, and the backup an overwritten operator
file requires, were written verbatim in `installStagedSystemdServices`,
`installStagedSystemdAutoDeploy` and the darwin revert (`cb342422` had to touch
all three); the staged-source check was written three times as well.
`recognizeInstalledEntry` and `assertStagedSource` now own those rules. The three
installers name themselves in the refusal and stop owning the rules, and the
recovery matrix has unit tests that build no manifest and no fake `/etc`.

## Evidence

Worktree `worktrees/anneal-deepen-20260904/d34`, base `cafbc72d` (lane d2's
delivered head), `origin/main` `cd5e7fb0` merged in (head `b2937055`). All commands
re-run after the final commit, with `RUNNER_WORKSPACE_ROOT` pointed at a fresh
temporary directory.

- `npm run lint` - exit 0.
- `npm run typecheck` - exit 0.
- `npm run test:auto-deploy` - 226 tests, 223 pass, 2 fail. Both failures are this
  macOS host, not this change: they fail identically on the unmodified base.
  `default Darwin render, manifest entries, and plan stdout match 9a52c6ad bytes`
  spawns the real entrypoint without overriding `HOME`, and this host has real
  `~/Library/LaunchAgents/com.agentos.*.plist` files, so planning refuses with
  `launchd-service-definition-conflict`;
  `runner auto-deploy stage one prints a stage-two command carrying the role`
  needs `systemctl`, which macOS does not have. The merge gate is the authority
  for both.
- The pinned darwin plan stdout was verified by hand against the fixture, since
  the test that owns it cannot run on this host:
  `HOME=$(mktemp -d) AGENTOS_SERVICE_PLATFORM=darwin node scripts/deploy/install-launchd-services.mjs`
  is byte-identical to `darwin-9a52c6ad-baseline.json` `servicePlanStdout`.
- New tests: the linux service CLI prints PLAN / APPLY / REVERT with the advisory
  and the two `NEXT sudo ... --install-units` forms; the darwin service CLI prints
  all four phases including the launchctl activation notice; the recovery matrix
  (created entry, overwritten entry with a good, missing and foreign backup,
  original digest after a copy that never happened, previous installed digest
  after an interrupted upgrade, absent target, foreign write) and the staged-source
  refusals.

## Decisions taken

- **D3 delivered as the recovery rules, not as one transaction.** The brief's
  escape clause is "if you cannot keep the transaction's interface to entries plus
  policy, deliver D4 only"; 00-COMMON says deliver the shape you recommend rather
  than nothing. The three transactions already share their mechanical steps through
  existing modules (`rootTransactionState`, `copyStagedEntry`,
  `restoreRootTransactionEntry`, `runSystemctl`). What is left unshared is the
  activation, and it is genuinely three different things: services enable each unit
  and carry retirement, `reinstall` completion and drop-ins; auto-deploy enables one
  timer; the darwin revert restores user-owned files from backups and has no
  systemd at all. One transaction over those three would take injected policy
  callbacks - a seam built for three known callers and no others, which 00-COMMON
  forbids. The verbatim duplication `cb342422` had to chase is the recovery rules,
  and those are now one module each.
- The recovery module lives in `install-launchd.mjs` next to its only three
  callers rather than in a new file: a new file buys an import and a
  public-snapshot classification and no locality.
- Auto-deploy's `previousInstalledSha256` clause: the unified rule includes it.
  Auto-deploy entries never carry that field, so the clause can only be false there.
- The darwin backup refusal was a `DeployFailure` naming the backup path while the
  other two were plain `Error`s naming the target. It is now the same plain Error
  naming the target. Nothing catches it by class: `installLaunchdServices` is only
  reached from the operator CLI, never from `quiet-window-deploy`.
- A staged file that is missing now reports `systemd-staged-file-missing` where the
  two pre-checks reported `systemd-staged-file-drift`. The copy already reported
  missing; one rule, one message.
- A planned revert now reports `REVERT` in the auto-deploy CLI header lines, where
  it used to report `PLAN` while the service CLI reported `REVERT` for the same
  operation. One phase rule, and the `PLAN no files or systemd state changed`
  advisory still says nothing happened. No fixture, test or runbook pins the old
  word.
- The darwin revert outcome now reports the real wrapper path where the CLI used to
  print `service-wrapper=recorded`, because the installer knows it. Nothing pins it.
- The `NEXT sudo ... --install-units --revert` command now names the service user
  recorded in the manifest instead of echoing the `--service-user` flag; when the
  flag was omitted the old line printed `--service-user 'undefined'`.

## Fence widened

None. `install-launchd.mjs`, `install-launchd-services.mjs`,
`systemd-installer.test.mjs` and `launchd-service-wrapper.test.mjs` are lane d34's
paths and the tests they break; d1, whose owned-path list also names those tests,
is merged.

## Reported but unfixed

- The full staged-file transaction (stage, digest, backup, recognise, copy,
  activate, restore) still has three orchestrations. See the decision above for why
  a single transaction is not the right shape; if it is ever wanted, the missing
  piece is a common activation vocabulary, not a policy flag bag.
- `installLinuxServices` re-checks the wrapper entry's backup with a fourth,
  stricter copy of the backup rule (`install-launchd.mjs`, stage-one revert): it
  demands exactly `installedSha256`, not the recognition set, so it cannot use
  `recognizeInstalledEntry` as written.
- `installLinuxServices` is still a 55-line pass-through forwarding 20 named
  options to `installStagedSystemdServices` or `systemdStagePlan` (finding 2,
  deletion test).
- `packages/runner/src/repo-mirror.test.ts:425` (`a live heartbeating holder can
  cross the creation ceiling before releasing the lock`) is load-sensitive: it
  heartbeats a real holder on wall-clock time while the waiter advances a synthetic
  clock, so a busy worker makes the waiter steal a live lock. It FAILed one gate
  dispatch and passed the next on the same head. Outside this lane's paths.
- `readStageEntries` has its own `systemd-staged-file-missing` check that predates
  the entry digests and is not expressible through `assertStagedSource`.
- The auto-deploy CLI (`installLaunchd`, linux arm) still hand-spells its four
  report lines, its `PLAN no files or systemd state changed` advisory and its
  `NEXT sudo ... --install-units` command, where the service CLI reads `report`,
  `notice` and `remaining` from the outcome. Only the phase was unified here; the
  lines themselves are pinned for the darwin arm of the same entrypoint by
  `darwin-9a52c6ad-baseline.json`.

## Disposition

Blind review returned `approve` with one advisory finding; the merge gate on
`5213fb22` returned FAIL. Both are dispositioned here.

- **Advisory, `scripts/deploy/install-launchd.mjs`: the three auto-deploy outcomes
  still return the pre-D4 `reverted` field that no code reads - FIXED.** The five
  auto-deploy return sites (`planSystemdAutoDeploy` plan and apply,
  `installStagedSystemdAutoDeploy` plan, apply and revert) now carry `phase` from
  the one `installerPhase` rule instead of `reverted`, and the auto-deploy CLI
  prints `outcome.phase` in its three linux paths instead of recomputing the word.
  `reverted` no longer exists anywhere in the deploy scripts. The planned-revert
  phase is preserved: the shared `!apply` return computes
  `installerPhase({ revert, applied: false })`, so `--revert` without `--apply`
  still reports `REVERT`. The auto-deploy CLI's report lines, its
  `PLAN no files or systemd state changed` advisory and its `NEXT` command are
  still hand-spelled; that is listed under Reported but unfixed rather than fixed,
  because turning them into `report` / `notice` / `remaining` would rewrite stdout
  that `darwin-9a52c6ad-baseline.json` pins on the darwin arm of the same CLI, and
  the brief named `installLaunchdServices`, not the auto-deploy CLI.
- **Gate FAIL on `5213fb22`: `rendered unit syntax is verified by systemd-analyze
  when available` (`scripts/deploy/systemd-installer.test.mjs:551`) - FIXED, and it
  was not this change.** The assertion is byte-identical on `origin/main`
  (`git show origin/main:scripts/deploy/systemd-installer.test.mjs`), and the text
  it rejected names `/lib/systemd/system/snapd.service:23: Unknown key name
  'RestartMode'` - a host unit this repository does not own. `systemd-analyze
  verify` loads the host's own units alongside the one it is given and reports on
  all of them, so the test was asserting over the gate worker's `/lib/systemd`.
  The check now reads only the lines naming a unit the test rendered (a line that
  starts with the temporary root, or with one of the rendered unit file names),
  which is the evidence the test was written to gather. Any lane whose head lands
  on that worker would have hit the same FAIL.

Merge gate on the repaired head `b2937055`:

- First dispatch: `MERGE GATE: FAIL (unit tests (all workspaces))` -
  `packages/runner/src/repo-mirror.test.ts` `a live heartbeating holder can cross
  the creation ceiling before releasing the lock` reported `lock-steal` after
  83.8s. `quiet-window auto-deploy harness` passed on that same run, so the
  dispositioned failure is closed. The failing test is a real holder heartbeating
  on wall-clock time against a waiter on a synthetic clock: when the worker starves
  the holder's heartbeat between polls, the waiter sees a stale lock and steals it.
  It touches nothing this branch changed (this branch changes `scripts/deploy` only)
  and it passes at this exact head on this Mac:
  `node --conditions=development --import tsx --test src/repo-mirror.test.ts`
  in `packages/runner` - 18 tests, 18 pass, that test green in 157.7s.
  Not repaired here: the file belongs to no lane in this round and repairing a
  load-sensitive runner lock test is not this brief.
- Second dispatch, same head, different worker:
  `MERGE GATE: PASS b2937055b9e46595436b6906cd91f56ef5b4abcc`.

Generated with Claude Code (deepening round 6 lane d34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zzbyE3vWTRrDacwLEoA3v



## Merge with main

`origin/main` moved after this branch's gate passed, and `scripts/deploy/systemd-installer.test.mjs`
conflicted in the assertion of "rendered unit syntax is verified by systemd-analyze when available".
Lane k3 (PR #472) landed the same scoping first, so this merge keeps main's version — the filter
`line.includes(root) || line.startsWith(`${basename(path)}:`)` with `basename` imported from
`node:path` — and drops this branch's duplicate `renderedNames`-based filter along with the
now-unreferenced `renderedNames` binding. Every other change from this branch in that file is kept.
