### PR TITLE
docs: streamline routing and delivery runbooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,107 +1,90 @@
 # Contributing
 
-Thank you for reading this before opening something.
-
 ## The current state of contributions
 
-Anneal v0.7.0 is a Developer Preview published so that people can evaluate it,
-read it, and tell us where it is wrong. **We are not yet accepting outside pull
-requests.** The review and merge process this repository uses is built around a
-single gate run by maintainers, and we would rather say that plainly than leave
-pull requests sitting unread.
+Anneal v0.7.0 is a Developer Preview. **We are not yet accepting outside pull
+requests.** Contributions currently take the form of:
 
-What is genuinely useful right now:
+- Bug reports with the release tag or commit, platform, command, and exact
+  error. See the [support matrix](docs/release/support-matrix.md).
+- Documentation corrections naming the file, line, and discrepancy.
+- Private security reports through [SECURITY.md](SECURITY.md), never public issues.
 
-- **Bug reports** with the release tag or commit, your platform, the exact
-  command, and the exact reason code or message. The authoritative support
-  statement is in
-  [`docs/release/support-matrix.md`](docs/release/support-matrix.md).
-- **Documentation corrections**, especially anywhere a document claims something
-  the code does not do. That class of error is the one we most want reported, and
-  a report naming the file and line is enough — you do not need to send a patch.
-- **Security reports**, through the private channel in
-  [`SECURITY.md`](SECURITY.md), never a public issue.
-
-When outside pull requests open, this file will say so and will describe the
-process. Until then, an issue is the contribution.
+This file will announce when outside pull requests open and describe the process.
 
 ## If you are working in a fork
 
-Everything below applies to anyone changing this repository, including someone
-who arrived with a fork and no context.
+The following rules apply to every repository change, including forks.
 
 ### The gate
 
-`scripts/merge-gate.sh` is this repository's only CI. It pins the candidate and
-baseline, enforces frozen records, tests its automatic profile classifier, and
-selects evidence from that exact diff. Content-only modifications to an explicit
-prose allowlist use the `docs-only` profile: diff hygiene, the closed public
-snapshot scan, and final HEAD/worktree drift. Adds, deletes, renames, mode
-changes, runtime-coupled documentation, code, configuration, and unknown paths
-use the full profile: a clean `npm ci` whose postinstall generates the database
-client, the database CLI typecheck, repository lint, the whole-workspace build,
-unit tests, the gate schema's migration, the database tests, and final drift
-verification. A caller cannot select the cheaper profile. Those steps run as
-three concurrent groups rather than one serial chain; every one of them still
-runs, and a group passes only when all of its members do.
+`scripts/merge-gate.sh` is the only CI. It pins candidate and baseline, checks
+frozen records and its profile classifier, then selects proof from that diff:
+
+- `docs-only`: content-only edits to an explicit prose allowlist; checks diff
+  hygiene, the closed public snapshot, and final HEAD/worktree drift.
+- `full`: additions, deletions, renames, mode changes, runtime-coupled docs, code,
+  config, or unknown paths. Runs clean `npm ci` with database client generation,
+  database CLI typecheck, repository lint and build, unit tests, gate-schema
+  migration, database tests, and final drift verification.
+
+The gate selects the profile; callers cannot request the cheaper one. Parallel
+execution does not omit checks; a group passes only when every member passes.
+Run one gate per worktree; a verdict belongs only to the exact commit it names.
 
 ```sh
 scripts/merge-gate.sh --expect-head <oid>
 ```
 
-Inside an Anneal Run (`AGENTOS_RUN_ID` set), the root `build`, `lint`,
-`typecheck`, `test`, `test:db`, and `merge-gate` scripts refuse before doing
-work and exit **78**. A direct `scripts/merge-gate.sh` invocation still
-refuses with `GATE NOT RUN:` and exits **76**. Run only the affected workspace
-checks and named test files inside a Run; for workspace lint, use
-`npm run lint -w <workspace>`. The Regression step owns repository-wide proof
-and the Merge Gate.
+Inside an Anneal Run (`AGENTOS_RUN_ID` set), run affected workspace checks and
+named test files, such as `npm run lint -w <workspace>`. Regression owns
+repository-wide proof. Root `build`, `lint`, `typecheck`, `test`, `test:db`, and
+`merge-gate` scripts refuse with exit **78**; direct gate invocation returns
+`GATE NOT RUN:` and **76**. Runs have no scratch PostgreSQL. Database tests are
+merge gate evidence: never attempt them inside a Run, including named files,
+or report their absence as a gap. `test:db -w @anneal/api` also exits **78**.
 
-`test:db -w @anneal/api` refuses with exit **78** inside a Run as well, named
-files included: a Run is granted no scratch PostgreSQL, so every `*.dbtest.ts`
-would die on import. Database tests are merge gate evidence — do not attempt
-them inside a Run, and do not report their absence as a gap.
+Run workspace verification shares a host proof-slot pool (default 3;
+`AGENTOS_HOST_PROOF_SLOTS` accepts 1–1024). Waits of at least 60 seconds are
+reported while waiting and on admission; a 20-minute timeout exits **75**.
+Run workspace tests use `--test-concurrency=2`. Regression and host commands
+bypass proof slots; host tests retain Node's default concurrency.
 
-Per-workspace `build`, `typecheck`, `lint`, and `test` verification inside an Anneal Run shares a host-wide pool of three proof slots by default; set `AGENTOS_HOST_PROOF_SLOTS` to an integer from 1 through 1024 to override the count. A wait of 60 seconds or more is reported on stderr once while it lasts and again with the total when the slot is admitted; shorter waits are silent, and a command exits **75** after 20 minutes if no slot becomes available. Inside a Run the workspace `test` scripts also pass `--test-concurrency=2` to Node's test runner, so one slot holds at most two test child processes instead of the host-wide default of one per core; the same scripts outside a Run keep Node's default. Regression-owned proof and commands running outside a Run use the host fast path and execute immediately without acquiring a slot.
-
-The merge gate holds a lock, so run one gate per worktree. A verdict belongs to the exact
-commit it names — not to an earlier one on the same branch, and not to "the
-branch".
-
-This local command is the public path available to every clone and fork. Remote
-gate workers are optional operator-provided infrastructure: the repository
-ships their provisioning code, but no worker, hostname or credential. Use the
-dispatcher only after configuring that capacity explicitly.
-
-Some checks are deliberately outside the gate and belong to the list a developer
-runs: `npm run test:dependency-gate` and `npm run verify:compose-binding`.
+The local gate is available to every clone. Remote workers require explicitly
+configured operator infrastructure; the repository provides no host or credentials.
+Checks outside the gate remain developer responsibilities:
+`npm run test:dependency-gate` and `npm run verify:compose-binding`.
 
 ### Delivering to main
 
-This section is for a repository maintainer with write authority to the target
-`origin`. It does not grant an outside contributor authority to advance the
-upstream repository.
+Only maintainers with write authority to the target `origin` may advance it.
+Work in your own branch and isolated worktree; keep the shared checkout on
+`main` without feature commits or branch switches. Prefer native worktree
+support, otherwise use `git worktree add "$(mktemp -d)/checkout" <branch>`.
+Stage only your changes and remove the worktree after merge.
 
-A merge requires `MERGE GATE: PASS <oid>` for the exact integrated head being
-merged (`scripts/merge-gate.sh --expect-head <oid>`). When another gate might
-be running and remote capacity has been configured explicitly, dispatch
-through `AGENTOS_WORKSPACE_PATH="$(git rev-parse --show-toplevel)" packages/runner/runtime-tools/gate-worker/gate-dispatch.sh <oid>`;
-otherwise run the local gate. Read
-[`docs/runbooks/gate-worker.md`](docs/runbooks/gate-worker.md) before
-operating any remote worker.
+Push the feature branch and open its PR before dispatching the gate. GitHub
+recognizes an existing PR as merged after fast-forward publication, but refuses
+to create one after `main` already contains its head.
 
-For one candidate, acquire `scripts/merge-lease.sh` before running the merge
-gate for the final integrated head and hold it until the merge consumes that
-proof. Writing code, pushing a feature branch, and opening a pull request need
-no lease. Pass `--task <id>` to both `acquire` and `release`: the default holder
-`user@host` is shared by every agent window on one machine, so a release without
-a task id cannot tell its own lease from a sibling's.
+For one candidate:
 
-When two or three host-side pull requests are ready together, their feature
-windows push, open the pull requests, and hand one coordinating window the
-ordered `(PR number, exact head OID)` tuples. They do not acquire the lease or
-advance `main` themselves. The coordinating window reads the gate-worker
-runbook, then runs one fixed-width cumulative batch:
+1. Acquire `scripts/merge-lease.sh` before proving the final integrated head;
+   hold the lease through publication. Pass `--task <id>` to both `acquire` and
+   `release` so windows sharing `user@host` cannot release each other's lease.
+   Implementation, feature push, and PR creation need no lease.
+2. Require `MERGE GATE: PASS <oid>` for that exact integrated head. If other
+   gates may run and remote capacity is configured, use
+   `AGENTOS_WORKSPACE_PATH="$(git rev-parse --show-toplevel)" packages/runner/runtime-tools/gate-worker/gate-dispatch.sh <oid>`;
+   otherwise run the local gate. Read the [worker runbook](docs/runbooks/gate-worker.md)
+   before operating a remote worker.
+3. Publish the proved head, then release your lease.
+
+When two or three host PRs are ready together, feature windows push, open PRs,
+and hand one coordinator ordered `(PR number, exact head OID)` tuples. They
+neither acquire the lease nor advance `main`. The coordinator reads the worker
+runbook and uses the authenticated `gh` CLI to verify exact PR state for one
+cumulative batch:
 
 ```sh
 scripts/merge-train.mjs \
@@ -111,99 +94,66 @@ scripts/merge-train.mjs \
   [--candidate <pr>:<40-character-head>]
 ```
 
-The command builds nested merge prefixes, gates them concurrently, and acquires
-the same merge lease only to publish the longest contiguous PASS prefix. A
-conflict ends the batch at the preceding prefix; the coordinator never resolves
-one. A stale `main` publishes nothing. Rerun the same command after a partial
-publication: it reads live `main`, skips candidate heads already contained
-there, and rebuilds the rest. The command requires an authenticated `gh` CLI to
-verify exact PR state.
+The train gates nested merge prefixes concurrently, then acquires the lease to
+publish the longest contiguous PASS prefix. Conflicts stop at the preceding
+prefix; the coordinator does not resolve them. Stale `main` publishes nothing.
+After partial publication, rerun the command: it skips heads already in live
+`main` and rebuilds the remaining prefixes.
 
-Changes to the merge train, merge lease, gate dispatcher, merge gate, or their
-delivery authority use the existing single-candidate path. Delivery machinery
-does not use its new implementation to authorize its own first publication.
-
-Open the pull request right after pushing the feature branch, before
-dispatching the gate: once the exact-head fast-forward lands, GitHub refuses a
-pull request from a branch main already contains, while one opened beforehand
-flips to merged on its own.
-
-Several agent windows share one checkout, and a branch switch there carries
-away another window's uncommitted work — the shared checkout stays on `main`
-and never receives feature commits. Deliver from an isolated worktree on your
-own branch: use your tool's native worktree mechanism when it has one, and
-otherwise create one under a fresh temporary directory
-(`git worktree add "$(mktemp -d)/checkout" <branch>`). Stage only the paths
-you changed, and remove the worktree once merged.
+Changes to delivery authority, merge train, lease, dispatcher, or gate use the
+existing single-candidate path. New delivery machinery cannot authorize its own
+first publication.
 
 ### Testing red lines
 
-These are not style preferences. Each one exists because ignoring it destroys
-something outside the checkout.
+- Set `export RUNNER_WORKSPACE_ROOT=$(mktemp -d)` before tests. Also pin `home`
+  in hand-built `RunnerConfig` objects to a temporary directory: runner tests
+  provision real workspaces and persistent repository mirrors.
+- Database tests destroy their targets. Use a throwaway PostgreSQL for
+  `TEST_DATABASE_URL` and `TEST_DATABASE_MAINTENANCE_URL`, with a distinct
+  non-`public` `?schema=` per worktree. Set `AGENTOS_ALLOW_SCRATCH_DATABASES=1`
+  and a password of at least 24 characters; tests spawning the API inherit it
+  as `POSTGRES_PASSWORD` and enforce the startup password check.
+- Do not commit during a database suite: `build-provenance.dbtest.ts` requires
+  the build stamp to match the worktree commit.
+- Edit canonical templates in `agents/templates/` and deliver through a PR;
+  the closed sync contract still applies. Operators may edit unused,
+  non-canonical clones through the [API](docs/operator-api.md).
+- A checkout named by a loaded service is an appliance checkout. Follow the
+  [deployment ownership contract](docs/runbooks/quiet-window-auto-deploy.md)
+  and develop in a separate worktree.
 
-- `export RUNNER_WORKSPACE_ROOT=$(mktemp -d)` before any test run. The runner's
-  tests provision real workspaces, and without this they are provisioned wherever
-  the configuration points — which on a working checkout is a directory holding
-  someone's runs. The same applies to `home` in a hand-built `RunnerConfig`:
-  provisioning keeps its persistent repository mirror under it.
-- Database tests target a scratch PostgreSQL and nothing else. Point
-  `TEST_DATABASE_URL` and `TEST_DATABASE_MAINTENANCE_URL` at a throwaway server,
-  and give each worktree its own `?schema=` so parallel runs stay apart. Never
-  point them at a database whose contents you would miss: `npm run test:db` drops
-  and recreates what it is given.
-- A hand-built scratch server has three requirements the harness enforces but
-  does not advertise, each of which otherwise costs a full run to discover.
-  Export `AGENTOS_ALLOW_SCRATCH_DATABASES=1`; the `@anneal/db` suite refuses
-  without it. Give the server a password of at least 24 characters, because the
-  tests that spawn the real API entrypoint inherit it as `POSTGRES_PASSWORD` and
-  the startup check refuses a shorter one. Name a schema other than `public` in
-  `TEST_DATABASE_URL`, because the harness resets the schema it is given.
-- Do not commit while a database suite is running. `build-provenance.dbtest.ts`
-  asserts that the build stamp names the commit the worktree is at, so a commit
-  mid-run fails the suite on the first file and aborts everything after it.
-- Repository-owned canonical templates are edited in `agents/templates/` and
-  reach production through an ordinary pull request; the closed sync contract
-  remains enforced here. Operators can clone canonical or custom templates and
-  edit unused, non-canonical clones through the API documented in
-  [`docs/operator-api.md`](docs/operator-api.md).
-- A checkout named by a loaded Anneal service is an appliance checkout. Follow
-  its ownership and isolation contract in
-  [`docs/runbooks/quiet-window-auto-deploy.md`](docs/runbooks/quiet-window-auto-deploy.md);
-  use a separate worktree for development. In a fresh worktree, workspace
-  typecheck, unit-test, and focused API database-test commands need `npm install`
-  and `npm run db:generate`, but no prior workspace build. Workflows that execute
-  built artifacts run after the Merge Gate's preceding full build.
+Fresh-worktree typechecks, unit tests, and focused API database tests need
+`npm install` and `npm run db:generate`, but no prior workspace build.
+Workflows executing built artifacts run after the Merge Gate's full build.
 
 ### Development database bootstrap
 
-`npm run db:migrate` is `prisma migrate dev`. It bypasses the release migration
-preflight and may create or rewrite development migration history. Use it only
-against a disposable developer database. It is never an installation or upgrade
-command; the release install path is `npm run db:migrate:release -- --fresh`.
-Adding a migration does not bump `RELEASE_CANDIDATE_MIGRATIONS`; the release-cut
-commit (the `chore(release): prepare` commit) does.
+`npm run db:migrate` runs `prisma migrate dev`, bypasses release preflight, and
+may rewrite development migration history. Use it only on disposable developer
+databases, never for installation or upgrades. The release install command is
+`npm run db:migrate:release -- --fresh`.
+The release-cut commit (`chore(release): prepare`) updates
+`RELEASE_CANDIDATE_MIGRATIONS`; ordinary migration additions leave it unchanged.
+A migration timestamped before the recorded terminal but merged after the cut
+is the exception: its merge must update the pin. See the pin contract in
+[release-migrate.ts](packages/db/src/release-migrate.ts).
 
 ### The public surface is closed by default
 
-`public-snapshot.json` names what may be published. Every tracked file must be
-classified: a file no rule reaches is a scan failure, not a silent inclusion. If
-you add a file that belongs in the public release, add it to the manifest with a
-purpose; if it does not, add it to the exclusions with a reason. `npm run
-snapshot:scan` checks this, and it requires a clean worktree matching `HEAD`.
+Every tracked file must be classified in `public-snapshot.json`. Add published
+files with a purpose or excluded files with a reason; an unclassified path
+fails the scan. `npm run snapshot:scan` requires a clean worktree matching `HEAD`.
 
 ### Records that do not change
 
-`docs/reviews/`, `docs/merge-notes/`, `docs/briefs/` and `docs/plans/archive/`
-are dated records of finished work: append-only, and never current authority.
-They are not kept here — they live in this project's private operator
-repository — so nothing you contribute needs to read them.
-`scripts/check-frozen-docs.sh` still runs in the gate: it would enforce those
-directories if they appeared, and it enforces the `> Superseded by ` marker
-shape on every tracked `*.md`.
+Finished records under `docs/reviews/`, `docs/merge-notes/`, `docs/briefs/`, and
+`docs/plans/archive/` are append-only history, not current authority. They live
+in private operator documentation and are not contribution prerequisites.
+The gate's `scripts/check-frozen-docs.sh` would enforce these directories if
+present and validates `> Superseded by ` markers in all tracked Markdown.
 
 ### Style
 
-Match the code you are changing. Comments in this repository explain why a thing
-is the way it is, not what the line does; several of them exist because the
-obvious alternative was tried and was wrong. If you remove one, be sure you know
-which failure it was standing in front of.
+Match surrounding code. Comments explain reasons and failed alternatives;
+understand the failure a comment guards before removing it.

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -1,28 +1,40 @@
 # Task Routing Contract v1
 
-Version: 1.10 (2026-09-02: corrects the basis for serializing two migration-adding chains — the release-candidate pin moves when a migration's timestamp moves the recorded terminal, not on every migration — and realigns the recorded snapshot block with the current version)
-
-Previous: 1.9 (2026-09-02: configurable approval gates add project defaults, per-dispatch overrides, and TODO-only slot toggles while preserving exact-head merge-tail authorization)
-
-Previous: 1.8 (2026-09-02: dependency qualification names parallel dispatch as the default, narrows the true-dependency test to code and deploy order, and records that an `afterTaskId` binding is one-way)
+Version: 1.10 (2026-09-02)
 
 Status: Active
 
 ## Applies to
 
-This contract governs the design, creation, dispatch, and routing of Anneal tasks, task chains, and task templates. Every runnable task or chain requires one versioned Product Contract; a chain does not create a separate contract per step.
+This contract governs the design, creation, dispatch, and routing of Anneal
+tasks, task chains, and task templates. Every runnable task or chain has one
+versioned Product Contract; a chain does not create a contract per step.
 
-This contract records dispatch-time governance only. Execution structure, step prompts, and model or runner defaults live in their canonical sources named below and are not copied here.
+This is dispatch-time governance. Execution structure, step prompts, and model
+or runner defaults remain in their canonical sources and are not copied here.
 
 ## Authority boundaries
 
-The Product Contract fixes the objective, scope, acceptance criteria, evidence, risk boundaries, stopping conditions, and dependencies. Within those boundaries, the dispatcher and execution chain may choose implementation details.
+The Product Contract fixes the task's boundaries and required evidence. The
+dispatcher and execution chain choose implementation details only within those
+boundaries; see [Minimum Product Contract](#minimum-product-contract) for the
+required fields.
 
-The human user holds dispatch authority. Work stays in the current session unless the user explicitly requests a task chain. Complexity, risk, or an available template may support recommending a chain, but none authorizes creating or dispatching one.
+The human user holds dispatch authority. Work stays in the current session
+unless the user explicitly requests a task chain. Complexity, risk, or an
+available template may justify a recommendation, never chain creation or
+dispatch.
 
-Changing the objective, scope, acceptance criteria, required evidence, authority, or risk boundary requires a new Product Contract version and product-owner approval. Any downshift of the selected route, effort, or safeguards requires the same approval.
+Changing the objective, scope, acceptance criteria, required evidence,
+authority, or risk boundary requires a new Product Contract version and
+product-owner approval. A downshift of the selected route, effort, or
+safeguards requires the same approval.
 
-Model and effort routing follows the operator's current routing policy. Select the implementation role and record the routing snapshot at dispatch. Rerouting uses a new process and a new snapshot; an active Agent does not change model or effort in-session. Model and effort belong in agent configuration, not task prompts.
+Model and effort routing follows the operator's current routing policy. Select
+the implementation role and record the routing snapshot at dispatch. Rerouting
+starts a new process and snapshot; an active Agent does not change model or
+effort in-session. Model and effort belong in agent configuration, not task
+prompts.
 
 ## Minimum Product Contract
 
@@ -34,85 +46,132 @@ A runnable task or chain records:
 - Acceptance criteria and required evidence.
 - Risks, authority boundaries, and stopping conditions.
 - Dependencies and prerequisites.
-- The routing snapshot defined below.
+- The routing snapshot below.
 
-SPEC and Plan are optional. The Product Contract is not.
+SPEC and Plan are optional. The Product Contract is required.
 
 ## Task tiers
 
-Work done directly in the current session is outside these tiers and does not require a Product Contract. The tiers apply only after the human user explicitly requests a task chain.
+Current-session work is outside these tiers and needs no Product Contract. The
+tiers apply only to a task chain the human user explicitly requests.
 
-Choose the shortest tier that satisfies the Product Contract. This contract defines two chain tiers:
+Choose the shortest tier satisfying the Product Contract:
 
-- Direct: no specification or plan; implementation proceeds straight from the task brief and is delivered through parallel reviews, a self-adjudicating fix step, regression, and the mechanical merge tail.
-- Full Assurance: the full chain; its specification and plan stages own decomposition.
+- Direct: no specification or plan; implementation starts from the task brief
+  and proceeds through parallel reviews, a self-adjudicating fix step,
+  regression, and the mechanical merge tail.
+- Full Assurance: the full chain; its specification and plan stages own
+  decomposition.
 
-Direct is a formal chain route, not an exemption from review or exact-head mechanical authorization. Full Assurance is required when the Product Contract calls for specification, planning, plan review, or revised-plan implementation authorization.
+Direct is a formal chain route and still requires review and exact-head
+mechanical authorization. Full Assurance is required when the Product Contract
+calls for specification, planning, plan review, or revised-plan implementation
+authorization.
 
-Choose Direct when one implementation context window can deliver a brief whose change points are enumerable; write the brief from `docs/BRIEF-TEMPLATE.md` before instantiating, because the chain's implementation `description` is the specification of record. Choose Full Assurance when the work exceeds one implementation window or decomposes into independently demonstrable slices; a surface too large for a brief to enumerate belongs here, not to an assignee escalation.
+Choose Direct when one implementation context window can deliver a brief with
+enumerable change points. Write it from `docs/BRIEF-TEMPLATE.md`; the chain's
+implementation `description` is the specification of record. Choose Full
+Assurance when the work exceeds one implementation window or decomposes into
+independently demonstrable slices. A surface too large for a brief to enumerate
+belongs in Full Assurance, not in assignee escalation.
 
 ## Implementation assignee routing
 
-Keep the template's default implementation assignee. Assign `senior-dev` (same rule for the review-fix step) only when the work touches persisted data or a defense-list path — merge gate, gate worker, migrations, merge automation — or when that classification is uncertain. Assign `frontend-dev` when the work is primarily a new or redesigned web page or UI surface (the operator 2026-08-27); the defense-list rule wins when both apply.
+Keep the template's default implementation assignee. Use `senior-dev` (the
+same rule applies to the review-fix step) only for persisted data, a
+defense-list path (merge gate, gate worker, migrations, or merge
+automation), or uncertain classification. Use `frontend-dev` for work primarily
+consisting of a new or redesigned web page or UI surface. The defense-list rule
+wins when both apply.
 
-A backlog card that needs a non-default implementation assignee states it as the machine-readable line `Route: implementation=<agent-name>` in its description. Direct-template instantiation consumes that line, resolves the named Agent in the project, applies the existing override safety checks, and assigns it to the implementation step. Explicit `stepOverrides` remain a separate API mechanism; supplying both mechanisms for the direct implementation step is refused. A well-formed route line on any other template refuses instantiation with `implementation_route_template_unsupported`; remove the line or route that template through `stepOverrides`. Other templates do not interpret malformed Route-looking prose.
+A backlog card needing a non-default implementation assignee includes this
+machine-readable line in its description:
+  `Route: implementation=<agent-name>`.
+Direct-template instantiation consumes the line, resolves the named Agent in
+the project, applies the existing override safety checks, and assigns the
+implementation step. `stepOverrides` is a separate API mechanism; supplying
+both for the direct implementation step is refused. A well-formed route line
+on another template refuses instantiation with
+`implementation_route_template_unsupported`; remove the line or use
+`stepOverrides`. Other templates do not interpret malformed Route-looking
+prose.
 
 ## Critical classification
 
-Critical means only that the work touches persisted data or performs an irreversible external action. No other condition makes a task Critical by itself.
+Critical applies only when work touches persisted data or performs an
+irreversible external action. It is a risk label, not a routing tier or model
+route; it determines the slices and review attention owed to the work, while
+model and effort remain with assigned roles.
 
-Critical is a risk label, not a routing tier or a model route: it marks the slices and review attention a chain owes the work, while model and effort stay with the assigned roles. Here, `persisted data` means runtime-created user or system data, including its schema, that must survive a version change. Structural risk means a change to a public interface, persisted data, a component boundary, or a foundational dependency.
+Persisted data means runtime-created user or system data, including schema,
+that must survive a version change. Structural risk means a change to a public
+interface, persisted data, a component boundary, or a foundational dependency.
 
 ## Canonical execution graphs
 
-The seeded templates under `agents/templates/` are the execution canon: step prompts, layer structure, blind-review isolation, and the mechanical merge tail live in those Markdown sources, and `agents/README.md` owns the structural rules that bind them. Model and runner defaults live in `agents/roles/` frontmatter and `packages/db/src/agent-contract.ts`.
+Seeded templates under `agents/templates/` are the execution canon: their
+Markdown owns step prompts, layer structure, blind-review isolation, and the
+mechanical merge tail. `agents/README.md` owns the structural rules that bind
+them. Model and runner defaults live in `agents/roles/` frontmatter and
+`packages/db/src/agent-contract.ts`.
 
-Chains instantiated before a template change keep their stored prompts, assignments, and behavior; canonical sync preserves superseded templates under deterministic legacy identities instead of rewriting instantiated work. A rollover leaves each task's stored prompt unchanged.
+Chains instantiated before a template change retain stored prompts,
+assignments, and behavior. Canonical sync preserves superseded templates under
+deterministic legacy identities; it does not rewrite instantiated work. A
+rollover leaves each task's stored prompt unchanged.
 
 ## Human approval placement
 
-`Task.approvalGate` is the sole runtime authority for an Agent step. A role persists its output and finishes; the control plane moves a gated task to REVIEW and an ungated task to DONE. An Agent may ask a blocking Product Contract question, but it does not create a second approval request merely because its artifact is a specification or plan.
+`Task.approvalGate` is the sole runtime authority for an Agent step. A role
+persists its output and finishes; the control plane moves a gated task to
+REVIEW and an ungated task to DONE. An Agent may ask a blocking Product
+Contract question, but does not create a second approval request for a
+specification or plan artifact.
 
-Both configurable approval gates are off by default, so a newly created project
-and its chains remain fully autonomous unless an operator enables a gate. The
-two configurable slots are the specification step (`outputKind: spec`, the
-specification step in the Full Assurance/compound chain) and the server-owned
-merge readiness step (the step recognised by `isMergeReadinessStep`, step 11 in
-the compound chain and step 7 in the direct chain). No other step is a gate
-slot.
+Both configurable gates default to off, so new projects and their chains stay
+autonomous until an operator enables one. The only configurable slots are the
+specification step (`outputKind: spec` in the Full Assurance/compound chain)
+and the server-owned merge-readiness step recognized by
+`isMergeReadinessStep` (step 11 in compound and step 7 in Direct). No other
+step is a configurable gate slot.
 
-Each project has independent `specGateDefault` and `mergeGateDefault` boolean
-defaults, both initially `false`. At dispatch, the optional `gates.spec` and
-`gates.merge` values override the corresponding project default for that chain
-only. For either slot, resolution is exactly: dispatch override, then project
-default, then the template step's frontmatter `approvalGate`. Every other step
-keeps its frontmatter value. An operator may toggle a slot task's
-`approvalGate` after dispatch only while that task is still `TODO`; a non-slot
-chain task or a slot already `DOING`, `REVIEW`, or `DONE` is refused. Existing
-chains retain their stored gate values.
+Each project has independent boolean `specGateDefault` and `mergeGateDefault`,
+both initially `false`. At dispatch, optional boolean `gates.spec` and
+`gates.merge` override the corresponding project default for that chain only.
+For either slot, resolution is exactly dispatch override, then project
+default, then template frontmatter `approvalGate`. Every other step keeps its
+frontmatter value. An operator may toggle a slot task's `approvalGate` after
+dispatch only while it is `TODO`; a non-slot task or a slot in `DOING`,
+`REVIEW`, or `DONE` is refused. Existing chains retain stored gate values.
 
 Place the fewest gates that preserve human judgment:
 
-- Add a specification gate only when the spec step resolves product behavior, acceptance semantics, or a data-contract ambiguity left open by the approved Product Contract.
-- Do not gate the plan step before independent review. In Full Assurance, put implementation authorization after reviewed-plan closure at the revise-plan step.
-- Keep implementation, review, adjudication, repair, regression, and documentation automatic inside approved boundaries.
-For a gated merge-readiness slot, completion of regression opens the existing
-integrator-feeding gate with regression evidence and server-read evidence (the
-pull-request head, base, and required-check conclusions) shown before approval.
-Approval records an
-exact-head operator authorization and releases the readiness task to its
-ordinary server-owned readiness worker; it does not mark readiness `DONE` or
-activate merge execution directly. The worker performs its ordinary
-exact-head, base, ancestry, defense, and lease re-verification before the sole
-integrator authorization is produced. If the head or base drifts after
-approval, the tail stops without merging and regression/readiness reopen the
-gate with a fresh evidence card for the changed state; the old authorization is
-not reused. Rejecting the merge gate ends the chain terminal, never activates
-the merge execution step, and leaves the pull request open and unmerged. A
-specification-gate rejection keeps the existing requeue behavior and consumes
-the task's normal `maxSessionsPerTask` budget.
+- Add a specification gate only when the spec resolves product behavior,
+  acceptance semantics, or a data-contract ambiguity left open by the approved
+  Product Contract.
+- Do not gate the plan step before independent review. When the Product
+  Contract requires revised-plan implementation authorization in Full
+  Assurance, put it after reviewed-plan closure at `revise-plan` in the
+  template before instantiation. It is not a dispatch/TODO-configurable slot.
+- Keep implementation, review, adjudication, repair, regression, and
+  documentation automatic inside approved boundaries.
 
-Direct has no planning gates. Gate selection is recorded at dispatch; an active Agent does not rewrite it.
+When merge-readiness is gated, regression completion opens the existing
+integrator-feeding gate with regression evidence and server-read evidence
+(pull-request head, base, and required-check conclusions) shown before
+approval. Approval records exact-head operator authorization and releases the
+readiness task to its ordinary server-owned readiness worker; it does not mark
+readiness `DONE` or activate merge execution. That worker re-verifies
+exact head, base, ancestry, defense, and lease before the sole integrator
+authorization is produced. If head or base drifts, the tail stops without
+merging; regression/readiness reopen with a fresh evidence card and the old
+authorization is not reused. Rejecting the merge gate ends the chain terminal,
+never activates merge execution, and leaves the pull request open and
+unmerged. A specification-gate rejection keeps existing requeue behavior and
+consumes normal `maxSessionsPerTask` budget.
+
+Direct has no planning gates. Gate selection is recorded at dispatch; an active
+Agent does not rewrite it.
 
 ## Per-chain routing snapshot
 
@@ -126,49 +185,76 @@ Critical: no
 Reason: Bounded change; Direct review and exact-head acceptance remain intact.
 ```
 
-If risk or ambiguity increases during execution, pause before the newly unsafe work and reroute. If rerouting changes a Product Contract boundary, return to the product owner for approval. New work uses the current routing contract; active work keeps its recorded snapshot until explicitly rerouted.
+If risk or ambiguity increases, pause before the newly unsafe work and reroute.
+If rerouting changes a Product Contract boundary, obtain product-owner
+approval. New work uses the current routing contract; active work keeps its
+recorded snapshot until explicitly rerouted.
 
 ## Backlog card lifecycle
 
-A backlog card is a dispatch-ready brief waiting for a decision, not a work item of its own. The board holds either the card or its chain, never both.
+A backlog card is a dispatch-ready brief awaiting a decision, not work of its
+own. The board holds either the card or its chain, never both.
 
-- Create the card with `assigneeType: HUMAN` so no runner claims it, with the brief as its description (written from `docs/BRIEF-TEMPLATE.md`) plus the machine-readable `Route:` line when the implementation assignee is non-default. The create API accepts an optional `status` of `BACKLOG` or `TODO` and defaults to `TODO`; pass `status: BACKLOG` to create a human Backlog card atomically without a follow-up PATCH.
-- Dispatch instantiates a chain from the card: the card's name is passed as the instantiate `name`, the brief becomes the instantiate `description` (the chain's implementation task is then the specification of record), and direct-template instantiation consumes and validates its `Route:` line. Chain-to-chain ordering passes `afterTaskId` (the predecessor chain's final task) to the instantiate endpoint; the bound chain dispatches when the predecessor completes. `afterTaskId` is incompatible with `autoStart`, and each predecessor task takes one successor.
-- Dependency qualification precedes every instantiation: classify the new chain against every in-flight or co-dispatched chain and pick exactly one outcome. Parallel is the default; bind with `afterTaskId` only for a true dependency, and serialize by choice only for heavy overlap or a concurrent migration.
-  1. True dependency — this chain's code reads code the other chain merges, or the other chain must be deployed before this one can be verified: bind with `afterTaskId` and record the basis (`Depends on: <chain> — <what is consumed or why deploy-first>`) in the instantiate description or the card's activity log. A brief that mentions the other chain, shares a document with it, or ships an adjacent feature on the same surface is independent. Binding is one-way: the bound chain's first step refuses a manual start until the predecessor is DONE, and only deleting the bound chain releases it (see the instantiate route in `docs/operator-api.md`).
-  2. Heavy overlap — no dependency, but both chains rewrite the same code area: weigh expected refresh-conflict repair cost against serial wall-clock loss; either choice is valid, and a serial choice records its reason the same way.
-  3. Independent — dispatch in parallel, no justification needed; the merge tail and the deploy quiet window already serialize delivery.
-  Serialize an independent pair anyway when the merge would be clean but the semantics unsafe — changes to the same fail-closed enforcement path, behavior coupled across disjoint files (examples, not a closed list). Serialize unconditionally when both chains add a Prisma migration, whichever tables they touch: a migration merged after a release cut updates the `RELEASE_CANDIDATE_MIGRATIONS` pin in `packages/db/src/release-migrate.ts` whenever its timestamp moves the recorded terminal, so two concurrent migration-adding chains land on the same two lines (7 of the 19 refresh-conflict repairs between 2026-08-24 and 2026-08-31 were exactly those two lines).
-- Archive the card at the moment of instantiation. The archived card remains recoverable in the Archived view; re-dispatching its work is a new decision, not a revival of the card.
+- Create it with `assigneeType: HUMAN` so no runner claims it. Its description
+  is the brief from `docs/BRIEF-TEMPLATE.md`, plus the `Route:` line when the
+  implementation assignee is non-default. The create API accepts `status` as
+  optional `status` as `BACKLOG` or `TODO` and defaults to `TODO`; pass `status: BACKLOG` to create
+  a human Backlog card atomically, without a follow-up PATCH.
+- Dispatch passes the card's name as instantiate `name` and the brief as
+  instantiate `description`; the chain implementation task then owns the
+  specification of record. Direct-template instantiation consumes and validates
+  its `Route:` line. Chain ordering passes `afterTaskId` (the predecessor
+  chain's final task) to the instantiate endpoint; the bound chain dispatches
+  when the predecessor completes. `afterTaskId` cannot combine with
+  `autoStart`, and each predecessor task accepts one successor.
+- Before every instantiation, classify the new chain against every in-flight
+  or co-dispatched chain and select exactly one dependency outcome. Parallel is
+  the default. Bind with `afterTaskId` only for a true dependency; serialize by
+  choice only for heavy overlap or a concurrent migration.
+  1. True dependency: this chain reads code the other merges, or the other
+     must be deployed before this chain can be verified. Bind with
+     `afterTaskId` and record `Depends on: <chain> — <what is consumed or why deploy-first>` in the instantiate description or card activity log. A
+     mention of the other chain, a shared document, or an adjacent feature on
+     the same surface is independent. Binding is one-way: the bound chain's
+     first step refuses manual start until the predecessor is `DONE`, and only
+     deleting the bound chain releases it (see the instantiate route in
+     `docs/operator-api.md`).
+  2. Heavy overlap: no dependency, but both chains rewrite the same code area.
+     Weigh expected refresh-conflict repair cost against serial wall-clock
+     loss; either choice is valid, and a serial choice records its reason.
+  3. Independent: dispatch in parallel with no justification. The merge tail
+     and deploy quiet window already serialize delivery.
+  Serialize an independent pair when a clean merge would still be semantically
+  unsafe, including the same fail-closed enforcement path or behavior coupled
+  across disjoint files (examples; not a closed list). Serialize every pair whose chains add a Prisma
+  migration. `RELEASE_CANDIDATE_MIGRATIONS` normally changes only in the
+  release-cut `chore(release): prepare` commit; adding a migration does not
+  update it. The exception is a migration created before the recorded terminal
+  but merged after the release cut: if its timestamp moves the terminal's
+  recorded position, that merge must update the pin in
+  `packages/db/src/release-migrate.ts`.
+- Archive the card at instantiation. It remains recoverable in the Archived
+  view; re-dispatching is a new decision, not revival of the card.
 
 ## Board column semantics
 
-The board shows where work sits in the intent-to-delivery flow. The
-[Backlog card lifecycle](#backlog-card-lifecycle) defines card creation,
-dispatch, and archival; the definitions here cover the column semantics.
+The [Backlog card lifecycle](#backlog-card-lifecycle) defines card creation,
+dispatch, and archival. The board columns mean:
 
-- **Backlog — intent.** An un-instantiated brief that is still being refined,
-  awaits a decision, or is deliberately parked; it is not connected to
-  execution. For an indefinitely parked HUMAN card, prefix its title with
-  `Parked:`.
-- **Todo — runnable execution.** An instantiated chain or step whose
-  specification of record is final, runnable now or waiting for activation or
-  a dependency unlock. The entry boundary is explicit: un-instantiated intent
-  enters the board in Backlog; instantiated chains and their steps enter in
-  Todo and then move through the later columns.
-- **Doing — active execution.** The runner has activated an AGENT task and work
-  is in progress.
-- **Review — awaiting a lifecycle decision.** An AGENT task is paused for an
-  approval or review gate, or has surfaced a run issue that needs attention
-  before the chain can continue.
-- **Done — complete.** The task or chain step is finished.
+| Column | Meaning |
+| --- | --- |
+| Backlog | Un-instantiated intent being refined, awaiting a decision, or parked; it is not connected to execution. Prefix the title of an indefinitely parked HUMAN card with `Parked:`. |
+| Todo | An instantiated chain or step whose specification of record is final, runnable or waiting for activation/dependency unlock. Un-instantiated intent enters Backlog; instantiated work enters Todo. |
+| Doing | An AGENT task activated by the runner and in progress. |
+| Review | An AGENT task paused for an approval/review gate or a run issue needing attention before continuation. |
+| Done | A finished task or chain step. |
 
-An operator can stop and park a running chain step, which returns it to Backlog
-as a parked step. Resume it with **Start now** or **Recover parked step**, not
-ordinary card dispatch.
+An operator can stop and park a running chain step, returning it to Backlog as
+a parked step. Resume with **Start now** or **Recover parked step**, not ordinary
+card dispatch.
 
 The operator owns Backlog and Todo transitions and marking HUMAN tasks Done.
 The runner and chain scheduler own Doing, Review, and Done transitions for
 AGENT tasks. In the usual flow, the operator moves finalized intent from
-Backlog to Todo, then the runner advances each instantiated step through Doing,
-Review, and Done.
+Backlog to Todo, then the runner advances each instantiated step through
+Doing, Review, and Done.

--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -1,58 +1,51 @@
 # Quiet-window auto-deploy
 
-> **Audience and support status.** This runbook documents the repository
-> maintainer's macOS appliance-deployment profile and its Linux systemd
-> deployment profile. It is published for auditability and reproducibility, but
-> it is not part of the Developer Preview Quickstart, the supported installation
-> shape, or a production-support commitment.
+> This runbook covers the maintainer's macOS appliance and Linux systemd
+> deployment profiles. It is published for auditability and reproducibility;
+> it is outside the Developer Preview Quickstart, the supported installation
+> shape, and a production-support commitment.
 
-On macOS, this job advances the appliance from the release named by `current`
-to an exact `main` commit. It controls `com.agentos.api`, `com.agentos.inbox`,
-the configured runner labels (ten by default), and `com.agentos.web`; that is
-thirteen labels at the default count. The Linux systemd profile below uses the
-same generated inventory. The release artifact also carries the resident
-merge-executor runtime, but that process is outside this activation set. The
-job never deploys an Anneal run workspace.
+The job advances the release named by `current` to an exact target commit from
+`main`. On the control-plane host it manages `com.agentos.api`,
+`com.agentos.inbox`, the configured runner labels (10 by default), and
+`com.agentos.web` (13 labels at the default count). Linux uses the same
+generated inventory. The release may contain the resident merge-executor
+runtime, but that service is outside this activation set. An Anneal Run
+workspace is never deployed.
 
 ## Runner-only host
 
-When runners live on a second host, set `AGENTOS_DEPLOY_ROLE=runner` while
-rendering that host's service and auto-deploy definitions. The unset value (or
-explicit `control-plane`) remains the role for the host that owns the API,
-Inbox, web, database, and canonical prompts. The install manifest records the
-role, and stage two refuses to install a manifest whose recorded role does not
-match the configured role.
+Set `AGENTOS_DEPLOY_ROLE=runner` while rendering a separate runner host's
+service and auto-deploy definitions. The unset value, or explicit
+`control-plane`, is the host role for the API, Inbox, web, database, and
+canonical prompts. The install manifest records the role; stage two refuses a
+manifest whose recorded role differs from the configured role.
 
-The runner role's service inventory contains only the configured
-`com.agentos.runner` labels, using `AGENTOS_RUNNER_COUNT` and
-`AGENTOS_RUNNER_ID_PREFIX`. The prefix is required for this role and must be
-host-specific and disjoint from the control-plane host's runner IDs; an empty
-prefix stops deployment preflight. It never installs, restarts, or verifies
-`com.agentos.api`, `com.agentos.inbox`, or `com.agentos.web`. Its phase table
-also omits `backup`, `guarded-migration`, `generate-prisma-client`,
-`canonical-prompt-sync`, and `verify-runtime-prisma-client`; a runner-only host
-does not back up or change the control-plane database or canonical prompts.
+A runner host installs only the configured `com.agentos.runner` labels,
+controlled by `AGENTOS_RUNNER_COUNT` and `AGENTOS_RUNNER_ID_PREFIX`. Its prefix
+is required, host-specific, and disjoint from the control-plane host's runner
+IDs; an empty or invalid prefix fails preflight. It never installs, restarts,
+or verifies `com.agentos.api`, `com.agentos.inbox`, or `com.agentos.web`. Its
+deployment phases omit `backup`, `guarded-migration`,
+`generate-prisma-client`, `canonical-prompt-sync`, and
+`verify-runtime-prisma-client`, so it does not change the control-plane
+database or canonical prompts.
 
-Each runner deployment reads the control plane's `GET /version` from the
-configured `RUNNER_API_URL`, which must be the numeric-loopback HTTP origin
-`http://127.0.0.1:<port>` (normally a tunnel to the control-plane host). The
-runner host also needs `OPERATOR_TOKEN` because registration verification reads
-the operator-only `GET /runners` endpoint. These values and the required prefix
-are checked before an artifact is built. The deployment targets the reported
-clean `commit`, which must be present in the source remote before the runner
-builds its local artifact. This keeps the runner host on exactly the build the
-control plane is running. After building and acquiring the deploy barrier, it
-reads `/version` again and refuses to publish if the control plane advanced in
-the meantime. An unreachable or dirty control-plane build, an unreadable source
-remote, or a commit absent from the source remote stops preflight.
+Before building, the runner reads the control plane's clean, stamped API
+commit from `GET /version`. `RUNNER_API_URL` must be exactly a numeric-loopback
+HTTP origin such as `http://127.0.0.1:<port>` (normally a tunnel), and
+`OPERATOR_TOKEN` is required for the operator-only `GET /runners` check. The
+reported commit must be present in the source remote. After building and
+acquiring the deploy barrier, the runner reads `/version` again and refuses to
+publish if the control plane advanced. An unreachable or dirty control-plane
+build, an unreadable source remote, or an unavailable commit stops preflight.
 
-Quiet-window blocking is scoped to active Runs whose `runnerId` belongs to this
-host's inventory. After restart, verification requires every local runner to
-register with the control plane again and for `GET /runners` to report each
-runner's `daemonVersion` as the deployed build commit. A missing registration
-or mismatched build fails verification, rolls `current` back to `previous`,
-and restarts the runners from the previous release. Recovery is complete only
-after every local runner registers again after that restart and reports the
+Quiet-window blockers on this host are active Runs whose `runnerId` is in this
+host's generated inventory. After restart, every local runner must be online,
+register again with a newer observation, and report the deployed build commit
+through `GET /runners`. A missing, stale, offline, or mismatched registration
+fails verification; the job points `current` back to `previous`, restarts the
+local runners, and succeeds in recovery only after they all report the
 previous release's commit.
 
 ## Runtime layout
@@ -60,58 +53,61 @@ previous release's commit.
 ```text
 releases/<commit>-<digest>/   immutable, verified runtime artifacts
 shared/.env                   mode-0600 operator configuration
-shared/{files,runs,state,...} mutable operator data
+shared/{files,runs,dependency-cache,repo-mirrors,state}/ mutable operator data
 shared/bin/                   stable service wrapper
 current -> releases/...       activation authority
 previous -> releases/...      pointer rollback target
 ```
 
-Release artifacts contain the compiled applications, runtime dependency graph,
-Prisma schema, DB maintenance source modules, generated client, native assets,
-deployment scripts, build stamps, and canonical agent sources. The verifier
-checks every Prisma maintenance import rooted at `packages/db/src` before the
-quiet window. Release artifacts contain no `.env`, credentials, or
-mutable operator state. Every excluded secret-shaped path is written to the
-builder log and the release manifest.
+Artifacts contain the compiled applications and dependency graph, Prisma
+schema and maintenance sources, generated client, native and web/runner
+assets, deployment scripts, build stamps, and canonical agent sources. The
+verifier checks every Prisma maintenance import rooted at `packages/db/src`.
+Secret-shaped paths are excluded and recorded in the builder log and release
+manifest; artifacts contain no `.env`, credentials, or mutable operator state.
 
 The source checkout is inspection state. Services and auto-deploy run through
-`current`; deployment does not read, fast-forward, clean, or publish files from
-the source checkout. Development happens in an independent clone or worktree.
+`current`; deployment does not read, fast-forward, clean, or publish files
+from the source checkout. Develop in an independent clone or worktree.
 
-`com.agentos.web` serves `apps/web/dist` with Vite preview on
-`http://127.0.0.1:4173`. The numeric loopback address is intentional; the
+`com.agentos.web` serves `apps/web/dist` with Vite preview at
+`http://127.0.0.1:4173`. Use the numeric loopback address; the
 credential-bearing proxy rejects other origins.
 
 ## Preconditions
 
-Run operator commands as the account that owns the LaunchAgents, never as
-root. Require:
+For macOS and unprivileged Linux stages, use the account that owns the service
+definitions; never run those stages as `root`. Linux stage two is the explicit
+root-only exception described below. Require:
 
-- `current` and `previous` to be relative symlinks to direct children of
+- `current` and `previous` are relative symlinks to direct children of
   `releases/`;
-- `shared/.env` to be mode 0600 and contain `DATABASE_URL`,
-  `FEISHU_DEFAULT_CHAT_ID`, `GITHUB_READ_TOKEN`, and the five absolute
-  persistent paths beneath `shared/`;
-- all configured service labels to use `shared/bin/agentos-service-wrapper.mjs`;
-- the configured PostgreSQL container and its `pg_dump` binary to be running;
-- the source remote, Node, npm CLI, Git, and Docker paths recorded in the
-  auto-deploy plist to remain executable.
+- `shared/.env` is mode 0600 and contains `DATABASE_URL`,
+  `FEISHU_DEFAULT_CHAT_ID`, and `GITHUB_READ_TOKEN` (the latter must be in the
+  file), plus the five absolute persistent paths beneath `shared/`:
+  `FILES_ROOT`, `RUNNER_WORKSPACE_ROOT`, `RUNNER_DEPENDENCY_CACHE_ROOT`,
+  `RUNNER_REPO_MIRROR_ROOT`, and `CONTROL_PLANE_STATE_DIR`;
+- every configured service definition uses
+  `shared/bin/agentos-service-wrapper.mjs`;
+- the control-plane PostgreSQL container and its `pg_dump` binary are running
+  when container backup mode is selected; and
+- the source remote is readable and the Node, npm CLI, Git, and Docker paths
+  recorded in the auto-deploy definition are absolute and executable.
 
-Do not delete or synchronize legacy mutable-data roots during deploy. Their
-retirement is a separate operator decision.
+Legacy mutable-data roots are not deleted or synchronized during deployment;
+retiring one is a separate operator decision.
 
 ## Build a release artifact explicitly
 
-The builder and activator are separate programs. The builder alone may clone
-the exact target into a disposable build directory, install its lockfile, and
-compile it. It then assembles, hashes, makes read-only, probes, and verifies the
-release directory before returning its identity. A failed build never enters
-the quiet-window phase.
+The builder and activator are separate. The builder alone clones the exact
+target into a disposable build directory, installs the lockfile, builds,
+assembles, hashes, makes read-only, probes, and verifies the release. A failed
+build never enters the quiet-window phase.
 
 Auto-deploy invokes the builder as its first ledger-backed phase and records
-`ARTIFACT_PREPARED` after its receipt is independently verified. For an
-operator build before `--dry-run`, set the same explicit toolchain contract and
-pass a full commit:
+`ARTIFACT_PREPARED` only after independently verifying the builder receipt. For
+an operator build before `--dry-run`, use the same explicit toolchain contract
+and a full commit:
 
 ```sh
 export AGENTOS_REPOSITORY_ROOT="$PWD"
@@ -123,14 +119,15 @@ target="$(git ls-remote --exit-code "$DEPLOY_SOURCE_REMOTE" refs/heads/main | aw
 "$DEPLOY_NODE_BINARY" current/scripts/deploy/build-release-artifact.mjs "$target"
 ```
 
-The final line is `RELEASE-ARTIFACT` followed by the release name, commit, and
+The final line is `RELEASE-ARTIFACT` followed by release name, commit, and
 digest. An existing exact artifact is reverified and reused. Missing output,
-wrong build stamps, excluded secret-shaped paths, ambiguous identities, and
-content digest drift are named outcomes; none falls back inside the activator.
+wrong stamps, excluded secret-shaped paths, ambiguous identities, and digest
+drift are named failures; the activator has no fallback for them.
 
 ## Read-only verification
 
-Define the production backup contract without printing secrets:
+For control-plane container backup mode, define the backup contract without
+printing secrets:
 
 ```sh
 DEPLOY_DOCKER_BINARY="$(command -v docker)"
@@ -147,36 +144,37 @@ Then run:
 node current/scripts/deploy/quiet-window-deploy.mjs --dry-run
 ```
 
-Dry-run does not take the deploy lock, build, back up, migrate, sync, activate,
-write Inbox rows, or restart services. It reports the deployed and target
-commits, exact artifact readiness, blocking Run count, all thirteen service
-states, backup readiness, and every skipped activation step. `claimed`,
-`provisioning`, and `running` block; `queued` and `waiting-inbox` do not.
-
-Do not proceed after a non-zero dry-run. Build or repair the named artifact or
-resolve the named production precondition first.
+Dry-run reads the target, blocking Runs, artifact, services, and (on the
+control-plane role) backup readiness. It takes no deploy lock and does not
+build, back up, migrate, synchronize, activate, write Inbox rows, or restart
+services. It reports the current and target commits, quiet-window state,
+artifact readiness, service readiness, backup readiness, and each role's
+activation steps as `mutation=skipped`. `claimed`, `provisioning`, and
+`running` block; `queued` and `waiting-inbox` do not. A non-zero dry-run stops
+the procedure until its named artifact or precondition is repaired.
 
 ## Install service wrappers
 
-The wrapper migration is required before pointer activation. Plan and apply the
-complete thirteen-service definition set:
+The wrapper migration must finish before pointer activation. On macOS, plan
+then apply the complete generated service inventory:
 
 ```sh
 node scripts/deploy/install-launchd-services.mjs --replace-existing
 node scripts/deploy/install-launchd-services.mjs --replace-existing --apply
 ```
 
-The installer creates `shared/bin/agentos-service-wrapper.mjs`, records the
-original definitions and manifest, and writes wrapper-based plists. It does not
-call `launchctl`. Reload labels one by one, allowing a graceful predecessor to
-disappear before bootstrapping the same label. Require every label to be
-running, every log to name the same `current` identity, `/health` to pass, and
-`/version` to report the current exact commit.
+The installer records original definitions and manifests, creates
+`shared/bin/agentos-service-wrapper.mjs`, and writes wrapper-based plists. Its
+apply path may `bootout` retired labels and `kickstart` changed owned labels;
+if a label must be reloaded manually, let its graceful predecessor disappear
+before bootstrapping the same label. Require every inventory label to be
+running, each log to identify the same `current` release, `/health` to pass,
+and `/version` to report the exact current commit.
 
 ## Install auto-deploy
 
-The old definition must be explicitly unloaded and removed before a definition
-with a different log path is installed. Plan, then apply:
+If an existing macOS definition has a different log path, explicitly unload
+and remove it before installing the new definition. Plan, then apply:
 
 ```sh
 node scripts/deploy/install-launchd.mjs \
@@ -194,33 +192,34 @@ node scripts/deploy/install-launchd.mjs \
 launchctl print "gui/$(id -u)/com.agentos.auto-deploy"
 ```
 
-The plist runs `current/scripts/deploy/quiet-window-deploy.mjs`, records the
-source remote and absolute toolchain, logs under `~/Library/Logs/Anneal`, runs
-at load, and repeats every five minutes. The installer refuses to overwrite a
-different existing definition.
+The macOS plist runs `current/scripts/deploy/quiet-window-deploy.mjs` with the
+source remote and absolute toolchain recorded, logs under
+`~/Library/Logs/Anneal`, runs at load, and repeats every five minutes. The
+installer refuses to overwrite a different existing definition. A runner-only
+host does not need database backup arguments because its backup phase is
+omitted.
 
 ## Linux systemd
 
-Linux uses system-level systemd units and selects this profile with
-`AGENTOS_SERVICE_PLATFORM=linux`. The platform resolver accepts only `darwin`
-or `linux`; an unsupported value stops the operation rather than selecting the
-macOS profile. The Linux installer is a two-stage operation: rendering and
-staging are unprivileged, while copying into `/etc/systemd/system`, changing
-systemd state, and installing the control grant are root-only.
-The merge executor is installed by hand under its separate operator runbook;
-it is not generated, enabled, restarted, or rolled back by this activation set.
+Set `AGENTOS_SERVICE_PLATFORM=linux` to select system-level systemd units. The
+resolver accepts only `darwin` or `linux`; an unsupported value fails instead
+of selecting the macOS profile. Rendering and staging are unprivileged.
+Copying into `/etc/systemd/system`, changing systemd state, and installing the
+control grant are root-only stage-two operations. The merge executor remains a
+separate hand-installed service and is not generated, enabled, restarted, or
+rolled back here.
 
 ### Two-stage install
 
-Set an existing, non-root Linux service account in `SERVICE_USER`. The
-`--service-user` value is required on Linux, is validated before rendering,
-and is refused when it names an unknown account or `root`. Keep the staging
-directory operator-owned; it lives below the existing `.agentos-deploy/`
-install root.
+Set `SERVICE_USER` to an existing non-root Linux service account. `--service-user`
+is required on Linux and is validated before rendering; an unknown account or
+`root` is refused. Keep the staging directory operator-owned under the
+existing `.agentos-deploy/` install root.
 
 First plan, then render both installer manifests as the operator. The
-auto-deploy command below uses the host `pg_dump` mode; set its absolute path
-in `DEPLOY_PG_DUMP_BINARY` before running it.
+control-plane example below uses host `pg_dump`; set its absolute path in
+`DEPLOY_PG_DUMP_BINARY` first. For a runner-only host, omit that export and the
+backup options, retaining the runner role and prefix environment.
 
 ```sh
 export AGENTOS_SERVICE_PLATFORM=linux
@@ -248,74 +247,63 @@ node scripts/deploy/install-launchd.mjs \
   --apply
 ```
 
-The plan prints `PLAN platform=linux`, the system unit directory, the
-count-derived unit total, the staging path, and
-`PLAN no files or systemd state changed`. A stage-one apply writes only the
-rendered service units, the auto-deploy oneshot and timer, the staged
-os-isolation drop-ins, the stable wrapper, and their digest-and-backup
-manifests below `.agentos-deploy/`. It does not write `/etc`, call
-`systemctl`, or require privilege. Each installer prints the exact root
-command for its second stage; run those commands as printed, with
-`--install-units`, rather than constructing a different path by hand.
+The plan prints `PLAN platform=linux`, the unit directory, count-derived unit
+total, staging path, and `PLAN no files or systemd state changed`. Stage-one
+apply writes only staged service units, the auto-deploy oneshot and timer,
+os-isolation drop-ins, the stable wrapper, and digest/backup manifests below
+`.agentos-deploy/`. It does not write `/etc`, call `systemctl`, or require
+privilege. Each installer prints the exact root command for stage two; run
+that printed command with `--install-units` rather than constructing a path.
 
-Stage two verifies the already operator-installed stable wrapper, copies only
-the system-owned staged files to `/etc/systemd/system` as `root:root` with
-mode 0644, independently validates the rendered units and generated
-`/etc/sudoers.d/anneal-service-control` with `visudo -c`, runs
-`systemctl daemon-reload`, and then enables the generated inventory. The
-sudoers grant is rendered from the control adapter's own description of its
-verbs, so it names only the generated unit names, only `/bin/systemctl`, and
-only the verbs `restart`, `is-active`, and `show -p ExecStart --value`. It
-does not grant `enable`, `disable`, or `daemon-reload`; those operations
-remain in the root install stage. A non-root control call uses `sudo -n`, and
-a denied command is a deployment failure rather than a successful no-op.
+Stage two verifies the installed operator-owned wrapper and copies staged system-owned files
+to `/etc/systemd/system` as `root:root` mode 0644. It validates the rendered
+units, checks `/etc/sudoers.d/anneal-service-control` with `visudo -c`, runs
+`systemctl daemon-reload`, and enables the generated inventory. The sudoers
+grant is generated from the control adapter and names only generated units,
+`/bin/systemctl`, and `restart`, `is-active`, and `show -p ExecStart --value`.
+It grants neither `enable`, `disable`, nor `daemon-reload`; those remain in
+the root install stage. Control calls use `sudo -n`; denial is a deployment
+failure.
 
 Before replacing an existing system file, stage two records its bytes,
-ownership, mode, and enabled/active state in a root-owned mode-0600 transaction
-record beside the unit definitions. The unprivileged staging manifest cannot
-rewrite that record. A successful revert consumes and removes it after the
-final `daemon-reload`.
+ownership, mode, and enabled/active state in a root-owned mode-0600
+transaction record. The unprivileged manifest cannot rewrite that record. A
+successful revert consumes and removes it after the final `daemon-reload`.
 
-The service installer manifest includes the stable wrapper as its first entry
-and one entry for every generated service definition. The separate
-auto-deploy installer owns its own definition manifest: one plist on macOS,
-and a `Type=oneshot` service plus its timer on Linux. The oneshot service is
-installed but is never enabled or started directly: `enable --now` is applied
-to the timer so installation cannot trigger an immediate deployment.
+The service manifest has the stable wrapper as its first entry and one entry
+per generated service. The auto-deploy manifest is separate: one plist on
+macOS, or a `Type=oneshot` service and timer on Linux. The Linux oneshot is
+installed but never enabled or started directly; `enable --now` applies to the
+timer only, so installation cannot trigger an immediate deployment.
 
 ### Runner count, accounts, and logs
 
-`AGENTOS_RUNNER_COUNT` controls the generated inventory and defaults to 10;
-valid values are integers from 1 through 64. The service labels remain in
-inventory order: API, inbox, `com.agentos.runner` for runner 1,
-`com.agentos.runner-2` through the configured count, then web. The
-os-isolation scripts use `ACCOUNT_COUNT` (default 8) for the account pool and
-map runner `i` to account `((i - 1) % ACCOUNT_COUNT) + 1`. Thus a count of 16
-places two runners on each of the eight accounts, with runners 1 and 9 on
-account 1. Each account keeps its own mode-700 home and its own Git and CLI
-state; no account's credentials are copied or shared with another account.
+`AGENTOS_RUNNER_COUNT` defaults to 10 and accepts integers 1 through 64. In
+control-plane inventory order, labels are API, Inbox, runner 1 as
+`com.agentos.runner`, runners 2 through the configured count, then web. A
+runner-only inventory contains only the runner labels.
 
-At the default count there are thirteen long-running service units. At a
-count of 16 there are nineteen. Stage two runs `systemctl enable --now
-<label>.service` for every long-running service and
-`systemctl enable --now com.agentos.auto-deploy.timer`; it never enables or
-starts `com.agentos.auto-deploy.service` directly.
+The os-isolation account pool uses `ACCOUNT_COUNT` (default 8) and maps runner
+`i` to account `((i - 1) % ACCOUNT_COUNT) + 1`. Each account has its own mode-700
+home and Git/CLI state; credentials are not copied or shared. At the default
+count there are 13 long-running control-plane services; at count 16 there are
+19. Stage two runs `systemctl enable --now <label>.service` for each long-lived
+service and `systemctl enable --now com.agentos.auto-deploy.timer`; it never
+enables or starts `com.agentos.auto-deploy.service` directly.
 
-Linux service output is in the systemd journal, not in
-`~/Library/Logs/Anneal`. Inspect a service with:
+Linux output is in the systemd journal. Inspect a service with:
 
 ```sh
 journalctl --no-pager -u <label>.service
 ```
 
-No deployment code parses per-service log files on Linux. The auto-deploy
-oneshot's output is likewise inspected through its journal unit.
+The auto-deploy oneshot is inspected through its journal unit; deployment code
+does not parse per-service log files on Linux.
 
 ### Activation and rollback
 
-The release and pointer workflow is unchanged. After the verified `current`
-pointer is activated, the Linux control adapter performs the following checks
-for each generated service label, in inventory order:
+After `current` points to the verified release, the Linux control adapter
+checks each generated label in inventory order:
 
 ```sh
 sudo -n /bin/systemctl restart <label>.service
@@ -323,122 +311,118 @@ sudo -n /bin/systemctl is-active <label>.service
 sudo -n /bin/systemctl show -p ExecStart --value <label>.service
 ```
 
-`is-active` must return `active`, and the `ExecStart` value must contain both
-the stable wrapper path and the label. The HTTP readiness probes, release
-identity checks, and deploy barrier remain the same as on macOS. If
-verification fails after activation, atomically point `current` back to
-`previous`, then repeat the same `restart`, `is-active`, and wrapper-boundary
-checks for the prior release. The auto-deploy oneshot is not restarted as part
-of service rollback; its timer remains the scheduler.
+`is-active` must return `active`; `ExecStart` must contain both the stable
+wrapper path and the label. HTTP readiness, release identity, and the deploy
+barrier checks are the same as on macOS. If activation verification fails,
+atomically point `current` to `previous`, then repeat restart, active, and
+wrapper-boundary checks for the prior release. The auto-deploy oneshot is not
+restarted; its timer remains the scheduler.
 
-To undo the service installation, first run the unprivileged wrapper-revert
-stage; it restores only the operator-owned stable wrapper and prints the exact
-root command that reverts the system-owned files:
+To undo service installation, first run the unprivileged wrapper-revert stage;
+it restores only the operator-owned wrapper and prints the exact root command
+for system-owned files:
 
 ```sh
 node scripts/deploy/install-launchd-services.mjs \
   --service-user "$SERVICE_USER" --revert --apply
 ```
 
-Run that printed `--install-units --revert` command, then use the separate
-auto-deploy installer's `--install-units --revert` mode for its oneshot and
-timer. The recorded manifests are authoritative: a digest
-drift refuses the revert without changing anything; otherwise the installer
-restores or removes every recorded file, records `systemctl disable --now` for
-units it removes, and finishes with `systemctl daemon-reload`. This restores
-the system-unit files, timer, staged drop-ins, wrapper, and generated control
-grant to their recorded pre-install state.
+Run the printed `--install-units --revert` command, then use the auto-deploy
+installer's `--install-units --revert` mode for its oneshot and timer. Recorded
+manifests are authoritative: digest drift refuses the revert without changing
+anything; otherwise every recorded file is restored or removed, removed units
+receive `systemctl disable --now`, and the process finishes with
+`systemctl daemon-reload`. This restores system-unit files, timer, staged
+drop-ins, wrapper, and generated control grant to their recorded pre-install
+state.
 
 ## Activation sequence
 
-For a new remote commit, the job records `STARTED`, invokes the explicit
-builder, and then performs exactly this sequence:
+For a new target commit, the job records `STARTED`, invokes the explicit
+builder, and performs this order:
 
-1. After `ARTIFACT_PREPARED`, verify the artifact directory name, exact commit stamp, manifest inventory,
-   content digest, excluded-path record, and read-only permissions. Record
-   `ARTIFACT_VERIFIED`. A missing artifact or digest mismatch records `FAILED`
-   before quiet-window acquisition.
+1. After `ARTIFACT_PREPARED`, verify release name, exact commit stamp, manifest
+   inventory, content digest, excluded-path record, and read-only permissions;
+   record `ARTIFACT_VERIFIED`. A missing artifact or digest mismatch records
+   `FAILED` before quiet-window acquisition.
 2. Query for zero blockers, acquire the exclusive PostgreSQL deploy barrier,
    and query again. Hold the barrier through activation, verification, or
    recovery.
-3. Copy the verified release to a disposable writable operation workspace.
-   This is not a Git checkout and is never published.
-4. Prove every configured service is running through the stable wrapper
-   and still identify the old `current` release.
-5. Stream a custom-format `pg_dump` to a mode-0600 temporary host file, fsync
-   it, and rename it only after a successful non-empty result. Record
-   `BACKED_UP`.
-6. Run the guarded migration preflight and Prisma migration from the operation
-   workspace with configuration inherited from `shared/.env`. No environment
-   file is copied into any workspace. Record `SCHEMA_ADVANCED` with migration
-   tails.
-7. Regenerate and verify the operation workspace Prisma Client, then run the
-   canonical prompt sync. Structural drift remains a terminal refusal.
-8. Recheck the deploy barrier and blocking statuses, then reverify the original
-   immutable artifact.
+3. Copy the verified release to a disposable writable operation workspace. It
+   is not a Git checkout and is never published.
+4. Prove every configured service is running through the stable wrapper and
+   still identifies the old `current` release.
+5. On the control-plane role, stream a custom-format `pg_dump` to a mode-0600
+   temporary host file, fsync it, and rename it only after a successful,
+   non-empty result; record `BACKED_UP`.
+6. On the control-plane role, run guarded migration preflight and Prisma
+   migration from the operation workspace using `shared/.env`; copy no
+   environment file into any workspace. Record `SCHEMA_ADVANCED` with
+   migration tails.
+7. On the control-plane role, regenerate and verify the operation workspace
+   Prisma Client, then run canonical prompt sync. Structural drift is a
+   terminal refusal.
+8. Recheck the barrier and blocking statuses, then reverify the immutable
+   artifact. On a runner host, also read the control plane's `/version` and
+   require the same target commit immediately before publication.
 9. Atomically update `previous` and `current`, durably record `ACTIVATED`, and
    restart every configured label.
-10. Require all labels running, `/health` successful, and `/version` reporting
-    the target clean commit. Record `VERIFIED` and `SUCCEEDED` and write the
-    success Inbox record.
+10. Require all labels running. On the control plane, require `/health` success
+    and `/version` reporting the exact clean target commit. On a runner host,
+    require every local registration online, newer than its pre-restart
+    observation, and on that commit. Record `VERIFIED` and `SUCCEEDED`, then
+    write the success Inbox record.
 
-There is no install, compile, Git checkout mutation, or multi-directory
-publication in this sequence. The only activation unit is the verified release
+The sequence has no install, compile, source-checkout mutation, or
+multi-directory publication. The activation unit is the verified release
 directory selected by the pointer.
 
 ### Step deadlines and barrier watchdog
 
-Every command-backed deployment step has its own deadline. The artifact build,
-migration preflight, migration, Prisma Client generation, prompt sync, and
-service-control commands are budgeted independently; there is no single global
-step timeout. A step that reaches its deadline is terminated with `SIGTERM`,
-followed by `SIGKILL` if it does not exit, and is reported as a
-`DeployFailure`.
+Each command-backed phase has its own deadline: artifact build, migration
+preflight, migration, Prisma Client generation, prompt sync, backup, and
+service control are budgeted independently. A deadline sends `SIGTERM`, then
+`SIGKILL` if needed, and becomes a `DeployFailure`.
 
-The deploy barrier also has an independent duration watchdog. It starts with
-barrier acquisition and covers hangs outside a child command, so a process
-that is no longer making step progress cannot keep new Run claims closed
-without an escalation. A watchdog expiry is logged, written to
+The deploy barrier has an independent watchdog beginning at acquisition. It
+covers hangs outside a child command; expiry is logged, written to
 `.agentos-deploy/escalated.json`, and sent to the operator Inbox through the
-same escalation mechanism as other deployment failures.
+same escalation path as other failures.
 
-Timeouts for ordinary steps follow the normal failure path: the deployment
-process exits, its session-scoped PostgreSQL barrier is released automatically,
-and before publication the current release remains active. After publication,
-recovery attempts to restore the prior release and services; database
-migrations are not rolled back. The `prisma migrate deploy` migration step is
-the deliberate exception. If it
-reaches its deadline, the child is terminated and the failure is written to
-`escalated.json` and notified, but the deploy process remains alive with the
-same database session and barrier held. The current release's service processes
-remain running, but no new Run may be claimed and activation and restart do not
-proceed. The barrier is not a service-process stop; do not restart services onto
-a possibly half-applied schema.
+Ordinary timeout failure exits the deployment and releases the session-scoped
+barrier automatically. Before publication, `current` stays active. After
+publication, recovery restores the prior pointer and services; database
+migrations are never rolled back.
 
-After the cause has been repaired, use the existing `--clear-escalation`
-operation. The held deploy process observes the cleared marker, releases its
-barrier, and exits non-zero. Only after that normal exit should the scheduled
-job be kicked again using the retry procedure below.
+Migration deploy timeout is the exception. The child is terminated and the
+failure is written to `escalated.json` and notified, while the deploy process
+keeps the same database session and barrier. Current services stay running;
+new Runs cannot be claimed, and activation and restart do not proceed. The
+barrier is not a service stop, so do not restart services onto a possibly
+half-applied schema.
+
+After repairing the cause, run the existing `--clear-escalation` operation.
+The held process observes the cleared marker, releases its barrier, and exits
+non-zero. Wait for that old process to exit normally; only then kick the
+scheduled job with the retry command below.
 
 While the log says `HOLD deploy-barrier migration-timeout`, do not boot out,
 kickstart, or kill `com.agentos.auto-deploy`, and do not log out or reboot the
-host. `SIGTERM` is deliberately refused during this hold, but launchd can
-eventually escalate to `SIGKILL`, which would drop the session-scoped barrier.
-The existing `--clear-escalation` operation is the only safe way to end the
-hold after an operator has established that the schema is safe.
+host. The process deliberately refuses `SIGTERM`; `--clear-escalation` is the
+only safe way to end the hold after the operator has established that the
+schema is safe.
 
 #### Timeout or hang evidence
 
-Start with `~/Library/Logs/Anneal/auto-deploy.log` and identify the stalled
-auto-deploy child PID. Before changing process state, capture its stack on the
-affected host:
+Start with `~/Library/Logs/Anneal/auto-deploy.log`, identify the stalled child
+PID, and capture its stack before changing process state:
 
 ```sh
 sample <pid> 10 -file ~/Library/Logs/Anneal/auto-deploy-<pid>.sample.txt
 ```
 
-At the same time, record machine load and the competing process inventory,
-including merge-gate workers and `packages/db` test processes. For example:
+At the same time record machine load, I/O, and competing process inventory,
+including merge-gate workers and `packages/db` test processes:
 
 ```sh
 uptime
@@ -447,22 +431,20 @@ ps -axo pid,ppid,lstart,state,%cpu,%mem,command
 iostat -w 1 -c 3
 ```
 
-Preserve these outputs with the auto-deploy log timestamps. The observed slow
-incident had no database connection from the stalled Prisma parent, and a
-later real migration completed normally, so do not restart diagnosis at
-PostgreSQL locks or connection counts; collect the process stack, host load,
-I/O state, and concurrent-task evidence first.
+Preserve these outputs with the auto-deploy log timestamps. Use the process
+stack, host load, I/O state, and concurrent-task evidence to choose the next
+diagnostic action.
 
-If restart or health verification fails after pointer activation, the job
-atomically points `current` back at `previous`, records the rollback outcome,
-and restarts the prior release. Database migration rollback is not attempted.
-There is no checkout or partial-directory fallback.
+If restart or health verification fails after pointer activation, atomically
+point `current` back to `previous`, record the rollback outcome, and restart
+the prior release. Do not roll back database migrations, check out source, or
+fall back to a partial directory.
 
 After success or a no-op, retention keeps the newest three immutable releases
-while protecting both pointer targets, the newest fourteen database dumps, one
-dump per UTC day for thirty days, and the newest fourteen deployment ledgers.
-Locks, escalation state, operation workspaces, and unrecognized entries are
-not retention candidates.
+while protecting both pointer targets, the newest 14 database dumps, one dump
+per UTC day for 30 days, and the newest 14 deployment ledgers. Locks,
+escalation state, operation workspaces, and unrecognized entries are not
+retention candidates.
 
 Apply retention explicitly with:
 
@@ -472,46 +454,38 @@ node current/scripts/deploy/quiet-window-deploy.mjs --prune-history
 
 ## Failure and escalation
 
-Remote-main-unreadable is treated as a potentially transient transport failure.
-Before escalating that class, a scheduled invocation retries the remote-main
-read within a bounded retry budget and uses backoff between attempts. The retry
-burst and each resulting outcome are visible in the deploy log; a successful
-retry continues without writing an escalation.
+Remote-main reads use a bounded retry budget with backoff; each retry and
+outcome is visible in the deploy log. A successful retry continues without an
+escalation.
 
-An existing escalation is eligible for an unattended retry only when its reason
-is one of `remote-main-unreadable`, `remote-main-read-timeout`,
-`quiet-window-query-failed`, or `deploy-barrier-unavailable`. These reasons
-cover transient remote, platform-database, and deploy-barrier reads. Environment,
-Prisma client import, authentication, malformed remote state, build, verify,
-artifact, and filesystem-state failures remain operator-latched.
+An existing escalation may be retried unattended only for
+`remote-main-unreadable`, `remote-main-read-timeout`,
+`control-plane-version-unreachable`, `control-plane-commit-unavailable`,
+`source-remote-unreadable`, `source-remote-read-timeout`,
+`quiet-window-query-failed`, or `deploy-barrier-unavailable`. Environment,
+authentication, malformed remote state, build, artifact, verification, and
+filesystem-state failures stay operator-latched.
 
-The initial escalation is attempt 1. Each later failed eligible run atomically
-replaces the marker with an incremented attempt count. Attempts below the fixed
-cap of 5 may run again; a marker at attempt 5 blocks subsequent ticks exactly
-like a permanent escalation. This bounds repeated artifact preparation when an
-eligible condition flaps.
+The initial escalation is attempt 1. Later eligible failures atomically
+replace the marker with an incremented count. Attempts below the fixed cap of
+5 may run again; attempt 5 blocks later ticks like a permanent escalation.
+Admission alone never clears a marker. A full successful deployment, or proof
+that the target is already deployed, must complete before the job reports
+recovery, removes `.agentos-deploy/escalated.json`, and logs
+`SELF-CLEAR escalation reason=<reason> attempts=<n>`. If the recovery
+notification fails, the marker remains. Confirm the SELF-CLEAR entry and
+closed recovery notification before dismissing the original failure.
 
-Admission alone never clears the marker. The scheduled cycle must complete the
-full deployment successfully, or prove that the target is already deployed.
-Only then does it report the recovery through the existing notification channel,
-remove `.agentos-deploy/escalated.json`, and log
-`SELF-CLEAR escalation reason=<reason> attempts=<n>`. If that success
-notification fails, the marker remains for the next tick. The original failure
-notification remains historical evidence; confirm the SELF-CLEAR entry and
-closed recovery notification before dismissing it.
+For any non-allowlisted escalation or an eligible escalation at the cap,
+inspect the ledger, logs, pointer identities, service states, and Inbox record;
+repair the named cause, build and verify the artifact again, and rerun
+`--dry-run`.
 
-Every non-allowlisted escalation and every eligible escalation at the cap stays
-latched for manual clearing. Inspect the ledger, logs, pointer identities,
-service states, and Inbox record; repair the named cause; build and verify the
-artifact again; and rerun `--dry-run`.
-
-Only then clear and retry:
-
-Run this from the deployment root — the directory holding `current/` and
-`.agentos-deploy/`. The marker path hangs off `AGENTOS_REPOSITORY_ROOT`, so
-without it the command resolves its state directory to `current/.agentos-deploy/`,
-deletes nothing, and prints `NO-ESCALATION-TO-CLEAR path=...` while the real
-marker stays latched. Check that path in the output before assuming the
+Only then clear and retry. Run this from the deployment root, the directory
+holding `current/` and `.agentos-deploy/`. The marker is resolved from
+`AGENTOS_REPOSITORY_ROOT`; without it the command looks under
+`current/.agentos-deploy/`, deletes nothing, and prints
+`NO-ESCALATION-TO-CLEAR path=...`. Check the printed path before assuming the
 escalation is gone.
 
 ```sh
@@ -520,7 +494,9 @@ AGENTOS_REPOSITORY_ROOT="$PWD" \
 launchctl kickstart -k "gui/$(id -u)/com.agentos.auto-deploy"
 ```
 
-Signals before activation enter the normal `FAILED` path and remove the
-operation workspace. Signals after activation perform pointer recovery before
-releasing the deploy barrier. An uncatchable stale process owner is reclaimed
-once and escalated instead of starting an unrecorded second deployment.
+The second command is valid only after a migration-timeout hold has ended as
+described above. Signals before activation enter the normal `FAILED` path and
+remove the operation workspace. Signals after activation perform pointer
+recovery before releasing the barrier. An uncatchable stale process owner is
+reclaimed once and escalated instead of starting an unrecorded second
+deployment.


### PR DESCRIPTION
Shortens the task-routing contract, contributor guide, and auto-deploy runbook while retaining authorization boundaries, command templates, and recovery ordering. Clarifies template approval placement and corrects migration-pin and deployment descriptions against the existing implementation.

Validation: headings, links, and shell templates checked; focused documentation checks, dependency-gate, and compose-binding passed. Local auto-deploy tests reported 217 passes, 4 failures, and 1 skip: two failures from absent node_modules/dotenv, one from an existing Mac LaunchAgent conflicting with a fixture, and one from unavailable systemctl on the Mac. The full remote merge gate passed for integrated head `15548f97f28f317d44cf1241ea9ba97193fe19c7`, including deployment harness, build, lint, unit tests, and database tests.
