### PR TITLE
docs: correct reader surface after the 2026-09-04 documentation audit

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -140,6 +140,8 @@ Developer Preview 7（v0.7.0）：接口与存储数据形态在 preview 之间�
 Linux 与 Intel macOS 预计可运行，但尚未完成 release-level 验证；Windows
 不支持。
 
+Pull-request 工作流请按 [Add a project](docs/runbooks/add-a-project.md) 操作。
+
 **把它指向任何你在乎的东西之前先读这段：** Anneal 以非交互的权限旁路
 方式启动 coding CLI，以你的 macOS 用户身份运行，不在沙箱内。请使用可
 丢弃的仓库和一台你愿意让 agent 修改的机器。详见

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,10 +52,6 @@ Local runner -----> ephemeral git workspace
    controls whether delivery also attempts to open a pull request. A gated task
    moves to review for a human decision; an ungated successful task can finish.
 
-> **Pending (OSS-C): public demo evidence.** The screenshots above illustrate
-> the interface only. No video, timing, benchmark, or end-to-end demo claim is
-> part of this README until the OSS-C evidence gate is complete.
-
 ## Security defaults and limits
 
 - Operator, runner, and per-run session principals are separate. Runner routes

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -199,8 +199,8 @@ own. The board holds either the card or its chain, never both.
 
 - Create it with `assigneeType: HUMAN` so no runner claims it. Its description
   is the brief from `docs/BRIEF-TEMPLATE.md`, plus the `Route:` line when the
-  implementation assignee is non-default. The create API accepts `status` as
-  optional `status` as `BACKLOG` or `TODO` and defaults to `TODO`; pass `status: BACKLOG` to create
+  implementation assignee is non-default. The create API accepts an
+  optional `status` of `BACKLOG` or `TODO` and defaults to `TODO`; pass `status: BACKLOG` to create
   a human Backlog card atomically, without a follow-up PATCH.
 - Dispatch passes the card's name as instantiate `name` and the brief as
   instantiate `description`; the chain implementation task then owns the

--- a/docs/public-snapshot.md
+++ b/docs/public-snapshot.md
@@ -51,8 +51,9 @@ runbooks are maintained outside this repository.
 The exact list is the point. A directory glob would publish anything dropped into
 `docs/release/` afterwards. The internal record classes a maintainer checkout does
 carry — `docs/reviews/**`, `docs/briefs/**`, `docs/merge-notes/**` and
-`docs/plans/**`, the same directories the frozen-record guard in
-`scripts/check-frozen-docs.sh` protects — are excluded by name, each with a
+`docs/plans/**` — a superset of the directories the frozen-record guard in
+`scripts/check-frozen-docs.sh` protects, which stops at `docs/plans/archive/`
+so an unarchived plan stays editable — are excluded by name, each with a
 reason, so a file dropped into one is classified as held back rather than as a
 file nobody looked at. A scanner test derives the open docs set from the manifest and
 asserts that every entry names one literal file rather than a glob.

--- a/docs/release/license-and-assets.md
+++ b/docs/release/license-and-assets.md
@@ -118,7 +118,7 @@ identifier, recorded below.
 | `apps/web/src/tests/fixtures/tc-ux-v1-prompts.json` | `application/json` | `25d2062e60a618783de79b1d7a824711adb29931e0334c958e0640fec9a53da2` | 53465 |
 | `apps/web/src/tests/fixtures/tc-ux-v1-prompts.provenance.json` | `application/json` | `bab04df18c4680804120478e2362256de41b3a484b81d08024bcc096cdf009d4` | 264 |
 | `docs/release/fixtures/oss-b0-smoke-task.json` | `application/json` | `a716ed8fc39420c1b671574450b92c61d913352539078948f9429bef42650de6` | 1875 |
-| `scripts/fixtures/local-api-origin-cases.json` | `application/json` | `e40ad18b723d231ebee217afe10194ecebc519639ff93d74b3fbf7baf4185bf0` | 7682 |
+| `scripts/fixtures/local-api-origin-cases.json` | `application/json` | `02a07bb85cd1e80db5097100bb5b0d1c37e35df841dcf2ad1e238e1106e8360f` | 7698 |
 | `scripts/fixtures/onboarding-remote-cases.json` | `application/json` | `82ff59b740b4dcc6ef43270fb301800360eecefb65b74ee7ad9e1dc4eafb257f` | 5963 |
 
 Every one of them is first-party, owned by Moson Lab and covered by `LICENSE`,
@@ -141,7 +141,7 @@ is the part worth writing down:
   digest it records is the fixture's actual digest in this commit, so the pair
   checks itself.
 - **`oss-b0-smoke-task.json`** — the frozen deterministic smoke task the
-  quickstart's step 8 creates. Authored here; no credential, no personal data.
+  quickstart's step 10 creates. Authored here; no credential, no personal data.
 - **`local-api-origin-cases.json`** — the shared policy table deciding which
   local API destinations are accepted and refused. Its hostile URLs are synthetic
   and are the cases being refused, not endpoints anything contacts.
@@ -155,9 +155,10 @@ is the part worth writing down:
 `public-snapshot.json`'s `exclude` rules name each held-back file with a reason,
 and its `deny` rules close whole path classes repository-wide: generated build
 output, installed dependencies, caches, dumps, logs, process files and captured
-process output. Plans, reviews, runbooks, internal specifications, design
-references and private operational material are excluded by name or by
-directory. `docs/public-snapshot.md` describes the boundary and how it is
+process output. Plans, reviews, briefs, merge notes, internal specifications,
+design references and private operational material are excluded by name or by
+directory; the four test-coupled runbooks under `docs/runbooks/` are published
+by exact name. `docs/public-snapshot.md` describes the boundary and how it is
 checked.
 
 ## Re-deriving this page

--- a/scripts/check-frozen-docs.sh
+++ b/scripts/check-frozen-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Frozen-record check (AGENTS.md "Frozen records"). Two mechanical rules, and one
+# Frozen-record check (CONTRIBUTING.md "Records that do not change"). Two mechanical rules, and one
 # statement of what is deliberately not mechanical.
 #
 #   1. Append-only directories. docs/reviews, docs/merge-notes, docs/briefs and
@@ -8,7 +8,7 @@
 #      is on master it is history: a branch may add files, but may not modify or
 #      delete one. Every file a branch adds there must carry a YYYY-MM-DD-
 #      basename prefix, which is the half of the convention the first version of
-#      this script wrote down in AGENTS.md and then never checked.
+#      this script wrote down in CONTRIBUTING.md and then never checked.
 #
 #      One rename is allowed: a byte-identical rename inside the same frozen
 #      directory to a dated name. That is the only way a record merged under a
@@ -25,8 +25,8 @@
 #
 #      What this cannot decide is whether a doc that *should* be marked is:
 #      nothing in a diff says "this document stopped being authority". So the
-#      gate enforces the marker's form, never its presence. AGENTS.md says the
-#      same thing; do not quote this script as enforcing more than that.
+#      gate enforces the marker's form, never its presence. CONTRIBUTING.md
+#      says the same thing; do not quote this script as enforcing more than that.
 #
 # Baseline. The rules are about what is already on master, so the answer depends
 # entirely on which commit "master" is. In order:
@@ -270,7 +270,7 @@ done <<< "${marker_files}"
 # --- verdict ----------------------------------------------------------------
 
 if [ -n "${violations}" ]; then
-  printf 'frozen records (AGENTS.md "Frozen records"), against merge-base %.12s of %s:\n%s\n' \
+  printf 'frozen records (CONTRIBUTING.md "Records that do not change"), against merge-base %.12s of %s:\n%s\n' \
     "${base}" "${baseline_source}" "${violations}" >&2
   exit 1
 fi

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -50,7 +50,7 @@
 # serialise runs whose commits have already moved on — so a live holder is an
 # immediate FAIL naming the process that holds it.
 #
-# The frozen-record rules (AGENTS.md "Frozen records") are checked immediately
+# The frozen-record rules (CONTRIBUTING.md "Records that do not change") are checked immediately
 # after the commit is pinned and before Docker is touched: they need nothing
 # installed and nothing running, and a branch that rewrites history should hear
 # that instead of a preflight failure about a daemon it never needed.


### PR DESCRIPTION
## Summary

Documentation audit at `a0c458a8` over all 38 documentation candidates. Every candidate stays (KEEP); no ARCHIVE or DELETE row. The public-snapshot include whitelist has 185 entries and none matches zero tracked files.

Corrections where the text contradicted the code:

- `docs/release/license-and-assets.md`: refresh the digest and size of `scripts/fixtures/local-api-origin-cases.json`; the quickstart creates the smoke task at step 10; runbooks are published by exact name, not excluded.
- `docs/public-snapshot.md`: the frozen-record guard stops at `docs/plans/archive`, so the manifest exclude set is a superset of what it protects.
- `docs/architecture.md`: drop the orphaned OSS-C "screenshots above" block.
- `docs/governance/task-routing-v1.md`: fix the duplicated "status as optional status" clause.
- `README.zh-CN.md`: carry the Add-a-project pointer the English README has.
- `scripts/check-frozen-docs.sh`, `scripts/merge-gate.sh`: point at CONTRIBUTING.md "Records that do not change"; AGENTS.md has no "Frozen records" section.

## Verification

`npm run lint`, `test:snapshot-scan` (21), `test:release-docs` (14), `test:operator-api-docs` (13), `test:frozen-docs` (28), `merge-gate-profile.test.mjs` (5), `setup-local.test.mjs` (41) all pass; `npm run snapshot:scan` exits 0 on the committed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q43dWMeLErrT5hfgCPrUBS