### PR TITLE
docs: verify Linux as a platform and document second-machine runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ written.
 
 ## Unreleased
 
+### Documentation
+
+- Linux (Ubuntu 24.04 LTS, x86_64) is now a maintainer-verified platform
+  alongside macOS on Apple Silicon; the install documents drop their
+  macOS-only wording. Running some runners on a second machine over an SSH
+  tunnel is documented as experimental in `docs/install.md`.
+
 ## v0.7.0 — Developer Preview 7
 
 The seventh preview opens Anneal to more than one project: a documented

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ already signed in to.
 
 [![status](https://img.shields.io/badge/status-developer%20preview-orange)](#status)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![platform](https://img.shields.io/badge/platform-macOS%20Apple%20Silicon%20verified-lightgrey)](#status)
+[![platform](https://img.shields.io/badge/platform-macOS%20Apple%20Silicon%20%7C%20Linux-lightgrey)](#status)
 [![node](https://img.shields.io/badge/node-22.17.0-brightgreen)](.nvmrc)
 
 [Install](#quick-start) · [How it works](#how-it-works) · [Status](#status) · [简体中文](README.zh-CN.md)
@@ -126,15 +126,15 @@ board column semantics in the
 
 The verified release path needs:
 
-- an Apple Silicon Mac
+- an Apple Silicon Mac or a Linux machine (Ubuntu 24.04 LTS verified)
 - Node.js satisfying `^20.19.0 || ^22.13.0 || >=24`; use `22.17.0` from
   `.nvmrc`, with npm 10.9.2+
 - Docker Compose and Git
-- the official Codex CLI signed in under the same macOS account
+- the official Codex CLI signed in under the account that runs the runner
   (Claude Code and Pi optional)
 
-Linux and macOS on Intel are expected to work but are not yet
-release-verified. This quick start documents the verified Apple Silicon path.
+macOS on Intel is expected to work but is not yet release-verified;
+Windows is unsupported.
 
 ```sh
 git clone https://github.com/mosonlab/anneal.git
@@ -156,14 +156,15 @@ The full sequence with its preflights is in
 
 Developer Preview 7 (v0.7.0): interfaces and stored data shapes may
 change between previews, and the only upgrade path is a fresh install.
-The verified target is macOS on Apple Silicon. Linux and macOS on Intel
-are expected to work but are not yet release-verified; Windows is unsupported.
+The verified targets are macOS on Apple Silicon and Linux (Ubuntu 24.04 LTS,
+x86_64). macOS on Intel is expected to work but is not yet release-verified;
+Windows is unsupported.
 
 For the pull-request workflow, follow [Add a project](docs/runbooks/add-a-project.md).
 
 **Read before pointing this at anything you care about:** Anneal
 launches coding CLIs with non-interactive permission bypass, as your
-macOS user, outside a sandbox. Use a disposable repository and a
+own user account, outside a sandbox. Use a disposable repository and a
 machine you are willing to let an agent modify. Details in
 [`docs/release/security.md`](docs/release/security.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@ Anneal 在你自己的本地机器上驱动一条条 coding agent 任务链。�
 
 [![status](https://img.shields.io/badge/status-developer%20preview-orange)](#当前状态)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![platform](https://img.shields.io/badge/platform-macOS%20Apple%20Silicon%20verified-lightgrey)](#当前状态)
+[![platform](https://img.shields.io/badge/platform-macOS%20Apple%20Silicon%20%7C%20Linux-lightgrey)](#当前状态)
 [![node](https://img.shields.io/badge/node-22.17.0-brightgreen)](.nvmrc)
 
 [安装](#快速开始) · [工作原理](#工作原理) · [当前状态](#当前状态) · [English](README.md)
@@ -109,14 +109,13 @@ merge-tail 修复。</sub>
 
 已验证的 release 路径需要：
 
-- Apple Silicon 的 Mac
+- Apple Silicon 的 Mac，或一台 Linux 机器（已验证 Ubuntu 24.04 LTS）
 - Node.js 满足 `^20.19.0 || ^22.13.0 || >=24`；使用 `.nvmrc` 指定的
   `22.17.0`，并配合 npm 10.9.2+
 - Docker Compose 与 Git
-- 在同一 macOS 账户下已登录的官方 Codex CLI（Claude Code 与 Pi 可选）
+- 在运行 runner 的同一账户下已登录的官方 Codex CLI（Claude Code 与 Pi 可选）
 
-Linux 与 Intel macOS 预计可运行，但尚未完成 release-level 验证；本快速
-开始只记录已经验证的 Apple Silicon 路径。
+Intel macOS 预计可运行，但尚未完成 release-level 验证；Windows 不支持。
 
 ```sh
 git clone https://github.com/mosonlab/anneal.git
@@ -136,12 +135,12 @@ npm run db:migrate:release -- --fresh
 ## 当前状态
 
 Developer Preview 7（v0.7.0）：接口与存储数据形态在 preview 之间可能
-变化，唯一升级路径是全新安装。已验证的目标平台是 Apple Silicon macOS；
-Linux 与 Intel macOS 预计可运行，但尚未完成 release-level 验证；Windows
-不支持。
+变化，唯一升级路径是全新安装。已验证的目标平台是 Apple Silicon macOS 与
+Linux（Ubuntu 24.04 LTS，x86_64）；Intel macOS 预计可运行，但尚未完成
+release-level 验证；Windows 不支持。
 
 **把它指向任何你在乎的东西之前先读这段：** Anneal 以非交互的权限旁路
-方式启动 coding CLI，以你的 macOS 用户身份运行，不在沙箱内。请使用可
+方式启动 coding CLI，以你自己的用户账户身份运行，不在沙箱内。请使用可
 丢弃的仓库和一台你愿意让 agent 修改的机器。详见
 [`docs/release/security.md`](docs/release/security.md)。
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,9 +6,10 @@ installation sequence is
 
 ## Start locally
 
-The verified Developer Preview release path targets an Apple Silicon Mac.
-Linux and macOS on Intel are expected to work but are not yet release-verified;
-Windows is unsupported. For this release, use Node.js `22.17.0` from `.nvmrc`.
+The verified Developer Preview release path targets an Apple Silicon Mac or
+Linux (Ubuntu 24.04 LTS, x86_64). macOS on Intel is expected to work but is
+not yet release-verified; Windows is unsupported. For this release, use Node.js
+`22.17.0` from `.nvmrc`.
 Installation enforces Node.js satisfying `^20.19.0 || ^22.13.0 || >=24`, the
 range shared by the locked toolchain; Node 22.12.x and 23 are refused. You also
 need
@@ -19,7 +20,7 @@ need
 - a read-only GitHub token for `GITHUB_READ_TOKEN`; every API process requires
   it at startup, independently of whether Direct or Full Assurance is enabled;
 - the official **Codex CLI, already installed and already signed in**, under the
-  same macOS account that will run the Anneal runner;
+  same user account that will run the Anneal runner;
 - the GitHub CLI (`gh`), installed and authenticated under that account, for
   every GitHub-backed run configured to open a pull request. If `gh` cannot
   record an open pull request, the run fails while preserving its already-pushed
@@ -66,6 +67,24 @@ LaunchDaemon and Linux systemd profiles in the public
 [`docs/runbooks/merge-executor.md`](runbooks/merge-executor.md) runbook.
 Those procedures do not change the platform classifications above or the
 authoritative support matrix.
+
+## Runners on a second machine (experimental)
+
+One installation can run its control plane on one machine and some runners on
+another, for example Codex on Linux and Claude Code on a Mac. This shape is
+experimental: it works, and nothing in Anneal is designed around it.
+
+- The API listens on loopback only, by design. On the runner machine, forward
+  that loopback with `ssh -L 3000:127.0.0.1:3000 <control-plane-host>` and keep
+  `RUNNER_API_URL=http://127.0.0.1:3000`; the runner refuses any other origin.
+- Give every runner its own `RUNNER_ID` and the installation's `RUNNER_TOKEN`.
+  Each machine keeps its own repository mirrors and workspaces; nothing is
+  shared over the network, and delivery is a Git push from the runner machine.
+- Each machine signs in to the provider CLIs its runners use, and its runners
+  set `RUNNER_SERVED_KINDS` to those kinds so a runner never claims work for a
+  CLI that machine does not have.
+- The tunnel's authentication, liveness and reconnection are yours. It adds no
+  identity to Anneal, so the support matrix's remote-access row still stands.
 
 ## Pre-seed a repository mirror
 

--- a/docs/release/developer-preview.md
+++ b/docs/release/developer-preview.md
@@ -8,10 +8,10 @@
 > release tag remains immutable; use this corrected page when installing it.
 
 > **One verified path, one shape of install.** This page is the supported
-> sequence for macOS on Apple Silicon, run by the machine's own operator, on
+> sequence for macOS on Apple Silicon and Linux, run by the machine's own operator, on
 > loopback, against repositories you are willing to have an agent write to.
-> Linux and macOS on Intel are expected to work but are not yet release-verified;
-> Windows is unsupported.
+> macOS on Intel is expected to work but is not yet release-verified; Windows is
+> unsupported.
 > [`support-matrix.md`](support-matrix.md) states what is supported
 > and on what evidence; anything not in it is not supported.
 
@@ -30,12 +30,12 @@ fresh install.
 
 | Requirement | Exact expectation |
 | --- | --- |
-| Machine | The verified path uses an Apple Silicon Mac running macOS. Keep the checkout, `~/.agentos/control-plane`, and runner workspaces on a local APFS or HFS+ volume. NFS, SMB/CIFS, FUSE, unknown filesystem types, and symlinked control-state path components are refused. Linux and macOS on Intel are expected to work but are not yet release-verified; Windows is unsupported. |
+| Machine | The verified path uses an Apple Silicon Mac running macOS, or Linux (Ubuntu 24.04 LTS, x86_64). Keep the checkout, `~/.agentos/control-plane`, and runner workspaces on a local APFS or HFS+ volume on macOS, or ext4, XFS or Btrfs on Linux. NFS, SMB/CIFS, FUSE, unknown filesystem types, and symlinked control-state path components are refused. macOS on Intel is expected to work but is not yet release-verified; Windows is unsupported. |
 | Node.js | Use `22.17.0`, recorded in `.nvmrc`. Installation is enforced at `^20.19.0 \|\| ^22.13.0 \|\| >=24`, the range shared by the locked toolchain; Node 22.12.x and 23 are refused. |
 | npm | 10.9.2 or newer, the npm generation floor recorded for this release. Use it with Node.js 22.17.0. |
 | Docker | Docker Desktop must be running, with Docker Compose available. The supported local shape needs loopback ports `5432`, `3000`, and `5173` free. |
 | Git | Any recent version, with `user.name` and `user.email` configured for the runner account. The source must be a working clone. |
-| Codex CLI | The official Codex CLI, already installed **and already signed in**, under the same macOS account that will run the Anneal runner. The runner does not inherit your interactive shell's `PATH`; see the preflight below. |
+| Codex CLI | The official Codex CLI, already installed **and already signed in**, under the same user account that will run the Anneal runner. The runner does not inherit your interactive shell's `PATH`; see the preflight below. |
 | GitHub CLI | Optional for branch-only delivery and the deterministic smoke task. `gh` is required for automatic pull-request creation and must be authenticated as the runner account. If a run must open a pull request and `gh` cannot record one, Anneal preserves the pushed branch and fails the run for retry. Manual PR instructions are reserved for non-GitHub remotes, where automatic creation is impossible by design. |
 | GitHub read token | A read-only token exported as `GITHUB_READ_TOKEN` while running setup. Every API process requires it at startup; setup copies it into the mode-0600 `.env` and never prints it. |
 
@@ -132,7 +132,7 @@ Documents enabled, agent writes may be uploaded and dataless placeholders may
 fail to read. Set an absolute `FILES_ROOT` outside synced folders if that matters.
 With the shipped same-user runner, Filesystem Grants authorize and audit
 Anneal's Files API; they do not stop the coding CLI from accessing files the
-macOS user itself can access.
+runner's user account itself can access.
 
 If setup is interrupted, first make sure no other setup process is running, then
 inspect for abandoned credential files without printing their contents:

--- a/docs/release/support-matrix.md
+++ b/docs/release/support-matrix.md
@@ -25,9 +25,9 @@ has never walked.
 
 | Platform | Status | Evidence boundary |
 | --- | --- | --- |
-| macOS on Apple Silicon | **Target platform** | The only platform this release targets. The install shape is in [`developer-preview.md`](developer-preview.md). |
+| macOS on Apple Silicon | **Target platform** | The install shape is in [`developer-preview.md`](developer-preview.md). |
 | macOS on Intel | **Unverified** | The portable design and locked `darwin-x64` dependencies make this path expected to work, but nothing has been run there. |
-| Linux | **Unverified** | The POSIX design, explicit Linux command branches and locked Linux dependencies make this path expected to work, but no release install or Run has been exercised there. |
+| Linux | **Maintainer-verified** | Ubuntu 24.04 LTS on x86_64, Node.js 26.8.1, Codex CLI 0.153.4: the maintainer's own installation runs the API, web console, PostgreSQL, release migrations, sixteen Codex and Pi runners and the merge executor there. Other distributions are **Unverified**. |
 | Windows | **Unsupported** | The runner relies on POSIX process-group, path and command behaviour. This is a design position, not a gap waiting to be filled. |
 
 ## Runtime prerequisites
@@ -88,6 +88,7 @@ the CLI vendor.
 | Repository command-line interface | **Retired** | This release ships no repository CLI. v0.1.0 and v0.2.0 contained a help-only interface; v0.3.0 retires it rather than carrying it forward without operational command families. |
 | Feishu / Lark integration | **Experimental** | A maintainer's own integration, published because it is in the tree rather than because it is offered. Not part of the quickstart sequence and not part of the committed surface. |
 | launchd service definitions | **Unsupported** | Outside the supported install shape. |
+| Runners on a second machine | **Experimental** | The runner machine forwards the control plane's loopback port over its own SSH tunnel; see [`install.md`](../install.md). The maintainer runs Claude Code runners this way. The tunnel adds no identity, so the row below stands. |
 | Remote access of any kind | **Unsupported** | There is no remote authentication design — no login, no per-user identity, no session model for anyone but the machine's own operator. A tunnel or a reverse proxy does not add one. |
 
 ## Data and operations


### PR DESCRIPTION
Docs-only.

- Support matrix: Linux (Ubuntu 24.04 LTS, x86_64) moves from Unverified to Maintainer-verified on the evidence of the maintainer's production installation; other distributions stay Unverified. New Experimental row for runners on a second machine.
- README (en/zh), install.md, developer-preview.md: platform wording names both verified targets and drops macOS-only account phrasing. Windows stays unsupported.
- install.md: short experimental section on running runners on a second machine over an SSH tunnel to the loopback API.
- CHANGELOG Unreleased entry.

Checks: `npm run test:snapshot-scan` passes in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QRCaaZkzwtpP4qWdtU4eV