### PR TITLE
docs: correct the decision-record surface after deepening round 6

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,8 +31,9 @@ the frontier.
 
 **Merge gate**:
 The chain-tail verification that must pass before a chain's branch may merge:
-lint, types, and tests run by a gate worker in a clean environment. Gate
-evidence belongs to the chain tail only; review steps never run the gate.
+lint, types, and tests run by the merge gate on the exact head, locally or on a
+remote gate worker. Gate evidence belongs to the chain tail only; review steps
+never run the gate.
 
 **Merge readiness**:
 The mechanical chain step that validates durable **Merge gate** evidence
@@ -41,29 +42,33 @@ the exact merge. It performs no semantic review.
 
 **Lease**:
 The time-bounded claim a runner holds on a run, kept alive by heartbeats. An
-expired lease returns the run to the queue. The merge Lease is a separate
+expired lease marks the run lost; a retry run opens while the task's run budget
+remains, otherwise the task moves to review. The merge Lease is a separate
 global claim: **Merge readiness** obtains it and hands it to merge execution so
 only one chain integrates at a time.
 
 **Specification of record**:
 The single authoritative statement of what to build, which every later step
 obeys: the approved spec for a compound chain, the task brief for a direct
-chain. Materialized into the **Chain workspace** by the chain's first working
-step.
+chain. Materialized into the **Chain workspace** before implementation starts:
+by the plan step in a compound chain, by the platform when it hands a direct or
+PR chain branch to the runner.
 
 **Chain workspace**:
 The `.chain/<branchName>/` directory on the chain branch holding the
 materialized spec, slices, and decisions. Stripped from the mainline at merge;
-the chain branch is archived with it intact.
+the chain branch keeps it.
 
 **Blind review**:
 The two independent review passes (separate models, one fully isolated from
-prior step attachments) pinned to the same implementation range. Their
-findings go to a single **Disposition** step.
+prior step attachments) pinned to the same implementation range. The isolated
+pass is optional and a project may omit it. Their findings go to a single
+**Disposition**.
 
 **Disposition**:
-The per-finding ruling step after review: each finding is fixed, rejected
-with a reason, or accepted as follow-up. No finding is dropped silently.
+The per-finding ruling made by the review-fix step, with no adjudication step
+between the reviews and it: each finding is adopted and fixed, rejected with a
+reason, or merged into another finding. No finding is dropped silently.
 
 **Approval gate**:
 A chain step that halts until the operator approves its persisted output

--- a/docs/adr/0002-coordinate-main-delivery-with-merge-trains.md
+++ b/docs/adr/0002-coordinate-main-delivery-with-merge-trains.md
@@ -119,6 +119,7 @@ the existing path. New machinery never authorizes its own first publication.
 | Candidate B conflicts while building P2 | End the batch at P1; report B and its conflicted files |
 | A candidate head changes or its PR closes | Cut publication before that candidate |
 | `main` changes while gates run | Publish nothing; rerun from the new live base |
+| The merge lease is held by another task at publication | Publish nothing; report `lease-contended`; rerun after the holder releases (the gates are rebuilt) |
 | Process exits before publication | No remote state changed; rerun |
 | Process exits after publishing P1 | Rerun; P1's candidate is skipped and the rest are rebuilt |
 | Push fails and read-back says `main` is unchanged | Release the lease and fail loudly |

--- a/docs/adr/0002-coordinate-main-delivery-with-merge-trains.md
+++ b/docs/adr/0002-coordinate-main-delivery-with-merge-trains.md
@@ -119,7 +119,6 @@ the existing path. New machinery never authorizes its own first publication.
 | Candidate B conflicts while building P2 | End the batch at P1; report B and its conflicted files |
 | A candidate head changes or its PR closes | Cut publication before that candidate |
 | `main` changes while gates run | Publish nothing; rerun from the new live base |
-| The merge lease is held by another task at publication | Publish nothing; report `lease-contended`; rerun after the holder releases (the gates are rebuilt) |
 | Process exits before publication | No remote state changed; rerun |
 | Process exits after publishing P1 | Rerun; P1's candidate is skipped and the rest are rebuilt |
 | Push fails and read-back says `main` is unchanged | Release the lease and fail loudly |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,10 +52,6 @@ Local runner -----> ephemeral git workspace
    controls whether delivery also attempts to open a pull request. A gated task
    moves to review for a human decision; an ungated successful task can finish.
 
-> **Pending (OSS-C): public demo evidence.** The screenshots above illustrate
-> the interface only. No video, timing, benchmark, or end-to-end demo claim is
-> part of this README until the OSS-C evidence gate is complete.
-
 ## Security defaults and limits
 
 - Operator, runner, and per-run session principals are separate. Runner routes

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -200,8 +200,8 @@ own. The board holds either the card or its chain, never both.
 
 - Create it with `assigneeType: HUMAN` so no runner claims it. Its description
   is the brief from `docs/BRIEF-TEMPLATE.md`, plus the `Route:` line when the
-  implementation assignee is non-default. The create API accepts an optional
-  `status` of `BACKLOG` or `TODO` and defaults to `TODO`; pass `status: BACKLOG` to create
+  implementation assignee is non-default. The create API accepts an
+  optional `status` of `BACKLOG` or `TODO` and defaults to `TODO`; pass `status: BACKLOG` to create
   a human Backlog card atomically, without a follow-up PATCH.
 - Dispatch passes the card's name as instantiate `name` and the brief as
   instantiate `description`; the chain implementation task then owns the

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -114,8 +114,9 @@ interface, persisted data, a component boundary, or a foundational dependency.
 Seeded templates under `agents/templates/` are the execution canon: their
 Markdown owns step prompts, layer structure, blind-review isolation, and the
 mechanical merge tail. `agents/README.md` owns the structural rules that bind
-them. Model and runner defaults live in `agents/roles/` frontmatter and
-`packages/db/src/agent-contract.ts`.
+them. Model and runner defaults live in `agents/roles/` frontmatter;
+`packages/db/src/agent-contract.ts` validates them against the model catalog in
+`packages/db/src/model-routing.ts`.
 
 Chains instantiated before a template change retain stored prompts,
 assignments, and behavior. Canonical sync preserves superseded templates under
@@ -199,8 +200,8 @@ own. The board holds either the card or its chain, never both.
 
 - Create it with `assigneeType: HUMAN` so no runner claims it. Its description
   is the brief from `docs/BRIEF-TEMPLATE.md`, plus the `Route:` line when the
-  implementation assignee is non-default. The create API accepts `status` as
-  optional `status` as `BACKLOG` or `TODO` and defaults to `TODO`; pass `status: BACKLOG` to create
+  implementation assignee is non-default. The create API accepts an optional
+  `status` of `BACKLOG` or `TODO` and defaults to `TODO`; pass `status: BACKLOG` to create
   a human Backlog card atomically, without a follow-up PATCH.
 - Dispatch passes the card's name as instantiate `name` and the brief as
   instantiate `description`; the chain implementation task then owns the

--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -24,12 +24,13 @@ Concurrency changes latency, never the question the gate asks — every step sti
 runs, with the same command, and a group passes only when all of its members do.
 
 An interrupted gate stops its members before it tears anything down. Members run
-as process-group leaders, and `cleanup` signals each group, gives it five
-seconds, then kills it — all before it removes `GATE_TMP`, releases the worktree
-lock and deletes the container. Signalling the gate process alone would leave a
-build still writing `dist/` while the next gate takes the lock this one just
-released, so do not remove the `set -m` around the spawn: it is what makes the
-whole tree reachable rather than just the member's own shell.
+as process-group leaders (`scripts/gate-worker/step-engine.sh`), and `cleanup`
+in `scripts/gate-worker/verdict.sh` signals each group, gives it five seconds,
+then kills it — all before it removes `GATE_TMP`, releases the worktree lock and
+deletes the container. Signalling the gate process alone would leave a build
+still writing `dist/` while the next gate takes the lock this one just released,
+so do not remove the `set -m` around the spawn in `step-engine.sh`: it is what
+makes the whole tree reachable rather than just the member's own shell.
 
 How wide each group runs is derived from a stated share of the host, not from
 the core count. `run-gate.sh` exports `AGENTOS_GATE_HOST_SHARE` as the worker's
@@ -519,9 +520,10 @@ systemically full. That is a capacity signal, not an error to retry harder:
 either stagger the merges, or repeat the same-commit overlap acceptance before
 changing host capacity.
 
-**`GATE NOT RUN: the slot locks are unusable (...)`** — the named slots have a
-lock this dispatcher cannot operate, so nothing was gated and nothing will be
-until they are cleared. Look in the slot directory named by the dispatcher's
+**`GATE NOT RUN: no configured worker produced a verdict`** with a stderr line
+naming `broken:` slots or `the locks of <slots> are unusable` — the named slots
+have a lock this dispatcher cannot operate, so nothing was gated and nothing
+will be until they are cleared. Look in the slot directory named by the dispatcher's
 startup line (see the accounting-unit paragraph above): a `<slot>.lock`
 *directory* is a leftover from the pre-#132 dispatcher and can go once no old
 `gate-dispatch.sh` is running; a `<slot>.slot` file that does not contain a pid


### PR DESCRIPTION
Documentation accuracy audit after deepening rounds 5 and 6 (doc-audit skill, scoped to docs/adr, CONTEXT.md, docs/architecture.md, docs/governance/task-routing-v1.md, docs/runbooks/merge-executor.md, docs/runbooks/gate-worker.md). This PR carries only fixes that need no decision; the audit table and the rows for the operator's decision live in the private records.

Fixes:
- CONTEXT.md: specification of record is materialized before implementation (plan step in compound, platform for direct/PR); the chain branch keeps `.chain` (nothing archives it); the isolated review pass is optional; disposition is made by the review-fix step (ADOPTED/REJECTED/MERGED); an expired run lease marks the run lost and opens a budgeted retry; the merge gate runs locally or on a remote worker.
- docs/architecture.md: removed the "Pending (OSS-C)" blockquote (no screenshots exist in the file; OSS-C is recorded as retained elsewhere). Same hunk as PR #479; merges clean.
- docs/governance/task-routing-v1.md: `packages/db/src/agent-contract.ts` validates against `packages/db/src/model-routing.ts`; duplicated `status` clause removed (same fix as PR #479, wrap aligned).
- docs/runbooks/gate-worker.md: interrupt/cleanup behaviour attributed to `scripts/gate-worker/step-engine.sh` and `verdict.sh`; the `GATE NOT RUN` troubleshooting heading now quotes the printed line.

Unchanged on purpose: docs/adr/0001 (body is history by its own amendment; archiving it is an operator decision), docs/adr/0002 (accurate today; the running merge-train wait chain writes its amendment), docs/adr/0003 and docs/runbooks/merge-executor.md (verified accurate).

Checks at root: `npm run lint`, `npm run test:snapshot-scan`, `npm run test:frozen-docs`, `npm run test:release-docs`, `npm run test:gate-worker`, `node --test scripts/gate-worker/gate-dispatch.test.mjs`, `node --test scripts/merge-gate-profile.test.mjs`, `npm run snapshot:scan`: all pass. No TypeScript touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXBmoUMpUiUJspMi15oAMU
