### PR TITLE
docs: close the 2026-09-04 audit follow-ups

### DIFF
--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -252,7 +252,7 @@ dispatch, and archival. The board columns mean:
 | Done | A finished task or chain step. |
 
 An operator can stop and park a running chain step, returning it to Backlog as
-a parked step. Resume with **Start now** or **Recover parked step**, not ordinary
+a parked step. Resume with **Start next step** or **Recover parked step**, not ordinary
 card dispatch.
 
 The operator owns Backlog and Todo transitions and marking HUMAN tasks Done.

--- a/docs/release/developer-preview.md
+++ b/docs/release/developer-preview.md
@@ -245,7 +245,7 @@ path or set `RUNNER_PATH` in `.env`.
 The starter agent uses `gpt-5.6-sol:medium`. A green startup preflight proves
 that the Codex CLI exists, exposes the `exec`/resume flags and stdin/JSON
 protocol Anneal uses, and reports a signed-in session. Its capability report is
-bound to that starter model; version 0.148.0 is the recorded compatible CLI. The
+bound to that starter model; version 0.153.4 is the recorded compatible CLI. The
 preflight does not spend a model turn, so the deterministic smoke task remains
 the first entitlement and end-to-end model-access check.
 

--- a/docs/release/support-matrix.md
+++ b/docs/release/support-matrix.md
@@ -59,7 +59,7 @@ the CLI vendor.
 
 | Provider runtime | Status | Evidence boundary |
 | --- | --- | --- |
-| Codex CLI | **Verified adapter; model access Pending smoke** | Startup preflight checks the installed version, the exact `exec`/resume flags and stdin/JSON protocol Anneal uses, and login status; its capability report is bound to the starter model `gpt-5.6-sol:medium`. OpenAI publishes no minimum CLI semver for this combination, so compatibility is capability-based rather than an invented version floor; 0.148.0 is the last version recorded as compatible. Entitlement still requires the deterministic smoke task. |
+| Codex CLI | **Verified adapter; model access Pending smoke** | Startup preflight checks the installed version, the exact `exec`/resume flags and stdin/JSON protocol Anneal uses, and login status; its capability report is bound to the starter model `gpt-5.6-sol:medium`. OpenAI publishes no minimum CLI semver for this combination, so compatibility is capability-based rather than an invented version floor; 0.153.4 is the last version recorded as compatible. Entitlement still requires the deterministic smoke task. |
 | Claude Code | **Verified** / **Maintainer-verified** | Adapter and runtime are verified. Claude Pro/Max subscription authentication is maintainer-verified on macOS Apple Silicon. |
 | Pi | **Verified** | Adapter/runtime and subscription authentication path are verified. Pi authenticates through the Codex login. |
 

--- a/scripts/merge-gate-profile.test.mjs
+++ b/scripts/merge-gate-profile.test.mjs
@@ -7,6 +7,14 @@ const changes = (...entries) => Buffer.from(`${entries.flat().join("\0")}\0`);
 
 test("modified allowlisted prose selects docs-only", () => {
   assert.equal(classifyDiff({ nameStatus: changes("M", "AGENTS.md") }), "docs-only");
+  for (const path of [
+    "SECURITY.md",
+    "THIRD_PARTY_NOTICES.md",
+    "docs/BRIEF-TEMPLATE.md",
+    "docs/public-snapshot.md",
+  ]) {
+    assert.equal(classifyDiff({ nameStatus: changes("M", path) }), "docs-only", path);
+  }
   assert.equal(
     classifyDiff({
       nameStatus: changes(


### PR DESCRIPTION
## Summary

Follow-ups from the 2026-09-04 documentation audit (PR #479):

- `docs/release/support-matrix.md`, `docs/release/developer-preview.md`: the last Codex CLI version recorded as compatible is 0.153.4. Both hosts run it and production Runs have succeeded on it since the 2026-09-04 upgrade.
- `docs/governance/task-routing-v1.md`: the resume control is labelled "Start next step" (`chain.startNext`), not "Start now".
- `scripts/merge-gate-profile.test.mjs`: assert the docs-only classification of the four FAST_DOCUMENTS members that were previously unpinned (SECURITY.md, THIRD_PARTY_NOTICES.md, docs/BRIEF-TEMPLATE.md, docs/public-snapshot.md).

## Verification

`npm run lint`, `merge-gate-profile.test.mjs`, `test:release-docs`, `test:snapshot-scan` pass; `npm run snapshot:scan` exits 0 on the committed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q43dWMeLErrT5hfgCPrUBS