### PR TITLE
docs: record maintainer evidence for gate worker, merge tail and executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ written.
   alongside macOS on Apple Silicon; the install documents drop their
   macOS-only wording. Running some runners on a second machine over an SSH
   tunnel is documented as experimental in `docs/install.md`.
+- The remote gate-worker profile, the autonomous merge tail and the Linux
+  systemd merge executor move from Unverified to Maintainer-verified in the
+  support matrix; the macOS LaunchDaemon executor profile stays Unverified.
 
 ## v0.7.0 — Developer Preview 7
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -62,11 +62,10 @@ repository's `postinstall` generates the Prisma client — so `--ignore-scripts`
 is not supported. The Inbox service is optional. No launchd definition is
 shipped for the foreground Developer Preview sequence; remote access and this
 repository's internal task-chain templates are also outside that sequence. A
-separate self-hosted merge executor instead has documented but unverified macOS
-LaunchDaemon and Linux systemd profiles in the public
+separate self-hosted merge executor instead has a maintainer-verified Linux
+systemd profile and an unverified macOS LaunchDaemon profile in the public
 [`docs/runbooks/merge-executor.md`](runbooks/merge-executor.md) runbook.
-Those procedures do not change the platform classifications above or the
-authoritative support matrix.
+The authoritative classifications are in the support matrix.
 
 ## Runners on a second machine (experimental)
 

--- a/docs/release/support-matrix.md
+++ b/docs/release/support-matrix.md
@@ -34,7 +34,7 @@ has never walked.
 
 | Requirement | Status | Evidence boundary |
 | --- | --- | --- |
-| Node.js `22.17.0` | **Target version** | Recorded in `.nvmrc` and used by the corrected install instructions. |
+| Node.js `22.17.0` | **Target version** | Recorded in `.nvmrc` and used by the corrected install instructions. The maintainer's Linux installation runs 26.8.1, inside the enforced range below. |
 | Node.js `^20.19.0 \|\| ^22.13.0 \|\| >=24` | **Enforced** | Root engines, `engine-strict`, setup validation, the lockfile, and the Linux compatibility matrix carry the range required by the locked toolchain. Node 22.12.x and 23 are refused. |
 | npm 10.9.2 or newer | **Verified** | The npm generation floor recorded for this release. Use it with Node.js 22.17.0. |
 | Docker with Docker Compose | **Verified** | For the PostgreSQL service `docker-compose.yml` defines, published on `127.0.0.1:5432` only. |
@@ -73,11 +73,11 @@ the CLI vendor.
 | Git delivery: branch push | **Verified** | Requires non-interactive clone/push authentication and a configured Git author identity for the runner account. |
 | Automatic GitHub pull request | **Optional** | Requires the `gh` CLI installed and authenticated as the runner account. A run required to open a pull request fails after preserving its pushed branch when `gh` cannot record one; a non-GitHub remote instead returns manual PR instructions because automatic creation is impossible by design. |
 | Local repository merge gate | **Maintainer-verified** | `scripts/merge-gate.sh` judges one exact clean commit and provisions its own throwaway PostgreSQL. It needs Docker and the repository toolchain, but no remote gate worker. |
-| Remote gate-worker profile | **Unverified** | The public provisioning and dispatch path requires operator-owned SSH-reachable Ubuntu capacity configured explicitly. The repository provides no worker, hostname, credential or automatic topology. |
+| Remote gate-worker profile | **Maintainer-verified** | The maintainer dispatches every merge gate to an Ubuntu 24.04 worker over SSH through the published provisioning and dispatch path. It requires operator-owned SSH-reachable Ubuntu capacity configured explicitly; the repository provides no worker, hostname, credential or automatic topology. |
 | Direct workflow | **Maintainer-verified** | The canonical workflow additionally requires its configured Codex, Claude Code and Pi roles, authenticated GitHub PR delivery, an operator-provided gate worker, read-only GitHub evidence credentials and the self-hosted merge executor. None is silently substituted when absent. |
 | Full Assurance workflow | **Maintainer-verified** | The canonical workflow has the same advanced delivery prerequisites as Direct plus its planning roles. Provider accounts, model entitlement and every delivery service are supplied by the operator. |
-| Autonomous merge tail | **Unverified** | Public self-hosting requires an installation-local private GitHub App and an isolated `@anneal/merge-executor`; the Quickstart does not configure either. Missing evidence, authority or executor identity stops the chain. |
-| Self-hosted merge executor | **Unverified** | The public runbook documents GitHub App permissions, OS-principal isolation and service profiles. Those profiles are procedures, not independently reproduced support evidence. |
+| Autonomous merge tail | **Maintainer-verified** | The maintainer's installation merges its chains this way daily. Public self-hosting requires an installation-local private GitHub App and an isolated `@anneal/merge-executor`; the Quickstart does not configure either. Missing evidence, authority or executor identity stops the chain. |
+| Self-hosted merge executor | **Maintainer-verified** | The maintainer runs the executor as the runbook's systemd unit on Ubuntu 24.04 with a dedicated service identity. The macOS LaunchDaemon profile is a documented procedure that nobody has run: **Unverified**. |
 | Quiet-window appliance deployment | **Unsupported** | The maintainer appliance profile is published for auditability and reproducibility. It is not the Developer Preview installation shape or a production-support commitment. |
 | Repository and filesystem grants | **Verified as a control-plane boundary** | They authorize and audit Anneal's own APIs. They are not host containment, and the repository access level does not gate delivery's push. |
 | Stored secrets (AES-256-GCM) | **Verified** | Neither plaintext nor ciphertext appears in the API's secret representations. There is no rotation command. |

--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -5,7 +5,7 @@
 > bundled with an Anneal installation. Public operators may provision their own
 > SSH-reachable Ubuntu workers and configure them explicitly. The local
 > `scripts/merge-gate.sh` path requires no remote worker. The remote-worker
-> profile is documented but unverified as a public self-hosting path.
+> profile is maintainer-verified on Ubuntu 24.04; see the support matrix.
 
 A merge gate selects its own profile from the exact baseline-to-candidate diff.
 Content-only modifications to the gate's explicit prose allowlist use the

--- a/docs/runbooks/merge-executor.md
+++ b/docs/runbooks/merge-executor.md
@@ -2,11 +2,10 @@
 
 This is the current public authority for provisioning and maintaining the
 self-hosted `@anneal/merge-executor`. It covers GitHub.com, a dedicated local
-service identity, and documented but unverified macOS LaunchDaemon and Linux
-systemd profiles. These profiles are procedures, not qualifying platform
-evidence or a support commitment. They do not change the public support matrix,
-and this runbook does not describe mosonlab's installation or any private
-operator service.
+service identity, a Linux systemd profile the maintainer runs in production,
+and a macOS LaunchDaemon profile nobody has run. The support matrix carries the
+classification of each; this runbook does not describe mosonlab's installation
+or any private operator service.
 
 The executor is fail closed. A missing permission, unreadable field, shared
 principal, unsafe key path, failed disarm, or uncertain merge result stops the

--- a/scripts/setup-merge-executor.test.mjs
+++ b/scripts/setup-merge-executor.test.mjs
@@ -208,8 +208,8 @@ test("health and platform claims match the implemented and evidenced surfaces", 
   assert.match(runbook, /`workspaceRoot: null` and `diskFreeBytes: null`/u);
   assert.match(runbook, /Run record[^.]*`adapterVersion`\s+and `cliVersion`[^.]*`merge-executor-v1`/u);
   assert.doesNotMatch(runbook, /Find the exact `MERGE_EXECUTOR_RUNNER_ID`, the `merge-executor-v1` adapter\/CLI identity/u);
-  assert.match(installDoc, /documented but unverified macOS\s+LaunchDaemon and Linux systemd profiles/u);
-  assert.match(runbook, /documented but unverified/u);
+  assert.match(installDoc, /maintainer-verified Linux\s+systemd profile and an unverified macOS LaunchDaemon profile/u);
+  assert.match(runbook, /macOS LaunchDaemon profile nobody has run/u);
 });
 
 test("the wizard links official concepts and ends with exact non-secret next commands", () => {


### PR DESCRIPTION
Docs-only follow-up to #480.

- Support matrix: remote gate-worker profile, autonomous merge tail and self-hosted merge executor move from Unverified to Maintainer-verified on the maintainer's Ubuntu 24.04 production evidence; the macOS LaunchDaemon executor profile stays Unverified. Node.js target row notes the Linux installation runs 26.8.1 inside the enforced range.
- install.md, merge-executor and gate-worker runbooks: drop the "documented but unverified" wording and point at the matrix.
- CHANGELOG Unreleased entry.

Checks: `npm run test:snapshot-scan` and `scripts/check-frozen-docs.sh` pass in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QRCaaZkzwtpP4qWdtU4eV