### PR TITLE
feat(agents): add senior-dev-opus Claude implementation route

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -119,9 +119,11 @@ contracts live in their Markdown directories under `templates/`.
 
 Provider-specific or temporary roles are not canonical defaults unless the
 cross-provider review contract explicitly requires separate identities.
-`senior-dev-sol` is canonical rather than an experiment because it is the
-explicit fallback implementation tier named by the implementation-assignee
-routing rules in `docs/governance/task-routing-v1.md`. Keep
+`senior-dev-sol` and `senior-dev-opus` are canonical rather than experiments
+because they are the explicit implementation tiers named by the
+implementation-assignee routing rules in `docs/governance/task-routing-v1.md`:
+the Sol fallback when the senior-dev model is unavailable, and the Claude
+Opus 5 medium route an operator names to spend Claude capacity. Keep
 experiments out of `roles/`; create them as local overlays and archive them
 when no longer needed so a seed cannot silently turn an experiment into a
 release default. Implementation-assignee escalation follows the

--- a/agents/roles/senior-dev-opus.md
+++ b/agents/roles/senior-dev-opus.md
@@ -1,0 +1,35 @@
+---
+name: senior-dev-opus
+title: Senior Developer (Opus medium)
+model: claude-opus-5:medium
+runner: claude
+inboxAccess: true
+collaborators: []
+---
+You are the senior developer. Your one job: implement the assigned work in
+the granted repo, exactly as the task's specification of record directs —
+the brief, the approved plan and slices, the review reports a step prompt
+names, or the task description itself when the task names no other.
+
+The specification of record governs. Implement what it enumerates and
+nothing beyond it: when it names change points, touch those and leave
+behavior outside the assignment untouched; when something in it is
+ambiguous or contradicts the actual code, do not improvise a wider change —
+pick the narrowest reading that satisfies its acceptance criteria and
+record the reading you chose in the activity log.
+
+Work on the branch the task names. Work test-first where the acceptance
+criteria name verifiable behavior: red before green, one criterion at a
+time. Run the repo's available tests — always the suites touching your
+changes, and the end-to-end tests when the task calls for them — and fix
+what your changes broke. Record in the activity log any suite you could
+not run and any failure demonstrably unrelated to your change. Commit with
+messages that say what changed and why.
+
+You are done when the specification of record's behavior is demonstrably
+delivered, tests pass, and the commits are in the granted repo. Never mark
+a finding resolved without a code change or evidence that none is needed,
+and never hand off with a regression you know about. Summarize the result
+in the activity log and finish the task. Inbox the human only when you are
+truly blocked — a missing credential, a failing dependency outside the
+repo, a contradiction in the task itself — and say what you tried first.

--- a/docs/BRIEF-TEMPLATE.md
+++ b/docs/BRIEF-TEMPLATE.md
@@ -74,7 +74,7 @@ it can.
 
 ## Routing
 
-Implementation has four routes:
+Implementation has five routes:
 
 - **senior-dev-luna** (template default): a brief with mechanical Acceptance
   is work that tier finishes under the chain's review and regression tail.
@@ -85,6 +85,10 @@ Implementation has four routes:
   brief defect.
 - **senior-dev-sol**, with the reason on the same line, only when the
   senior-dev model is unavailable for that work. It is never a default.
+- **senior-dev-opus**, with the reason on the same line, when the operator
+  chooses to spend Claude capacity on that work instead of Codex capacity.
+  It is the same senior-developer prompt on Claude Opus 5 medium; it is
+  never a default, and the chain keeps its Sol and blind reviews unchanged.
 - **frontend-dev** for frontend implementation work (UI components, pages,
   client-side behavior).
 

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -82,7 +82,9 @@ same rule applies to the review-fix step) only for persisted data, a
 defense-list path (merge gate, gate worker, migrations, or merge
 automation), or uncertain classification. Use `senior-dev-sol` for that same
 work only when named explicitly because the senior-dev model is unavailable;
-it is never a default. Use `frontend-dev` for work primarily
+it is never a default. Use `senior-dev-opus` when the operator names it to
+spend Claude capacity on the implementation instead of Codex capacity; it is
+never a default either. Use `frontend-dev` for work primarily
 consisting of a new or redesigned web page or UI surface. The defense-list rule
 wins when both apply.
 

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -125,6 +125,7 @@ test("named canonical roles use their model catalog runner and retired role name
     "librarian",
     "senior-dev",
     "senior-dev-sol",
+    "senior-dev-opus",
     "spec-revalidator",
     "implementation-plan-executioner",
   ]) {

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -39,6 +39,7 @@ import {
 } from "../src/template-sources.js";
 
 const SENIOR_DEV_SOL_AGENT_NAME = "senior-dev-sol";
+const SENIOR_DEV_OPUS_AGENT_NAME = "senior-dev-opus";
 
 // Canonical roles that no template step binds, so ordinary synchronization
 // never creates them: each is created once from an active source Agent row.
@@ -50,6 +51,7 @@ const SPECIAL_CANONICAL_AGENTS: readonly {
   { name: REGRESSION_VERIFIER_AGENT_NAME, source: "review-coordinator-sol", permissions: null },
   { name: SPEC_REVALIDATOR_AGENT_NAME, source: "review-coordinator-sol", permissions: RepoPermission.GIT_READ },
   { name: SENIOR_DEV_SOL_AGENT_NAME, source: "senior-dev", permissions: null },
+  { name: SENIOR_DEV_OPUS_AGENT_NAME, source: "senior-dev", permissions: null },
 ];
 
 const runtimeConfigRefusal = (agent: { model: string; runnerPreference: RunnerPreference }): string | null => {

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -1206,22 +1206,23 @@ test("sync recreates a missing spec revalidator with read-only repository covera
   }), [{ mountPath: repo.mountPath, permissions: RepoPermission.GIT_READ }]);
 });
 
-test("sync recreates a missing senior-dev-sol fallback Agent from senior-dev", async (t) => {
+for (const specialName of ["senior-dev-sol", "senior-dev-opus"] as const) {
+test(`sync recreates a missing ${specialName} Agent from senior-dev`, async (t) => {
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
-  const solSource = canonicalRuntime("senior-dev-sol");
+  const specialSource = canonicalRuntime(specialName);
   const source = await prisma.agent.findUniqueOrThrow({
     where: { projectId_name: { projectId: project.id, name: "senior-dev" } },
   });
   const existingSol = await prisma.agent.findUniqueOrThrow({
-    where: { projectId_name: { projectId: project.id, name: "senior-dev-sol" } },
+    where: { projectId_name: { projectId: project.id, name: specialName } },
   });
 
   const repo = await prisma.repo.create({
     data: {
       projectId: project.id,
-      name: `canonical-sync-sol-${randomBytes(4).toString("hex")}`,
-      remoteUrl: "file:///tmp/agentos-canonical-sync-sol.git",
-      mountPath: "/workspace/canonical-sync-sol",
+      name: `canonical-sync-${specialName}-${randomBytes(4).toString("hex")}`,
+      remoteUrl: `file:///tmp/agentos-canonical-sync-${specialName}.git`,
+      mountPath: `/workspace/canonical-sync-${specialName}`,
       dependencyProvisioning: "NONE",
     },
   });
@@ -1246,10 +1247,10 @@ test("sync recreates a missing senior-dev-sol fallback Agent from senior-dev", a
   assert.match(synced.output, /"createdAgentRepoGrants":1/u);
 
   const sol = await prisma.agent.findUniqueOrThrow({
-    where: { projectId_name: { projectId: project.id, name: "senior-dev-sol" } },
+    where: { projectId_name: { projectId: project.id, name: specialName } },
   });
-  assert.equal(sol.model, solSource.model);
-  assert.equal(sol.runnerPreference, solSource.runnerPreference);
+  assert.equal(sol.model, specialSource.model);
+  assert.equal(sol.runnerPreference, specialSource.runnerPreference);
   assert.equal(sol.inboxAccess, true);
   assert.equal(sol.environmentId, source.environmentId);
   assert.equal(sol.runtimeConfigCustomized, false);
@@ -1264,9 +1265,10 @@ test("sync recreates a missing senior-dev-sol fallback Agent from senior-dev", a
   assert.equal(second.status, 0, second.output);
   assert.match(second.output, /"createdAgents":0/u);
   assert.equal(await prisma.agent.count({
-    where: { projectId: project.id, name: "senior-dev-sol" },
+    where: { projectId: project.id, name: specialName },
   }), 1);
 });
+}
 
 test("canonical sync adopts the tolerated differences and refuses every other one before mutating", async () => {
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });

--- a/packages/db/src/verify-agent-template.dbtest.ts
+++ b/packages/db/src/verify-agent-template.dbtest.ts
@@ -506,7 +506,7 @@ test("--project refuses the differences canonical sync would adopt", async () =>
 test("default verification keeps the complete-inventory requirement and success sentence", async () => {
   const verified = verify();
   assert.equal(verified.status, 0, verified.output);
-  assert.match(verified.output, /Agent\/template contract verified for 17 active agents and 24 steps across 3 templates\./u);
+  assert.match(verified.output, /Agent\/template contract verified for 18 active agents and 24 steps across 3 templates\./u);
 
   const canonical = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   const customized = await prisma.agent.findUniqueOrThrow({


### PR DESCRIPTION
## Summary
- Add canonical role `senior-dev-opus`: the senior-dev prompt on Claude Opus 5 medium (runner claude), for direct chains where the operator chooses to spend Claude capacity on implementation. Never a template default; selected via `Route: implementation=senior-dev-opus - <reason>`. Sol and blind review steps are unchanged.
- Canonical sync creates it from `senior-dev` like `senior-dev-sol`, inheriting the source Agent's repo write grants; the sync dbtest now loops over both special implementation roles, and the agent contract test pins its runner.
- Routing docs (`docs/BRIEF-TEMPLATE.md`, `docs/governance/task-routing-v1.md`, `agents/README.md`) list the fifth implementation route.

## Verification
- `npm run lint`, `npm run typecheck -w packages/db`, `npm run test -w packages/db` (459 pass), `npm run test:snapshot-scan` (21 pass) locally.
- `canonical-prompt-sync.dbtest.ts` is merge gate evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3Z7APNySdzWuyA4Ww9fq4