### PR TITLE
docs(contributing): pre-acquire the merge lease before a host-run merge train

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,21 @@ prefix; the coordinator does not resolve them. Stale `main` publishes nothing.
 After partial publication, rerun the command: it skips heads already in live
 `main` and rebuilds the remaining prefixes.
 
+The train acquires the lease only after its gates pass, so another window can
+take the lease during those minutes and the proved prefix is discarded as
+`lease-contended`. A host window that wants the train to publish acquires the
+lease first with the train's own task id, then runs the train in the same
+shell:
+
+```sh
+scripts/merge-lease.sh acquire --task <coordinator-id> --reason "<why>" --timeout-minutes <n>
+scripts/merge-train.mjs --task <coordinator-id> --candidate <pr>:<40-character-head>
+```
+
+Acquire is reentrant for the same task, so the train's own acquire succeeds and
+its release ends the hold. Never pre-acquire with another task's id or steal a
+lease another window holds.
+
 Changes to delivery authority, merge train, lease, dispatcher, or gate use the
 existing single-candidate path. New delivery machinery cannot authorize its own
 first publication.


### PR DESCRIPTION
## Summary
- `scripts/merge-train.mjs` acquires the lease only after its gates pass, so another window can take the lease during the gate and the proved prefix is discarded as `lease-contended` (happened twice on PR #484 today).
- Document the fix in the single-candidate/train procedure: pre-acquire with the train's own task id (acquire is reentrant for the same task), run the train in the same shell, let the train release.

## Verification
- `npm run test:snapshot-scan` (21 pass). Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3Z7APNySdzWuyA4Ww9fq4