### PR TITLE
fix(web): phone shell follow-ups and an archived-agent sync remedy

### DIFF
--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -86,17 +86,21 @@ export const ThemeCycleButton = ({ className }: { className?: string }): ReactNo
 /** Count meaning and cadence unchanged (spec §4.4.4) — only the transport moved.
  *  The label is there because a bare number beside "Inbox" reads as nothing at
  *  all to a screen reader. */
-const InboxBadge = ({ summaryError, openCount, className }: {
+const InboxBadge = ({ summaryError, openCount, className, bare = false }: {
   summaryError: unknown;
   openCount: number | undefined;
   className: string;
+  /** The tab bar shows the red count alone; the sidebar's grey `COUNT` capsule
+   *  around it is a 32px halo on a 20px icon. */
+  bare?: boolean;
 }): ReactNode => {
   const t = useT();
+  const shell = bare ? className : cn(COUNT, className);
   if (summaryError !== null) {
-    return <span className={cn(COUNT, className)} aria-label={t("sidebar.inbox.unavailable")}><span className={BADGE_COUNT}>!</span></span>;
+    return <span className={shell} aria-label={t("sidebar.inbox.unavailable")}><span className={BADGE_COUNT}>!</span></span>;
   }
   if (openCount === undefined || openCount === 0) return null;
-  return <span className={cn(COUNT, className)} aria-label={t("sidebar.inbox.unread", { n: openCount })}><span className={BADGE_COUNT}>{openCount}</span></span>;
+  return <span className={shell} aria-label={t("sidebar.inbox.unread", { n: openCount })}><span className={BADGE_COUNT}>{openCount}</span></span>;
 };
 
 const Sidebar = ({ path, badge }: { path: string; badge: ReactNode }): ReactNode => {
@@ -156,7 +160,9 @@ const MobileChrome = ({ path, badge, children }: { path: string; badge: ReactNod
           <IconMore />{t("sidebar.nav.more")}
         </button>
       </nav>
-      <Dialog open={open} onOpenChange={setOpen}>
+      {/* Mounted only while open, like `Modal`: a closed Radix dialog in the tree
+          is one more portal root for nothing. */}
+      {open ? <Dialog open onOpenChange={setOpen}>
         <DialogContent className={SHEET}>
           <DialogTitle className={SHEET_TITLE}>{t("sidebar.nav.more")}</DialogTitle>
           <nav className="grid gap-[2px]">
@@ -173,7 +179,7 @@ const MobileChrome = ({ path, badge, children }: { path: string; badge: ReactNod
             <ThemeCycleButton className={SHEET_ITEM} />
           </nav>
         </DialogContent>
-      </Dialog>
+      </Dialog> : null}
     </>
   );
 };
@@ -199,7 +205,7 @@ export const Shell = ({ children }: { children: ReactNode }): ReactNode => {
   if (narrow) {
     return (
       <div className={SHELL}>
-        <MobileChrome path={path} badge={<InboxBadge summaryError={summaryError} openCount={openCount} className={MOBILE_TAB_BADGE} />}>
+        <MobileChrome path={path} badge={<InboxBadge summaryError={summaryError} openCount={openCount} className={MOBILE_TAB_BADGE} bare />}>
           {children}
         </MobileChrome>
       </div>

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -106,14 +106,14 @@ export const SIDEBAR_FOOT = "mt-auto grid gap-[2px] pt-[10px]";
 /* The phone shell. A top bar that carries the project and the runner's one dot,
  * a fixed five-slot tab bar for the four places an operator goes many times a
  * day, and a sheet behind the fifth slot for everything else. Sticky and fixed
- * geometry is stated here once: `MobileTaskList` pins its status strip under
- * the top bar, and `PAGE` / `BOARD_PAGE` clear the tab bar. */
-export const MOBILE_TOPBAR_HEIGHT = 52;
+ * geometry is stated here once: the top bar is 52px, which `MobileTaskList`
+ * repeats as the `top` of its sticky status strip, and `PAGE` / `BOARD_PAGE`
+ * clear the tab bar. */
 export const MOBILE_TOPBAR = "sticky top-0 z-[5] flex h-[52px] items-center gap-[4px] border-b border-[color:var(--border-soft)] bg-sidebar px-[8px]";
 export const MOBILE_TABBAR = "fixed inset-x-0 bottom-0 z-[5] grid grid-cols-5 border-t border-[color:var(--border-soft)] bg-sidebar pb-[env(safe-area-inset-bottom)]";
 export const MOBILE_TAB = "relative flex h-[56px] flex-col items-center justify-center gap-[5px] border-0 bg-transparent text-[10.5px] leading-none text-muted-foreground [&_svg]:size-[20px] [&_svg]:opacity-85";
 export const MOBILE_TAB_ACTIVE = "text-foreground [&_svg]:opacity-100 after:absolute after:top-0 after:h-[2px] after:w-[28px] after:rounded-full after:bg-primary";
-export const MOBILE_TAB_BADGE = "absolute top-[7px] left-[calc(50%+6px)]";
+export const MOBILE_TAB_BADGE = "absolute top-[6px] left-[calc(50%+4px)] inline-grid";
 export const SHEET = "inset-x-0 top-auto bottom-0 left-0 max-h-[85dvh] w-full translate-x-0 translate-y-0 overflow-y-auto rounded-t-[16px] rounded-b-none border-[color:var(--border-soft)] bg-popover px-[10px] pt-[14px] pb-[calc(10px+env(safe-area-inset-bottom))] font-mono";
 export const SHEET_TITLE = "mb-[8px] px-[12px] text-[11.5px] font-normal tracking-[.04em] text-[color:var(--faint)] uppercase";
 export const SHEET_ITEM = "flex w-full items-center gap-[12px] rounded-lg border-0 bg-transparent px-[12px] py-[12px] text-left text-[14px] text-secondary-foreground [&_svg]:flex-none [&_svg]:opacity-85";

--- a/apps/web/src/tests/shell-mobile.test.tsx
+++ b/apps/web/src/tests/shell-mobile.test.tsx
@@ -1,0 +1,77 @@
+// Radix decides at import time whether portals may mount; see dom-preload.ts.
+import "./dom-preload";
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { JSDOM } from "jsdom";
+import { act } from "react";
+
+import { LocaleProvider } from "../lib/i18n";
+import { ProjectProvider } from "../lib/project";
+import { storage } from "../lib/storage";
+import { ThemeProvider } from "../lib/theme";
+import { mountPage, type PageRoutes } from "./dom-harness";
+
+const PROJECT = { id: "p-selected", name: "Selected project", slug: "selected-project" };
+
+const routes = (): PageRoutes => ({
+  "/projects": [PROJECT],
+  "/projects/p-selected/agents": [],
+  "/inbox/messages/summary?projectId=p-selected": { needsReply: 3 },
+});
+
+/**
+ * The phone chrome only exists below 900px, and jsdom has no `matchMedia`, so
+ * every other test renders the desktop sidebar. This one answers the query the
+ * way a 390px phone would.
+ */
+const phone = (dom: JSDOM): void => {
+  storage.set("agentos.projectId", PROJECT.id);
+  Object.defineProperty(dom.window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      matches: query === "(max-width: 900px)",
+      media: query,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    }),
+  });
+};
+
+test("below 900px the shell renders a tab bar, the Inbox count, and a More sheet that reaches the runner, Settings and the theme", async () => {
+  const [{ Shell }] = await Promise.all([import("../components/Shell")]);
+  const page = await mountPage(
+    <ThemeProvider><LocaleProvider initialLocale="en"><ProjectProvider><Shell><div /></Shell></ProjectProvider></LocaleProvider></ThemeProvider>,
+    routes(),
+    "http://127.0.0.1:5173/#/tasks",
+    phone,
+  );
+  try {
+    const { container } = page;
+    assert.equal(container.querySelector("aside"), null, "the desktop sidebar must not render on a phone");
+    const tabBar = container.querySelector('nav[aria-label="Primary navigation"]');
+    assert.ok(tabBar, "phone tab bar missing");
+    const tabs = [...tabBar.querySelectorAll("a, button")].map((element) => element.textContent?.trim());
+    assert.deepEqual(tabs, ["Inbox3", "Tasks", "Sessions", "Costs", "More"]);
+    assert.match(tabBar.querySelector('a[href="#/inbox"] [aria-label]')?.getAttribute("aria-label") ?? "", /3 unread/);
+
+    // The runner row is on the top bar as a link to Settings, never a hover-only button.
+    const topBarRunner = container.querySelector('header a[href="#/settings"]');
+    assert.ok(topBarRunner, "top bar runner link missing");
+
+    const more = tabBar.querySelector("button");
+    assert.ok(more);
+    await act(async () => { more.click(); });
+    await page.settle();
+    const sheet = document.querySelector('[data-slot="dialog-content"]');
+    assert.ok(sheet, "More sheet did not open");
+    const items = [...sheet.querySelectorAll("a, button")].map((element) => element.textContent?.trim()).filter((text) => text !== "" && text !== "Close");
+    assert.deepEqual(items.slice(0, 5), ["Goals", "Agents", "Projects", "Connections", "Secrets"]);
+    assert.ok(sheet.querySelector('a[href="#/settings"]'), "sheet runner link missing");
+    assert.ok(items.includes("Settings"));
+    assert.ok(items.some((text) => text?.startsWith("Theme:")));
+  } finally {
+    await page.dispose();
+  }
+});

--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -495,7 +495,33 @@ launchctl kickstart -k "gui/$(id -u)/com.agentos.auto-deploy"
 ```
 
 The second command is valid only after a migration-timeout hold has ended as
-described above. Signals before activation enter the normal `FAILED` path and
+described above.
+
+### Canonical prompt sync refused by an archived Agent
+
+`reason=canonical-prompt-sync-refused` with the detail
+`Agent <name> (<id>) is archived; sync will not resurrect it` means a role
+that main now treats as canonical shares its name with an Agent the operator
+archived earlier in that project. Sync refuses by design: resurrecting an
+archived Agent would silently bring back its old prompt, model, and grants.
+
+Repair through the operator API, not SQL. Rename the archived Agent out of
+the way so that sync creates the canonical one fresh from its source role:
+
+```sh
+curl -X PATCH "$BASE_URL/agents/$AGENT_ID" \
+  -H "Authorization: Bearer $OPERATOR_TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"<name>-legacy-<yyyymmdd>"}'
+```
+
+If that PATCH answers `Model <m> requires <runner>, but this Agent stores
+<other>`, the archived row carries a model/runner pair the current catalog
+rejects; include a matching `runnerPreference` in the same request. Do not
+unarchive instead: an archived row whose `title` or runtime configuration
+drifted from the canonical Markdown is refused again one step later as
+`differs from canonical Markdown structure`. Then clear the escalation as
+above; the next tick creates the Agent, logs `createdAgents` for the project,
+and continues to publication. Signals before activation enter the normal `FAILED` path and
 remove the operation workspace. Signals after activation perform pointer
 recovery before releasing the barrier. An uncatchable stale process owner is
 reclaimed once and escalated instead of starting an unrecorded second


### PR DESCRIPTION
## What

- Tab-bar Inbox count renders the red count alone (the sidebar's grey `COUNT` capsule was a 32px halo on a 20px icon and touched the cell edge). Measured at 390×844: badge 20×18 at the icon's top-right.
- The More sheet mounts its Dialog only while open, like `Modal`; the unused `MOBILE_TOPBAR_HEIGHT` export is removed.
- New `shell-mobile.test.tsx` injects a phone `matchMedia` and asserts the tab bar, the count, and the sheet's runner link / Settings / theme. It imports `dom-preload` first so Radix can mount its portal under jsdom.
- `docs/runbooks/quiet-window-auto-deploy.md`: remedy for `canonical-prompt-sync-refused` caused by an archived Agent sharing a canonical role's name (API rename, not unarchive, not SQL), from today's production incident.

## Verification

- `npm test -w @anneal/web`: 618 pass. `npm run lint`, `npm run typecheck -w @anneal/web`, `npm run test:snapshot-scan`, `npm run test:frozen-docs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QRCaaZkzwtpP4qWdtU4eV
