### PR TITLE
feat(agents): bind the review-fix step to senior-dev-astra-low

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -109,7 +109,8 @@ The seed installs three templates over these roles: the twelve-step Full
 Assurance chain, the eight-step bound-capable direct chain
 (`direct-engineer-workflow`) — revalidation for bound briefs, implementation by
 `senior-dev-luna` from the task brief, parallel Sol and blind review siblings
-whose findings the fix step adjudicates itself, exact-head regression,
+whose findings the fix step (`senior-dev-astra-low`, the senior-dev prompt at
+Astra low) adjudicates itself, exact-head regression,
 server-side readiness, and mechanical merge — and the four-step pull-request
 chain (`pr-engineer-workflow`), which runs implementation, Sol and blind
 reviews, and review-fix application before ending at an open pull request with
@@ -123,7 +124,9 @@ cross-provider review contract explicitly requires separate identities.
 because they are the explicit implementation tiers named by the
 implementation-assignee routing rules in `docs/governance/task-routing-v1.md`:
 the Sol fallback when the senior-dev model is unavailable, and the Claude
-Opus 5 medium route an operator names to spend Claude capacity. Keep
+Opus 5 medium route an operator names to spend Claude capacity.
+`senior-dev-astra-low` is canonical because every template binds it to the
+review-fix step; it is not an implementation route. Keep
 experiments out of `roles/`; create them as local overlays and archive them
 when no longer needed so a seed cannot silently turn an experiment into a
 release default. Implementation-assignee escalation follows the

--- a/agents/roles/senior-dev-astra-low.md
+++ b/agents/roles/senior-dev-astra-low.md
@@ -1,0 +1,35 @@
+---
+name: senior-dev-astra-low
+title: Senior Developer (Astra low)
+model: gpt-6-astra:low
+runner: codex
+inboxAccess: true
+collaborators: []
+---
+You are the senior developer. Your one job: implement the assigned work in
+the granted repo, exactly as the task's specification of record directs —
+the brief, the approved plan and slices, the review reports a step prompt
+names, or the task description itself when the task names no other.
+
+The specification of record governs. Implement what it enumerates and
+nothing beyond it: when it names change points, touch those and leave
+behavior outside the assignment untouched; when something in it is
+ambiguous or contradicts the actual code, do not improvise a wider change —
+pick the narrowest reading that satisfies its acceptance criteria and
+record the reading you chose in the activity log.
+
+Work on the branch the task names. Work test-first where the acceptance
+criteria name verifiable behavior: red before green, one criterion at a
+time. Run the repo's available tests — always the suites touching your
+changes, and the end-to-end tests when the task calls for them — and fix
+what your changes broke. Record in the activity log any suite you could
+not run and any failure demonstrably unrelated to your change. Commit with
+messages that say what changed and why.
+
+You are done when the specification of record's behavior is demonstrably
+delivered, tests pass, and the commits are in the granted repo. Never mark
+a finding resolved without a code change or evidence that none is needed,
+and never hand off with a regression you know about. Summarize the result
+in the activity log and finish the task. Inbox the human only when you are
+truly blocked — a missing credential, a failing dependency outside the
+repo, a contradiction in the task itself — and say what you tried first.

--- a/agents/templates/compound-engineer-workflow/08-apply-review-fixes.md
+++ b/agents/templates/compound-engineer-workflow/08-apply-review-fixes.md
@@ -1,7 +1,7 @@
 ---
 stepIndex: 8
 layer: 7
-agent: senior-dev
+agent: senior-dev-astra-low
 approvalGate: false
 optional: false
 outputKind: fixed-implementation

--- a/agents/templates/direct-engineer-workflow/05-apply-review-fixes.md
+++ b/agents/templates/direct-engineer-workflow/05-apply-review-fixes.md
@@ -1,7 +1,7 @@
 ---
 stepIndex: 5
 layer: 4
-agent: senior-dev
+agent: senior-dev-astra-low
 approvalGate: false
 optional: false
 outputKind: fixed-implementation

--- a/agents/templates/pr-engineer-workflow/04-apply-review-fixes.md
+++ b/agents/templates/pr-engineer-workflow/04-apply-review-fixes.md
@@ -1,7 +1,7 @@
 ---
 stepIndex: 4
 layer: 3
-agent: senior-dev
+agent: senior-dev-astra-low
 approvalGate: false
 optional: false
 outputKind: fixed-implementation

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -77,8 +77,8 @@ belongs in Full Assurance, not in assignee escalation.
 
 ## Implementation assignee routing
 
-Keep the template's default implementation assignee. Use `senior-dev` (the
-same rule applies to the review-fix step) only for persisted data, a
+Keep the template's default implementation assignee. Use `senior-dev` only
+for persisted data, a
 defense-list path (merge gate, gate worker, migrations, or merge
 automation), or uncertain classification. Use `senior-dev-sol` for that same
 work only when named explicitly because the senior-dev model is unavailable;
@@ -86,7 +86,8 @@ it is never a default. Use `senior-dev-opus` when the operator names it to
 spend Claude capacity on the implementation instead of Codex capacity; it is
 never a default either. Use `frontend-dev` for work primarily
 consisting of a new or redesigned web page or UI surface. The defense-list rule
-wins when both apply.
+wins when both apply. The review-fix step keeps its template assignee
+`senior-dev-astra-low` on every route; routing does not move it.
 
 A backlog card needing a non-default implementation assignee includes this
 machine-readable line in its description:

--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -168,7 +168,7 @@ curl "$BASE_URL/projects" -H "Authorization: Bearer $OPERATOR_TOKEN"
 - A successful request creates the Project and, in the same transaction, one
   `local` Environment with `networking` `OPEN` and `allowedHosts` `[]`, four
   Agents (`senior-dev-luna`, `review-coordinator-sol`,
-  `review-coordinator-opus`, and `senior-dev`) bound to that Environment, and
+  `review-coordinator-opus`, and `senior-dev-astra-low`) bound to that Environment, and
   the canonical `pr-engineer-workflow` TaskTemplate with its four steps.
   The returned Project read shape includes `specGateDefault`,
   `mergeGateDefault`, and `skipOptionalSteps`, all `false` for a newly created

--- a/docs/runbooks/add-a-project.md
+++ b/docs/runbooks/add-a-project.md
@@ -60,7 +60,7 @@ export CHAIN_NAME="Demo: open the first pull request"
 Call `POST /projects` with a name and lowercase hyphenated slug. A1 creates
 the Project in one bootstrap operation with its `local` Environment, the four
 workflow Agents `senior-dev-luna`, `review-coordinator-sol`,
-`review-coordinator-opus`, and `senior-dev`, and the canonical
+`review-coordinator-opus`, and `senior-dev-astra-low`, and the canonical
 `pr-engineer-workflow` TaskTemplate.
 
 ```sh

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -190,6 +190,16 @@ const agentSnapshot = async (projectIds: string[]) => db.agent.findMany({
 
 /* ------------------------------------------------------ the fresh-seed negative */
 
+/** Every registered legacy generation still bound its review-fix step to
+ * senior-dev; a fixture that rebuilds one from current rows restores that. */
+const rebindFixStepToRetiredSeniorDev = async (projectId: string, templateId: string): Promise<void> => {
+  const seniorDev = await db.agent.findUniqueOrThrow({ where: { projectId_name: { projectId, name: "senior-dev" } } });
+  await db.taskTemplateStep.updateMany({
+    where: { taskTemplateId: templateId, outputKind: "fixed-implementation" },
+    data: { assigneeAgentId: seniorDev.id },
+  });
+};
+
 test("a fresh seed writes the twelve-step, eight-step, and four-step canonical templates", async () => {
   const seeded = await seed();
   assert.equal(seeded.code, 0, seeded.output);
@@ -342,6 +352,7 @@ test("canonical sync installs the reviewed PR prompt generation while instantiat
     data: { provisionDependencies: true },
   });
   await db.taskTemplateStep.update({ where: { id: fixed.id }, data: { prompt: reviewedPrompt } });
+  await rebindFixStepToRetiredSeniorDev(project.id, template.id);
   const reviewedSteps = await db.taskTemplateStep.findMany({
     where: { taskTemplateId: template.id },
     include: { assigneeAgent: true },
@@ -477,6 +488,7 @@ test("canonical sync rolls quiescent adjudication-era graphs only after active R
         orderBy: { stepIndex: "asc" },
       });
     }
+    await rebindFixStepToRetiredSeniorDev(template.projectId, template.id);
     const blind = historicalSteps.find((step) => step.outputKind === "blind-findings")!;
     // The adjudicator role is archived, so the seed no longer creates its
     // Agent row; production still carries the row the old node was bound to.

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -260,7 +260,7 @@ test("a fresh seed writes the twelve-step, eight-step, and four-step canonical t
     "Implementation", "Code review (Sol)", "Code review (Opus blind)", "Apply review fixes",
   ]);
   assert.deepEqual(pullRequest.steps.map(({ assigneeAgent }) => assigneeAgent?.name), [
-    "senior-dev-luna", "review-coordinator-sol", "review-coordinator-opus", "senior-dev",
+    "senior-dev-luna", "review-coordinator-sol", "review-coordinator-opus", "senior-dev-astra-low",
   ]);
   assert.deepEqual(pullRequest.steps.map(({ opensPullRequest }) => opensPullRequest), [true, false, false, false]);
   assert.deepEqual(pullRequest.steps.map(({ requiresCommit }) => requiresCommit), [true, false, false, false]);

--- a/packages/api/src/project-bootstrap.dbtest.ts
+++ b/packages/api/src/project-bootstrap.dbtest.ts
@@ -239,7 +239,7 @@ test("role and template source failures happen before any Project row is written
       loaders: {
         loadAgentSources: async () => ({
           ...actualRoles,
-          roles: actualRoles.roles.filter(({ name }) => name !== "senior-dev"),
+          roles: actualRoles.roles.filter(({ name }) => name !== "senior-dev-astra-low"),
         }),
       },
     },

--- a/packages/api/src/project-bootstrap.ts
+++ b/packages/api/src/project-bootstrap.ts
@@ -33,7 +33,7 @@ export const PROJECT_BOOTSTRAP_ROLE_NAMES = [
   "senior-dev-luna",
   "review-coordinator-sol",
   "review-coordinator-opus",
-  "senior-dev",
+  "senior-dev-astra-low",
 ] as const;
 
 export type ProjectBootstrapRoleLoader = () => Promise<AgentSources>;

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -67,11 +67,13 @@ test("canonical role frontmatter matches the Prisma seed contract", async () => 
 });
 
 test("canonical OpenAI roles pin their Codex model and runner", async () => {
-  const [reviewCoordinator, reviewCoordinatorSol, librarian, specRevalidator] = await Promise.all([
+  const [reviewCoordinator, reviewCoordinatorSol, librarian, specRevalidator, seniorDev, reviewFix] = await Promise.all([
     roleSource("review-coordinator"),
     roleSource("review-coordinator-sol"),
     roleSource("librarian"),
     roleSource("spec-revalidator"),
+    roleSource("senior-dev"),
+    roleSource("senior-dev-astra-low"),
   ]);
 
   assert.equal(frontmatterValue(reviewCoordinator, "model"), "gpt-6-astra:medium");
@@ -82,6 +84,11 @@ test("canonical OpenAI roles pin their Codex model and runner", async () => {
   assert.equal(frontmatterValue(librarian, "runner"), "codex");
   assert.equal(frontmatterValue(specRevalidator, "model"), "gpt-5.6-luna:xhigh");
   assert.equal(frontmatterValue(specRevalidator, "runner"), "codex");
+  assert.equal(frontmatterValue(seniorDev, "model"), "gpt-6-astra:medium");
+  assert.equal(frontmatterValue(seniorDev, "runner"), "codex");
+  assert.equal(frontmatterValue(reviewFix, "model"), "gpt-6-astra:low");
+  assert.equal(frontmatterValue(reviewFix, "runner"), "codex");
+  assert.equal(reviewFix.rolePrompt, seniorDev.rolePrompt);
 });
 
 test("canonical profiles start at Default and native child capability replaces Agent subprocess profiles", async () => {
@@ -126,6 +133,7 @@ test("named canonical roles use their model catalog runner and retired role name
     "senior-dev",
     "senior-dev-sol",
     "senior-dev-opus",
+    "senior-dev-astra-low",
     "spec-revalidator",
     "implementation-plan-executioner",
   ]) {
@@ -225,7 +233,7 @@ test("the canonical twelve-step layered template sources split review and preser
       { stepIndex: 5, layer: 5, agentName: "implementation-plan-executioner", outputKind: "implementation" },
       { stepIndex: 6, layer: 6, agentName: "review-coordinator-sol", outputKind: "sol-findings" },
       { stepIndex: 7, layer: 6, agentName: "review-coordinator-opus", outputKind: "blind-findings" },
-      { stepIndex: 8, layer: 7, agentName: "senior-dev", outputKind: "fixed-implementation" },
+      { stepIndex: 8, layer: 7, agentName: "senior-dev-astra-low", outputKind: "fixed-implementation" },
       { stepIndex: 9, layer: 8, agentName: "librarian", outputKind: "documentation" },
       { stepIndex: 10, layer: 9, agentName: "regression-verifier", outputKind: "regression-verification-v2" },
       { stepIndex: 11, layer: 10, agentName: "review-coordinator", outputKind: "merge-authorization" },
@@ -316,7 +324,7 @@ test("the direct template sources expose the layered review spine and mechanical
       { stepIndex: 2, layer: 2, agentName: "senior-dev-luna", outputKind: "implementation" },
       { stepIndex: 3, layer: 3, agentName: "review-coordinator-sol", outputKind: "sol-findings" },
       { stepIndex: 4, layer: 3, agentName: "review-coordinator-opus", outputKind: "blind-findings" },
-      { stepIndex: 5, layer: 4, agentName: "senior-dev", outputKind: "fixed-implementation" },
+      { stepIndex: 5, layer: 4, agentName: "senior-dev-astra-low", outputKind: "fixed-implementation" },
       { stepIndex: 6, layer: 5, agentName: "regression-verifier", outputKind: "regression-verification-v2" },
       { stepIndex: 7, layer: 6, agentName: "review-coordinator", outputKind: "merge-authorization" },
       { stepIndex: 8, layer: 7, agentName: "merge-integrator", outputKind: "merge-result" },

--- a/packages/db/prisma/sync-canonical-prompts.ts
+++ b/packages/db/prisma/sync-canonical-prompts.ts
@@ -40,9 +40,11 @@ import {
 
 const SENIOR_DEV_SOL_AGENT_NAME = "senior-dev-sol";
 const SENIOR_DEV_OPUS_AGENT_NAME = "senior-dev-opus";
+const SENIOR_DEV_ASTRA_LOW_AGENT_NAME = "senior-dev-astra-low";
 
-// Canonical roles that no template step binds, so ordinary synchronization
-// never creates them: each is created once from an active source Agent row.
+// Canonical roles added after the canonical project was seeded, so ordinary
+// synchronization never creates them: each is created once from an active
+// source Agent row (copying its environment, tools, and repo access).
 const SPECIAL_CANONICAL_AGENTS: readonly {
   name: string;
   source: string;
@@ -52,6 +54,7 @@ const SPECIAL_CANONICAL_AGENTS: readonly {
   { name: SPEC_REVALIDATOR_AGENT_NAME, source: "review-coordinator-sol", permissions: RepoPermission.GIT_READ },
   { name: SENIOR_DEV_SOL_AGENT_NAME, source: "senior-dev", permissions: null },
   { name: SENIOR_DEV_OPUS_AGENT_NAME, source: "senior-dev", permissions: null },
+  { name: SENIOR_DEV_ASTRA_LOW_AGENT_NAME, source: "senior-dev", permissions: null },
 ];
 
 const runtimeConfigRefusal = (agent: { model: string; runnerPreference: RunnerPreference }): string | null => {

--- a/packages/db/src/canonical-prompt-sync-multi-project.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync-multi-project.dbtest.ts
@@ -263,6 +263,12 @@ const downgradeDirectToHistoricalSevenStep = async (projectId: string): Promise<
       },
     });
   }
+  // The retired seven-step graph still bound its review-fix step to senior-dev.
+  const seniorDev = await prisma.agent.findUniqueOrThrow({ where: { projectId_name: { projectId, name: "senior-dev" } } });
+  await prisma.taskTemplateStep.updateMany({
+    where: { taskTemplateId: template.id, outputKind: "fixed-implementation" },
+    data: { assigneeAgentId: seniorDev.id },
+  });
 };
 
 before(async () => {
@@ -955,6 +961,7 @@ test("sync refusal classes include every available Project and object identifier
 test("summary reports every Project, nested canonical keys, lexical slugs, and field-wise totals", async (t) => {
   const active = await createProject(`aaa-a2-summary-${randomBytes(4).toString("hex")}`);
   const activeNames = new Set([
+    "senior-dev",
     ...await templateAssigneeNames("pr-engineer-workflow"),
     ...await templateAssigneeNames("compound-engineer-workflow"),
   ]);

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -119,6 +119,16 @@ const ADJUDICATION_STEPS = {
  * optional review omission, not just the older Regression script path. The
  * generation digest authenticates the whole template.
  */
+/** Every registered legacy generation still bound its review-fix step to
+ * senior-dev; a fixture that rebuilds one from current rows restores that. */
+const rebindFixStepToRetiredSeniorDev = async (projectId: string, templateId: string): Promise<void> => {
+  const seniorDev = await prisma.agent.findUniqueOrThrow({ where: { projectId_name: { projectId, name: "senior-dev" } } });
+  await prisma.taskTemplateStep.updateMany({
+    where: { taskTemplateId: templateId, outputKind: "fixed-implementation" },
+    data: { assigneeAgentId: seniorDev.id },
+  });
+};
+
 const restorePreOptionalReviewPrompt = (prompt: string): string => prompt
   .replace(
     "Read the immutable `sol-findings` review output and, when present, the immutable `blind-findings` output through their Anneal step outputs. The blind review may be absent when its optional step was omitted; when it is absent, the Sol report is the sole report. Verify that every present report's reviewed head is the HEAD you are about to fix. When both reports are present, also verify that they report the same reviewed base and the same reviewed head.",
@@ -312,6 +322,7 @@ test("sync rolls the checkout Regression prompt generation once and preserves ch
       where: { taskTemplateId: template.id },
       data: { provisionDependencies: true, optional: false },
     });
+    await rebindFixStepToRetiredSeniorDev(project.id, template.id);
     const regression = template.steps.find(({ outputKind }) => outputKind === "regression-verification-v2");
     assert.ok(regression);
     assert.equal(regression.prompt.split(runnerResolver).length - 1, 3);
@@ -434,6 +445,7 @@ test("sync rolls the deployed pre-optional-review prompt generation once", async
       where: { taskTemplateId: template.id },
       data: { optional: false },
     });
+    await rebindFixStepToRetiredSeniorDev(project.id, template.id);
     const fix = template.steps.find(({ outputKind }) => outputKind === "fixed-implementation");
     const regression = template.steps.find(({ outputKind }) => outputKind === "regression-verification-v2");
     assert.ok(fix);
@@ -523,6 +535,7 @@ test("sync rolls parked and not-yet-started v1 chains forward without changing t
       where: { taskTemplateId: template.id },
       data: { provisionDependencies: true, optional: false },
     });
+    await rebindFixStepToRetiredSeniorDev(project.id, template.id);
     await prisma.taskTemplateStep.updateMany({
       where: { taskTemplateId: template.id, outputKind: "regression-verification-v2" },
       data: { outputKind: "regression-verification", prompt: oldPrompt },
@@ -650,6 +663,7 @@ test("sync rolls the exact adjudication-era graphs forward without touching inst
       where: { taskTemplateId: template.id },
       data: { provisionDependencies: true, optional: false },
     });
+    await rebindFixStepToRetiredSeniorDev(project.id, template.id);
     // Walk down so the (template, stepIndex) unique never collides while the
     // hole opens; every step the adjudication node preceded also sat one layer
     // later than it does now.
@@ -790,6 +804,7 @@ test("sync rolls the pre-zero-gate compound graph forward and leaves the direct 
     where: { taskTemplateId: full.id },
     data: { provisionDependencies: true, optional: false },
   });
+  await rebindFixStepToRetiredSeniorDev(project.id, full.id);
   await prisma.taskTemplateStep.updateMany({
     where: { taskTemplateId: full.id, stepIndex: { in: [1, 4] } },
     data: { approvalGate: true },

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -180,7 +180,7 @@ test("sync creates the pull-request template when the pre-existing canonical ins
   });
   assert.deepEqual(created.variables, ["branchName"]);
   assert.deepEqual(created.steps.map(({ assigneeAgent }) => assigneeAgent?.name), [
-    "senior-dev-luna", "review-coordinator-sol", "review-coordinator-opus", "senior-dev",
+    "senior-dev-luna", "review-coordinator-sol", "review-coordinator-opus", "senior-dev-astra-low",
   ]);
   assert.equal(JSON.stringify(await prisma.taskTemplate.findMany({
     where: {
@@ -1206,7 +1206,7 @@ test("sync recreates a missing spec revalidator with read-only repository covera
   }), [{ mountPath: repo.mountPath, permissions: RepoPermission.GIT_READ }]);
 });
 
-for (const specialName of ["senior-dev-sol", "senior-dev-opus"] as const) {
+for (const specialName of ["senior-dev-sol", "senior-dev-opus", "senior-dev-astra-low"] as const) {
 test(`sync recreates a missing ${specialName} Agent from senior-dev`, async (t) => {
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   const specialSource = canonicalRuntime(specialName);

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -1221,7 +1221,10 @@ test("sync recreates a missing spec revalidator with read-only repository covera
   }), [{ mountPath: repo.mountPath, permissions: RepoPermission.GIT_READ }]);
 });
 
-for (const specialName of ["senior-dev-sol", "senior-dev-opus", "senior-dev-astra-low"] as const) {
+// senior-dev-astra-low is also created through the special-agent table, but
+// every template binds it, so deleting it here would leave a bound step with
+// no assignee; its creation is exercised by the canonical seed instead.
+for (const specialName of ["senior-dev-sol", "senior-dev-opus"] as const) {
 test(`sync recreates a missing ${specialName} Agent from senior-dev`, async (t) => {
   const project = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   const specialSource = canonicalRuntime(specialName);

--- a/packages/db/src/canonical-template-registry.test.ts
+++ b/packages/db/src/canonical-template-registry.test.ts
@@ -29,6 +29,9 @@ test("the pull-request template has current identity, prompt history, and explic
     }, {
       marker: "pre-pr-head-tree-check",
       promptDigest: "805b9e911be94c84e451cdbf4d1cdb93ab10031c031c6854947f56d306fb1906",
+    }, {
+      marker: "pre-astra-low-review-fix",
+      promptDigest: undefined,
     }],
   );
   assert.deepEqual(CURRENT_CANONICAL_STEP_ORDINALS[PR_TEMPLATE_NAME], {
@@ -102,7 +105,7 @@ test("a matching no-history pull-request row is current, never a rollover", () =
       stepIndex: 4,
       name: "Apply review fixes",
       layer: 3,
-      agentName: "senior-dev",
+      agentName: "senior-dev-astra-low",
       approvalGate: false,
       optional: false,
       outputKind: "fixed-implementation",

--- a/packages/db/src/canonical-template-transition.test.ts
+++ b/packages/db/src/canonical-template-transition.test.ts
@@ -403,11 +403,11 @@ test("the pull-request workflow has a registered prompt-only generation and curr
   assert.equal(generation.promptDigest, "93a72d354876a6c26020e8638b6c365fb15e4ca4a400a2d6ca80084994f249d6");
   assert.equal(generation.shape.length, 4);
   // The retired graph against the current one, field by field through the
-  // shared table: identical except that its review steps predate opting out of
-  // dependency provisioning, which is what tells the two shapes apart.
+  // shared table: its review steps predate opting out of dependency
+  // provisioning, and its fix step predates the Astra-low review-fix Agent.
   assert.deepEqual(
     asPersisted(current).map((step, index) => retiredStepShapeDifferences(step, generation.shape[index]!)),
-    [[], ["provisionDependencies"], ["provisionDependencies"], []],
+    [[], ["provisionDependencies"], ["provisionDependencies"], ["agent"]],
   );
   assert.equal(templatePromptGenerationDigest(current), CANONICAL_SOURCE_PROMPT_GENERATIONS[PR_TEMPLATE_NAME]);
   assert.equal(matchedLegacyGeneration(PR_TEMPLATE_NAME, asPersisted(current)), null);
@@ -489,16 +489,50 @@ test("optional review omission is a registered prompt-only rollover in both temp
     assert.equal(generation.promptDigest, retiredDigests[templateName]);
     assert.notEqual(generation.promptDigest, templatePromptGenerationDigest(current));
     assert.equal(matchedLegacyGeneration(templateName, asPersisted(current)), null);
-    // The deployed rows carry the outgoing prompts on the current shape: no
-    // optional steps, and the review steps opting out of dependency
-    // provisioning as the source does.
+    // The rows that generation retired carried the outgoing prompts on its
+    // shape: no optional steps, the review steps opting out of dependency
+    // provisioning as the source does, and the fix step still on senior-dev.
     assert.equal(
       legacyGenerationMatches(
         { marker: generation.marker, shape: generation.shape },
-        asPersisted(current).map((step) => ({ ...step, optional: false })),
+        asPersisted(current).map((step) => ({
+          ...step,
+          optional: false,
+          assigneeAgent: step.outputKind === "fixed-implementation" ? { name: "senior-dev" } : step.assigneeAgent,
+        })),
       ),
       true,
     );
+  }
+});
+
+test("the Astra-low review-fix rebinding is a registered structural rollover in every template", async () => {
+  const sources = await loadAllTemplateStepSources();
+  for (const templateName of Object.keys(LEGACY_TEMPLATE_GENERATIONS) as CanonicalTemplateRegistryName[]) {
+    const current = sources.get(templateName);
+    assert.ok(current, `${templateName} must load from source`);
+    const generation = LEGACY_TEMPLATE_GENERATIONS[templateName].at(-1);
+    assert.ok(generation);
+    assert.equal(generation.marker, "pre-astra-low-review-fix");
+    assert.equal(generation.promptDigest, undefined, templateName);
+    assert.deepEqual(generation.successorStepOrdinals, canonicalStepOrdinals(templateName, null), templateName);
+    const fixIndex = current.findIndex((step) => step.outputKind === "fixed-implementation");
+    assert.equal(current[fixIndex]!.agentName, "senior-dev-astra-low", templateName);
+    assert.deepEqual(
+      asPersisted(current).map((step, index) => retiredStepShapeDifferences(step, generation.shape[index]!)),
+      current.map((_step, index) => (index === fixIndex ? ["agent"] : [])),
+      templateName,
+    );
+    // The deployed rows carry the current prompts on the retired binding, so
+    // the structural entry matches them regardless of prompt digest.
+    assert.equal(
+      matchedLegacyGeneration(templateName, asPersisted(current).map((step) => (
+        step.outputKind === "fixed-implementation" ? { ...step, assigneeAgent: { name: "senior-dev" } } : step
+      ))),
+      "pre-astra-low-review-fix",
+      templateName,
+    );
+    assert.equal(matchedLegacyGeneration(templateName, asPersisted(current)), null, templateName);
   }
 });
 

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -43,6 +43,9 @@ import type { PersistedTemplateStepStructure } from "./template-sources.js";
  * tree.
  * `pre-pr-head-tree-check`: the first handover-quality prompt generation,
  * whose cleanup verification inspected the index rather than committed HEAD.
+ * `pre-astra-low-review-fix`: the graphs whose review-fix step was still bound
+ * to `senior-dev` before it moved to `senior-dev-astra-low`. Structural in all
+ * three templates; prompts unchanged.
  */
 export type LegacyTemplateGeneration = Readonly<{
   marker: string;
@@ -232,6 +235,23 @@ const legacyTemplateGenerations = {
         { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
       ],
     },
+    {
+      // Structural: the review-fix step moved from senior-dev (Astra medium) to
+      // senior-dev-astra-low. Ordinals are unchanged; prompts are unchanged, so
+      // no digest is needed.
+      marker: "pre-astra-low-review-fix",
+      successorStepOrdinals: { revalidation: 1, implementation: 2, "sol-findings": 3, "blind-findings": 4, "fixed-implementation": 5, regression: 6, readiness: 7, integrator: 8 },
+      shape: [
+        { name: "Revalidate specification", agentName: "spec-revalidator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, optional: true, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+      ],
+    },
   ],
   "compound-engineer-workflow": [
     {
@@ -398,6 +418,27 @@ const legacyTemplateGenerations = {
         { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
       ],
     },
+    {
+      // Structural: the review-fix step moved from senior-dev (Astra medium) to
+      // senior-dev-astra-low. Ordinals are unchanged; prompts are unchanged, so
+      // no digest is needed.
+      marker: "pre-astra-low-review-fix",
+      successorStepOrdinals: { spec: 1, plan: 2, "plan-review": 3, "revised-plan": 4, implementation: 5, "sol-findings": 6, "blind-findings": 7, "fixed-implementation": 8, documentation: 9, regression: 10, readiness: 11, integrator: 12 },
+      shape: [
+        { name: "Write a spec", agentName: "spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Plan", agentName: "plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan review", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Revise plan", agentName: "plan-reviser", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Implementation", agentName: "implementation-plan-executioner", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null, provisionDependencies: false },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, optional: true, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null, provisionDependencies: false },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+        { name: "Librarian", agentName: "librarian", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "documentation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 8, spawnPolicy: null },
+        { name: "Regression verification", agentName: "regression-verifier", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 9, spawnPolicy: null },
+        { name: "Merge authorization", agentName: "review-coordinator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 10, spawnPolicy: null },
+        { name: "Merge execution", agentName: "merge-integrator", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
+      ],
+    },
   ],
   [PR_TEMPLATE_NAME]: [
     {
@@ -423,6 +464,19 @@ const legacyTemplateGenerations = {
         { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
         { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null },
+        { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+      ],
+    },
+    {
+      // Structural: the review-fix step moved from senior-dev (Astra medium) to
+      // senior-dev-astra-low. Ordinals are unchanged; prompts are unchanged, so
+      // no digest is needed.
+      marker: "pre-astra-low-review-fix",
+      successorStepOrdinals: { implementation: 1, "sol-findings": 2, "blind-findings": 3, "fixed-implementation": 4 },
+      shape: [
+        { name: "Implementation", agentName: "senior-dev-luna", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Code review (Sol)", agentName: "review-coordinator-sol", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "sol-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null, provisionDependencies: false },
+        { name: "Code review (Opus blind)", agentName: "review-coordinator-opus", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 1, layer: 2, spawnPolicy: null, provisionDependencies: false },
         { name: "Apply review fixes", agentName: "senior-dev", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
       ],
     },

--- a/packages/db/src/seed-canonical-drift.dbtest.ts
+++ b/packages/db/src/seed-canonical-drift.dbtest.ts
@@ -90,6 +90,12 @@ test("seed rolls a registered canonical generation over inside its installation 
       },
     });
   }
+  // The retired seven-step graph still bound its review-fix step to senior-dev.
+  const seniorDev = await prisma.agent.findUniqueOrThrow({ where: { projectId_name: { projectId: project.id, name: "senior-dev" } } });
+  await prisma.taskTemplateStep.updateMany({
+    where: { taskTemplateId: outgoing.id, outputKind: "fixed-implementation" },
+    data: { assigneeAgentId: seniorDev.id },
+  });
 
   const rolled = seed();
   assert.equal(rolled.status, 0, rolled.output);

--- a/packages/db/src/template-sources.test.ts
+++ b/packages/db/src/template-sources.test.ts
@@ -268,7 +268,7 @@ test("the pull-request workflow source exposes its exact four-step graph and pro
         name: "Apply review fixes",
         stepIndex: 4,
         layer: 3,
-        agent: "senior-dev",
+        agent: "senior-dev-astra-low",
         approvalGate: false,
         optional: false,
         outputKind: "fixed-implementation",

--- a/packages/db/src/verify-agent-template.dbtest.ts
+++ b/packages/db/src/verify-agent-template.dbtest.ts
@@ -72,7 +72,7 @@ const partialRoleNames = [
   "senior-dev-luna",
   "review-coordinator-sol",
   "review-coordinator-opus",
-  "senior-dev",
+  "senior-dev-astra-low",
 ] as const;
 
 type ProjectFixture = {
@@ -261,7 +261,7 @@ test("--project rejects every canonical Agent field drift with project and Agent
       name: "collaborators",
       apply: async (fixture) => {
         const agent = fixture.agents.get("senior-dev-luna")!;
-        const allowed = fixture.agents.get("senior-dev")!;
+        const allowed = fixture.agents.get("senior-dev-astra-low")!;
         await prisma.agentCollaboration.create({
           data: { agentId: agent.id, allowedAgentId: allowed.id, projectId: fixture.id },
         });
@@ -423,7 +423,7 @@ test("--project rejects every canonical template step field with template/step i
     { name: "agent", apply: async (fixture, step) => {
       await prisma.taskTemplateStep.update({
         where: { id: step.id },
-        data: { assigneeAgentId: fixture.agents.get("senior-dev")!.id },
+        data: { assigneeAgentId: fixture.agents.get("senior-dev-astra-low")!.id },
       });
     } },
     { name: "assigneeType", apply: async (_fixture, step) => {
@@ -506,7 +506,7 @@ test("--project refuses the differences canonical sync would adopt", async () =>
 test("default verification keeps the complete-inventory requirement and success sentence", async () => {
   const verified = verify();
   assert.equal(verified.status, 0, verified.output);
-  assert.match(verified.output, /Agent\/template contract verified for 18 active agents and 24 steps across 3 templates\./u);
+  assert.match(verified.output, /Agent\/template contract verified for 19 active agents and 24 steps across 3 templates\./u);
 
   const canonical = await prisma.project.findUniqueOrThrow({ where: { slug: "agentos-example" } });
   const customized = await prisma.agent.findUniqueOrThrow({

--- a/scripts/operator-api-docs.test.mjs
+++ b/scripts/operator-api-docs.test.mjs
@@ -88,7 +88,7 @@ test("POST /projects documents bootstrap rows, canonical roles/template, and slu
     "senior-dev-luna",
     "review-coordinator-sol",
     "review-coordinator-opus",
-    "senior-dev",
+    "senior-dev-astra-low",
   ]) {
     assert.match(text, new RegExp("`" + role + "`", "u"));
   }
@@ -189,7 +189,7 @@ test("Inbox list and summary document shared Project-plus-global scope", () => {
 
 test("the add-project runbook and public links cover A1 pull-request onboarding", () => {
   assert.match(addProjectRunbook, /POST "\$BASE_URL\/projects"/u);
-  assert.match(addProjectRunbook, /`local` Environment[\s\S]*four[\s\S]*`senior-dev-luna`[\s\S]*`review-coordinator-sol`[\s\S]*`review-coordinator-opus`[\s\S]*`senior-dev`/u);
+  assert.match(addProjectRunbook, /`local` Environment[\s\S]*four[\s\S]*`senior-dev-luna`[\s\S]*`review-coordinator-sol`[\s\S]*`review-coordinator-opus`[\s\S]*`senior-dev-astra-low`/u);
   assert.match(addProjectRunbook, /`pr-engineer-workflow`/u);
   assert.match(addProjectRunbook, /POST "\$BASE_URL\/projects\/\$PROJECT_ID\/repos"/u);
   assert.match(addProjectRunbook, /"grantAgents":true/u);


### PR DESCRIPTION
## Summary

- Add canonical role `senior-dev-astra-low`: the senior-dev prompt on `gpt-6-astra:low`, runner codex.
- Bind the **Apply review fixes** step of all three templates (compound, direct, pull-request) to it. `senior-dev` stays `gpt-6-astra:medium` and remains the routed implementation tier.
- Register the retired binding as structural generation `pre-astra-low-review-fix` in every template, with explicit successor ordinals; prompts unchanged, so the source prompt pins are unchanged.
- Create the new Agent in the canonical project from `senior-dev` via the special-agent table; make it the fourth bootstrap role of `pr-engineer-workflow`.
- Update agent contract pins, verifier agent count (18 → 19), bound-name fixtures, README, task routing, operator API handbook, and add-a-project runbook.

Operator ruling 2026-09-05: review-fix runs at Astra low; implementation keeps medium.

## Deployment note

Projects other than the canonical one must have an active `senior-dev-astra-low` Agent before the rollover installs, otherwise their sync is refused with `cannot bind senior-dev-astra-low`. Done for word-factory before merge (Agent cmto38cf00007db3cfhbmf22m, GIT_WRITE on its repo).

## Verification

- `npm run lint`, `npm run test:snapshot-scan`, `typecheck` for db and api: clean
- `npm run test -w @anneal/db`: 463 pass; `npm run test -w @anneal/api`: 926 pass
- Database suites: merge gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1KMxWcjsX23QvAQdGhWyC