### PR TITLE
feat(web): a phone reaches every control and reads every value

### DIFF
--- a/apps/web/src/components/mobile-task-list.tsx
+++ b/apps/web/src/components/mobile-task-list.tsx
@@ -24,8 +24,16 @@ import { Button } from "./ui/button";
  * scrolls, which is the only scroll a phone reliably has, and every card in the
  * selected status is reachable by scrolling to it.
  */
-const TABS = "sticky top-[52px] z-[3] -mx-[16px] flex gap-[6px] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden border-b border-[color:var(--border-soft)] bg-popover px-[16px] py-[10px]";
-const TAB = "flex flex-none items-center gap-[6px] rounded-lg border border-transparent px-[12px] py-[8px] text-[12.5px] whitespace-nowrap text-muted-foreground";
+/** The strip is wider than a phone — five statuses and their counts come to
+ *  about 470px — and it hides its scrollbar, so nothing said it could be
+ *  swiped: `Done` simply did not exist for anyone who did not try. The bar and
+ *  the scroller are two elements because the fade must not travel with the
+ *  content; `sticky` already positions the bar, so the overlay resolves against
+ *  it. The gradient ends in `--popover`, the bar's own background, so it is
+ *  invisible on a viewport wide enough to fit all five. */
+const TABS_BAR = "sticky top-[52px] z-[3] -mx-[16px] border-b border-[color:var(--border-soft)] bg-popover after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:w-[36px] after:bg-[linear-gradient(to_right,transparent,var(--popover))]";
+const TABS = "flex gap-[6px] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden px-[16px] py-[10px]";
+const TAB = "flex min-h-[44px] flex-none items-center gap-[6px] rounded-lg border border-transparent px-[12px] py-[8px] text-[12.5px] whitespace-nowrap text-muted-foreground";
 const TAB_ON = "border-border bg-accent text-foreground";
 const LIST = "mt-[14px] grid grid-cols-[minmax(0,1fr)] gap-[10px]";
 const LIST_EMPTY = "px-0 py-[40px] text-center text-[12.5px] text-[color:var(--faint)]";
@@ -48,31 +56,33 @@ export const MobileTaskList = ({ tab, counts, tasks: entries, loading, onSelectT
   return <>
     {/* A tablist, not five buttons: it is the page's primary navigation and the
         arrow keys are what a screen reader user reaches for. */}
-    <div className={TABS} role="tablist" aria-label={t("tasks.mobile.statusTabs")}>
-      {COLUMNS.map((column) => (
-        <button
-          key={column.status}
-          type="button"
-          role="tab"
-          id={`tab-${column.status}`}
-          aria-selected={tab === column.status}
-          aria-controls="mobile-task-list"
-          tabIndex={tab === column.status ? 0 : -1}
-          className={cn(TAB, tab === column.status && TAB_ON)}
-          onClick={() => onSelectTab(column.status)}
-          onKeyDown={(event) => {
-            const step = event.key === "ArrowRight" ? 1 : event.key === "ArrowLeft" ? -1 : 0;
-            if (step === 0) return;
-            event.preventDefault();
-            const index = COLUMNS.findIndex((candidate) => candidate.status === tab);
-            const next = COLUMNS[(index + step + COLUMNS.length) % COLUMNS.length]!;
-            onSelectTab(next.status);
-            document.getElementById(`tab-${next.status}`)?.focus();
-          }}
-        >
-          {t(column.labelKey)}<span className={COUNT}>{counts[column.status]}</span>
-        </button>
-      ))}
+    <div className={TABS_BAR}>
+      <div className={TABS} role="tablist" aria-label={t("tasks.mobile.statusTabs")}>
+        {COLUMNS.map((column) => (
+          <button
+            key={column.status}
+            type="button"
+            role="tab"
+            id={`tab-${column.status}`}
+            aria-selected={tab === column.status}
+            aria-controls="mobile-task-list"
+            tabIndex={tab === column.status ? 0 : -1}
+            className={cn(TAB, tab === column.status && TAB_ON)}
+            onClick={() => onSelectTab(column.status)}
+            onKeyDown={(event) => {
+              const step = event.key === "ArrowRight" ? 1 : event.key === "ArrowLeft" ? -1 : 0;
+              if (step === 0) return;
+              event.preventDefault();
+              const index = COLUMNS.findIndex((candidate) => candidate.status === tab);
+              const next = COLUMNS[(index + step + COLUMNS.length) % COLUMNS.length]!;
+              onSelectTab(next.status);
+              document.getElementById(`tab-${next.status}`)?.focus();
+            }}
+          >
+            {t(column.labelKey)}<span className={COUNT}>{counts[column.status]}</span>
+          </button>
+        ))}
+      </div>
     </div>
 
     {/* Archive All lives here on a phone rather than in a column head there is

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -57,7 +57,14 @@ export const PAGE_ACTIONS = "flex flex-wrap items-center justify-end gap-[9px] [
  *  the viewport. */
 export const DETAIL_HEAD = "mb-[18px] flex flex-wrap items-center gap-[12px]";
 export const DETAIL_HEAD_H1 = "text-[20px] [overflow-wrap:anywhere] [@media(max-width:900px)]:flex-[1_0_60%] [@media(max-width:900px)]:text-[18px]";
-export const BACK_LINK = "inline-flex items-center gap-[8px] text-[12.5px] text-muted-foreground hover:text-foreground";
+/** A 44px finger target on a phone, drawn as a halo rather than as padding: the
+ *  bare-arrow form of this link is 16px square, and growing its box would push
+ *  the detail title across by the same amount on every detail page. A
+ *  `::before` overlay belongs to the link for hit testing and to nothing for
+ *  layout. The same idiom is on the icon button, the checkbox and the dialog's
+ *  close, which are the other controls too small to grow in place. */
+export const TOUCH_HALO = "relative before:absolute before:content-[''] [@media(max-width:900px)]:before:-inset-[14px]";
+export const BACK_LINK = `inline-flex items-center gap-[8px] text-[12.5px] text-muted-foreground hover:text-foreground ${TOUCH_HALO}`;
 export const TOOLBAR = "mb-[16px] flex items-center gap-[10px]";
 
 /** `.fieldRow` — `align-items: start` keeps a hint-less control from stretching to
@@ -69,7 +76,10 @@ export const FIELD_ROW = "grid grid-cols-[repeat(auto-fit,minmax(190px,1fr))] it
 export const CARD_TITLE = "mb-[14px] flex items-center gap-[9px] text-[13.5px]";
 export const COUNT = "inline-grid h-[19px] min-w-[20px] place-items-center rounded-md bg-accent px-[6px] text-[11.5px] text-muted-foreground";
 export const HINT = "text-[11.5px] leading-[1.5] text-[color:var(--faint)]";
-export const METRICS = "grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-[14px]";
+/** Two per row on a phone: `minmax(180px,…)` resolves to one column at 358px, so
+ *  three metrics claimed a whole first screen and pushed the page they head
+ *  below the fold. 140px still fits `0 done · 2 open` on one line. */
+export const METRICS = "grid grid-cols-[repeat(auto-fit,minmax(180px,1fr))] gap-[14px] [@media(max-width:900px)]:grid-cols-[repeat(auto-fit,minmax(140px,1fr))]";
 export const STAT_PILLS = "flex flex-wrap gap-[8px]";
 export const STAT_PILL = "inline-flex items-center gap-[7px] rounded-lg border border-border bg-card px-[11px] py-[5px] text-[12px] text-secondary-foreground";
 export const CODE_BLOCK = "max-h-[460px] overflow-auto rounded-lg border border-[color:var(--border-soft)] bg-[color:var(--code-background)] px-[16px] py-[14px] text-[12px] leading-[1.65] whitespace-pre-wrap text-secondary-foreground [overflow-wrap:anywhere]";
@@ -116,17 +126,17 @@ export const MOBILE_TAB_ACTIVE = "text-foreground [&_svg]:opacity-100 after:abso
 export const MOBILE_TAB_BADGE = "absolute top-[7px] left-[calc(50%+6px)]";
 export const SHEET = "inset-x-0 top-auto bottom-0 left-0 max-h-[85dvh] w-full translate-x-0 translate-y-0 overflow-y-auto rounded-t-[16px] rounded-b-none border-[color:var(--border-soft)] bg-popover px-[10px] pt-[14px] pb-[calc(10px+env(safe-area-inset-bottom))] font-mono";
 export const SHEET_TITLE = "mb-[8px] px-[12px] text-[11.5px] font-normal tracking-[.04em] text-[color:var(--faint)] uppercase";
-export const SHEET_ITEM = "flex w-full items-center gap-[12px] rounded-lg border-0 bg-transparent px-[12px] py-[12px] text-left text-[14px] text-secondary-foreground [&_svg]:flex-none [&_svg]:opacity-85";
+export const SHEET_ITEM = "flex min-h-[44px] w-full items-center gap-[12px] rounded-lg border-0 bg-transparent px-[12px] py-[12px] text-left text-[14px] text-secondary-foreground [&_svg]:flex-none [&_svg]:opacity-85";
 export const SHEET_ITEM_ACTIVE = "bg-accent text-foreground";
 export const SHEET_RULE = "my-[8px] border-t border-[color:var(--border-soft)]";
-export const PROJECT_SWITCHER = "flex w-full items-center gap-[9px] rounded-lg border border-transparent bg-transparent p-[8px] mb-[10px] text-left hover:bg-secondary";
+export const PROJECT_SWITCHER = "flex w-full items-center gap-[9px] rounded-lg border border-transparent bg-transparent p-[8px] mb-[10px] text-left hover:bg-secondary [@media(max-width:900px)]:min-h-[44px]";
 export const PROJECT_MARK = "grid flex-none place-items-center size-[26px] rounded-[7px] bg-primary text-[12px] font-bold text-primary-foreground";
 export const PROJECT_NAME = "min-w-0 flex-1 overflow-hidden text-[13px] text-ellipsis whitespace-nowrap";
 export const CHEVRON = "flex-none text-[color:var(--faint)]";
 export const RUNNER_ROW = "flex items-center gap-[10px] px-[10px] py-[8px] text-[12.5px] text-secondary-foreground whitespace-nowrap";
 export const RUNNER_STATE = "ml-auto text-[11.5px] text-muted-foreground";
 /** The top-bar form of the runner row: the dot and the state word, no label. */
-export const RUNNER_ROW_COMPACT = "flex flex-none items-center gap-[7px] rounded-lg px-[10px] py-[8px] text-[11.5px] text-muted-foreground";
+export const RUNNER_ROW_COMPACT = "flex min-h-[44px] flex-none items-center gap-[7px] rounded-lg px-[10px] py-[8px] text-[11.5px] text-muted-foreground";
 export const CONTENT = "min-w-0 bg-popover";
 
 export const Page = ({ className, children }: { className?: string; children: ReactNode }): ReactNode => (
@@ -217,8 +227,13 @@ export const KeyValue = ({ items, columns }: {
   columns?: 2 | 3;
 }): ReactNode => (
   <div className={cn(
-    "grid gap-x-[40px] gap-y-[16px] [&>div]:min-w-0",
-    columns === 3 ? "grid-cols-[repeat(3,minmax(0,1fr))] [@media(max-width:900px)]:grid-cols-[repeat(2,minmax(0,1fr))]" : "grid-cols-[repeat(2,minmax(0,1fr))]",
+    /* One column on a phone. Two columns of a 358px page are ~145px each, which
+     * is a dozen monospace characters: `Environment networking` broke over two
+     * lines as a label and `danger-full-access` broke mid-word as a value, so
+     * the list read as a column of fragments. Height is the cheap axis on a
+     * phone and width is the scarce one. */
+    "grid gap-x-[40px] gap-y-[16px] [&>div]:min-w-0 [@media(max-width:900px)]:grid-cols-[minmax(0,1fr)] [@media(max-width:900px)]:gap-y-[14px]",
+    columns === 3 ? "grid-cols-[repeat(3,minmax(0,1fr))]" : "grid-cols-[repeat(2,minmax(0,1fr))]",
   )}>
     {items.map((item) => (
       <div key={item.k}>
@@ -248,7 +263,10 @@ export const Metric = ({ label, value }: { label: string; value: ReactNode }): R
  *  and `.on` came second — so the selected button did not react to hover. As
  *  utilities the hover variant would sort last and win, so the hover colour is
  *  attached to the unselected buttons only. */
-const SEGMENTED_BUTTON = "rounded-[7px] border-0 bg-transparent px-[13px] py-[6px] text-[12.5px]";
+/** The phone height is the 44px finger target; the segmented control and the
+ *  tab strip are how an operator changes what a page is showing, so they are
+ *  the two shapes a mis-tap costs the most. */
+const SEGMENTED_BUTTON = "rounded-[7px] border-0 bg-transparent px-[13px] py-[6px] text-[12.5px] [@media(max-width:900px)]:min-h-[44px]";
 
 export const Segmented = <T extends string>({ options, value, onChange, accent }: {
   options: Array<{ value: T; label: string }>;
@@ -277,7 +295,7 @@ export const Segmented = <T extends string>({ options, value, onChange, accent }
 );
 
 /** `.tabs button` had no hover rule, unlike `.segmented button`. */
-const TABS_BUTTON = "rounded-[7px] border-0 bg-transparent px-[14px] py-[7px] text-[12.5px] whitespace-nowrap";
+const TABS_BUTTON = "rounded-[7px] border-0 bg-transparent px-[14px] py-[7px] text-[12.5px] whitespace-nowrap [@media(max-width:900px)]:min-h-[44px]";
 
 export const Tabs = <T extends string>({ options, value, onChange }: {
   options: Array<{ value: T; label: string }>;
@@ -474,7 +492,7 @@ export const RowMenu = ({ items, label, onOpenChange }: { items: RowMenuEntry[];
     <DropdownMenu {...(onOpenChange === undefined ? {} : { onOpenChange })}>
       <span className="relative" onClick={(event) => event.stopPropagation()}>
         <DropdownMenuTrigger asChild>
-          <Button type="button" variant="icon" size="legacyIcon" aria-label={label ?? t("ui.rowMenu.more")}><IconDots /></Button>
+          <Button type="button" variant="icon" size="legacyIcon" className={TOUCH_HALO} aria-label={label ?? t("ui.rowMenu.more")}><IconDots /></Button>
         </DropdownMenuTrigger>
       </span>
       <DropdownMenuContent align="end" className="min-w-32 border-border bg-popover font-mono text-popover-foreground" onClick={(event) => event.stopPropagation()}>

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -54,8 +54,12 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",
         icon: "h-9 w-9",
-        legacy: "h-[34px] gap-[7px] px-[13px] text-[12.5px] rounded-lg whitespace-nowrap",
-        legacySmall: "h-[28px] gap-[7px] px-[10px] text-[12px] rounded-lg",
+        /** The phone heights are the 44px finger target, and they are `min-h`
+         *  rather than `h`: a call site that passes `h-auto` — the onboarding
+         *  wizard does — must still clear it. Type size is untouched, so the
+         *  button reads the same and only its padding grows. */
+        legacy: "h-[34px] gap-[7px] px-[13px] text-[12.5px] rounded-lg whitespace-nowrap [@media(max-width:900px)]:min-h-[44px]",
+        legacySmall: "h-[28px] gap-[7px] px-[10px] text-[12px] rounded-lg [@media(max-width:900px)]:min-h-[44px]",
         legacyIcon: "size-[28px] rounded-[7px] text-[13px]",
       },
     },

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -47,7 +47,7 @@ function DialogContent({ className, children, ...props }: React.ComponentProps<t
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-hidden focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm before:absolute before:content-[''] [@media(max-width:900px)]:before:-inset-[16px] opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-hidden focus-visible:ring-ring/50 focus-visible:ring-[3px] disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
           <X className="h-4 w-4" />
           <span className="sr-only">{t("common.close")}</span>
         </DialogPrimitive.Close>

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -42,7 +42,7 @@ function DropdownMenuItem({
     <DropdownMenuPrimitive.Item
       data-slot="dropdown-menu-item"
       className={cn(
-        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden [@media(max-width:900px)]:min-h-[44px] [@media(max-width:900px)]:px-3 transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
         inset && "pl-8",
         className
       )}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -28,7 +28,7 @@ function Input({ className, type = "text", ...props }: React.ComponentProps<"inp
       type={type}
       data-slot="input"
       className={cn(
-        "flex h-9 w-full rounded-lg border border-border bg-[color:var(--surface-input)] px-[11px] py-[9px] text-[12.5px] text-foreground outline-0 shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus:border-primary focus-visible:outline-hidden focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-9 w-full [@media(max-width:900px)]:min-h-[44px] rounded-lg border border-border bg-[color:var(--surface-input)] px-[11px] py-[9px] text-[12.5px] text-foreground outline-0 shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus:border-primary focus-visible:outline-hidden focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -21,8 +21,11 @@ function Select({ className, ...props }: React.ComponentProps<"select">) {
     <select
       data-slot="select"
       className={cn(
-        "flex w-full appearance-none rounded-lg border border-border bg-[color:var(--surface-input)] px-[11px] py-[9px] text-[12.5px] text-foreground outline-0 shadow-sm transition-colors focus:border-primary focus-visible:outline-hidden focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive disabled:cursor-not-allowed disabled:opacity-50",
+        "flex w-full [@media(max-width:900px)]:min-h-[44px] appearance-none rounded-lg border border-border bg-[color:var(--surface-input)] px-[11px] py-[9px] text-[12.5px] text-foreground outline-0 shadow-sm transition-colors focus:border-primary focus-visible:outline-hidden focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive disabled:cursor-not-allowed disabled:opacity-50",
         "bg-[image:linear-gradient(45deg,transparent_50%,var(--faint)_50%),linear-gradient(135deg,var(--faint)_50%,transparent_50%)] bg-[position:right_14px_top_15px,right_9px_top_15px] bg-[size:5px_5px] bg-no-repeat pr-[30px]",
+        /* The chevron is painted from the top edge, so the phone height moves it
+         * off centre unless it is re-placed against the taller box. */
+        "[@media(max-width:900px)]:bg-[position:right_14px_top_19px,right_9px_top_19px]",
         className
       )}
       {...props}

--- a/apps/web/src/pages/Costs.tsx
+++ b/apps/web/src/pages/Costs.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useMemo, useState } from "react";
 
 import { formatDateTime, formatT, titleCase, usageMoney } from "../lib/format";
-import { useLocalStorage, usePoll } from "../lib/hooks";
+import { useLocalStorage, useMediaQuery, usePoll } from "../lib/hooks";
 import { useT } from "../lib/i18n";
 import { useProjectScope } from "../lib/project";
 import type { CostsReport } from "../lib/types";
@@ -94,23 +94,42 @@ const busyPercentage = (value: number): string => Number.isFinite(value) ? `${va
 /* ------------------------------------------------------------------- chart */
 
 /* Geometry is in viewBox units and the SVG scales uniformly, so these are
- * proportions rather than pixels. 1200x240 is close to the rendered box on a
- * full-width page, which keeps the type in the chart near the type around it. */
-const VIEW_WIDTH = 1200;
-const VIEW_HEIGHT = 240;
-const PAD_LEFT = 62;
-const PAD_RIGHT = 10;
-const PAD_TOP = 12;
-const PAD_BOTTOM = 24;
-const PLOT_WIDTH = VIEW_WIDTH - PAD_LEFT - PAD_RIGHT;
-const PLOT_HEIGHT = VIEW_HEIGHT - PAD_TOP - PAD_BOTTOM;
+ * proportions rather than pixels — including `fontSize`, which is why the shape
+ * of the box decides whether the axis is legible. 1200x240 is close to the
+ * rendered box on a full-width page, which keeps the type in the chart near the
+ * type around it. */
+export type ChartGeometry = {
+  width: number; height: number;
+  padLeft: number; padRight: number; padTop: number; padBottom: number;
+  /** At a seven-day window a column would otherwise be 160 units wide, which
+   *  reads as a block diagram rather than a bar chart. */
+  maxBar: number;
+  fontSize: number;
+};
+
+export const WIDE_CHART: ChartGeometry = {
+  width: 1200, height: 240, padLeft: 62, padRight: 10, padTop: 12, padBottom: 24,
+  maxBar: 52, fontSize: 13,
+};
+
+/**
+ * The same chart on a phone, where the card is about 306px wide.
+ *
+ * Reusing `WIDE_CHART` there scaled a unit to a quarter of a CSS pixel: the
+ * plot came out 61px tall and both axes rendered at 3.3px, which is a picture of
+ * a chart rather than a chart. A viewBox 400 units wide puts a unit at about
+ * 0.77px, so `fontSize: 15` lands near the 11.5px the hints around it use, and
+ * `padLeft: 82` is the gutter `$1234.56` needs at that size.
+ */
+export const PHONE_CHART: ChartGeometry = {
+  width: 400, height: 340, padLeft: 82, padRight: 6, padTop: 10, padBottom: 30,
+  maxBar: 26, fontSize: 15,
+};
+
 /** A surface-coloured gap between stacked fills, so two adjacent segments read
  *  as two values and not one. */
 const SEGMENT_GAP = 2;
 const CORNER = 4;
-/** At a seven-day window a column would otherwise be 160 units wide, which reads
- *  as a block diagram rather than a bar chart. */
-const MAX_BAR = 52;
 
 export type ChartSegment = {
   key: string;
@@ -131,21 +150,24 @@ export const chartSegments = (
   daily: CostsReport["daily"],
   order: readonly string[],
   max: number,
+  geometry: ChartGeometry = WIDE_CHART,
 ): ChartSegment[] => {
   if (daily.length === 0 || max <= 0) return [];
-  const column = PLOT_WIDTH / daily.length;
-  const barWidth = Math.min(MAX_BAR, column * 0.72);
+  const plotWidth = geometry.width - geometry.padLeft - geometry.padRight;
+  const plotHeight = geometry.height - geometry.padTop - geometry.padBottom;
+  const column = plotWidth / daily.length;
+  const barWidth = Math.min(geometry.maxBar, column * 0.72);
   const segments: ChartSegment[] = [];
   daily.forEach((bucket, index) => {
-    const x = PAD_LEFT + column * index + (column - barWidth) / 2;
+    const x = geometry.padLeft + column * index + (column - barWidth) / 2;
     // Stacked from the baseline up, in the legend's order, so a given agent sits
     // at the same height in every column and the shape is comparable across days.
     const stacked = order
       .map((agent) => ({ agent, usd: Number(bucket.byAgent[agent] ?? 0) }))
       .filter((entry) => entry.usd > 0);
-    let baseline = PAD_TOP + PLOT_HEIGHT;
+    let baseline = geometry.padTop + plotHeight;
     stacked.forEach((entry, position) => {
-      const full = (entry.usd / max) * PLOT_HEIGHT;
+      const full = (entry.usd / max) * plotHeight;
       // The gap comes out of the segment, never out of the value it encodes: a
       // sliver thinner than the gap keeps its full height instead of vanishing.
       const hasSegmentAbove = position < stacked.length - 1;
@@ -186,21 +208,25 @@ export const axisDates = (daily: CostsReport["daily"]): number[] => {
   return [...new Set([0, Math.floor((daily.length - 1) / 2), daily.length - 1])];
 };
 
-export const DailySpendChart = ({ daily, order, colors }: {
+export const DailySpendChart = ({ daily, order, colors, geometry = WIDE_CHART }: {
   daily: CostsReport["daily"];
   order: readonly string[];
   colors: (agent: string) => string;
+  /** `PHONE_CHART` below 900px. A prop rather than a media query inside this
+   *  component, so the geometry stays testable without a matchMedia. */
+  geometry?: ChartGeometry;
 }): ReactNode => {
   const t = useT();
   const totals = daily.map((bucket) => Object.values(bucket.byAgent).reduce((sum, usd) => sum + Number(usd), 0));
   const max = Math.max(0, ...totals);
-  const segments = chartSegments(daily, order, max);
-  const column = daily.length === 0 ? 0 : PLOT_WIDTH / daily.length;
-  const baseline = PAD_TOP + PLOT_HEIGHT;
+  const segments = chartSegments(daily, order, max, geometry);
+  const plotWidth = geometry.width - geometry.padLeft - geometry.padRight;
+  const column = daily.length === 0 ? 0 : plotWidth / daily.length;
+  const baseline = geometry.height - geometry.padBottom;
   if (segments.length === 0) return <EmptyState>{t("costs.chart.empty")}</EmptyState>;
   return (
     <svg
-      viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+      viewBox={`0 0 ${geometry.width} ${geometry.height}`}
       className="h-auto w-full"
       role="img"
       aria-label={t("costs.chart.aria", { amount: usageMoney(max), n: daily.length })}
@@ -209,14 +235,14 @@ export const DailySpendChart = ({ daily, order, colors }: {
           `--border-soft` is very nearly `--card` in the dark theme, so a scale
           line drawn in it would simply not exist there; `--border` is the
           quietest token still visible against both surfaces. */}
-      <line x1={PAD_LEFT} y1={PAD_TOP} x2={VIEW_WIDTH - PAD_RIGHT} y2={PAD_TOP}
+      <line x1={geometry.padLeft} y1={geometry.padTop} x2={geometry.width - geometry.padRight} y2={geometry.padTop}
         stroke="var(--border)" strokeWidth="1" />
-      <line x1={PAD_LEFT} y1={baseline} x2={VIEW_WIDTH - PAD_RIGHT} y2={baseline}
+      <line x1={geometry.padLeft} y1={baseline} x2={geometry.width - geometry.padRight} y2={baseline}
         stroke="var(--border)" strokeWidth="1.5" />
-      <text x={PAD_LEFT - 8} y={PAD_TOP + 4} textAnchor="end" fontSize="13" fill="var(--faint)">
+      <text x={geometry.padLeft - 8} y={geometry.padTop + 4} textAnchor="end" fontSize={geometry.fontSize} fill="var(--faint)">
         {usageMoney(max)}
       </text>
-      <text x={PAD_LEFT - 8} y={baseline} textAnchor="end" fontSize="13" fill="var(--faint)">0</text>
+      <text x={geometry.padLeft - 8} y={baseline} textAnchor="end" fontSize={geometry.fontSize} fill="var(--faint)">0</text>
       {segments.map((segment) => (
         <path key={segment.key} d={segmentPath(segment)} fill={colors(segment.agent)}>
           <title>{t("costs.chart.tooltip", {
@@ -229,10 +255,10 @@ export const DailySpendChart = ({ daily, order, colors }: {
       {axisDates(daily).map((index) => (
         <text
           key={daily[index]?.date ?? index}
-          x={PAD_LEFT + column * (index + 0.5)}
-          y={VIEW_HEIGHT - 6}
+          x={geometry.padLeft + column * (index + 0.5)}
+          y={geometry.height - 6}
           textAnchor={index === 0 ? "start" : index === daily.length - 1 ? "end" : "middle"}
-          fontSize="13"
+          fontSize={geometry.fontSize}
           fill="var(--faint)"
         >
           {daily[index]?.date ?? ""}
@@ -483,6 +509,7 @@ export const CostsPage = (): ReactNode => {
   // and refuses the request without one, so the browser's zone travels with the
   // window rather than being guessed at the other end.
   const timeZone = browserTimeZone();
+  const narrow = useMediaQuery("(max-width: 900px)");
   const path = projectId === ""
     ? null
     : `/projects/${encodeURIComponent(projectId)}/costs?days=${days}&tz=${encodeURIComponent(timeZone)}`;
@@ -573,7 +600,7 @@ export const CostsPage = (): ReactNode => {
             <div className={COSTS_COLUMNS}>
               <div className={STACK}>
                 <Card title={t("costs.chart.title")}>
-                  <DailySpendChart daily={daily} order={order} colors={colors} />
+                  <DailySpendChart daily={daily} order={order} colors={colors} geometry={narrow ? PHONE_CHART : WIDE_CHART} />
                   {order.length > 1 ? <ChartLegend order={order} colors={colors} /> : null}
                 </Card>
 

--- a/apps/web/src/pages/Inbox.tsx
+++ b/apps/web/src/pages/Inbox.tsx
@@ -260,8 +260,13 @@ export const InboxThreadPage = ({ messageId }: { messageId: string }): ReactNode
       </div>
 
       <div className={STACK}>
-        <div className={ROW}>
-          <h1 className="text-[18px]">{firstLine(message.body)}</h1>
+        {/* The subject is the first line of a message body, so it is arbitrary
+            text: an auto-deploy notice carries two 40-character shas, which in a
+            non-wrapping row pushed the status pill off the right of a phone and
+            gave the document a horizontal scroll. The title breaks inside a word
+            and the pills fall to their own line. */}
+        <div className={cn(ROW, "[@media(max-width:900px)]:flex-wrap")}>
+          <h1 className="min-w-0 text-[18px] [overflow-wrap:anywhere]">{firstLine(message.body)}</h1>
           <InboxPill status={message.status} />
           {message.gateTaskId === null ? null : <Pill tone="violet">{t("inbox.approvalGate")}</Pill>}
         </div>

--- a/apps/web/src/pages/Onboarding.tsx
+++ b/apps/web/src/pages/Onboarding.tsx
@@ -8,7 +8,7 @@ import {
 } from "../lib/onboarding";
 import type { OnboardingInstallation, OnboardingStatus, RunnersResponse } from "../lib/types";
 import { type CodexReadiness, CodexReadinessNotice, codexReady, useFreshnessClock } from "../components/runner-status";
-import { Card, ErrorNotice, Field, HINT, KeyValue, NOTICE, Page, STACK } from "../components/ui";
+import { Card, ErrorNotice, Field, HINT, KeyValue, NOTICE, Page, STACK, TOUCH_HALO } from "../components/ui";
 import { Button } from "../components/ui/button";
 import { Checkbox } from "../components/ui/checkbox";
 import { Input } from "../components/ui/input";
@@ -318,7 +318,7 @@ export const OnboardingPage = ({ onInstalled, recoverCompleted = true }: {
               {codex.state === "ready" ? null : <div className={NOTICE}><CodexReadinessNotice readiness={codex} /></div>}
               <div className={NOTICE}>{t("onboarding.confirm.credentials")}</div>
               <label className="flex items-start gap-[10px] text-[12.5px]">
-                <Checkbox checked={acknowledged} onCheckedChange={(next) => setAcknowledged(next === true)}
+                <Checkbox className={TOUCH_HALO} checked={acknowledged} onCheckedChange={(next) => setAcknowledged(next === true)}
                   aria-label={t("onboarding.confirm.acknowledge")} />
                 <span>{t("onboarding.confirm.acknowledge")}</span>
               </label>

--- a/apps/web/src/pages/Sessions.tsx
+++ b/apps/web/src/pages/Sessions.tsx
@@ -553,7 +553,7 @@ export const DebugEvents = ({ events }: { events: SessionEvent[] }): ReactNode =
     filter === "all" || (filter === "runner" ? event.source === "RUNNER" : event.source !== "RUNNER"));
   return (
     <Card
-      title={<button type="button" className="flex items-center gap-[8px] border-0 bg-transparent p-0 text-[13.5px]" onClick={() => setOpen(!open)}>
+      title={<button type="button" className="flex items-center gap-[8px] border-0 bg-transparent p-0 text-[13.5px] [@media(max-width:900px)]:min-h-[44px]" onClick={() => setOpen(!open)}>
         <span className="text-muted-foreground"><IconChevron open={open} /></span>{t("sessions.debug.title")}
       </button>}
       extra={<span className={COUNT}>{events.length}</span>}
@@ -587,7 +587,7 @@ export const FilesTouched = ({ files, hint }: { files: Array<{ path: string; cou
   const t = useT();
   return (
     <Card
-      title={<button type="button" className="flex items-center gap-[8px] border-0 bg-transparent p-0 text-[13.5px]" onClick={() => setOpen(!open)}>
+      title={<button type="button" className="flex items-center gap-[8px] border-0 bg-transparent p-0 text-[13.5px] [@media(max-width:900px)]:min-h-[44px]" onClick={() => setOpen(!open)}>
         <span className="text-muted-foreground"><IconChevron open={open} /></span>{t("sessions.files.title")}
       </button>}
       extra={<span className={COUNT}>{files.length}</span>}

--- a/apps/web/src/tests/costs.test.tsx
+++ b/apps/web/src/tests/costs.test.tsx
@@ -6,7 +6,8 @@ import { mountPage } from "./dom-harness";
 
 import {
   COSTS_COLUMNS, COSTS_RANGES, ChartLegend, DailySpendChart, ModelBar, SERIES_SLOTS, axisDates,
-  ChainsTable, sortCostChains, chartSegments, chartSeries, percent, seriesColor, sharePct, wasteShare,
+  ChainsTable, PHONE_CHART, WIDE_CHART, sortCostChains, chartSegments, chartSeries, percent,
+  seriesColor, sharePct, wasteShare,
 } from "../pages/Costs";
 import type { CostsReport } from "../lib/types";
 import type { CostsPageReport } from "../pages/Costs";
@@ -71,6 +72,35 @@ test("an empty window produces no geometry at all", () => {
   assert.deepEqual(chartSegments([], ["Dev"], 5), []);
 });
 
+test("the phone geometry is a taller box in fewer units, so its type stays legible", () => {
+  // Everything in the chart is measured in viewBox units, `fontSize` included,
+  // so a 306px-wide card renders a 1200-unit box at a quarter scale: the plot
+  // came out 61px tall and both axes at 3.3px. Fewer units across is what buys
+  // the type back, and a taller box is what buys the bars back.
+  assert.ok(PHONE_CHART.width < WIDE_CHART.width / 2);
+  assert.ok(PHONE_CHART.height / PHONE_CHART.width > WIDE_CHART.height / WIDE_CHART.width);
+  // 306px of card over 400 units is 0.77px a unit, so 15 units lands near the
+  // 11.5px the hints around the chart use.
+  assert.ok(PHONE_CHART.fontSize * (306 / PHONE_CHART.width) > 11);
+  // `$1234.56` is eight monospace characters at ~0.6em; the gutter has to hold
+  // them plus the 8px the label is offset by.
+  assert.ok(PHONE_CHART.padLeft >= 8 * PHONE_CHART.fontSize * 0.6 + 8);
+});
+
+test("a full-height day rests on the phone baseline too, and its bar stays a bar", () => {
+  const [only] = chartSegments([bucket("2026-08-26", { Dev: "5" })], ["Dev"], 5, PHONE_CHART);
+  assert.ok(only);
+  assert.equal(only.y, PHONE_CHART.padTop);
+  assert.equal(only.y + only.height, PHONE_CHART.height - PHONE_CHART.padBottom);
+  // Thirty days of a 322-unit plot make a 10.7-unit column, so the cap never
+  // binds and a bar is never wider than its column.
+  const month = Array.from({ length: 30 }, (_, index) => bucket(`d${index}`, { Dev: "1" }));
+  for (const segment of chartSegments(month, ["Dev"], 1, PHONE_CHART)) {
+    assert.ok(segment.width <= PHONE_CHART.maxBar);
+    assert.ok(segment.width < (PHONE_CHART.width - PHONE_CHART.padLeft - PHONE_CHART.padRight) / month.length);
+  }
+});
+
 test("the date axis shows three labels however long the window is", () => {
   assert.deepEqual(axisDates(Array.from({ length: 90 }, (_, index) => bucket(`d${index}`, {}))), [0, 44, 89]);
   assert.deepEqual(axisDates(Array.from({ length: 7 }, (_, index) => bucket(`d${index}`, {}))), [0, 3, 6]);
@@ -93,6 +123,21 @@ test("the chart renders one fill per segment, each with a readable tooltip", () 
   assert.ok(markup.includes('role="img"'));
   // Ink stays on text tokens; only the fills carry series colour.
   assert.ok(markup.includes('fill="var(--faint)"'));
+});
+
+test("the phone chart draws itself in the phone viewBox", () => {
+  const daily = [bucket("2026-08-26", { Dev: "3" })];
+  const markup = renderToStaticMarkup(
+    <DailySpendChart daily={daily} order={["Dev"]} colors={colorsFor(["Dev"])} geometry={PHONE_CHART} />,
+  );
+  assert.ok(markup.includes(`viewBox="0 0 ${PHONE_CHART.width} ${PHONE_CHART.height}"`));
+  assert.ok(markup.includes(`font-size="${PHONE_CHART.fontSize}"`));
+  // The default is still the wide box, so nothing that does not ask for a phone
+  // gets one.
+  const wide = renderToStaticMarkup(
+    <DailySpendChart daily={daily} order={["Dev"]} colors={colorsFor(["Dev"])} />,
+  );
+  assert.ok(wide.includes(`viewBox="0 0 ${WIDE_CHART.width} ${WIDE_CHART.height}"`));
 });
 
 test("a window with no spend says so instead of drawing an empty box", () => {

--- a/apps/web/src/tests/mobile-reach.test.tsx
+++ b/apps/web/src/tests/mobile-reach.test.tsx
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { KeyValue, METRICS, Segmented } from "../components/ui";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Select } from "../components/ui/select";
+
+/**
+ * What a phone must be able to reach and read.
+ *
+ * The shapes below were measured at 390x844 against the production control
+ * plane: a two-column definition list broke `danger-full-access` mid-word, three
+ * metrics claimed a whole first screen, and every text control was 28-34px tall
+ * against the 44px an operator's finger needs. The assertions are on class
+ * strings because jsdom computes no layout and the breakpoint is a media query —
+ * so what is pinned is the rule, not the rendered pixel.
+ */
+
+/** The one breakpoint the application has; `max-[900px]:` is not the same query
+ *  and would stop a pixel short (see the note in components/ui.tsx). */
+const PHONE = "[@media(max-width:900px)]:";
+
+const source = (file: string): string =>
+  readFileSync(fileURLToPath(new URL(`../components/${file}`, import.meta.url)), "utf8");
+
+test("a definition list is one column on a phone, whatever it is on a desktop", () => {
+  const markup = renderToStaticMarkup(
+    <KeyValue columns={3} items={[{ k: "Codex sandbox", v: "danger-full-access" }]} />,
+  );
+  assert.match(markup, /grid-cols-\[repeat\(3,minmax\(0,1fr\)\)\]/);
+  assert.ok(markup.includes(`${PHONE}grid-cols-[minmax(0,1fr)]`), "the phone column count is not pinned");
+  // The two-column default takes the same phone rule, so no call site is left
+  // holding a second column it never asked for.
+  const two = renderToStaticMarkup(<KeyValue items={[{ k: "Branch", v: "main" }]} />);
+  assert.ok(two.includes(`${PHONE}grid-cols-[minmax(0,1fr)]`));
+});
+
+test("metrics sit two to a row on a phone rather than one", () => {
+  assert.ok(METRICS.includes(`${PHONE}grid-cols-[repeat(auto-fit,minmax(140px,1fr))]`));
+});
+
+test("the controls an operator taps are at least 44px on a phone", () => {
+  const legacy = renderToStaticMarkup(<Button variant="legacy" size="legacy">Refresh</Button>);
+  const small = renderToStaticMarkup(<Button variant="legacy" size="legacySmall">Edit</Button>);
+  for (const markup of [legacy, small]) assert.ok(markup.includes(`${PHONE}min-h-[44px]`));
+  // `min-h`, not `h`: the onboarding wizard passes `h-auto` and must still clear
+  // the target rather than collapse back to its content height.
+  for (const markup of [renderToStaticMarkup(<Input />), renderToStaticMarkup(<Select />)]) {
+    assert.ok(markup.includes(`${PHONE}min-h-[44px]`));
+  }
+  const segmented = renderToStaticMarkup(
+    <Segmented value="a" onChange={() => undefined} options={[{ value: "a", label: "Today" }, { value: "b", label: "7d" }]} />,
+  );
+  assert.ok(segmented.includes(`${PHONE}min-h-[44px]`));
+});
+
+test("the controls too small to grow carry a hit halo instead", () => {
+  // A `::before` overlay is hit-tested as part of its host and takes no space in
+  // the flow, which is the only way the 16px back arrow and the 28px row menu
+  // reach 44px without moving the title and the card content beside them.
+  const ui = source("ui.tsx");
+  assert.ok(ui.includes(`export const TOUCH_HALO = "relative before:absolute before:content-[''] ${PHONE}before:-inset-[14px]"`),
+    "the halo lost its shape");
+  assert.ok(ui.includes("BACK_LINK = `") && ui.includes("${TOUCH_HALO}`"), "the back link lost its halo");
+  assert.match(ui, /variant="icon" size="legacyIcon" className=\{TOUCH_HALO\}/);
+  assert.ok(source("ui/dialog.tsx").includes(`${PHONE}before:-inset-[16px]`), "the dialog close lost its halo");
+});
+
+test("the phone status strip says it can be swiped without showing a scrollbar", () => {
+  const list = source("mobile-task-list.tsx");
+  // Two elements: the fade is painted by the bar, which does not scroll, and the
+  // tablist is the scroller inside it. One element cannot do both — an overlay
+  // inside a scroll container travels with the content it is meant to fade.
+  assert.match(list, /const TABS_BAR = "sticky top-\[52px\][^"]*after:bg-\[linear-gradient\(to_right,transparent,var\(--popover\)\)\]"/);
+  assert.match(list, /const TABS = "flex gap-\[6px\] overflow-x-auto \[scrollbar-width:none\] \[&::-webkit-scrollbar\]:hidden/);
+  assert.match(list, /<div className=\{TABS_BAR\}>\s*<div className=\{TABS\} role="tablist"/);
+});


### PR DESCRIPTION
Second pass over the sub-900px application. Every page below was opened at
390x844 against the production control plane, in light and dark, and read
before it was changed.

## What each page showed

| Page | Found | Done |
| --- | --- | --- |
| Onboarding (5 screens) | No overflow. The confirmation's disclosure list broke `danger-full-access` mid-word and split `Environment networking` over two lines; Back/Next 34px, inputs 39px, the acknowledge checkbox 13px | One-column list, 44px controls, a hit halo on the checkbox |
| Inbox thread | **Horizontal page scroll**: the subject is the first line of the body, and an auto-deploy notice carries two 40-character shas, so the title ran to 460px and pushed the status pill to 530px in a 380px viewport | The title breaks inside a word; the pills wrap to their own line on a phone |
| Goal detail | No overflow. Three metric cards claimed the whole first screen | Metrics two to a row |
| Project detail | No overflow. Four metric cards, same problem | Same |
| Trigger detail | No overflow, nothing to fix (the example project has no trigger with a secret, so this was read on a plain template) | — |
| Session detail | No overflow, but the worst squeeze in the application: a task title read two words to a line and a workspace path was chopped into three | One-column list; the disclosure toggles ("Files touched", "Debug events") were 20px |
| New Task panel | Nothing structural. It is a `FullPanel`, not the centred dialog — it already goes edge to edge below 900px. Only its controls were small | 44px controls |
| `Modal` dialogs (New Project, New Secret, the task wave dialogs) | Fit the viewport; the close X was a 16px target | Hit halo |
| Costs, lower half | **The daily spend chart was unreadable**: 306x61 with both axes at 3.3px | A phone geometry; 306x260 with legible dates |
| Task card row menu | Trigger 28px, menu items 26px | Halo on the trigger, 44px menu items |
| Board status strip | Cut off after "Review" with no scrollbar and no other hint | Right-edge fade |

Sweep after the change: `document.scrollWidth === clientWidth` on all 20 routes,
list and detail. The only elements still wider than the viewport are inside
`overflow-x: auto` containers (the data tables) or truncate with an ellipsis by
design (the sessions list).

## The four changes worth reading

**Definition lists go to one column below 900px.** Two columns of a 358px page
are about 145px each, which is a dozen monospace characters. Height is the cheap
axis on a phone and width is the scarce one.

**Metrics go the other way.** `minmax(180px,…)` resolved to a single column at
358px, so `METRICS` gets `minmax(140px,…)` on a phone.

**The chart gets its own geometry.** Everything in `DailySpendChart` is measured
in viewBox units, `fontSize` included, so a 306px card rendered the 1200-unit box
at a quarter scale. `chartSegments` and the component now take a `ChartGeometry`;
`WIDE_CHART` is the default and unchanged, `PHONE_CHART` is 400x340 with a
`padLeft` sized for `$1234.56`.

**Touch targets are 44px, two ways.** Controls that can grow do
(`min-h`, not `h`, because the onboarding wizard passes `h-auto`). Controls that
cannot — the 16px back arrow, the 28px row menu, the checkbox, the dialog close —
carry a `::before` halo, which is hit-tested as part of its host and takes no
space in the flow. Growing the back arrow in place would have pushed the title
across on every detail page.

## Deliberately not done

- **Data tables → card lists (Agents, Projects, Connections, Secrets, Costs'
  three tables).** They scroll horizontally today and the name column stays
  readable, so they work; the columns behind it need a swipe nobody advertises.
  A card list is a per-table decision about which two facts survive, times six
  tables, plus tests and copy — a PR of its own. The cheap half-measure, a
  right-edge fade on `table-container` like the status strip's, is a one-line
  change if Moson wants the affordance before the conversion.
- **iOS focus zoom.** Safari zooms when a focused field is under 16px, and this
  application's inputs are 12.5px. Raising them to 16px on a phone would be the
  fix; it would also make the form type larger than the prose around it, in an
  application whose whole scale is pinned to a 13px root. Left alone; the
  alternative, `maximum-scale=1`, disables pinch zoom and is worse.
- **`Toggle` (38x21) and `Check` (17px).** A halo on either would overlap the
  row above and below in the stacked lists they appear in, and taps in the
  overlap would land on the wrong control. They are wide targets already; a
  proper fix is row-level, not control-level.
- Inline text links inside prose and table cells stay their own height.

## Checks

`npm test -w @anneal/web` (630 tests), `npm run lint`, `npm run typecheck -w @anneal/web`.
No `docs/` change. Desktop layout is untouched: every rule added is inside
`[@media(max-width:900px)]`, except the inbox title's `min-w-0` and the chart's
default geometry, which is `WIDE_CHART`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZA4mLcGZUv8vRimrtVByx