### PR TITLE
chore(gate): give type-aware eslint a 3.5 GiB heap

### DIFF
--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -766,11 +766,13 @@ run_database_tests() {
 
 parallel_lint() {
   local biome="${GATE_TMP}/lint-biome.log" types="${GATE_TMP}/lint-types.log" biome_pid types_pid failed=0
-  local eslint_node_options="${NODE_OPTIONS:+${NODE_OPTIONS} }--max-old-space-size=2560"
+  local eslint_node_options="${NODE_OPTIONS:+${NODE_OPTIONS} }--max-old-space-size=3584"
   (cd "${REPO_ROOT}" && npm run lint:biome) >"${biome}" 2>&1 & biome_pid=$!
   # Node 26 caps its heap near 1.8 GiB on the 4 GiB worker; the type-aware
   # project service now crosses that boundary before completing. Raise only
-  # this process's ceiling. The option is a limit, not a reservation.
+  # this process's ceiling. The option is a limit, not a reservation. 2560
+  # was exceeded on 2026-09-05 (main already scavenged at ~2.5 GiB; the
+  # staffing console tree pushed it over), so the limit is 3.5 GiB now.
   (cd "${REPO_ROOT}" && NODE_OPTIONS="${eslint_node_options}" npm run lint:types) >"${types}" 2>&1 & types_pid=$!
   wait "${biome_pid}" || failed=1
   wait "${types_pid}" || failed=1


### PR DESCRIPTION
The merge gate pinned eslint's heap at 2560 MiB. PR #493 (staffing console) failed the gate twice with a V8 heap OOM inside `lint:types`; main already scavenges at ~2.5 GiB on ci-desktop-worker. Raise only this process's ceiling to 3584 MiB (a limit, not a reservation). No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UqwgvXDD1PJ2EFUEGcNdZ