### PR TITLE
fix(web): the board card's hold action reads "Hold"

### DIFF
--- a/apps/web/src/components/chain-aggregate-card.tsx
+++ b/apps/web/src/components/chain-aggregate-card.tsx
@@ -149,7 +149,7 @@ export const ChainAggregateCard = ({ aggregate, members = [], representativeTask
           data-chain-hold=""
           onClick={(event) => { event.stopPropagation(); handlers.onHold(controlAction.taskId); }}
         >
-          {t(state === "running" ? "tasks.aggregate.stopAfter" : "tasks.aggregate.hold")}
+          {t("tasks.aggregate.hold")}
         </Button>,
       ] : []),
       ...(controlAction?.kind === "resume" ? [

--- a/apps/web/src/locales/en.ts
+++ b/apps/web/src/locales/en.ts
@@ -981,7 +981,6 @@ export const en = {
   "tasks.aggregate.state.settled": "Settled",
   "tasks.aggregate.state.stopsAfter": "Stops after step",
   "tasks.aggregate.state.waiting-on-predecessor": "Waiting",
-  "tasks.aggregate.stopAfter": "Stop after current step",
   "tasks.aggregate.waitingOn": "Locked by: {name}",
   "tasks.announcement.moved": "Moved {name} to {status}",
   "tasks.archiveAll": "Archive All",

--- a/apps/web/src/locales/zh.ts
+++ b/apps/web/src/locales/zh.ts
@@ -974,7 +974,6 @@ export const zh = {
   "tasks.aggregate.state.settled": "已完成",
   "tasks.aggregate.state.stopsAfter": "将在步骤完成后停止",
   "tasks.aggregate.state.waiting-on-predecessor": "等待中",
-  "tasks.aggregate.stopAfter": "在当前步骤完成后停止",
   "tasks.aggregate.waitingOn": "已锁定：{name}",
   "tasks.announcement.moved": "已将 {name} 移至{status}",
   "tasks.archiveAll": "全部归档",

--- a/apps/web/src/tests/chain-aggregate-board.test.tsx
+++ b/apps/web/src/tests/chain-aggregate-board.test.tsx
@@ -164,7 +164,7 @@ test("an aggregate board card carries the stranded salvage count from its member
 
 test("the hold pill and Resume follow the persisted hold, running or held", () => {
   const running = renderToStaticMarkup(<ChainAggregateCard aggregate={aggregate()} />);
-  assert.match(running, />Stop after current step<\/button>/u);
+  assert.match(running, />Hold<\/button>/u);
 
   const held = renderToStaticMarkup(<ChainAggregateCard aggregate={aggregate({
     activation: {
@@ -216,7 +216,7 @@ test("the card and the Doing column head offer Hold for exactly the same chains"
     const projection = aggregate({ activation, status: "DOING" });
     const card = renderToStaticMarkup(<ChainAggregateCard aggregate={projection} />);
     const head = holdColumn(boardEntries([chainStep("step-3", 3, "DOING", projection)]));
-    const onCard = offersButton(card, translate("en", activation.state === "running" ? "tasks.aggregate.stopAfter" : "tasks.aggregate.hold"));
+    const onCard = offersButton(card, translate("en", "tasks.aggregate.hold"));
     assert.equal(onCard, offered, `card, ${activation.state}`);
     assert.equal(offersButton(head, translate("en", "tasks.holdAll")), offered, `column head, ${activation.state}`);
   }

--- a/apps/web/src/tests/tasks-board.test.tsx
+++ b/apps/web/src/tests/tasks-board.test.tsx
@@ -1133,7 +1133,7 @@ test("aggregate Hold and Resume post fresh chain-control request ids", async () 
     "*": [],
   });
   try {
-    await page.press(en("tasks.aggregate.stopAfter"));
+    await page.press(en("tasks.aggregate.hold"));
     await page.press(en("tasks.aggregate.resume"));
     const controlRequests = page.requests.filter(({ method, path }) => method === "POST" && /chain\/(?:hold|resume)$/u.test(path));
     assert.deepEqual(controlRequests.map(({ path }) => path), [


### PR DESCRIPTION
The Doing-column chain card labelled its hold action "Stop after current step" while a Run was active and "Hold" otherwise. Same action, two labels; the long one crowded the card and read as a harsher operation than the column's "Hold all". The hold pill already says "Stops after step" once pressed.

- `chain-aggregate-card.tsx`: one label, `tasks.aggregate.hold`.
- `en.ts` / `zh.ts`: the unused `tasks.aggregate.stopAfter` key is removed.
- Tests updated to the single label.

Verified: `npm run lint`, `npm run test -w @anneal/web`. Merge gate dispatched on the pushed head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UqwgvXDD1PJ2EFUEGcNdZ