### PR TITLE
test(runner): merge-train noisy fixture gate flushes its verdict before exiting

### DIFF
--- a/packages/runner/src/merge-train-script.test.ts
+++ b/packages/runner/src/merge-train-script.test.ts
@@ -118,14 +118,18 @@ if (behavior === "delayed-pass") {
   console.log("MERGE GATE: FAIL (fixture failure)");
   process.exit(1);
 } else if (behavior === "noisy-fail" || behavior === "noisy-pass") {
+  // The real gate is a shell script whose writes block until the reader drains.
+  // This fixture writes far more than a pipe holds, so it must end by falling
+  // off the bottom rather than through process.exit(): exiting discards the
+  // still-queued tail, which is exactly the verdict line the tool classifies.
   console.log("run-gate: failure excerpt (last 200 lines per failing step)");
   for (let line = 0; line < 200; line += 1) console.log("noise ".repeat(12) + line);
   if (behavior === "noisy-pass") {
     console.log("MERGE GATE: PASS " + oid);
-    process.exit(0);
+  } else {
+    console.log("MERGE GATE: FAIL (fixture failure)");
+    process.exitCode = 1;
   }
-  console.log("MERGE GATE: FAIL (fixture failure)");
-  process.exit(1);
 } else if (behavior === "block-cleanup") {
   fs.chmodSync(require("node:path").dirname(process.cwd()), 0o500);
   console.log("MERGE GATE: PASS " + oid);


### PR DESCRIPTION
Since bf3d3f86 (#533) every merge gate run inside a platform Run failed deterministically in `merge-train-script.test.ts` ("a gate excerpt larger than the budget still carries its verdict line", noisy-fail → `no-verdict`). Root cause is the test fixture: the noisy gate script wrote ~15 KB then called `process.exit(1)`, which discards queued pipe output on a loaded Linux worker, so the `MERGE GATE: FAIL` line never reached the tool. The tool's verdict logic (`merge-train.mjs` `gateVerdict`) is correct and unchanged. The fixture now sets `process.exitCode` and exits naturally.

Reproduced at component level on the Linux gate host (200-line noise: stdout truncated with `process.exit`, complete with `process.exitCode`); Mac could not reproduce end to end. Runner tests 607 pass / 2 skipped, typecheck, lint and snapshot-scan green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrVjUxF6renFin2NcwYZQ3