### PR TITLE
chore(merge-tail): allow three automatic review-fix and gate-fix attempts

### DIFF
--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -55,6 +55,14 @@ SPEC and Plan are optional. The Product Contract is required.
 Current-session work is outside these tiers and needs no Product Contract. The
 tiers apply only to a task chain the human user explicitly requests.
 
+A change stays in the session when its diff can be named in one sentence
+before it is written and its Acceptance is an existing named suite: a
+constant, a threshold, prose, configuration, a rename, or a single-function
+fix. The host window delivers it through the gate and the single-candidate
+path in `CONTRIBUTING.md`. A change goes to a chain when writing it takes
+implementation judgement the review steps must check, or when it alters what
+the merge gate, merge automation, or a migration does.
+
 Choose the shortest tier satisfying the Product Contract:
 
 - Direct: no specification or plan; implementation starts from the task brief

--- a/packages/api/src/merge-tail-actions.ts
+++ b/packages/api/src/merge-tail-actions.ts
@@ -1151,7 +1151,8 @@ export const handleRegressionCompletion = async (
   // A refresh conflict is a merge of two fixed trees: a second resolver run on
   // the same head has nothing new to work with. A semantic or gate FAIL does —
   // the first repair moved the tree, and the verdict it now fails on is a
-  // different one — so those get a second attempt before the tail stops.
+  // different one — so those get further attempts, up to the limit, before
+  // the tail stops.
   const attemptLimit = repairKind === "refresh-conflict" ? 1 : MAX_MERGE_TAIL_REPAIR_ATTEMPTS;
   if (priorAttempts >= attemptLimit) {
     return stop(repairKind === "refresh-conflict"

--- a/packages/api/src/merge-tail-repair-reentry.test.ts
+++ b/packages/api/src/merge-tail-repair-reentry.test.ts
@@ -335,7 +335,7 @@ test("operator recovery repair maps a gate verdict onto the gate-fix budget", as
 
   const exhausted = scenario({
     verdict: "gate-fail",
-    markers: [marker("gate-fix", "older-run-1"), marker("gate-fix", "older-run-2")],
+    markers: [marker("gate-fix", "older-run-1"), marker("gate-fix", "older-run-2"), marker("gate-fix", "older-run-3")],
   });
   const result = await request(exhausted);
   assert.equal("detail" in result && result.detail?.code, "merge_tail_repair_budget_exhausted");
@@ -365,6 +365,7 @@ test("operator recovery repair counts the existing per-kind budget", async () =>
   const observed = scenario({ markers: [
     marker("review-fix", "older-run-1"),
     marker("review-fix", "older-run-2"),
+    marker("review-fix", "older-run-3"),
   ] });
 
   const result = await request(observed);

--- a/packages/api/src/merge-tail-repair.dbtest.ts
+++ b/packages/api/src/merge-tail-repair.dbtest.ts
@@ -43,6 +43,7 @@ const BASE = "b".repeat(40);
 const BRANCH = "agentos/repair-test";
 const RESOLVED = "c".repeat(40);
 const REPAIRED = "d".repeat(40);
+const REPAIRED_AGAIN = "e".repeat(40);
 const exec = promisify(execFile);
 
 let seedCounter = 0;
@@ -698,7 +699,7 @@ test("a renamed canonical resolver still receives the refresh-conflict repair", 
   }), 0);
 });
 
-test("a gate FAIL is repaired twice and the third FAIL escalates with both heads in activity", async () => {
+test("a gate FAIL is repaired three times and the fourth FAIL escalates with both heads in activity", async () => {
   const seeded = await exercise("gate-fail");
   const first = await repairFor(seeded, "gate-fix");
   assert.equal((await db.agent.findUniqueOrThrow({ where: { id: first.assigneeAgentId! } })).name, "senior-dev-astra-medium");
@@ -716,9 +717,18 @@ test("a gate FAIL is repaired twice and the third FAIL escalates with both heads
   await completeRepair(seeded, second.id, "Fixed the remaining failure and reran the affected suite.", REPAIRED);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 3);
   assert.equal(await failRegressionAgain(seeded, "gate-fail", 3, REPAIRED), "handled");
-  assert.equal(await repairCount(seeded), 2);
+  assert.equal(await repairCount(seeded), 3);
+  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 0);
+  const third = await db.task.findFirstOrThrow({
+    where: { projectId: seeded.project.id, name: "Autonomous merge tail: gate-fix" },
+    orderBy: { createdAt: "desc" },
+  });
+  await completeRepair(seeded, third.id, "Fixed the last failure and reran the affected suite.", REPAIRED_AGAIN);
+  assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 4);
+  assert.equal(await failRegressionAgain(seeded, "gate-fail", 4, REPAIRED_AGAIN), "handled");
+  assert.equal(await repairCount(seeded), 3);
   const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
-  assert.match(notice.body, /after 2 automatic repair attempts/u);
+  assert.match(notice.body, /after 3 automatic repair attempts/u);
   const trail = await db.taskActivity.findMany({ where: { taskId: seeded.regression.id }, select: { body: true } });
   assert.match(trail.map(({ body }) => body).join("\n"), new RegExp(`${HEAD}.*${BASE}`, "s"));
 });
@@ -774,7 +784,7 @@ test("a gate-fix prompt renders its failure excerpt while other repair prompts r
   ].join("\n\n"));
 });
 
-test("a semantic FAIL skips the gate path and is repaired twice before it escalates", async () => {
+test("a semantic FAIL skips the gate path and is repaired three times before it escalates", async () => {
   const seeded = await exercise("review-fail");
   const first = await repairFor(seeded, "review-fix");
   assert.equal((await db.agent.findUniqueOrThrow({ where: { id: first.assigneeAgentId! } })).name, "senior-dev-astra-medium");
@@ -793,9 +803,18 @@ test("a semantic FAIL skips the gate path and is repaired twice before it escala
   await completeRepair(seeded, second.id, "Closed the remaining finding and reran its focused regression.", REPAIRED);
   assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 3);
   assert.equal(await failRegressionAgain(seeded, "review-fail", 3, REPAIRED), "handled");
-  assert.equal(await repairCount(seeded), 2);
+  assert.equal(await repairCount(seeded), 3);
+  assert.equal(await db.inboxMessage.count({ where: { taskId: seeded.regression.id } }), 0);
+  const third = await db.task.findFirstOrThrow({
+    where: { projectId: seeded.project.id, name: "Autonomous merge tail: review-fix" },
+    orderBy: { createdAt: "desc" },
+  });
+  await completeRepair(seeded, third.id, "Closed the last finding and reran its focused regression.", REPAIRED_AGAIN);
+  assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), 4);
+  assert.equal(await failRegressionAgain(seeded, "review-fail", 4, REPAIRED_AGAIN), "handled");
+  assert.equal(await repairCount(seeded), 3);
   const notice = await db.inboxMessage.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
-  assert.match(notice.body, /after 2 automatic repair attempts/u);
+  assert.match(notice.body, /after 3 automatic repair attempts/u);
 });
 
 test("all five merge-tail repairs grant the sixth Regression run without changing the configured budget", async () => {
@@ -815,8 +834,8 @@ test("all five merge-tail repairs grant the sixth Regression run without changin
     await completeRepair(seeded, repair.id, output, headSha);
   };
 
-  // The repair cap is one refresh conflict plus two attempts for each review
-  // and gate failure. Every successful repair queues a fresh Regression Run;
+  // The repair cap is one refresh conflict plus three attempts for each review
+  // and gate failure; five repairs stay inside it. Every successful repair queues a fresh Regression Run;
   // only those platform requeues should accumulate grants.
   await completeLatest("review-fix", repairOutput, heads[1]!);
   assert.equal(await failRegressionAgain(seeded, "gate-fail", 2, heads[1]!), "handled");

--- a/packages/db/src/merge-tail.ts
+++ b/packages/db/src/merge-tail.ts
@@ -37,10 +37,10 @@ export const MERGE_TAIL_KIND = {
 /**
  * How many automatic repairs one chain gets per repair kind before the tail
  * stops. A semantic or gate FAIL after a repair is a different verdict against
- * a different tree, so one more attempt is progress rather than a loop; a
+ * a different tree, so another attempt is progress rather than a loop; a
  * refresh conflict is not covered by this and stays at one attempt per head.
  */
-export const MAX_MERGE_TAIL_REPAIR_ATTEMPTS = 2;
+export const MAX_MERGE_TAIL_REPAIR_ATTEMPTS = 3;
 
 export const MAX_AUTOMATIC_BASE_DRIFT_RECOVERIES = 2;
 


### PR DESCRIPTION
Raises `MAX_MERGE_TAIL_REPAIR_ATTEMPTS` from 2 to 3: a chain's merge tail now retries a review-fix or gate-fix repair three times before stopping for the operator. Refresh-conflict stays at one attempt per head.

- `packages/db/src/merge-tail.ts`: constant and comment
- `merge-tail-repair.dbtest.ts`: the two stop tests run a third repair and a fourth FAIL
- `merge-tail-repair-reentry.test.ts`: budget-exhausted cases carry three prior markers
- `docs/governance/task-routing-v1.md`: states which changes stay in the host session and which go to a chain

Verified locally: root `npm run lint`, `npm run test:snapshot-scan`, and the two affected unit files (34 pass). Database tests are merge gate evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNUKJqaZQmo9C3WUz7Bei7