### PR TITLE
fix(api): converge merge train refusals and offline recovery

### DIFF
--- a/packages/api/src/merge-readiness-worker.ts
+++ b/packages/api/src/merge-readiness-worker.ts
@@ -1493,6 +1493,11 @@ export const readinessTick = async (
       discover: discoverReadiness,
       read: (database, task, at) => readReadiness(database, task, at, daemons),
       authorize: authorizeReadinessSettlement,
+      refuse: (read, decision) => decision.kind === "stop"
+        ? stopReadinessSettlement({ readinessTaskId: read.readiness.id, regressionTaskId: read.regression.id,
+          reason: decision.evidence, recovery: read.recovery, refusalCode: null, now: read.input.now })
+        : requeueRegressionSettlement({ readinessTaskId: read.readiness.id, regressionTaskId: read.regression.id,
+          ...decision, recovery: read.recovery, now: read.input.now }),
       executor: {
         blocking: () => executorsBlockingAuthorization(daemons),
         closeEpisode: (tx, read) => closeExecutorOfflineEpisodeTx(tx, read.readiness.id, read.claim, "executor observed online under the train Lease"),

--- a/packages/api/src/merge-tail-readiness.dbtest.ts
+++ b/packages/api/src/merge-tail-readiness.dbtest.ts
@@ -2150,7 +2150,7 @@ test("a tick whose readiness claim was replaced cannot close the offline episode
   });
 });
 
-test("executor return re-arms a ceiling stop without discarding its recovery aggregate", async () => {
+for (const width of [0, 2]) test(`executor return re-arms a ceiling stop with train width ${width} without discarding its recovery aggregate`, async () => {
   await withExecutorAllowlist(EXECUTOR_RUNNER_ID, async () => {
     const seeded = await seedReadiness();
     const run = await db.run.findFirstOrThrow({ where: { taskId: seeded.regression.id } });
@@ -2169,21 +2169,23 @@ test("executor return re-arms a ceiling stop without discarding its recovery agg
       authorizedHeadSha: HEAD, authorizedBaseSha: BASE, observedBaseSha: BASE, currentBaseSha: BASE,
     } });
     const offline = executorsAt(OFFLINE_NOW);
-    await readinessTick(db, reader(), OFFLINE_NOW, 5, releaseChainLease, runWithMergeLease, offline);
+    await readinessTick(db, reader(), OFFLINE_NOW, 5, releaseChainLease, runWithMergeLease, offline, width);
     const expired = new Date(OFFLINE_NOW.getTime() + MERGE_EXECUTOR_OFFLINE_WAIT_MS);
-    await readinessTick(db, reader(), expired, 5, releaseChainLease, runWithMergeLease, offline);
+    await readinessTick(db, reader(), expired, 5, releaseChainLease, runWithMergeLease, offline, width);
     assert.equal((await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: aggregate.id } })).status,
       MergeRecoveryStatus.BLOCKED_DOWNSTREAM);
     const result = await readinessTick(db, reader([], snapshot({ baseSha: "d".repeat(40) })),
-      new Date(expired.getTime() + 1_000), 5, releaseChainLease, runWithMergeLease, executorsAt(ONLINE_NOW));
+      new Date(expired.getTime() + 1_000), 5, releaseChainLease, runWithMergeLease, executorsAt(ONLINE_NOW), width);
     assert.equal(await db.inboxMessage.count({ where: {
       taskId: seeded.regression.id, status: "OPEN",
       dedupeKey: { startsWith: "merge-base-drift-recovery-tail-stop:" },
     } }), 0);
     assert.equal(result.authorized, 0);
-    assert.equal(result.requeued, 1);
+    assert.equal(result.requeued, width === 0 ? 1 : 0);
+    assert.equal((await db.task.findUniqueOrThrow({ where: { id: seeded.readiness.id } })).status, TaskStatus.TODO);
     assert.equal((await db.mergeRecoveryAttempt.findUniqueOrThrow({ where: { id: aggregate.id } })).status,
-      MergeRecoveryStatus.REPAIRING);
+      width === 0 ? MergeRecoveryStatus.REPAIRING : MergeRecoveryStatus.AWAITING_AUTHORIZATION);
+    assert.equal(await db.run.count({ where: { taskId: seeded.regression.id } }), width === 0 ? 2 : 1);
   });
 });
 

--- a/packages/api/src/merge-train-readiness.dbtest.ts
+++ b/packages/api/src/merge-train-readiness.dbtest.ts
@@ -1003,7 +1003,7 @@ test("a changed PR head aborts the train before it can authorize a stale candida
     headShaByPr: new Map([[seed.candidates[0]!.prNumber, changedHead]]),
   }), new Date(TEST_NOW.getTime() + 1_000), 5, releaseChainLease, runWithMergeLease, () => []);
   assert.equal(settled.authorized, 0);
-  assert.equal(settled.requeued, 0);
+  assert.equal(settled.requeued, 1);
   assert.equal(settled.stopped, 0);
   assert.equal(await db.taskActivity.count({ where: {
     taskId: { in: seed.candidates.map((candidate) => candidate.readiness.id) },
@@ -1015,9 +1015,43 @@ test("a changed PR head aborts the train before it can authorize a stale candida
   assert.equal(marker.state, "aborted");
   assert.match(String(marker.reason), /stale PASS head/u);
   assert.deepEqual(releasedChainIds, [seed.candidates[0]!.chainId]);
+  // One formation and one settlement acquisition; candidate requeue never
+  // reacquires or releases the train's Lease independently.
+  assert.equal(leasedTargets.length, 2);
+  const changed = seed.candidates[0]!;
+  assert.notEqual((await db.task.findUniqueOrThrow({ where: { id: changed.regression.id } })).status, TaskStatus.DONE);
+  assert.equal(await db.run.count({ where: { taskId: changed.regression.id } }), 2);
+  const next = await readinessTick(db, readerFor(seed, {
+    headShaByPr: new Map([[changed.prNumber, changedHead]]),
+  }), new Date(TEST_NOW.getTime() + 2_000), 5, releaseChainLease, runWithMergeLease, () => []);
+  assert.equal(next.authorized, 1);
+  assert.equal(next.requeued, 0);
+  assert.equal(await db.task.count({ where: { projectId: seed.project.id, chainId: null } }), 1);
+  assert.equal(await db.run.count({ where: { taskId: changed.regression.id } }), 2);
 });
 
-test("a trailing second-read refusal preserves the passing prefix and returns only that candidate to ready", async () => {
+test("a permanent second-read refusal stops the candidate before the next train tick", async () => {
+  process.env.MERGE_TRAIN_WIDTH = "2";
+  const seed = await seedTrainCandidates(2);
+  await readinessTick(db, readerFor(seed), TEST_NOW, 5, releaseChainLease, runWithMergeLease, () => []);
+  await finishTrainRun(seed, await recordFor(seed, ["pass", "pass"], 2));
+  const facts = readerFor(seed);
+  const refused: PullRequestReader = { ...facts, compareCommits: async (...args) => ({
+    ...await facts.compareCommits!(...args), filesComplete: false,
+  }) };
+  const settled = await readinessTick(db, refused, new Date(TEST_NOW.getTime() + 1_000),
+    5, releaseChainLease, runWithMergeLease, () => []);
+  assert.equal(settled.authorized, 0);
+  assert.equal(settled.stopped, 2);
+  for (const candidate of seed.candidates) {
+    assert.equal((await db.task.findUniqueOrThrow({ where: { id: candidate.readiness.id } })).status, TaskStatus.REVIEW);
+  }
+  await readinessTick(db, refused, new Date(TEST_NOW.getTime() + 2_000), 5, releaseChainLease, runWithMergeLease, () => []);
+  assert.equal(await db.task.count({ where: { projectId: seed.project.id, chainId: null } }), 1);
+  assert.equal(leasedTargets.length, 2);
+});
+
+test("a trailing stale head preserves the passing prefix and requeues only that candidate", async () => {
   process.env.MERGE_TRAIN_WIDTH = "3";
   const seed = await seedTrainCandidates(3);
   await readinessTick(db, readerFor(seed), TEST_NOW, 5, releaseChainLease, runWithMergeLease, () => []);
@@ -1031,6 +1065,7 @@ test("a trailing second-read refusal preserves the passing prefix and returns on
 
   assert.equal(settled.authorized, 2);
   assert.equal(settled.stopped, 0);
+  assert.equal(settled.requeued, 1);
   for (const candidate of seed.candidates.slice(0, 2)) {
     assert.equal((await db.task.findUniqueOrThrow({ where: { id: candidate.readiness.id } })).status, TaskStatus.DONE);
   }
@@ -1040,10 +1075,17 @@ test("a trailing second-read refusal preserves the passing prefix and returns on
     metadata: { path: ["kind"], equals: "mergeTail.repairAttempt" },
   } }), 0);
   const marker = (await trainMarkersFor(trailing.readiness.id)).at(-1)!.metadata as Record<string, unknown>;
-  assert.equal(marker.outcome, "ready");
+  assert.equal(marker.outcome, "requeued");
   assert.equal(marker.settlement, "no-verdict");
   assert.match(String(marker.reason), /stale PASS head/u);
   assert.deepEqual(releasedChainIds, [seed.candidates[0]!.chainId]);
+  assert.notEqual((await db.task.findUniqueOrThrow({ where: { id: trailing.regression.id } })).status, TaskStatus.DONE);
+  assert.equal(await db.run.count({ where: { taskId: trailing.regression.id } }), 2);
+  const next = await readinessTick(db, readerFor(seed), new Date(TEST_NOW.getTime() + 2_000),
+    5, releaseChainLease, runWithMergeLease, () => []);
+  assert.equal(next.authorized, 0);
+  assert.equal(next.requeued, 0);
+  assert.equal(await db.task.count({ where: { projectId: seed.project.id, chainId: null } }), 1);
 });
 
 test("an unapproved gated candidate stops alone and truncates the authorized prefix", async () => {

--- a/packages/api/src/merge-train-readiness.ts
+++ b/packages/api/src/merge-train-readiness.ts
@@ -72,6 +72,7 @@ type TrainHooks = {
   candidates(db: PrismaClient, pageSize: number): AsyncGenerator<ReadinessCandidate>;
   discover(db: PrismaClient, task: ReadinessCandidate, now: Date): Promise<ReadinessDiscovery>;
   read(db: PrismaClient, task: ReadinessCandidate, now: Date): Promise<ReadinessRead>;
+  refuse(read: ClaimedReadiness, decision: Extract<ReadinessDecision, { kind: "stop" | "requeue-regression" }>): ReadinessSettlement;
   authorize(read: ClaimedReadiness, decision: Extract<ReadinessDecision, { kind: "authorize" }>, train: TrainAuthorization): ReadinessSettlement;
   single(db: PrismaClient, read: ClaimedReadiness, decision: ReadinessDecision, result: ReadinessTickResult,
     release: ReleaseMergeLease, lease: WithMergeLease, reader: PullRequestReader): Promise<void>;
@@ -491,17 +492,16 @@ const settleTrain = async (
     const bindingFailure = trainRecordBindingFailure(record, train, await liveBase(reader, reads[0]!));
     if (bindingFailure) throw new Error(bindingFailure);
     const decisions: ReadinessDecision[] = [];
-    for (const [index, read] of reads.entries()) {
+    for (const read of reads) {
       const decision = await evaluateReadiness(reader, { ...read.input,
         regression: { ...read.input.regression, baseHeadSha: record.baseSha },
         train: { baseSha: record.baseSha, candidateHeadSha: read.input.regression.headSha },
       });
-      // A stale base observed anywhere invalidates the whole record. Other
-      // refusals abort only inside the passing prefix: candidate-local trailing
-      // refusals leave that candidate ready without discarding its peers.
-      if ((decision.kind === "requeue-regression" && decision.condition === "train-base-stale")
-        || (decision.kind !== "authorize" && index < record.contiguousPassCount)) {
-        throw new Error(`Merge train second read refused ${read.readiness.id}: ${decision.kind}${"reason" in decision ? `: ${decision.reason}` : "evidence" in decision ? `: ${decision.evidence}` : ""}`);
+      // Base movement invalidates the cumulative record, not the candidate's
+      // Regression. Candidate-local refusals must settle below so an old PASS
+      // cannot form the same failing train again on the next tick.
+      if (decision.kind === "requeue-regression" && decision.condition === "train-base-stale") {
+        throw new Error(`Merge train second read refused ${read.readiness.id}: ${decision.kind}: ${decision.reason}`);
       }
       decisions.push(decision);
     }
@@ -513,6 +513,35 @@ const settleTrain = async (
       if ((await readLatestMarker(tx, train.taskId, "train"))?.state !== "queued") return { authorized: 0, stopped: 0, requeued: 0 };
       for (const read of reads) {
         if (!await evidenceStillMatches(tx, read)) throw new Error(`Merge train candidate ${read.readiness.id} evidence changed during settlement`);
+      }
+      const passingRefusal = decisions.slice(0, record.contiguousPassCount)
+        .find((decision) => decision.kind !== "authorize");
+      if (passingRefusal) {
+        const refusedRead = reads[decisions.indexOf(passingRefusal)]!;
+        const reason = `Merge train second read refused ${refusedRead.readiness.id}: ${passingRefusal.kind}${"reason" in passingRefusal ? `: ${passingRefusal.reason}` : "evidence" in passingRefusal ? `: ${passingRefusal.evidence}` : ""}`;
+        let stopped = 0;
+        let requeued = 0;
+        for (const [index, read] of reads.entries()) {
+          const decision = decisions[index]!;
+          if (decision.kind === "stop" || decision.kind === "requeue-regression") {
+            // Invoke only the settlement body: this transaction already owns
+            // candidate locks and the train owns the one external Merge Lease.
+            const applied = await hooks.refuse(read, decision).body(tx, read.claim);
+            if (!applied.value.applied) throw new Error(`Merge train readiness claim lost for ${read.readiness.id}`);
+            if (decision.kind === "stop" || applied.value.stopped) stopped += 1;
+            else requeued += 1;
+          } else {
+            const applied = await read.claim.settle(tx, { kind: "finish", at: now, apply: async (client) => {
+              await client.task.update({ where: { id: read.readiness.id }, data: { status: TaskStatus.TODO, failureReason: null } });
+              return { value: undefined, ownership: "released" };
+            } });
+            if (!applied.settled) throw new Error(`Merge train readiness claim lost for ${read.readiness.id}`);
+          }
+          await noticeMergeTrainAbort(tx, { readinessTaskId: read.readiness.id, trainTaskId: train.taskId, reason, now });
+          await candidateSettlementMarker(tx, train, index + 1, "aborted", reason);
+        }
+        await finishTrainMarker(tx, train, "aborted", reason, now);
+        return { authorized: 0, stopped, requeued };
       }
       // The approval gate applies per candidate, so one unapproved candidate
       // truncates the prefix here instead of discarding the whole train: the
@@ -548,6 +577,7 @@ const settleTrain = async (
       const summaries: string[] = [];
       let failed = false;
       let stopped = 0;
+      let requeued = 0;
       for (const [index, read] of reads.entries()) {
         const prefix = record.prefixes[index];
         let settlement = "ready";
@@ -582,6 +612,12 @@ const settleTrain = async (
             { verdict: prefix?.verdict ?? "skipped", ...(prefix ? { predecessorOid: prefix.predecessorOid } : {}) });
           summaries.push(`${index + 1}. ${read.readiness.id}: ${prefix?.verdict ?? "skipped"} → ${settlement}`);
           continue;
+        } else if (decision?.kind === "stop" || decision?.kind === "requeue-regression") {
+          const applied = await hooks.refuse(read, decision).body(tx, read.claim);
+          if (!applied.value.applied) throw new Error(`Merge train readiness claim lost for ${read.readiness.id}`);
+          settlement = decision.kind === "stop" || applied.value.stopped ? "stopped" : "requeued";
+          if (settlement === "stopped") stopped += 1;
+          else requeued += 1;
         } else {
           // A gate refusal truncates the published prefix at its position, so
           // every later prefix was gated against a predecessor this settlement
@@ -623,7 +659,7 @@ const settleTrain = async (
         summaries.push(`${index + 1}. ${read.readiness.id}: ${verdict} → ${settlement}`);
       }
       await finishTrainMarker(tx, train, "settled", summaries.join("\n"), now);
-      return { authorized: authorizedCount, stopped, requeued: 0 };
+      return { authorized: authorizedCount, stopped, requeued };
     }, serializable);
     result.authorized += counts.authorized;
     result.stopped += counts.stopped;
@@ -697,7 +733,10 @@ export const mergeTrainReadinessTick = async (
       const fallback: DiscoveredCandidate[] = [];
       for await (const candidate of hooks.candidates(db, Math.max(limit * 20, 100))) {
         if (!isMergeReadinessStep(candidate.templateStep)) continue;
-        if ((candidate.repoId && busyRepos.has(candidate.repoId)) || await excludedRecovery(db, candidate.id)) continue;
+        // REVIEW candidates must reach read(): an executor-offline ceiling
+        // parked their recovery in BLOCKED_DOWNSTREAM, which read can re-arm.
+        if (candidate.repoId && busyRepos.has(candidate.repoId)) continue;
+        if (candidate.status !== TaskStatus.REVIEW && await excludedRecovery(db, candidate.id)) continue;
         const discovery = await hooks.discover(db, candidate, now);
         const entry = { candidate, discovery };
         if (discovery.input.stage === "ready" && candidate.repoId && discovery.input.target.resolved) {
@@ -835,7 +874,9 @@ export const mergeTrainReadinessTick = async (
       // single-candidate tick; a formed train is bounded by `width` instead.
       if (result.claimed >= limit) break;
       if (!isMergeReadinessStep(candidate.templateStep)) continue;
-      if ((candidate.repoId && busyRepos.has(candidate.repoId)) || await excludedRecovery(db, candidate.id)) continue;
+      if (candidate.repoId && busyRepos.has(candidate.repoId)) continue;
+      // Keep the same re-arm path while draining trains after width is disabled.
+      if (candidate.status !== TaskStatus.REVIEW && await excludedRecovery(db, candidate.id)) continue;
       const read = await hooks.read(db, candidate, now);
       if (!read.claimed) continue;
       result.claimed += 1;


### PR DESCRIPTION
A changed PR head during merge train execution previously aborted the train while leaving its old Regression PASS eligible for the next tick. Candidate-local stale-head and stop decisions now settle under the train's existing Lease and readiness claim, so invalid evidence requeues or stops instead of repeatedly forming the same train. Passing peers remain protected by cumulative-prefix checks.

Executor-offline recovery candidates stopped at their ceiling can now reach the existing strict rearm checks while merge train is enabled. Other repairing or blocked candidates remain excluded.

Validation: API lint and typecheck; 43 focused unit tests; compose binding check. Added multi-tick database regressions for stale-head, permanent refusal, trailing refusal, and executor recovery at train widths 0/2. The required exact-head Merge gate will run before publication through the single-candidate path.

Delivery: `MERGE GATE: PASS a3683bb06581252f50bf8260f913392f1d99a9d6` against baseline `116a3c51b3d5fccdaaa02cbe800f6382e1941b86`. Independent review found no must-fix. Published that exact integrated head under the task-owned Merge Lease; GitHub confirms MERGED.
