### PR TITLE
fix(revalidation): preserve retired Chain output protocols

### DIFF
--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -2910,14 +2910,17 @@ curl "$BASE_URL/tasks/$TASK_ID/output" -H "Authorization: Bearer $OPERATOR_TOKEN
 - Required path parameter: `taskId`.
 - Required JSON fields: `kind`, `body`.
 - Optional JSON fields: `fencingToken`, `metadata`, `commitSha`.
-- When `kind` is `revalidation`, `body` must be the canonical version-2
+- On current Direct Steps, when `kind` is `revalidation`, `body` must be the canonical version-2
   revalidation object, including `schemaVersion`, `headSha`, `outcome`,
   `summary`, `changedReferences`, and a `route` object with one of the four
   tiers (`default`, `frontend`, `hard`, or `hazard`) and a non-empty reason.
   Version-1 bodies, missing routes, unknown tiers, and empty reasons are
-  rejected; the output kind and body schema must agree.
+  rejected; the output kind and body schema must agree. Retired Direct Chains
+  from before judged implementation routing retain their version-1 contract
+  without a route, selected by the persisted template generation. Their output
+  preserves the implementation assignee. The same rule applies to session output.
 - For a direct Chain's Route-less implementation Task with no Run, storing a
-  valid revalidation output applies the selected staffing profile's tier slot
+  valid version-2 revalidation output applies the selected staffing profile's tier slot
   to that Task in the same transaction. A Route line or explicit implementation
   `stepOverrides` assignee wins and is recorded as an override; an empty slot,
   an existing Run, or a missing Repo `GIT_WRITE` grant is recorded in the Task's

--- a/packages/api/src/canonical-task-output.test.ts
+++ b/packages/api/src/canonical-task-output.test.ts
@@ -644,3 +644,68 @@ test("a noncanonical implementation continuation does not diagnose its unrelated
   assert.equal("ok" in result && result.ok, true);
   assert.deepEqual(activities, []);
 });
+
+const persistRevalidationOutput = async (templateName: string, schemaVersion: number, includeRoute = false) => {
+  const task = {
+    id: "revalidation-task", projectId: "project", chainId: "chain", chainIndex: 1,
+    chainLayer: 1, status: "IN_PROGRESS",
+    templateStep: step(templateName, 1, "revalidation"),
+  };
+  let routeLookups = 0;
+  let writes = 0;
+  const tx = {
+    $queryRaw: async () => [{ id: "locked" }],
+    run: { findFirst: async (query: { select?: { taskId?: boolean } }) => (
+      query.select?.taskId ? { taskId: task.id } : { task }
+    ) },
+    task: { findUnique: async () => { routeLookups += 1; return null; } },
+    taskStepOutput: {
+      findUnique: async () => null,
+      upsert: async ({ create }: { create: Record<string, unknown> }) => {
+        writes += 1;
+        return { id: "output", ...create, metadata: null };
+      },
+    },
+  } as unknown as Prisma.TransactionClient;
+  const result = await persistSessionTaskOutput(tx, {
+    task,
+    fence: { runId: "revalidation-run", fencingToken: "fence", at: new Date() },
+    kind: "revalidation", commitSha: IMPLEMENTATION_HEAD,
+    body: JSON.stringify({
+      schemaVersion, headSha: IMPLEMENTATION_HEAD, outcome: "unchanged",
+      summary: "Specification still matches the tree", changedReferences: [],
+      ...(includeRoute ? { route: { tier: "default", reason: "No escalation criterion applies" } } : {}),
+    }),
+  });
+  return { result, routeLookups, writes };
+};
+
+test("retired revalidation v1 output persists without applying an absent implementation route", async () => {
+  const name = "direct-engineer-workflow-legacy-pre-judged-implementation-route-template-row";
+  const legacy = await persistRevalidationOutput(name, 1);
+  assert.ok("ok" in legacy.result && legacy.result.ok);
+  assert.equal(legacy.writes, 1);
+  assert.equal(legacy.routeLookups, 0);
+  assert.ok(legacy.result.ok && "output" in legacy.result);
+  assert.equal(canonicalOutputRefusal(
+    step(name, 1, "revalidation"), legacy.result.output, "revalidation-run", IMPLEMENTATION_HEAD,
+  ), null);
+  const wrongVersion = await persistRevalidationOutput(name, 2, true);
+  assert.match(persistenceRefusal(wrongVersion.result) ?? "", /violates schemaVersion 1/u);
+  assert.equal(wrongVersion.writes, 0);
+});
+
+test("current bare revalidation still requires v2 and routes its validated decision", async () => {
+  const name = "direct-engineer-workflow";
+  const legacy = await persistRevalidationOutput(name, 1);
+  assert.match(persistenceRefusal(legacy.result) ?? "", /violates schemaVersion 2/u);
+  assert.equal(legacy.writes, 0);
+  assert.equal(legacy.routeLookups, 0);
+  const missingRoute = await persistRevalidationOutput(name, 2);
+  assert.match(persistenceRefusal(missingRoute.result) ?? "", /route/u);
+  assert.equal(missingRoute.writes, 0);
+  const current = await persistRevalidationOutput(name, 2, true);
+  assert.ok("ok" in current.result && current.result.ok);
+  assert.equal(current.writes, 1);
+  assert.equal(current.routeLookups, 1);
+});

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -13,7 +13,7 @@ import {
   RunStatus,
   runOwnedHead,
   stepRole,
-  stepGeneration,
+  canonicalOutputGeneration,
   type CanonicalClosedReviewArtifact,
   type CanonicalFixedImplementationArtifact,
   type CanonicalReviewArtifact,
@@ -358,7 +358,7 @@ export const canonicalBodyRefusal = (
       : "";
     const schemaVersion = kind === REGRESSION_VERIFICATION_OUTPUT_KIND
       ? REGRESSION_VERIFICATION_SCHEMA_VERSION
-      : Number(stepGeneration(step).slice(1));
+      : Number(canonicalOutputGeneration(step).slice(1));
     return `${kind} task output body violates schemaVersion ${String(schemaVersion)} at ${first?.location ?? "body"}: ${first?.message ?? "invalid value"}${additional}`;
   }
   const bodyHead = (parsed.data as { headSha: string }).headSha;
@@ -560,7 +560,7 @@ export const persistSessionTaskOutput = async (
     }
   }
 
-  if (step && isRevalidationStep(step) && stepGeneration(step) === "v2") {
+  if (step && isRevalidationStep(step) && canonicalOutputGeneration(step) === "v2") {
     const artifact = JSON.parse(input.body) as { route: Parameters<typeof applyRevalidationRoute>[2] };
     await applyRevalidationRoute(tx, task.id, artifact.route);
   }

--- a/packages/api/src/canonical-task-output.ts
+++ b/packages/api/src/canonical-task-output.ts
@@ -13,6 +13,7 @@ import {
   RunStatus,
   runOwnedHead,
   stepRole,
+  stepGeneration,
   type CanonicalClosedReviewArtifact,
   type CanonicalFixedImplementationArtifact,
   type CanonicalReviewArtifact,
@@ -357,7 +358,7 @@ export const canonicalBodyRefusal = (
       : "";
     const schemaVersion = kind === REGRESSION_VERIFICATION_OUTPUT_KIND
       ? REGRESSION_VERIFICATION_SCHEMA_VERSION
-      : kind === "revalidation" ? 2 : 1;
+      : Number(stepGeneration(step).slice(1));
     return `${kind} task output body violates schemaVersion ${String(schemaVersion)} at ${first?.location ?? "body"}: ${first?.message ?? "invalid value"}${additional}`;
   }
   const bodyHead = (parsed.data as { headSha: string }).headSha;
@@ -559,7 +560,7 @@ export const persistSessionTaskOutput = async (
     }
   }
 
-  if (step && isRevalidationStep(step)) {
+  if (step && isRevalidationStep(step) && stepGeneration(step) === "v2") {
     const artifact = JSON.parse(input.body) as { route: Parameters<typeof applyRevalidationRoute>[2] };
     await applyRevalidationRoute(tx, task.id, artifact.route);
   }

--- a/packages/api/src/routes/tasks.test.ts
+++ b/packages/api/src/routes/tasks.test.ts
@@ -1707,3 +1707,53 @@ test("session and task detail return identical complete diagnostics for the same
     assert.equal(queries.filter((query) => query.sql?.includes('FROM "SessionEvent"')).length, 3);
   });
 });
+
+test("operator revalidation output respects the persisted template protocol", async () => {
+  await withTokens(async () => {
+    for (const [templateName, schemaVersion, includeRoute, expectedStatus, expectedRoutes] of [
+      ["direct-engineer-workflow-legacy-pre-judged-implementation-route-row", 1, false, 200, 0],
+      ["direct-engineer-workflow", 1, false, 409, 0],
+      ["direct-engineer-workflow", 2, false, 409, 0],
+      ["direct-engineer-workflow", 2, true, 200, 1],
+    ] as const) {
+      let routeLookups = 0;
+      let writes = 0;
+      const tx = {
+        $queryRaw: async () => [{ id: "task-1" }],
+        task: {
+          findUnique: async ({ select }: { select: Record<string, unknown> }) => {
+            if (select.templateId) { routeLookups += 1; return null; }
+            return { id: "task-1", projectId: "project-1", chainId: null };
+          },
+          findUniqueOrThrow: async () => ({ templateStep: {
+            outputKind: "revalidation", stepIndex: 1, taskTemplate: { name: templateName },
+          } }),
+        },
+        taskStepOutput: {
+          findUnique: async () => null,
+          upsert: async ({ create }: { create: Record<string, unknown> }) => {
+            writes += 1;
+            return { id: "output", ...create, metadata: null };
+          },
+        },
+      };
+      const database = {
+        ...tx, $transaction: async (operation: (client: typeof tx) => Promise<unknown>) => operation(tx),
+      } as unknown as PrismaClient;
+      const response = await createApp(database).request("/tasks/task-1/output", {
+        method: "PUT",
+        headers: { Authorization: "Bearer operator-unit-token", "Content-Type": "application/json" },
+        body: JSON.stringify({
+          kind: "revalidation", commitSha: "a".repeat(40),
+          body: JSON.stringify({
+            schemaVersion, headSha: "a".repeat(40), outcome: "unchanged", summary: "Still valid", changedReferences: [],
+            ...(includeRoute ? { route: { tier: "default", reason: "No escalation criterion applies" } } : {}),
+          }),
+        }),
+      });
+      assert.equal(response.status, expectedStatus, await response.text());
+      assert.equal(writes, expectedStatus === 200 ? 1 : 0);
+      assert.equal(routeLookups, expectedRoutes);
+    }
+  });
+});

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -32,7 +32,7 @@ import {
   stopStateFor,
   sumUsageCosts,
   stepRole,
-  stepGeneration,
+  canonicalOutputGeneration,
   TaskStatus,
   taskIsIntegratorStep,
   type ChainControlAddress,
@@ -1043,7 +1043,7 @@ export const registerTasksRoutes = (app: RouteApp, deps: RouteDeps): void => {
         if (body.kind !== "revalidation") return refusal("conflict", "task_output kind must be revalidation for this canonical step");
         const invalid = canonicalBodyRefusal(task.templateStep, body.body, body.commitSha ?? null, null);
         if (invalid) return refusal("conflict", invalid);
-        if (stepGeneration(task.templateStep) === "v2") {
+        if (canonicalOutputGeneration(task.templateStep) === "v2") {
           const artifact = JSON.parse(body.body) as { route: Parameters<typeof applyRevalidationRoute>[2] };
           await applyRevalidationRoute(tx, taskId, artifact.route);
         }

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -32,6 +32,7 @@ import {
   stopStateFor,
   sumUsageCosts,
   stepRole,
+  stepGeneration,
   TaskStatus,
   taskIsIntegratorStep,
   type ChainControlAddress,
@@ -1042,8 +1043,10 @@ export const registerTasksRoutes = (app: RouteApp, deps: RouteDeps): void => {
         if (body.kind !== "revalidation") return refusal("conflict", "task_output kind must be revalidation for this canonical step");
         const invalid = canonicalBodyRefusal(task.templateStep, body.body, body.commitSha ?? null, null);
         if (invalid) return refusal("conflict", invalid);
-        const artifact = JSON.parse(body.body) as { route: Parameters<typeof applyRevalidationRoute>[2] };
-        await applyRevalidationRoute(tx, taskId, artifact.route);
+        if (stepGeneration(task.templateStep) === "v2") {
+          const artifact = JSON.parse(body.body) as { route: Parameters<typeof applyRevalidationRoute>[2] };
+          await applyRevalidationRoute(tx, taskId, artifact.route);
+        }
       }
       const output = await tx.taskStepOutput.upsert({
         where: { taskId },

--- a/packages/db/src/canonical-output-schema.ts
+++ b/packages/db/src/canonical-output-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { canonicalTemplateIdentity, LEGACY_TEMPLATE_GENERATIONS } from "./canonical-template-transition.js";
 import { REGRESSION_VERIFICATION_SCHEMA_VERSION } from "./merge-tail.js";
 import { stepGeneration, stepRole, type StepRole, type TemplateStepLike } from "./step-role.js";
 
@@ -198,10 +199,21 @@ export const canonicalOutputSchemas: Readonly<Partial<Record<StepRole, SchemaByG
   },
 };
 
+/** Retained prompt protocols are registered with the template that owns them.
+ * Keep this above the importless role seam so registry imports cannot cycle. */
+export const canonicalOutputGeneration = (step: TemplateStepLike): string => {
+  const name = step.taskTemplate?.name ?? step.taskTemplateName;
+  const identity = name ? canonicalTemplateIdentity(name) : null;
+  const retained = identity?.generation
+    ? LEGACY_TEMPLATE_GENERATIONS[identity.canonicalName].find(({ marker }) => marker === identity.generation)
+    : null;
+  return retained?.outputGenerations?.[step.outputKind] ?? stepGeneration(step);
+};
+
 /** Resolve one Step output contract through the role and output protocol generation seam. */
 export const canonicalOutputSchema = (step: TemplateStepLike): z.ZodType | null => {
   const role = stepRole(step);
   if (role === null) return null;
-  const generation = stepGeneration(step);
+  const generation = canonicalOutputGeneration(step);
   return canonicalOutputSchemas[role]?.[generation] ?? null;
 };

--- a/packages/db/src/canonical-output-schema.ts
+++ b/packages/db/src/canonical-output-schema.ts
@@ -64,12 +64,16 @@ export const canonicalFixedImplementationArtifactSchema = canonicalEnvelope.exte
   residualRisks: z.array(z.string()),
 });
 
-/** The bound Direct revalidation decision, including the implementation route. */
-export const canonicalRevalidationArtifactSchema = canonicalEnvelope.extend({
-  schemaVersion: z.literal(2),
+/** The retained revalidation contract on pre-route Direct Chains. */
+const legacyRevalidationArtifactSchema = canonicalEnvelope.extend({
   outcome: z.enum(["updated", "unchanged", "proceeded-after-premise-collapse"]),
   summary: nonEmptyString,
   changedReferences: stringList,
+});
+
+/** The bound Direct revalidation decision, including the implementation route. */
+export const canonicalRevalidationArtifactSchema = legacyRevalidationArtifactSchema.extend({
+  schemaVersion: z.literal(2),
   route: z.object({
     tier: z.enum(["default", "frontend", "hard", "hazard"]),
     reason: nonEmptyString,
@@ -88,6 +92,7 @@ export const canonicalOutputSchemas: Readonly<Partial<Record<StepRole, SchemaByG
     v1: canonicalEnvelope.extend({ spec: nonEmptyString }),
   },
   revalidation: {
+    v1: legacyRevalidationArtifactSchema,
     v2: canonicalRevalidationArtifactSchema,
   },
   plan: {
@@ -197,8 +202,6 @@ export const canonicalOutputSchemas: Readonly<Partial<Record<StepRole, SchemaByG
 export const canonicalOutputSchema = (step: TemplateStepLike): z.ZodType | null => {
   const role = stepRole(step);
   if (role === null) return null;
-  // Template rollovers preserve an output protocol unless outputKind itself
-  // changes; the bare revalidation kind is the one explicit v2 exception.
   const generation = stepGeneration(step);
   return canonicalOutputSchemas[role]?.[generation] ?? null;
 };

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -58,6 +58,8 @@ import type { PersistedTemplateStepStructure } from "./template-sources.js";
  */
 export type LegacyTemplateGeneration = Readonly<{
   marker: string;
+  /** Retained output protocols when a prompt changed without renaming its kind. */
+  outputGenerations?: Readonly<Record<string, string>>;
   shape: readonly LegacyStepRecord[];
   /**
    * Whether this entry is retired from structural matching because a binding
@@ -200,6 +202,7 @@ const legacyTemplateGenerations = {
       // revalidation node, so an unbound seven-step row still matches
       // `pre-revalidate-step` above and rolls over structurally as before.
       marker: "pre-product-rename-anneal",
+      outputGenerations: { revalidation: "v1" },
       promptDigest: "0aa379a51d722ec9b8b5d91bc6158d9dd9a1f5d380b50695613d5aece9afda46",
       shape: [
         { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
@@ -214,6 +217,7 @@ const legacyTemplateGenerations = {
     },
     {
       marker: "pre-runner-provided-regression-tooling",
+      outputGenerations: { revalidation: "v1" },
       promptDigest: "c0ec5acb70b82b85bc3f3aff5840029a303d31e6098b7171a2bef35f105f3371",
       shape: [
         { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
@@ -228,6 +232,7 @@ const legacyTemplateGenerations = {
     },
     {
       marker: "pre-optional-review-omission",
+      outputGenerations: { revalidation: "v1" },
       promptDigest: "e8fdf5533275e85e33b0cf812db9474b00214de2401e4c97bb6eb0732f864df8",
       shape: [
         { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
@@ -246,6 +251,7 @@ const legacyTemplateGenerations = {
       // reads bindings this states the current graph, so it is kept as the
       // published-generation record and excluded from matching.
       marker: "pre-astra-low-review-fix",
+      outputGenerations: { revalidation: "v1" },
       retiredByBinding: true,
       shape: [
         { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
@@ -260,6 +266,7 @@ const legacyTemplateGenerations = {
     },
     {
       marker: "model-neutral-review-step-names",
+      outputGenerations: { revalidation: "v1" },
       shape: [
         { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Implementation", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -278,6 +285,7 @@ const legacyTemplateGenerations = {
       // stopping. The graph is unchanged, so `promptDigest` authenticates
       // the outgoing generation.
       marker: "pre-salvage-resume",
+      outputGenerations: { revalidation: "v1" },
       promptDigest: "8dbdb5fc5348a01eef73bd5908c4e142b4b6ca01bbb063eaf4916173fdc51543",
       shape: [
         { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
@@ -294,6 +302,7 @@ const legacyTemplateGenerations = {
       // Prompt-only rollover: the revalidation step now records the judged
       // implementation route and requires the v2 output envelope.
       marker: "pre-judged-implementation-route",
+      outputGenerations: { revalidation: "v1" },
       promptDigest: "04d473928d65443202bd68b6d865df61f26983fc35870cf43e5032279e1ed107",
       shape: [
         { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
@@ -308,6 +317,7 @@ const legacyTemplateGenerations = {
     },
     {
       marker: "pre-model-neutral-review-output",
+      outputGenerations: { revalidation: "v1" },
       shape: [
         { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Implementation", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },

--- a/packages/db/src/step-role.test.ts
+++ b/packages/db/src/step-role.test.ts
@@ -43,7 +43,7 @@ for (const [templateName, generations] of Object.entries(LEGACY_TEMPLATE_GENERAT
       const persistedName = templateRolloverName(templateName, generation.marker, "template-row");
       for (const step of generation.shape) {
         const { outputKind } = step;
-        const generation = outputKind === "revalidation" ? "v1" : stepGeneration({ outputKind });
+        const generation = stepGeneration({ outputKind });
         assert.equal(stepGeneration({ outputKind, taskTemplateName: persistedName }), generation);
         assert.equal(stepGeneration({ outputKind, taskTemplate: { name: persistedName } }), generation);
         assert.equal(stepRole({ outputKind, taskTemplateName: persistedName }), EXPECTED_ROLES[outputKind]);
@@ -133,17 +133,4 @@ test("step-role is a leaf module, so no sibling can close an import cycle throug
   // edit cannot reintroduce the cycle silently.
   const source = await readFile(new URL("./step-role.ts", import.meta.url), "utf8");
   assert.deepEqual(source.match(/^(?:\s*import\b|\s*export\b[^;]*\bfrom\b)|\bimport\s*\(/gmu), null);
-});
-
-test("bare revalidation only selects v1 for complete historical Direct identities", () => {
-  for (const name of [
-    "direct-engineer-workflow",
-    "direct-engineer-workflow-legacy-pre-judged-implementation-route-",
-    "direct-engineer-workflow-legacy-future-generation-row",
-    "custom-legacy-pre-judged-implementation-route-row",
-  ]) {
-    assert.equal(stepGeneration({ outputKind: "revalidation", taskTemplateName: name }), "v2");
-  }
-  const taskTemplateName = templateRolloverName("direct-engineer-workflow", "pre-judged-implementation-route", "row");
-  assert.equal(stepGeneration({ outputKind: "revalidation-v2", taskTemplateName }), "v2");
 });

--- a/packages/db/src/step-role.test.ts
+++ b/packages/db/src/step-role.test.ts
@@ -43,8 +43,9 @@ for (const [templateName, generations] of Object.entries(LEGACY_TEMPLATE_GENERAT
       const persistedName = templateRolloverName(templateName, generation.marker, "template-row");
       for (const step of generation.shape) {
         const { outputKind } = step;
-        assert.equal(stepGeneration({ outputKind, taskTemplateName: persistedName }), stepGeneration({ outputKind }));
-        assert.equal(stepGeneration({ outputKind, taskTemplate: { name: persistedName } }), stepGeneration({ outputKind }));
+        const generation = outputKind === "revalidation" ? "v1" : stepGeneration({ outputKind });
+        assert.equal(stepGeneration({ outputKind, taskTemplateName: persistedName }), generation);
+        assert.equal(stepGeneration({ outputKind, taskTemplate: { name: persistedName } }), generation);
         assert.equal(stepRole({ outputKind, taskTemplateName: persistedName }), EXPECTED_ROLES[outputKind]);
       }
       const implementation = { outputKind: "implementation", taskTemplate: { name: persistedName } };
@@ -128,8 +129,21 @@ test("step-role is a leaf module, so no sibling can close an import cycle throug
   // `stepGeneration` used to resolve a retired graph marker through
   // `canonical-template-transition.js`, which imports `stepRole` back: an ESM
   // cycle whose evaluation order decided whether either module saw the other's
-  // bindings. The branch is gone and the fix is structural — this module must
-  // stay importless, so a future edit cannot reintroduce the cycle silently.
+  // bindings. Generation compatibility must stay importless, so a future
+  // edit cannot reintroduce the cycle silently.
   const source = await readFile(new URL("./step-role.ts", import.meta.url), "utf8");
   assert.deepEqual(source.match(/^(?:\s*import\b|\s*export\b[^;]*\bfrom\b)|\bimport\s*\(/gmu), null);
+});
+
+test("bare revalidation only selects v1 for complete historical Direct identities", () => {
+  for (const name of [
+    "direct-engineer-workflow",
+    "direct-engineer-workflow-legacy-pre-judged-implementation-route-",
+    "direct-engineer-workflow-legacy-future-generation-row",
+    "custom-legacy-pre-judged-implementation-route-row",
+  ]) {
+    assert.equal(stepGeneration({ outputKind: "revalidation", taskTemplateName: name }), "v2");
+  }
+  const taskTemplateName = templateRolloverName("direct-engineer-workflow", "pre-judged-implementation-route", "row");
+  assert.equal(stepGeneration({ outputKind: "revalidation-v2", taskTemplateName }), "v2");
 });

--- a/packages/db/src/step-role.ts
+++ b/packages/db/src/step-role.ts
@@ -46,30 +46,9 @@ export const stepRole = (step: TemplateStepLike): StepRole | null => {
   return OUTPUT_KIND_ROLES[normalizedOutputKind] ?? null;
 };
 
-// These retired Direct templates keep their v1 prompt and instantiated Steps.
-// Keep this closed list here: importing the transition registry would create a
-// cycle through its structural role checks. Future rollovers default to v2.
-const REVALIDATION_V1_TEMPLATE_MARKERS = [
-  "pre-product-rename-anneal",
-  "pre-runner-provided-regression-tooling",
-  "pre-optional-review-omission",
-  "pre-astra-low-review-fix",
-  "model-neutral-review-step-names",
-  "pre-salvage-resume",
-  "pre-model-neutral-review-output",
-  "pre-judged-implementation-route",
-] as const;
-
-/** Explicit output-kind versions take precedence. Bare revalidation is v2,
- * except on the closed set of retired Direct templates whose prompt is v1. */
+/** The output-kind protocol version. Bare revalidation defaults to v2;
+ * canonicalOutputGeneration resolves retained template-specific contracts. */
 export const stepGeneration = (step: TemplateStepLike): string => {
-  if (step.outputKind === "revalidation") {
-    const name = step.taskTemplate?.name ?? step.taskTemplateName;
-    const legacy = name && REVALIDATION_V1_TEMPLATE_MARKERS.some((marker) => {
-      const prefix = `direct-engineer-workflow-legacy-${marker}-`;
-      return name.startsWith(prefix) && name.length > prefix.length;
-    });
-    return legacy ? "v1" : "v2";
-  }
+  if (step.outputKind === "revalidation") return "v2";
   return step.outputKind.match(VERSION_SUFFIX)?.[1] ?? "v1";
 };

--- a/packages/db/src/step-role.ts
+++ b/packages/db/src/step-role.ts
@@ -46,12 +46,30 @@ export const stepRole = (step: TemplateStepLike): StepRole | null => {
   return OUTPUT_KIND_ROLES[normalizedOutputKind] ?? null;
 };
 
-/** A Step's output protocol generation is the `-vN` suffix on its output kind,
- *  except for the bare revalidation kind, whose required route decision is the
- *  v2 contract without changing the kind used to identify the step. The
- *  `taskTemplate` fields stay on `TemplateStepLike` for role predicates that
- *  still read them. */
+// These retired Direct templates keep their v1 prompt and instantiated Steps.
+// Keep this closed list here: importing the transition registry would create a
+// cycle through its structural role checks. Future rollovers default to v2.
+const REVALIDATION_V1_TEMPLATE_MARKERS = [
+  "pre-product-rename-anneal",
+  "pre-runner-provided-regression-tooling",
+  "pre-optional-review-omission",
+  "pre-astra-low-review-fix",
+  "model-neutral-review-step-names",
+  "pre-salvage-resume",
+  "pre-model-neutral-review-output",
+  "pre-judged-implementation-route",
+] as const;
+
+/** Explicit output-kind versions take precedence. Bare revalidation is v2,
+ * except on the closed set of retired Direct templates whose prompt is v1. */
 export const stepGeneration = (step: TemplateStepLike): string => {
-  if (step.outputKind === "revalidation") return "v2";
+  if (step.outputKind === "revalidation") {
+    const name = step.taskTemplate?.name ?? step.taskTemplateName;
+    const legacy = name && REVALIDATION_V1_TEMPLATE_MARKERS.some((marker) => {
+      const prefix = `direct-engineer-workflow-legacy-${marker}-`;
+      return name.startsWith(prefix) && name.length > prefix.length;
+    });
+    return legacy ? "v1" : "v2";
+  }
   return step.outputKind.match(VERSION_SUFFIX)?.[1] ?? "v1";
 };

--- a/packages/db/src/template-sources.test.ts
+++ b/packages/db/src/template-sources.test.ts
@@ -9,7 +9,8 @@ import { test } from "node:test";
 import { z } from "zod";
 
 import { DIRECT_TEMPLATE_NAME, PR_TEMPLATE_NAME } from "./agent-contract.js";
-import { canonicalOutputSchema, canonicalOutputSchemas } from "./canonical-output-schema.js";
+import { canonicalOutputGeneration, canonicalOutputSchema, canonicalOutputSchemas } from "./canonical-output-schema.js";
+import { LEGACY_TEMPLATE_GENERATIONS, templateRolloverName } from "./canonical-template-transition.js";
 import { INTEGRATOR_TEMPLATE_NAME } from "./merge-integrator.js";
 import {
   retiredStepShapeDifferences,
@@ -723,4 +724,27 @@ test("one field table decides both row-vs-spec comparisons", async () => {
     retiredStepShapeDifferences({ ...persisted, optional: true, requiresCommit: false, provisionDependencies: true }, omitted),
     ["optional"],
   );
+});
+
+test("bare revalidation only selects v1 for complete historical Direct identities", () => {
+  for (const name of [
+    "direct-engineer-workflow",
+    "direct-engineer-workflow-legacy-pre-judged-implementation-route-",
+    "direct-engineer-workflow-legacy-future-generation-row",
+    "custom-legacy-pre-judged-implementation-route-row",
+  ]) {
+    assert.equal(canonicalOutputGeneration({ outputKind: "revalidation", taskTemplateName: name }), "v2");
+  }
+  const taskTemplateName = templateRolloverName("direct-engineer-workflow", "pre-judged-implementation-route", "row");
+  assert.equal(canonicalOutputGeneration({ outputKind: "revalidation-v2", taskTemplateName }), "v2");
+});
+
+test("registered pre-route Direct generations retain the v1 output protocol", () => {
+  for (const generation of LEGACY_TEMPLATE_GENERATIONS[DIRECT_TEMPLATE_NAME]) {
+    if (!generation.shape.some(({ outputKind }) => outputKind === "revalidation")) continue;
+    const taskTemplateName = templateRolloverName(DIRECT_TEMPLATE_NAME, generation.marker, "row");
+    assert.equal(canonicalOutputGeneration({ outputKind: "revalidation", taskTemplateName }), "v1");
+    assert.equal(canonicalOutputGeneration({ outputKind: "revalidation", taskTemplate: { name: taskTemplateName } }), "v1");
+    assert.equal(canonicalOutputGeneration({ outputKind: "revalidation-v2", taskTemplateName }), "v2");
+  }
 });


### PR DESCRIPTION
Direct Chains created before implementation-tier routing retain their v1 revalidation prompts after canonical template rollover. The API previously required v2 for every bare revalidation step, rejecting those retained outputs and attempting to apply a missing route.

Register retained output protocols in the canonical template transition registry and select v1 only for the closed set of retired Direct generations, preserve the existing assignee on their outputs, and keep current and future generations strict v2. Session persistence and operator output writes use the same generation rule; the handbook documents the exception.

Validation: db/API lint and typechecks, focused generation/schema/output/routing and operator route tests, handbook tests, and compose binding. Exact-head Merge gate is required before publication.

The first integrated gate exposed the legacy-name architecture guard; the follow-up removes duplicate identity parsing and keeps step-role importless. The guard and 201 focused tests pass, as do 14 runtime inventory/import checks. Independent review of the final registry design found no must-fix issues. Final Merge gate: PASS e79c4b8e0f62eafd933a3747480230d4c78c0e69 against a3683bb06581252f50bf8260f913392f1d99a9d6 on ci-desktop-worker, including the full database suite.
