### PR TITLE
fix(usage): preserve Claude totals across process resumes

### DIFF
--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -260,14 +260,16 @@ curl -X DELETE "$BASE_URL/projects/$PROJECT_ID" -H "Authorization: Bearer $OPERA
   metadata cannot classify priced spend. Unknown cache splits are counted and
   excluded from cache metrics; unpriced chain runs never receive a fabricated
   cost.
-- For Claude, `FINAL_OUTPUT` events with the same provider `session_id` are
-  session-cumulative: `total_cost_usd` and `modelUsage` are the running totals,
-  so the latest event supplies that provider session's cost and model tokens.
-  Events with different `session_id` values are separate sessions and their
-  latest totals are added. The top-level `usage` block remains per invocation.
-  Session usage recomputation from stored events applies the same rule and is
-  idempotent: repeating it without new events leaves the derived totals
-  unchanged.
+- For Claude, `total_cost_usd` and `modelUsage` are cumulative within one
+  provider process and `session_id`. The latest usable totals in that group
+  count once, including repeated task-notification results. Each persisted
+  `PROCESS_STARTED` starts a separate accounting group: resume retains the
+  provider `session_id` but resets its counters, so process totals are added.
+  Different provider session ids within a process are also added. The top-level
+  `usage` block remains per invocation. Historical events before the first
+  recorded process start form an initial group; missing boundaries cannot be
+  reconstructed from counter values alone. Recomputing stored events uses the
+  same rules and is idempotent. A process with no final result adds no usage.
 
 ```sh
 curl "$BASE_URL/projects/$PROJECT_ID/costs?days=1&tz=America%2FLos_Angeles" \

--- a/packages/api/src/run-lifecycle.test.ts
+++ b/packages/api/src/run-lifecycle.test.ts
@@ -56,7 +56,7 @@ const finalOutputPayload = {
 };
 
 const eventDatabase = (options: {
-  finalOutputRows?: Array<{ payload: unknown }>;
+  usageRows?: Array<{ type: string; payload: unknown }>;
   onUsageUpdate?: () => void;
   stored?: Array<Record<string, unknown>>;
   sessionWrites?: Array<Record<string, unknown>>;
@@ -80,7 +80,7 @@ const eventDatabase = (options: {
         stored.push(...data);
         return { count: data.length };
       },
-      findMany: async () => options.finalOutputRows ?? [],
+      findMany: async () => options.usageRows ?? [],
     },
     session: {
       findUnique: async () => ({
@@ -390,7 +390,7 @@ test("events normalize and persist through the lifecycle interface without chang
 test("FINAL_OUTPUT recomputes derived usage through the lifecycle interface", async () => {
   const sessionWrites: Array<Record<string, unknown>> = [];
   const result = await appendRunEvents(eventDatabase({
-    finalOutputRows: [{ payload: finalOutputPayload }],
+    usageRows: [{ type: "FINAL_OUTPUT", payload: finalOutputPayload }],
     sessionWrites,
   }), { runId: "run-1", body: eventBody(["MODEL_COMPLETED", "FINAL_OUTPUT"]), now });
 
@@ -409,7 +409,7 @@ test("FINAL_OUTPUT recomputes derived usage through the lifecycle interface", as
 test("events without FINAL_OUTPUT do not touch derived usage", async () => {
   const sessionWrites: Array<Record<string, unknown>> = [];
   const result = await appendRunEvents(eventDatabase({
-    finalOutputRows: [{ payload: finalOutputPayload }],
+    usageRows: [{ type: "FINAL_OUTPUT", payload: finalOutputPayload }],
     sessionWrites,
   }), { runId: "run-1", body: eventBody(["MODEL_COMPLETED", "TOOL_STARTED"]), now });
 
@@ -438,7 +438,7 @@ test("a failing derived usage write does not fail event ingestion", async () => 
   console.error = (...args: unknown[]) => { errors.push(args); };
   try {
     const result = await appendRunEvents(eventDatabase({
-      finalOutputRows: [{ payload: finalOutputPayload }],
+      usageRows: [{ type: "FINAL_OUTPUT", payload: finalOutputPayload }],
       onUsageUpdate: () => { throw new Error("value out of range for type integer"); },
     }), { runId: "run-1", body: eventBody(["FINAL_OUTPUT"]), now });
     assert.deepEqual(result, { accepted: 1 });

--- a/packages/api/src/specification-fidelity.test.ts
+++ b/packages/api/src/specification-fidelity.test.ts
@@ -223,7 +223,8 @@ test("a read deadline overrun is transient and exhausts the bounded retry schedu
   assert.match(verdict?.message ?? "", /last failure: repository content read exceeded the 5ms server deadline/u);
 });
 
-test("a read slower than the first deadline but faster than the last succeeds within one claim", async () => {
+test("a read slower than the first deadline but faster than the last succeeds within one claim", async (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
   assert.ok(
     SPECIFICATION_READ_ATTEMPT_TIMEOUTS_MS.every((timeoutMs, index) => (
       index === 0 || timeoutMs > SPECIFICATION_READ_ATTEMPT_TIMEOUTS_MS[index - 1]!
@@ -237,7 +238,11 @@ test("a read slower than the first deadline but faster than the last succeeds wi
   const readDurationMs = attemptTimeoutsMs[0]! + 8;
   assert.ok(readDurationMs < attemptTimeoutsMs.at(-1)!);
   let reads = 0;
-  const verdict = await verifyPreparedSpecification(
+  let firstReadStarted!: () => void;
+  const firstReadStartedPromise = new Promise<void>((resolve) => { firstReadStarted = resolve; });
+  let secondReadStarted!: () => void;
+  const secondReadStartedPromise = new Promise<void>((resolve) => { secondReadStarted = resolve; });
+  const verdict = verifyPreparedSpecification(
     {
       key: "key",
       repository: "acme/repo",
@@ -249,6 +254,8 @@ test("a read slower than the first deadline but faster than the last succeeds wi
     },
     { readFileAtCommit: async (_repository, _path, _commitSha, signal) => {
       reads += 1;
+      if (reads === 1) firstReadStarted();
+      if (reads === 2) secondReadStarted();
       return new Promise<Uint8Array>((resolve, reject) => {
         const timer = setTimeout(() => resolve(bytes("authoritative")), readDurationMs);
         signal.addEventListener("abort", () => {
@@ -260,7 +267,13 @@ test("a read slower than the first deadline but faster than the last succeeds wi
     new AbortController().signal,
     { retryDelaysMs: [0, 0], attemptTimeoutsMs, wait: async () => {} },
   );
-  assert.equal(verdict, null);
+  await firstReadStartedPromise;
+  assert.equal(reads, 1);
+  t.mock.timers.tick(attemptTimeoutsMs[0]!);
+  await secondReadStartedPromise;
+  assert.equal(reads, 2);
+  t.mock.timers.tick(readDurationMs);
+  assert.equal(await verdict, null);
   assert.equal(reads, 2);
 });
 

--- a/packages/api/src/usage.dbtest.ts
+++ b/packages/api/src/usage.dbtest.ts
@@ -112,7 +112,7 @@ test("0: the locked recompute runs at all against a real database", async () => 
 
 /* -------------------------------------------------------------- test 0b */
 
-test("0b: resumed Claude results use one cumulative total per provider session", async () => {
+test("0b: Claude notifications count once and resumed process totals survive recomputation", async () => {
   const seeded = await seedSession("claude-resume-usage");
   const result = {
     type: "result",
@@ -124,9 +124,12 @@ test("0b: resumed Claude results use one cumulative total per provider session",
     },
   };
 
-  // Claude emits the same session-cumulative result after each --resume. The
-  // old fold added every row, producing four times these values.
-  for (let seq = 1; seq <= 4; seq += 1) await addFinalOutput(seeded, seq, result);
+  // Task notifications repeat one process cumulative result with distinct UUIDs.
+  // They do not represent separate resume launches.
+  for (let seq = 1; seq <= 4; seq += 1) {
+    await addFinalOutput(seeded, seq, { ...result, uuid: `result-${seq}`,
+      ...(seq === 1 ? {} : { origin: { kind: "task-notification" } }) });
+  }
 
   assert.equal(await recomputeSessionUsage(db, seeded.session.id), true);
   const columns = await storedColumns(seeded.session.id);
@@ -142,6 +145,21 @@ test("0b: resumed Claude results use one cumulative total per provider session",
   assert.equal(unchanged.outputTokens, 20);
   assert.equal(unchanged.totalTokens, 120);
   assert.equal(unchanged.costUsd?.toString(), "1.25");
+
+  await db.sessionEvent.create({ data: {
+    sessionId: seeded.session.id, runId: seeded.run.id, seq: 5,
+    source: "RUNNER", type: "PROCESS_STARTED", payload: {},
+  } });
+  await addFinalOutput(seeded, 6, { ...result, total_cost_usd: 0, modelUsage: {},
+    usage: { input_tokens: 0, output_tokens: 0 }, origin: { kind: "task-notification" } });
+  await addFinalOutput(seeded, 7, { ...result, total_cost_usd: 0.5,
+    modelUsage: { "claude-opus-5": { inputTokens: 30, outputTokens: 10, costUSD: 0.5 } } });
+  assert.equal(await recomputeSessionUsage(db, seeded.session.id), true);
+  const resumed = await storedColumns(seeded.session.id);
+  assert.equal(resumed.costUsd?.toString(), "1.75");
+  assert.equal(resumed.inputTokens, 130);
+  assert.equal(resumed.outputTokens, 30);
+  assert.equal(await recomputeSessionUsage(db, seeded.session.id), false);
 });
 
 /* -------------------------------------------------------------- test 1 */

--- a/packages/api/src/usage.test.ts
+++ b/packages/api/src/usage.test.ts
@@ -230,7 +230,7 @@ const stubDatabase = (payloads: unknown[], columns: SessionColumns) => {
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation(database),
     $executeRawUnsafe: async () => 0,
     $queryRaw: async () => [],
-    sessionEvent: { findMany: async () => payloads.map((payload) => ({ payload })) },
+    sessionEvent: { findMany: async () => payloads.map((payload) => ({ type: "FINAL_OUTPUT", payload })) },
     session: {
       findUnique: async () => columns,
       update: async ({ data }: { data: SessionColumns }) => {
@@ -540,7 +540,7 @@ const resumedClaudeResult = (sessionId: string, cost: number, input: number, out
   modelUsage: { "claude-opus": { inputTokens: input, outputTokens: output } },
 });
 
-test("recomputeSessionUsage selects the last cumulative Claude resume total", async () => {
+test("recomputeSessionUsage selects the last cumulative Claude total within one process", async () => {
   const columns = emptyColumns();
   const events = [
     resumedClaudeResult("provider-a", 0.1, 100, 10),
@@ -612,7 +612,7 @@ test("recomputeSessionUsage does nothing when the session row is gone", async ()
     $transaction: async (operation: (tx: unknown) => Promise<unknown>) => operation(database),
     $executeRawUnsafe: async () => 0,
     $queryRaw: async () => [],
-    sessionEvent: { findMany: async () => [{ payload: CLAUDE_RESULT }] },
+    sessionEvent: { findMany: async () => [{ type: "FINAL_OUTPUT", payload: CLAUDE_RESULT }] },
     session: { findUnique: async () => null, update: async () => assert.fail("must not write") },
   } as unknown as PrismaClient;
   assert.equal(await recomputeSessionUsage(database, "missing"), false);

--- a/packages/db/src/usage.test.ts
+++ b/packages/db/src/usage.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { deriveUsageColumns, extractUsage, sumSessionUsage, sumUsage } from "./usage.js";
+import { deriveUsageColumns, extractUsage, sumSessionEventUsage, sumSessionUsage, sumUsage } from "./usage.js";
 
 type StoredSessionEvent = {
   child: string;
@@ -204,3 +204,37 @@ for (const sessionId of [undefined, "", 123]) {
     }
   });
 }
+
+for (const resumedCost of [0.556285, 12]) {
+  test(`sumSessionEventUsage adds resumed process totals regardless of counter direction (${resumedCost})`, () => {
+    const first = claudeResult("same-session", 7.69342375, 100, 10);
+    const final = (payload: unknown) => ({ type: "FINAL_OUTPUT", payload });
+    const events = [
+      // Legacy events before the first recorded start still count.
+      final(first),
+      final({ ...first, uuid: "different-result", origin: { kind: "task-notification" } }),
+      { type: "PROCESS_STARTED", payload: {} },
+      final({ type: "result", session_id: "same-session", total_cost_usd: 0, modelUsage: {},
+        origin: { kind: "task-notification" } }),
+      final(claudeResult("same-session", resumedCost, 200, 20)),
+      final(claudeResult("fresh-session", 1, 50, 5)),
+      // A failed launch with no final output cannot erase completed usage.
+      { type: "PROCESS_STARTED", payload: {} },
+      { type: "PROVIDER_RAW", payload: claudeResult("same-session", 999, 999, 999) },
+    ];
+    const actual = deriveUsageColumns(sumSessionEventUsage(events));
+    assert.equal(actual.inputTokens, 350);
+    assert.equal(actual.outputTokens, 35);
+    assert.equal(actual.costUsd?.toNumber(), Number((7.69342375 + resumedCost + 1).toFixed(4)));
+    assert.deepEqual(deriveUsageColumns(sumSessionEventUsage(events)), actual);
+  });
+}
+
+test("sumSessionEventUsage respects latest cost within a process without guessing resets", () => {
+  const events = [
+    { type: "FINAL_OUTPUT", payload: claudeResult("same", 8, 100, 10) },
+    { type: "FINAL_OUTPUT", payload: { type: "result", session_id: "same", total_cost_usd: 0,
+      origin: { kind: "task-notification" } } },
+  ];
+  assert.equal(deriveUsageColumns(sumSessionEventUsage(events)).costUsd?.toString(), "0");
+});

--- a/packages/db/src/usage.ts
+++ b/packages/db/src/usage.ts
@@ -102,8 +102,8 @@ const canonicalInputTokens = (uncached: number | null, cached: number | null): n
  * object is snake_case and describes ONE model, the primary one.
  *
  * In the single-invocation captures transcribed in `usage.test.ts`, top-level
- * `usage` equals `modelUsage["claude-opus-5"]` field for field. On resume,
- * `modelUsage` is session-cumulative while top-level `usage` remains per
+ * `usage` equals `modelUsage["claude-opus-5"]` field for field. Across results,
+ * `modelUsage` is process-cumulative while top-level `usage` remains per
  * invocation; `sumSessionUsage` reconciles snapshots and later fallback usage.
  * Adding both sources from one event double-counts the primary model, while
  * reading only top-level usage drops secondary models. This branch is therefore
@@ -257,7 +257,7 @@ type DecodedUsage = {
   cacheSplit: ExtractedCacheSplit;
   /**
    * Claude's `usage` object is per invocation. Keep it separate from the
-   * session-cumulative `modelUsage` breakdown so a payload-level aggregation
+   * process-cumulative `modelUsage` breakdown so a payload-level aggregation
    * can apply the provider's two different accounting rules without changing
    * the canonical one-payload result returned by `extractUsage`.
    */
@@ -543,20 +543,20 @@ type ClaudeSessionUsage = {
 };
 
 /**
- * Fold stored FINAL_OUTPUT payloads into one SessionUsage total.
+ * Fold FINAL_OUTPUT payloads from ONE provider process into a usage total.
  *
  * Claude's `result.total_cost_usd` and `result.modelUsage` are cumulative for
- * the provider conversation identified by `session_id`; the latest usable
- * value for each is therefore selected once per provider conversation. The
+ * each conversation within that process, identified by `session_id`; the latest
+ * usable value is therefore selected once per provider conversation. The
  * top-level `usage` object remains per invocation. It is summed when a Claude
  * payload has no usable model breakdown after the latest cumulative snapshot
  * (the same fallback used by `extractUsage`); a new snapshot replaces those
  * earlier increments. Payloads without a provider session id retain the original
  * additive behavior used by Codex and PI.
  *
- * `payloads` must be in FINAL_OUTPUT sequence order. The recompute path reads
- * SessionEvent rows ordered by `seq`, and callers using this helper directly
- * should preserve that same order so "latest" has its provider meaning.
+ * `payloads` must be in FINAL_OUTPUT sequence order within one process. A resume
+ * starts a new process whose counters reset even when `session_id` is unchanged.
+ * Stored event callers must use `sumSessionEventUsage` to preserve that boundary.
  */
 export const sumSessionUsage = (payloads: readonly unknown[]): SessionUsage => {
   const ungrouped: SessionUsage[] = [];
@@ -595,6 +595,32 @@ export const sumSessionUsage = (payloads: readonly unknown[]): SessionUsage => {
   }
 
   return sumUsage(ungrouped);
+};
+
+/** Fold durable events in seq order. PROCESS_STARTED is recorded for each
+ * provider launch, including resume/remediation; session_id survives those
+ * launches but Claude's accounting counters do not. Notifications in one
+ * process may repeat the same cumulative totals with different result UUIDs.
+ *
+ * Events predating the first recorded start form an initial process. A start
+ * with no FINAL_OUTPUT contributes nothing. Never infer resets from falling
+ * counters: a later process may cost more than its predecessor.
+ */
+export const sumSessionEventUsage = (
+  events: readonly { type: string; payload: unknown }[],
+): SessionUsage => {
+  const processes: SessionUsage[] = [];
+  let payloads: unknown[] = [];
+  for (const event of events) {
+    if (event.type === "PROCESS_STARTED") {
+      processes.push(sumSessionUsage(payloads));
+      payloads = [];
+    } else if (event.type === "FINAL_OUTPUT") {
+      payloads.push(event.payload);
+    }
+  }
+  processes.push(sumSessionUsage(payloads));
+  return sumUsage(processes);
 };
 
 type DerivedUsage = {
@@ -702,14 +728,14 @@ export const sessionUsageLockKey = (sessionId: string): number => {
 };
 
 /**
- * Recompute a session's derived usage columns from its stored `FINAL_OUTPUT`
- * events and write absolute values. Returns true when it actually wrote.
+ * Recompute a session's derived usage columns from stored `FINAL_OUTPUT` and
+ * `PROCESS_STARTED` events. Write absolute values; return true when changed.
  *
  * `SessionEvent` is the source of truth and the five columns are a derived
  * cache, which is what makes this idempotent: replaying an already-ingested
  * batch converges instead of drifting, a resumed session accumulates for free
- * (each provider conversation's latest cumulative `FINAL_OUTPUT` is selected,
- * while fresh provider conversations still add), a write lost to a crash
+ * (each process/conversation's latest cumulative `FINAL_OUTPUT` is selected,
+ * then distinct processes and conversations add), a write lost to a crash
  * between `createMany` and here is repaired by the next ingest or by the
  * backfill, and no NULL column is ever used in arithmetic.
  *
@@ -742,11 +768,11 @@ const recomputeSessionUsageOnce = async (db: PrismaClient, sessionId: string): P
     await tx.$queryRaw`SELECT pg_advisory_xact_lock(${SESSION_USAGE_LOCK_CLASS}::int, ${sessionUsageLockKey(sessionId)}::int)::text AS locked`;
 
     const rows = await tx.sessionEvent.findMany({
-      where: { sessionId, type: "FINAL_OUTPUT" },
+      where: { sessionId, type: { in: ["FINAL_OUTPUT", "PROCESS_STARTED"] } },
       orderBy: { seq: "asc" },
-      select: { payload: true },
+      select: { type: true, payload: true },
     });
-    const derived = deriveUsageColumns(sumSessionUsage(rows.map((row) => row.payload)));
+    const derived = deriveUsageColumns(sumSessionEventUsage(rows));
     const current = await tx.session.findUnique({
       where: { id: sessionId },
       select: {


### PR DESCRIPTION
Claude retains its provider session_id across process resumes, but each new CLI process resets cumulative counters. Grouping all stored FINAL_OUTPUT events by session_id alone therefore discarded earlier process usage. Production evidence included a Session whose retained $7.69342375 process total was followed by a resumed process reporting $0.556285; both must count.

Recompute now reads persisted PROCESS_STARTED boundaries alongside FINAL_OUTPUT events. Repeated cumulative notifications count once inside each process, while distinct process totals add. Existing events before the first recorded boundary form an initial group; missing boundaries are not guessed from falling counters. Live ingestion and historical recompute use the same locked path.

Validation: 57 focused unit tests; db/API lint and typechecks; compose binding. Added real-database recompute/idempotency coverage. The exact-head Merge gate runs before publication. Historical correction will run only with this corrected implementation and record measured before/after totals.

The first full gate passed the database suite and exposed two lifecycle mocks missing event types plus an unrelated wall-clock retry fixture race. The follow-up aligns mocks with the real event query and drives retry timing deterministically without changing production behavior or weakening assertions. Lifecycle 16 and specification 24 focused tests, API lint/typecheck pass. Final full Merge gate: PASS 1cd8f94ace4fa07fb65072550d86af9d0c53fc3f against e79c4b8e0f62eafd933a3747480230d4c78c0e69 on the configured fallback worker agentos-gate, including database and unit suites.

Historical correction executed 2026-09-08 UTC: 14 terminal Claude Sessions checked, 10 corrected, four unchanged; aggregate $274.2944 -> $106.4807 (-$167.8137). Per-Session readback and second-run idempotency passed. Raw events were preserved.
