### PR TITLE
fix(api): centralize queued candidate settlement and halt chain parks

### DIFF
--- a/packages/api/src/parallel-review-specification.dbtest.ts
+++ b/packages/api/src/parallel-review-specification.dbtest.ts
@@ -543,7 +543,7 @@ test("a raw abort from the reader is an ordinary transient, not an extendable de
   }), 0);
 });
 
-test("one poll settles every review sibling whose transient specification read budget expired", async () => {
+test("each poll settles one review sibling whose transient specification read budget expired", async () => {
   const fixture = await instantiateDirect();
   await completeImplementation(fixture, "sibling-exhaustion-implementation");
   const app = createApp(db, {
@@ -576,6 +576,10 @@ test("one poll settles every review sibling whose transient specification read b
   });
   await db.run.updateMany({ where: { id: { in: runIds } }, data: { readyAt: new Date(0) } });
 
+  assert.equal((await poll()).status, 204);
+  assert.equal(await db.run.count({
+    where: { id: { in: runIds }, status: RunStatus.FAILED },
+  }), 1);
   assert.equal((await poll()).status, 204);
   assert.equal(await db.run.count({
     where: { id: { in: runIds }, status: RunStatus.FAILED },
@@ -700,7 +704,7 @@ test("a faithful rolled-over compound chain still resolves the approved specific
   assert.ok([fixture.solTaskId, fixture.blindTaskId].includes(reviewed.run.taskId));
 });
 
-test("an unreadable review candidate is parked without blocking an unrelated claim in the same poll", async () => {
+test("chained unreadable reviews halt their polls before an unrelated candidate is claimed", async () => {
   const fixture = await instantiateDirect();
   await completeImplementation(fixture, "unreadable-implementation");
   const unrelatedChain = await instantiateTemplate(db, fixture.projectId, fixture.directTemplateId, {
@@ -713,11 +717,19 @@ test("an unreadable review candidate is parked without blocking an unrelated cla
   const unrelatedImplementationTask = unrelatedChain.tasks.find((task) => task.chainIndex === 1);
   assert.ok(unrelatedImplementationTask);
 
-  const response = await createApp(db, { specificationReader: null }).request("/runner/tasks/claim", {
+  const app = createApp(db, { specificationReader: null });
+  const poll = () => app.request("/runner/tasks/claim", {
     method: "POST",
     headers: { Authorization: `Bearer ${RUNNER_TOKEN}`, "Content-Type": "application/json" },
     body: JSON.stringify({ runnerId: "unrelated-runner", leaseSeconds: 120 }),
   });
+  for (const expectedFailed of [1, 2]) {
+    assert.equal((await poll()).status, 204);
+    assert.equal(await db.run.count({
+      where: { taskId: { in: [fixture.solTaskId, fixture.blindTaskId] }, status: RunStatus.FAILED },
+    }), expectedFailed);
+  }
+  const response = await poll();
   const responseText = await response.text();
   assert.equal(response.status, 200, responseText);
   const claimed = JSON.parse(responseText) as Claim;

--- a/packages/api/src/run-claim-settlement.ts
+++ b/packages/api/src/run-claim-settlement.ts
@@ -1,0 +1,149 @@
+import { FailureClass, type Prisma, RunStatus, TaskStatus } from "@anneal/db";
+import type { ClaimRefusal } from "@anneal/db/claim-contract";
+
+import { openMergeTailStopNotice } from "./merge-tail-actions.js";
+import { type SpecificationRefusal, SPEC_TRANSCRIPTION_REFUSAL_REASON } from "./specification-fidelity.js";
+import { writeTask } from "./task-write.js";
+
+export const SKIP = { outcome: "skip" } as const;
+export const HALT = { outcome: "halt" } as const;
+export type CandidateDecision = typeof SKIP | typeof HALT | ClaimRefusal;
+
+export type QueuedCandidateCondition =
+  | { kind: "repository-grant-missing" }
+  | { kind: "prior-output-missing"; missingKinds: string[] }
+  | { kind: "candidate-activation-failed"; reason: string; metadata: Record<string, unknown> }
+  | { kind: "regression-repair-handoff-invalid"; reason: string; previousRunId: string; metadata: Record<string, unknown> }
+  | { kind: "review-claim-refused"; refusal: SpecificationRefusal }
+  | { kind: "spec-transcription-refused"; refusal: SpecificationRefusal; implementationHeadSha: string }
+  | { kind: "specification-read-exhausted"; refusal: SpecificationRefusal; metadata: Record<string, unknown> };
+
+type Settlement = {
+  parkTo: "BACKLOG" | "REVIEW";
+  inbox: boolean;
+  failureReason: string;
+  activityBody: string;
+  inboxBody?: string;
+  metadata: Record<string, unknown>;
+  refusal?: ClaimRefusal;
+};
+
+export const queuedCandidateSettlement = (condition: QueuedCandidateCondition): Settlement => {
+  switch (condition.kind) {
+    case "repository-grant-missing":
+      return {
+        parkTo: "BACKLOG",
+        inbox: true,
+        failureReason: "repository-grant-missing: restore the agent Repo grant, then retry this run",
+        activityBody: "Queued run stopped because its repository grant is missing; restore the grant and retry",
+        inboxBody: "Queued run stopped and the task was parked in Backlog because its repository grant is missing; restore the grant and retry",
+        metadata: { condition: condition.kind },
+      };
+    case "prior-output-missing": {
+      const reason = `Prior output claim refused: missing declared output kind${condition.missingKinds.length === 1 ? "" : "s"}: ${condition.missingKinds.join(", ")}`;
+      return {
+        parkTo: "BACKLOG", inbox: true, failureReason: reason,
+        activityBody: `Prior output claim stopped: ${reason}`,
+        inboxBody: `Prior output claim failed and the task was parked in Backlog: ${reason}`,
+        metadata: { condition: condition.kind, missingKinds: condition.missingKinds },
+        refusal: { error: reason, reason: condition.kind },
+      };
+    }
+    case "candidate-activation-failed":
+      return {
+        parkTo: "BACKLOG", inbox: true, failureReason: condition.reason,
+        activityBody: `Queued run activation failed: ${condition.reason}`,
+        inboxBody: `Queued run activation failed and the task was parked in Backlog: ${condition.reason}`,
+        metadata: { condition: condition.kind, ...condition.metadata },
+      };
+    case "regression-repair-handoff-invalid":
+      return {
+        parkTo: "REVIEW", inbox: true, failureReason: condition.reason,
+        activityBody: `Fresh Regression Run stopped: ${condition.reason}`,
+        inboxBody: `Autonomous merge tail stopped: ${condition.reason}`,
+        // The repair-result marker remains authored by the claim's handoff reader.
+        metadata: condition.metadata,
+      };
+    case "review-claim-refused":
+    case "spec-transcription-refused":
+    case "specification-read-exhausted": {
+      const { refusal } = condition;
+      const exhausted = condition.kind === "specification-read-exhausted";
+      return {
+        parkTo: "BACKLOG", inbox: true, failureReason: refusal.message,
+        activityBody: exhausted
+          ? `Review claim stopped after its transient specification-read budget was exhausted: ${refusal.message}`
+          : `Review claim stopped: ${refusal.message}`,
+        inboxBody: exhausted
+          ? `Review claim failed and the task was parked in Backlog after its transient specification-read budget was exhausted: ${refusal.message}`
+          : `Review claim failed and the task was parked in Backlog: ${refusal.message}`,
+        metadata: {
+          condition: refusal.reason,
+          classification: refusal.classification,
+          ...(condition.kind === "spec-transcription-refused" ? { implementationHeadSha: condition.implementationHeadSha } : {}),
+          ...(exhausted ? condition.metadata : {}),
+        },
+        ...(condition.kind === "spec-transcription-refused" && refusal.reason === SPEC_TRANSCRIPTION_REFUSAL_REASON
+          ? { refusal: { error: refusal.message, reason: refusal.reason } } : {}),
+      };
+    }
+  }
+};
+
+export const settleQueuedCandidate = async (
+  tx: Prisma.TransactionClient,
+  candidate: { id: string; leaseGeneration: number; agentId: string; task: { id: string } | null },
+  condition: QueuedCandidateCondition,
+  now: Date,
+): Promise<CandidateDecision> => {
+  if (!candidate.task) throw new Error(`Queued candidate ${candidate.id} has no task to park`);
+  const settlement = queuedCandidateSettlement(condition);
+  const stopped = await tx.run.updateMany({
+    where: { id: candidate.id, status: RunStatus.QUEUED, leaseGeneration: candidate.leaseGeneration },
+    data: {
+      status: RunStatus.FAILED,
+      failureClass: FailureClass.TASK_FAILED,
+      failureReason: settlement.failureReason,
+      retryable: false,
+      endedAt: now,
+    },
+  });
+  if (stopped.count !== 1) return SKIP;
+  const parked = await writeTask(tx, candidate.task.id, async () => ({
+    update: { status: TaskStatus[settlement.parkTo], failureReason: settlement.failureReason },
+    activity: {
+      actorType: "control-plane",
+      body: settlement.activityBody,
+      metadata: { runId: candidate.id, ...settlement.metadata },
+    },
+    value: null,
+  }));
+  if (!parked.ok) throw new Error(`Queued candidate ${candidate.id} could not park its task: ${parked.refusal.kind}`);
+  if (settlement.inbox) {
+    if (condition.kind === "regression-repair-handoff-invalid") {
+      const sourceSession = await tx.session.findUnique({
+        where: { runId: condition.previousRunId }, select: { id: true },
+      });
+      await openMergeTailStopNotice(tx, {
+        taskId: candidate.task.id, agentId: candidate.agentId,
+        ...(sourceSession ? { sessionId: sourceSession.id } : {}),
+        reason: settlement.failureReason,
+      });
+    } else {
+      if (!settlement.inboxBody) throw new Error(`Queued candidate ${candidate.id} has no Inbox notice body`);
+      const dedupeKey = `${settlement.metadata.condition}:${candidate.id}`;
+      await tx.inboxMessage.upsert({
+        where: { dedupeKey },
+        create: {
+          from: "AGENT", agentId: candidate.agentId, taskId: candidate.task.id,
+          kind: "TEXT", body: settlement.inboxBody, dedupeKey,
+        },
+        update: {},
+      });
+    }
+  }
+  // Refusals already end the claim and preserve its wire contract. Otherwise a
+  // chain lock must halt: another candidate may hold a sibling Run while waiting
+  // for this chain mutex. Continuing the scan would invert that lock order.
+  return settlement.refusal ?? (parked.chainLocked ? HALT : SKIP);
+};

--- a/packages/api/src/run-claim.test.ts
+++ b/packages/api/src/run-claim.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { FailureClass, MERGE_TAIL_KIND, type Prisma, RunStatus, TaskStatus } from "@anneal/db";
+
+import { type QueuedCandidateCondition, queuedCandidateSettlement, settleQueuedCandidate } from "./run-claim-settlement.js";
+import type { SpecificationRefusal } from "./specification-fidelity.js";
+
+const refusal: SpecificationRefusal = {
+  reason: "spec-transcription-unreadable", classification: "non-transient", detail: "missing spec", message: "Cannot read spec",
+};
+const marker = {
+  kind: MERGE_TAIL_KIND.repairResult, schemaVersion: 1, state: "handoff-invalid",
+  runId: "run", previousRunId: "previous", reason: "Invalid handoff",
+};
+const cases: Array<{ condition: QueuedCandidateCondition; parkTo: string; reason: string; wire: boolean }> = [
+  { condition: { kind: "repository-grant-missing" }, parkTo: "BACKLOG", reason: "repository-grant-missing: restore the agent Repo grant, then retry this run", wire: false },
+  { condition: { kind: "prior-output-missing", missingKinds: ["plan", "spec"] }, parkTo: "BACKLOG", reason: "Prior output claim refused: missing declared output kinds: plan, spec", wire: true },
+  { condition: { kind: "candidate-activation-failed", reason: "Unpublished base", metadata: { unpublishedBaseSha: "sha" } }, parkTo: "BACKLOG", reason: "Unpublished base", wire: false },
+  { condition: { kind: "regression-repair-handoff-invalid", reason: "Invalid handoff", previousRunId: "previous", metadata: marker }, parkTo: "REVIEW", reason: "Invalid handoff", wire: false },
+  { condition: { kind: "review-claim-refused", refusal }, parkTo: "BACKLOG", reason: refusal.message, wire: false },
+  { condition: { kind: "spec-transcription-refused", refusal, implementationHeadSha: "head" }, parkTo: "BACKLOG", reason: refusal.message, wire: false },
+  { condition: { kind: "spec-transcription-refused", refusal: { ...refusal, reason: "spec-transcription-mismatch" }, implementationHeadSha: "head" }, parkTo: "BACKLOG", reason: refusal.message, wire: true },
+  { condition: { kind: "specification-read-exhausted", refusal, metadata: { budgetMs: 300_000 } }, parkTo: "BACKLOG", reason: refusal.message, wire: false },
+];
+
+for (const row of cases) {
+  test(`queued settlement maps ${row.condition.kind} (${row.wire ? "wire refusal" : "park"})`, () => {
+    const result = queuedCandidateSettlement(row.condition);
+    assert.equal(result.parkTo, row.parkTo);
+    assert.equal(result.inbox, true);
+    assert.equal(result.failureReason, row.reason);
+    assert.ok(result.activityBody.length > 0);
+    assert.ok(result.inboxBody?.length);
+    assert.equal(result.refusal !== undefined, row.wire);
+    if (result.refusal) assert.equal(result.refusal.error, row.reason);
+    if (row.condition.kind === "regression-repair-handoff-invalid") assert.deepEqual(result.metadata, marker);
+    if (row.condition.kind === "prior-output-missing") assert.deepEqual(result.metadata.missingKinds, ["plan", "spec"]);
+    if (row.condition.kind === "spec-transcription-refused") assert.equal(result.metadata.implementationHeadSha, "head");
+    if (row.condition.kind === "specification-read-exhausted") assert.equal(result.metadata.budgetMs, 300_000);
+  });
+}
+
+const candidate = { id: "run", leaseGeneration: 4, agentId: "agent", task: { id: "task" } };
+const now = new Date("2026-09-07T00:00:00Z");
+const transaction = (chainId: string | null, count = 1, absent = false, inboxError = false) => {
+  const events: string[] = [];
+  const writes: Record<string, unknown> = {};
+  const task = { id: "task", projectId: "project", chainId };
+  const tx = {
+    run: { updateMany: async (input: unknown) => { events.push("run"); writes.run = input; return { count }; } },
+    $queryRaw: async (strings: TemplateStringsArray) => {
+      events.push(strings.join("?").includes('"chainId" =') ? "chain-lock" : "task-lock");
+      return [{ id: "task" }];
+    },
+    task: {
+      findUnique: async () => absent ? null : task,
+      findUniqueOrThrow: async () => task,
+      update: async (input: unknown) => { events.push("park"); writes.task = input; return task; },
+    },
+    taskActivity: { create: async (input: unknown) => { events.push("activity"); writes.activity = input; return { id: "activity" }; } },
+    session: { findUnique: async () => ({ id: "source-session" }) },
+    inboxMessage: { upsert: async (input: unknown) => {
+      if (inboxError) throw new Error("Inbox unavailable");
+      events.push("inbox"); writes.inbox = input;
+    } },
+  };
+  return { tx: tx as unknown as Prisma.TransactionClient, events, writes };
+};
+
+for (const chainId of [null, "chain"]) {
+  for (const row of cases) {
+    test(`settlement ${row.condition.kind} ${row.wire} ends safely with chain=${chainId}`, async () => {
+      const { tx, events, writes } = transaction(chainId);
+      const decision = await settleQueuedCandidate(tx, candidate, row.condition, now);
+      assert.deepEqual(decision, queuedCandidateSettlement(row.condition).refusal ?? { outcome: chainId ? "halt" : "skip" });
+      assert.deepEqual(events, ["run", chainId ? "chain-lock" : "task-lock", "park", "activity", "inbox"]);
+      assert.deepEqual(writes.run, {
+        where: { id: "run", status: RunStatus.QUEUED, leaseGeneration: 4 },
+        data: { status: RunStatus.FAILED, failureClass: FailureClass.TASK_FAILED, failureReason: row.reason, retryable: false, endedAt: now },
+      });
+      assert.deepEqual(writes.task, { where: { id: "task" }, data: { status: row.parkTo === "REVIEW" ? TaskStatus.REVIEW : TaskStatus.BACKLOG, failureReason: row.reason } });
+      const inbox = writes.inbox as { create: { sessionId?: string; dedupeKey: string } };
+      if (row.condition.kind === "regression-repair-handoff-invalid") {
+        assert.equal(inbox.create.sessionId, "source-session");
+        assert.match(inbox.create.dedupeKey, /^merge-tail-stop:task:/);
+      } else {
+        assert.equal(inbox.create.dedupeKey, `${queuedCandidateSettlement(row.condition).metadata.condition}:run`);
+      }
+    });
+  }
+}
+
+test("a lost queued-Run CAS does not park or notify", async () => {
+  const { tx, events } = transaction("chain", 0);
+  assert.deepEqual(await settleQueuedCandidate(tx, candidate, { kind: "repository-grant-missing" }, now), { outcome: "skip" });
+  assert.deepEqual(events, ["run"]);
+});
+
+test("failed Task parking and Inbox writes fail loudly", async () => {
+  await assert.rejects(settleQueuedCandidate(transaction("chain", 1, true).tx, candidate, { kind: "repository-grant-missing" }, now), /could not park/);
+  await assert.rejects(settleQueuedCandidate(transaction(null, 1, false, true).tx, candidate, { kind: "repository-grant-missing" }, now), /Inbox unavailable/);
+});

--- a/packages/api/src/run-claim.ts
+++ b/packages/api/src/run-claim.ts
@@ -8,7 +8,6 @@ import {
   claimantMayTake,
   deployBarrierAllowsClaim,
   executionModeFor,
-  FailureClass,
   InboxStatus,
   integratorBindingRefusal,
   INTEGRATOR_OUTPUT_KIND,
@@ -45,10 +44,10 @@ import { isCanonicalBlindFindingsStep, previousRunHandoffForClaim } from "./cano
 import { chainStepPresence } from "./chain-step-omission.js";
 import { activeDispatchDrain } from "./dispatch-drain.js";
 import { makeFencingToken } from "./execution.js";
-import { openMergeTailStopNotice } from "./merge-tail-actions.js";
 import { hasOpenOperatorAlert, openOperatorAlert } from "./operator-alert.js";
 import { regressionRepairHandoffForClaim } from "./regression-repair-handoff.js";
 import { regressionRecoveryContextForClaim } from "./regression-recovery-context.js";
+import { HALT, SKIP, settleQueuedCandidate } from "./run-claim-settlement.js";
 import { activeRunStatuses } from "./run-fence.js";
 import { runnerBackendAllowsClaim } from "./runner-backend-health.js";
 import { decryptSecret } from "./secrets.js";
@@ -61,11 +60,10 @@ import {
   type SpecificationReader,
   type SpecificationRefusal,
   type SpecificationVerification,
-  SPEC_TRANSCRIPTION_REFUSAL_REASON,
   SPEC_TRANSCRIPTION_UNREADABLE_REASON,
   verifyPreparedSpecification,
 } from "./specification-fidelity.js";
-import { lockTaskMutationRows, writeTask } from "./task-write.js";
+import { lockTaskMutationRows } from "./task-write.js";
 import { isSerializationConflict, serializable } from "./transaction.js";
 
 const telemetry = <T extends z.ZodTypeAny>(schema: T) => schema.optional().catch(({ error, input }) => {
@@ -111,9 +109,6 @@ const isCandidateActivationFailure = (error: unknown): error is CandidateActivat
 
 const namedFailureReason = (error: CandidateActivationFailure): string => `${error.name}: ${error.message}`;
 
-const SKIP = { outcome: "skip" } as const;
-const HALT = { outcome: "halt" } as const;
-
 export type ClaimRunInput = {
   body: ClaimInput;
   claimantClass: ClaimantClass;
@@ -127,7 +122,6 @@ export type ClaimRunInput = {
 
 const MAX_OPERATOR_NOTES = 10;
 const MAX_OPERATOR_NOTES_CHARS = 4_000;
-const PRIOR_OUTPUT_MISSING_REASON = "prior-output-missing";
 export const OPERATOR_NOTE_METADATA_FIELD = "operatorNote";
 const SPECIFICATION_READ_DEFERRAL_CONDITION = "specification-read-claim-deferred";
 /** Any transient read failure other than a deadline hit keeps this budget. */
@@ -430,56 +424,6 @@ export const claimRun = async (
         });
       })();
     const executorRunnerIds = mergeExecutorRunnerIds();
-    const parkQueuedCandidate = async (
-      candidate: (typeof candidates)[number],
-      settlement: {
-        reason: string;
-        condition: string;
-        activityBody: string;
-        inboxBody: string;
-        metadata?: Record<string, unknown>;
-      },
-    ): Promise<{ chainLocked: boolean }> => {
-      if (!candidate.task) throw new Error(`Queued candidate ${candidate.id} has no task to park`);
-      const stopped = await tx.run.updateMany({
-        where: { id: candidate.id, status: RunStatus.QUEUED, leaseGeneration: candidate.leaseGeneration },
-        data: {
-          status: RunStatus.FAILED,
-          failureClass: FailureClass.TASK_FAILED,
-          failureReason: settlement.reason,
-          retryable: false,
-          endedAt: now,
-        },
-      });
-      if (stopped.count !== 1) return { chainLocked: false };
-      const parked = await writeTask(tx, candidate.task.id, async () => ({
-        update: { status: TaskStatus.BACKLOG, failureReason: settlement.reason },
-        activity: {
-          actorType: "control-plane",
-          body: settlement.activityBody,
-          metadata: {
-            runId: candidate.id,
-            condition: settlement.condition,
-            ...settlement.metadata,
-          },
-        },
-        value: null,
-      }));
-      const dedupeKey = `${settlement.condition}:${candidate.id}`;
-      await tx.inboxMessage.upsert({
-        where: { dedupeKey },
-        create: {
-          from: "AGENT",
-          agentId: candidate.agentId,
-          taskId: candidate.task.id,
-          kind: "TEXT",
-          body: settlement.inboxBody,
-          dedupeKey,
-        },
-        update: {},
-      });
-      return { chainLocked: parked.ok && parked.chainLocked };
-    };
     const priorSpecificationReadDeferrals = async (candidate: (typeof candidates)[number]) => {
       if (!candidate.task) throw new Error(`Queued candidate ${candidate.id} has no task to inspect`);
       return tx.taskActivity.findMany({
@@ -546,11 +490,9 @@ export const claimRun = async (
           elapsedMs,
           lastUnderlyingError: state.lastUnderlyingError,
         });
-      await parkQueuedCandidate(candidate, {
-        reason: refusal.message,
-        condition: refusal.reason,
-        activityBody: `Review claim stopped after its transient specification-read budget was exhausted: ${refusal.message}`,
-        inboxBody: `Review claim failed and the task was parked in Backlog after its transient specification-read budget was exhausted: ${refusal.message}`,
+      return await settleQueuedCandidate(tx, candidate, {
+        kind: "specification-read-exhausted",
+        refusal,
         metadata: {
           classification: refusal.classification,
           exhaustedCondition: SPECIFICATION_READ_DEFERRAL_CONDITION,
@@ -561,10 +503,7 @@ export const claimRun = async (
           implementationHeadSha,
           lastUnderlyingError: state.lastUnderlyingError,
         },
-      });
-      // Match the existing unreadable-refusal settlement: one parked review
-      // does not keep an eligible sibling from settling in this same poll.
-      return SKIP;
+      }, now);
     };
     const deferTransientSpecificationRead = async (
       candidate: (typeof candidates)[number],
@@ -670,34 +609,7 @@ export const claimRun = async (
         if (executionMode === "agent") return dispatchDrainingRefusal(drain);
       }
       if (!candidate.agent.repoAccess.some((grant) => grant.repoId === candidate.repoId && grant.projectId === candidate.projectId)) {
-        const reason = "repository-grant-missing: restore the agent Repo grant, then retry this run";
-        const stranded = await tx.run.updateMany({
-          where: { id: candidate.id, status: RunStatus.QUEUED, leaseGeneration: candidate.leaseGeneration },
-          data: {
-            status: RunStatus.FAILED,
-            failureClass: FailureClass.TASK_FAILED,
-            failureReason: reason,
-            retryable: false,
-            endedAt: now,
-          },
-        });
-        if (stranded.count === 1) {
-          const parked = await writeTask(tx, candidate.task.id, async () => ({
-            update: { status: TaskStatus.BACKLOG, failureReason: reason },
-            activity: {
-              actorType: "control-plane",
-              body: "Queued run stopped because its repository grant is missing; restore the grant and retry",
-              metadata: { runId: candidate.id, condition: "repository-grant-missing" },
-            },
-            value: null,
-          }));
-          // A chained park expands the lock order from this Run to every Task
-          // in the chain. End the transaction here: scanning another
-          // candidate could next wait on a sibling Run while its claimant
-          // already holds that Run and waits for this chain mutex.
-          if (parked.ok && parked.chainLocked) return HALT;
-        }
-        return SKIP;
+        return await settleQueuedCandidate(tx, candidate, { kind: "repository-grant-missing" }, now);
       }
       // §D-P4. A candidate whose (agent, step) binding is invalid is *skipped*,
       // not claimed: a mis-bound step-12 row must never be handed to anything,
@@ -797,46 +709,19 @@ export const claimRun = async (
         outputKind: candidate.task.templateStep?.outputKind ?? null,
       });
       if (regressionRepairHandoff.status === "invalid") {
-        const stopped = await tx.run.updateMany({
-          where: { id: candidate.id, status: RunStatus.QUEUED, leaseGeneration: candidate.leaseGeneration },
-          data: {
-            status: RunStatus.FAILED,
-            failureClass: FailureClass.TASK_FAILED,
-            failureReason: regressionRepairHandoff.reason,
-            retryable: false,
-            endedAt: now,
-          },
-        });
-        if (stopped.count === 1) {
-          const parked = await writeTask(tx, candidate.task.id, async () => ({
-            update: { status: TaskStatus.REVIEW, failureReason: regressionRepairHandoff.reason },
-            activity: {
-              actorType: "control-plane",
-              body: `Fresh Regression Run stopped: ${regressionRepairHandoff.reason}`,
-              metadata: {
-                kind: MERGE_TAIL_KIND.repairResult,
-                schemaVersion: 1,
-                state: "handoff-invalid",
-                runId: candidate.id,
-                previousRunId: regressionRepairHandoff.previousRunId,
-                reason: regressionRepairHandoff.reason,
-              },
-            },
-            value: null,
-          }));
-          const sourceSession = await tx.session.findUnique({
-            where: { runId: regressionRepairHandoff.previousRunId },
-            select: { id: true },
-          });
-          await openMergeTailStopNotice(tx, {
-            taskId: candidate.task.id,
-            agentId: candidate.agentId,
-            ...(sourceSession ? { sessionId: sourceSession.id } : {}),
+        return await settleQueuedCandidate(tx, candidate, {
+          kind: "regression-repair-handoff-invalid",
+          reason: regressionRepairHandoff.reason,
+          previousRunId: regressionRepairHandoff.previousRunId,
+          metadata: {
+            kind: MERGE_TAIL_KIND.repairResult,
+            schemaVersion: 1,
+            state: "handoff-invalid",
+            runId: candidate.id,
+            previousRunId: regressionRepairHandoff.previousRunId,
             reason: regressionRepairHandoff.reason,
-          });
-          if (parked.ok && parked.chainLocked) return HALT;
-        }
-        return SKIP;
+          },
+        }, now);
       }
       const grants = [
         ...candidate.agent.environment.secrets,
@@ -868,11 +753,9 @@ export const claimRun = async (
         // published, in the metadata as well as the prose, so an operator can
         // tell them apart without opening the database.
         const unpublishedBase = isPinnedBaseCommitError(error) ? error.unpublishedBase : undefined;
-        const parked = await parkQueuedCandidate(candidate, {
+        return await settleQueuedCandidate(tx, candidate, {
           reason,
-          condition: "candidate-activation-failed",
-          activityBody: `Queued run activation failed: ${reason}`,
-          inboxBody: `Queued run activation failed and the task was parked in Backlog: ${reason}`,
+          kind: "candidate-activation-failed",
           metadata: {
             failureType: error.name,
             reason,
@@ -883,9 +766,7 @@ export const claimRun = async (
               }
               : {}),
           },
-        });
-        if (parked.chainLocked) return HALT;
-        return SKIP;
+        }, now);
       }
       const blindReviewTask = isCanonicalBlindFindingsStep(candidate.task.templateStep);
       const declaredPriorOutputKinds = candidate.task.templateStep === null
@@ -929,15 +810,10 @@ export const claimRun = async (
           : null;
         const unresolvedMissingKinds = missingKinds.filter((kind) => presence?.ofKind(kind) !== "omitted");
         if (unresolvedMissingKinds.length > 0) {
-          const reason = `Prior output claim refused: missing declared output kind${unresolvedMissingKinds.length === 1 ? "" : "s"}: ${unresolvedMissingKinds.join(", ")}`;
-          await parkQueuedCandidate(candidate, {
-            reason,
-            condition: PRIOR_OUTPUT_MISSING_REASON,
-            activityBody: `Prior output claim stopped: ${reason}`,
-            inboxBody: `Prior output claim failed and the task was parked in Backlog: ${reason}`,
-            metadata: { missingKinds: unresolvedMissingKinds },
-          });
-          return { error: reason, reason: PRIOR_OUTPUT_MISSING_REASON };
+          return await settleQueuedCandidate(tx, candidate, {
+            kind: "prior-output-missing",
+            missingKinds: unresolvedMissingKinds,
+          }, now);
         }
       }
       const prepared = await prepareSpecificationVerification(
@@ -946,14 +822,10 @@ export const claimRun = async (
         implementationRange?.implementationHeadSha ?? null,
       );
       if (prepared.status === "refused") {
-        await parkQueuedCandidate(candidate, {
-          reason: prepared.refusal.message,
-          condition: prepared.refusal.reason,
-          activityBody: `Review claim stopped: ${prepared.refusal.message}`,
-          inboxBody: `Review claim failed and the task was parked in Backlog: ${prepared.refusal.message}`,
-          metadata: { classification: prepared.refusal.classification },
-        });
-        return SKIP;
+        return await settleQueuedCandidate(tx, candidate, {
+          kind: "review-claim-refused",
+          refusal: prepared.refusal,
+        }, now);
       }
       if (prepared.status === "ready") {
         const deferralState = await specificationReadDeferralState(candidate);
@@ -980,19 +852,11 @@ export const claimRun = async (
               deferralState,
             );
           }
-          await parkQueuedCandidate(candidate, {
-            reason: refusal.message,
-            condition: refusal.reason,
-            activityBody: `Review claim stopped: ${refusal.message}`,
-            inboxBody: `Review claim failed and the task was parked in Backlog: ${refusal.message}`,
-            metadata: {
-              classification: refusal.classification,
-              implementationHeadSha: prepared.verification.implementationHeadSha,
-            },
-          });
-          return refusal.reason === SPEC_TRANSCRIPTION_REFUSAL_REASON
-            ? { error: refusal.message, reason: refusal.reason }
-            : SKIP;
+          return await settleQueuedCandidate(tx, candidate, {
+            kind: "spec-transcription-refused",
+            refusal,
+            implementationHeadSha: prepared.verification.implementationHeadSha,
+          }, now);
         }
       }
       const generation = candidate.leaseGeneration + 1;


### PR DESCRIPTION
## What changed

Queued candidate settlement now owns the stopped Run write, Task park, activity, Inbox notice, and claim-loop decision behind one seam. Its interface accepts a named condition plus its evidence and the claim timestamp; callers no longer choose parking policy or interpret a chain-lock boolean. The pure `queuedCandidateSettlement` map exposes the policy for tests.

Deleted `parkQueuedCandidate` and both inline stop/park copies. Every queued-stop call now returns `settleQueuedCandidate` directly, including exhausted specification reads. Chain-locked parks end the claim; existing wire refusals still return their original error/reason. Regression repair marker content and stop-notice deduplication/session attribution are preserved.

Added condition-table and real `writeTask` transaction-double tests. Updated two database assertions that previously required multiple chained parks in one poll.

## Evidence

Base and findings anchors rechecked on `origin/main` at `a3683bb06581252f50bf8260f913392f1d99a9d6` using `git show origin/main:packages/api/src/run-claim.ts | rg -n 'parkQueuedCandidate|chainLocked|End the transaction|return SKIP|CandidateDecision|regressionRepair|repository-grant'`. The reported duplicate writers and missed halts were present.

- `npm install`: exit 0, Prisma generated.
- `git diff --cached --check`: passed before commit.
- After final commit `47793e779e3a9ae0250390fdd3faf46c5dca054e`, each verification command set `export RUNNER_WORKSPACE_ROOT=$(mktemp -d)` first, then ran in this order:
  - `npm run lint`: exit 0 (root Biome and ESLint).
  - `npm run typecheck`: exit 0 (root workspaces, including database CLI types).
  - `npm run test -w @anneal/api`: exit 0; 1289 tests, 1286 passed, 3 skipped, 0 failed. Includes `run-claim.test.ts`.
- Independent read-only Codex review of the final commit found no remaining correctness issues. No database tests or Merge gate commands were run; database execution is Merge gate evidence.

## Decisions taken

- Reject the old exhausted-read comment's throughput exception: an eligible sibling does not justify taking its Run lock after holding the chain mutex. A parked chained candidate now ends the poll. Existing explicit wire refusals remain terminal error/reason decisions because they also end the transaction; this preserves `claim-contract.ts` without weakening lock order.
- Keep prerequisite/access/activation/specification failures in BACKLOG: recovery requires fixing inputs or access before retry. Keep invalid Regression repair handoffs in REVIEW: the autonomous merge tail has stopped for operator assessment, with its existing marker and notice semantics.
- Add an Inbox notice for a missing repository grant. It needs operator recovery just like the other queued stops; an activity alone can strand the Task without a visible recovery request. Notice deduplication is per condition/Run, while Regression retains its existing per Task/reason digest.
- Pass `now` explicitly so `endedAt` remains the caller's single claim instant. A lost queued-Run CAS skips without writes; an unsuccessful Task park throws so the existing candidate savepoint rolls the stop back and reports the failure.
- Preserve the specification-read budget/evidence algorithm and Regression marker literal. The only edits in the deferred-read block replace its final settlement call and remove the unsafe continuation comment. Marker metadata remains authored at its existing claim site, passed unchanged through the new seam, leaving the later marker lane its ownership.

## Fence widened

None. The two changed assertions in `packages/api/src/parallel-review-specification.dbtest.ts` necessarily pinned the old same-poll behavior and are covered by the common test-file exception. Product edits stay within c7's owned paths.

## Reported but unfixed

None.
