### PR TITLE
fix(gate): preserve regression results and bound test concurrency

### DIFF
--- a/agents/roles/regression-verifier-luna-max.md
+++ b/agents/roles/regression-verifier-luna-max.md
@@ -16,9 +16,10 @@ the gate, or author the final task output.
 Read the complete persisted review package: both independent review reports,
 implementation with its dispositions and closed findings, the exact pre-fix and
 proposed fixed heads, the approved specification, and relevant prior outputs.
-Review the whole fix diff, account for every finding id, rerun focused
-regressions, and reject an unresolved adopted finding, an unsupported
-disposition, a regression, or a new defect.
+Review the whole fix diff and account for every finding id. Run focused
+regressions for the findings and changed behavior; the Merge gate owns full
+workspace and repository suites. Reject an unresolved adopted finding, an
+unsupported disposition, a regression, or a new defect.
 
 A failure you observe is this chain's defect until you have shown otherwise
 yourself. An earlier step's report that a failure is pre-existing, baseline or

--- a/agents/templates/compound-engineer-workflow/10-regression-verification.md
+++ b/agents/templates/compound-engineer-workflow/10-regression-verification.md
@@ -13,9 +13,10 @@ provisionDependencies: true
 baseFromStepIndex: null
 spawnPolicy: null
 ---
-The platform script owns refresh/merge, merge-lease operations, gate dispatch
-and retries, verdict transcription, and the final `regression-verification-v2`
-task output. Do not perform or restate those mechanical operations yourself.
+The platform script owns prepare-time refresh/merge, gate dispatch and retries,
+verdict transcription, and the final `regression-verification-v2` task output.
+Merge readiness checks the latest target under the Merge Lease before authorizing
+the exact merge. Do not perform or restate those mechanical operations yourself.
 
 Run `"${AGENTOS_TOOLS:?AGENTOS_TOOLS is required}/regression-verification.sh" prepare`. If it reports
 `refresh-conflict`, the final output is already persisted: record the outcome
@@ -24,8 +25,9 @@ every present review report (`review-findings` and, when instantiated,
 `blind-findings`), and the fixed implementation with its dispositions from
 Anneal. The blind review report may be absent when its optional step was
 omitted. Review the entire refreshed fix diff as one unit, account for every
-finding id in every present report, rerun focused regressions, and verify that the approved
-specification is preserved without a new defect. Do not modify code or repair
+finding id in every present report, and verify that the approved specification
+is preserved without a new defect. Run focused regressions for the findings and
+changed behavior; the Merge gate owns full workspace and repository suites. Do not modify code or repair
 a failure.
 
 If an adopted finding remains open, a rejection is unsupported, or a new
@@ -33,10 +35,8 @@ defect exists, run
 `"${AGENTOS_TOOLS:?AGENTOS_TOOLS is required}/regression-verification.sh" review-fail '<concise finding IDs or defect>'`
 and finish. Otherwise run `"${AGENTOS_TOOLS:?AGENTOS_TOOLS is required}/regression-verification.sh" finalize`.
 
-A finalize exit 0 means the script persisted exactly one of `pass`, `gate-fail`,
-or `refresh-conflict`; report the bounded `REGRESSION FINALIZE` status line it
-printed. A finalize exit 77 means the script integrated a newer target head
-outside the lease. Repeat the full semantic verification against that refreshed
-tree, then run either `review-fail` or `finalize` again. Any other nonzero script
-exit fails the run loudly. The script persists the one allowed v2 outcome;
-never call `task_output` for this step or write a report file.
+A finalize exit 0 means the script persisted `pass` or `gate-fail` for the head
+and baseline frozen by prepare; report the bounded `REGRESSION FINALIZE` status
+line it printed. Any nonzero script exit fails the run loudly.
+The script persists the one allowed v2 outcome; never call `task_output` for
+this step or write a report file.

--- a/agents/templates/direct-engineer-workflow/06-regression-verification.md
+++ b/agents/templates/direct-engineer-workflow/06-regression-verification.md
@@ -13,9 +13,10 @@ provisionDependencies: true
 baseFromStepIndex: null
 spawnPolicy: null
 ---
-The platform script owns refresh/merge, merge-lease operations, gate dispatch
-and retries, verdict transcription, and the final `regression-verification-v2`
-task output. Do not perform or restate those mechanical operations yourself.
+The platform script owns prepare-time refresh/merge, gate dispatch and retries,
+verdict transcription, and the final `regression-verification-v2` task output.
+Merge readiness checks the latest target under the Merge Lease before authorizing
+the exact merge. Do not perform or restate those mechanical operations yourself.
 
 Run `"${AGENTOS_TOOLS:?AGENTOS_TOOLS is required}/regression-verification.sh" prepare`. If it reports
 `refresh-conflict`, the final output is already persisted: record the outcome
@@ -24,8 +25,9 @@ every present review report (`review-findings` and, when instantiated,
 `blind-findings`), and the fixed implementation with its dispositions from
 Anneal. The blind review report may be absent when its optional step was
 omitted. Review the entire refreshed fix diff as one unit, account for every
-finding id in every present report, rerun focused regressions, and verify that the approved
-specification is preserved without a new defect. Do not modify code or repair
+finding id in every present report, and verify that the approved specification
+is preserved without a new defect. Run focused regressions for the findings and
+changed behavior; the Merge gate owns full workspace and repository suites. Do not modify code or repair
 a failure.
 
 If an adopted finding remains open, a rejection is unsupported, or a new
@@ -33,10 +35,8 @@ defect exists, run
 `"${AGENTOS_TOOLS:?AGENTOS_TOOLS is required}/regression-verification.sh" review-fail '<concise finding IDs or defect>'`
 and finish. Otherwise run `"${AGENTOS_TOOLS:?AGENTOS_TOOLS is required}/regression-verification.sh" finalize`.
 
-A finalize exit 0 means the script persisted exactly one of `pass`, `gate-fail`,
-or `refresh-conflict`; report the bounded `REGRESSION FINALIZE` status line it
-printed. A finalize exit 77 means the script integrated a newer target head
-outside the lease. Repeat the full semantic verification against that refreshed
-tree, then run either `review-fail` or `finalize` again. Any other nonzero script
-exit fails the run loudly. The script persists the one allowed v2 outcome;
-never call `task_output` for this step or write a report file.
+A finalize exit 0 means the script persisted `pass` or `gate-fail` for the head
+and baseline frozen by prepare; report the bounded `REGRESSION FINALIZE` status
+line it printed. Any nonzero script exit fails the run loudly.
+The script persists the one allowed v2 outcome; never call `task_output` for
+this step or write a report file.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/web -- /bin/sh -c 'tsc -b && vite build'",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/web -- tsc -b --pretty false",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/web -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/web -- /bin/sh -c 'TSX_TSCONFIG_PATH=tsconfig.app.json node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} \"src/**/*.test.ts\" \"src/**/*.test.tsx\"'",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/web -- /bin/sh -c 'TSX_TSCONFIG_PATH=tsconfig.app.json node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} \"src/**/*.test.ts\" \"src/**/*.test.tsx\"'",
     "dev": "vite",
     "preview": "vite preview"
   },

--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -33,11 +33,12 @@ so do not remove the `set -m` around the spawn in `step-engine.sh`: it is what
 makes the whole tree reachable rather than just the member's own shell.
 
 How wide each group runs is derived from a stated share of the host, not from
-the core count. `run-gate.sh` exports `AGENTOS_GATE_HOST_SHARE` as the worker's
-`host-share` setting, which defaults to its slot count, so on the two-slot
-desktop each gate sizes itself for half the machine and two concurrent gates
-still add up to one host. A gate invoked by hand states no share and takes half
-the machine. Do not restore a per-phase fan-out in
+the core count. This is a sizing target, not a hard CPU quota: the operating
+system can still schedule the gate alongside other work. `run-gate.sh` exports
+`AGENTOS_GATE_HOST_SHARE` as the worker's `host-share` setting, which defaults
+to its slot count, so on the two-slot desktop each gate sizes itself for half
+the machine. A gate invoked by hand states no share and takes half the machine.
+Do not restore a per-phase fan-out in
 `run-gate.sh`: `7886fad` set `AGENTOS_DBTEST_CONCURRENCY` there, `merge-gate.sh`
 recomputed that same variable moments later, and the bound silently never took
 effect while both logs claimed it had.
@@ -568,16 +569,23 @@ machine and strict FIFO order is not promised. The first waiter to acquire
 whichever usable local or remote slot frees runs there.
 
 The database step runs one file per lane, each with a database of its own and
-its own subdirectory of the roots the gate exports. The lane count is not read
-from the CPU count here: `run-gate.sh` exports only `AGENTOS_GATE_HOST_SHARE`,
-the worker's `host-share` setting, and `merge-gate.sh` derives every parallel
-width in the run from `availableParallelism() / AGENTOS_GATE_HOST_SHARE`. That
-setting defaults to the worker's capacity, so on the 14-vCPU desktop worker a
-capacity-two gate gets 7 unit and 7 database lanes and two of them add up to the
-host, while a hand-run gate with no stated share defaults to half the host. A
+its own subdirectory of the roots the gate exports. Unit tests use the same
+lane budget, but the workspace commands are submitted one at a time: the
+active workspace receives `--test-concurrency=${GATE_UNIT_LANES}` through the
+gate-only `AGENTOS_GATE_UNIT_TEST_CONCURRENCY` variable. This bounds top-level
+unit-test file workers across workspaces by `GATE_UNIT_LANES`; subprocesses
+started by a test remain outside that count. Every workspace keeps its test
+command, loader, and file glob. The lane
+count is not read from the CPU count here: `run-gate.sh` exports only
+`AGENTOS_GATE_HOST_SHARE`, the worker's `host-share` setting, and `merge-gate.sh`
+derives every parallel width in the run from `availableParallelism() /
+AGENTOS_GATE_HOST_SHARE`. That setting defaults to the worker's capacity, so on
+the 14-vCPU desktop worker a capacity-two gate sizes for 7 unit and 7 database
+lanes, while a hand-run gate with no stated share defaults to half the host. A
 worker whose host also runs runners states a larger share than its capacity and
 gets correspondingly fewer lanes. Deriving every width from the one number is
-what keeps that invariant true; do not fix a width independently of the share.
+what keeps the sizing consistent; do not fix a width independently of the
+share.
 `AGENTOS_DBTEST_CONCURRENCY` lowers the file concurrency on other paths and
 `AGENTOS_DBTEST_PROVISION=0` puts the step back on one shared schema, serial.
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/api -- /bin/sh -c 'tsc -p tsconfig.json && node ../build-info/stamp.mjs dist'",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/api -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/api -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/api -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts src/routes/*.test.ts src/files/*.test.ts",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/api -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts src/routes/*.test.ts src/files/*.test.ts",
     "test:db": "bash ../../scripts/host-proof-slot.sh test:db @anneal/api -- node --conditions=development --import tsx scripts/dbtest.mjs",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js"

--- a/packages/api/src/merge-integrator-seed.dbtest.ts
+++ b/packages/api/src/merge-integrator-seed.dbtest.ts
@@ -249,7 +249,7 @@ test("a fresh seed writes the twelve-step, eight-step, and four-step canonical t
     (await db.agent.findFirstOrThrow({ where: { name: "librarian-luna-xhigh" } })).id);
   assert.equal(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 10)?.attachmentsFromPrevious, true);
   assert.match(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 10)?.prompt ?? "", /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" prepare/u);
-  assert.match(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 10)?.prompt ?? "", /finalize exit 77[\s\S]*Repeat the full semantic verification/u);
+  assert.match(step.taskTemplate.steps.find((candidate) => candidate.stepIndex === 10)?.prompt ?? "", /head[\s\S]*and baseline frozen by prepare/u);
   // The fix step reads both reports itself; no node authors must-fix any more.
   assert.equal(step.taskTemplate.steps.some((candidate) => candidate.outputKind === "must-fix"), false);
   assert.match(

--- a/packages/api/src/templates.test.ts
+++ b/packages/api/src/templates.test.ts
@@ -893,7 +893,7 @@ test("canonical unbound direct instantiation retains the seven-task prompt snaps
     { name: "snapshot chain: Code review", descriptionSha256: "9b6d28537d11423006f897eb0661e6120ff8ea96f8857cfa6b4cfe06ad3c3c27" },
     { name: "snapshot chain: Blind code review", descriptionSha256: "af02f099a6e2b6b10f3ea2b31b8bcfd06a057cd91b134c16a3df552690fc979b" },
     { name: "snapshot chain: Apply review fixes", descriptionSha256: "89607144c06f5ee42b01f9d3e3ae1513d5d5232f8b0541d736b505b312408a8e" },
-    { name: "snapshot chain: Regression verification", descriptionSha256: "5ba403dde0fa9a2becfe969646691f59e3db947ef3eefed1ed2150db2db11dbd" },
+    { name: "snapshot chain: Regression verification", descriptionSha256: "e88247d9d62467ac81629ca66e5955845421127a32ffbfd3f9403072bdfba1e2" },
     { name: "snapshot chain: Merge authorization", descriptionSha256: "6cc850c691d3334a0ba8e4b26b24acdc3c7ab70c4b8cbac1fccb65ee708a7da7" },
     { name: "snapshot chain: Merge execution", descriptionSha256: "6f3ee10eef0967fec9bfdb09a73ab8b9f5e07aa3e4548e48d1174e2a90602a53" },
   ]);

--- a/packages/build-info/package.json
+++ b/packages/build-info/package.json
@@ -11,6 +11,6 @@
   },
   "scripts": {
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/build-info -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/build-info -- node --conditions=development --test ${AGENTOS_RUN_ID:+--test-concurrency=2} *.test.mjs"
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/build-info -- node --conditions=development --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} *.test.mjs"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -92,7 +92,7 @@
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/db -- /bin/sh -c 'tsc -p tsconfig.json --noEmit && npm run typecheck:cli'",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/db -- /bin/sh -c 'biome lint . && eslint .'",
     "typecheck:cli": "tsc -p tsconfig.cli.json --noEmit",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/db -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} prisma/*.test.ts src/*.test.ts",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/db -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} prisma/*.test.ts src/*.test.ts",
     "test:db": "bash ../../scripts/host-proof-slot.sh test:db @anneal/db -- node --conditions=development --import tsx --test --test-concurrency=1 src/*.dbtest.ts",
     "db:generate": "prisma generate",
     "db:migrate": "dotenv -e ../../.env -- prisma migrate dev",

--- a/packages/db/prisma/agent-contract.test.ts
+++ b/packages/db/prisma/agent-contract.test.ts
@@ -329,11 +329,11 @@ test("the canonical twelve-step layered template sources split review and preser
   assert.match(compoundFix, /No adjudication step stands between the reviews and this one/u);
   assert.match(compoundFix, /ADOPTED[\s\S]*REJECTED[\s\S]*MERGED/u);
   const compoundRegression = templateSteps.find((step) => step.stepIndex === 10)!.prompt;
-  assert.match(compoundRegression, /platform script owns refresh\/merge[\s\S]*final `regression-verification-v2`/u);
+  assert.match(compoundRegression, /platform script owns prepare-time refresh\/merge[\s\S]*final `regression-verification-v2`/u);
   assert.match(compoundRegression, /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" prepare/u);
   assert.match(compoundRegression, /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" review-fail/u);
   assert.match(compoundRegression, /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" finalize/u);
-  assert.match(compoundRegression, /finalize exit 77[\s\S]*Repeat the full semantic verification/u);
+  assert.match(compoundRegression, /head[\s\S]*and baseline frozen by prepare/u);
   assert.match(compoundRegression, /implementation summary,\s+every present review report/u);
   assert.match(compoundRegression, /blind review report may be absent/u);
   assert.match(compoundRegression, /fixed implementation with its dispositions/u);
@@ -423,7 +423,7 @@ test("the direct template sources expose the layered review spine and mechanical
   assert.match(directRegression, /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" prepare/u);
   assert.match(directRegression, /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" review-fail/u);
   assert.match(directRegression, /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" finalize/u);
-  assert.match(directRegression, /finalize exit 77[\s\S]*Repeat the full semantic verification/u);
+  assert.match(directRegression, /head[\s\S]*and baseline frozen by prepare/u);
   assert.doesNotMatch(directRegression, /merge-lease\.sh|gate-dispatch\.sh|gateProof/u);
   const directImplementation = directTemplateSteps.find((step) => step.stepIndex === 2)!.prompt;
   assert.match(directImplementation, /brief is the specification of record/u);

--- a/packages/db/src/canonical-prompt-sync-fixtures.test.ts
+++ b/packages/db/src/canonical-prompt-sync-fixtures.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { restorePreOptionalReviewPrompt, restorePreTierRevalidationPrompt } from "./canonical-prompt-sync-fixtures.js";
+import { restorePreFrozenRegressionPrompt, restorePreOptionalReviewPrompt, restorePreTierRevalidationPrompt } from "./canonical-prompt-sync-fixtures.js";
 import { LEGACY_TEMPLATE_GENERATIONS, templatePromptGenerationDigest } from "./canonical-template-transition.js";
 import { loadAllTemplateStepSources } from "./template-sources.js";
 
@@ -24,3 +24,11 @@ for (const marker of ["pre-runner-provided-regression-tooling", "pre-optional-re
     }
   });
 }
+
+test("sync fixtures reconstruct the registered pre-frozen-regression-baseline generation", async () => {
+  const sources = await loadAllTemplateStepSources();
+  for (const name of ["direct-engineer-workflow", "compound-engineer-workflow"] as const) {
+    const steps = sources.get(name)!.map((step) => ({ ...step, prompt: restorePreFrozenRegressionPrompt(step.prompt) }));
+    assert.equal(templatePromptGenerationDigest(steps), LEGACY_TEMPLATE_GENERATIONS[name].find((generation) => generation.marker === "pre-frozen-regression-baseline")!.promptDigest, name);
+  }
+});

--- a/packages/db/src/canonical-prompt-sync-fixtures.ts
+++ b/packages/db/src/canonical-prompt-sync-fixtures.ts
@@ -1,9 +1,23 @@
 /**
- * Prompt-only rollover fixtures must restore every prompt byte from before
- * optional review omission, not just the older Regression script path. The
- * generation digest authenticates the whole template.
+ * Restore the Regression bytes retired by the frozen-baseline rollover before
+ * applying older fixture transformations. Every historical generation digest
+ * authenticates the whole template, including this mechanical handoff.
  */
-export const restorePreOptionalReviewPrompt = (prompt: string): string => prompt
+export const restorePreFrozenRegressionPrompt = (prompt: string): string => prompt
+  .replace(
+    "The platform script owns prepare-time refresh/merge, gate dispatch and retries,\nverdict transcription, and the final `regression-verification-v2` task output.\nMerge readiness checks the latest target under the Merge Lease before authorizing\nthe exact merge.",
+    "The platform script owns refresh/merge, merge-lease operations, gate dispatch\nand retries, verdict transcription, and the final `regression-verification-v2`\ntask output.",
+  )
+  .replace(
+    "finding id in every present report, and verify that the approved specification\nis preserved without a new defect. Run focused regressions for the findings and\nchanged behavior; the Merge gate owns full workspace and repository suites.",
+    "finding id in every present report, rerun focused regressions, and verify that the approved\nspecification is preserved without a new defect.",
+  )
+  .replace(
+    "A finalize exit 0 means the script persisted `pass` or `gate-fail` for the head\nand baseline frozen by prepare; report the bounded `REGRESSION FINALIZE` status\nline it printed. Any nonzero script exit fails the run loudly.\nThe script persists the one allowed v2 outcome; never call `task_output` for\nthis step or write a report file.",
+    "A finalize exit 0 means the script persisted exactly one of `pass`, `gate-fail`,\nor `refresh-conflict`; report the bounded `REGRESSION FINALIZE` status line it\nprinted. A finalize exit 77 means the script integrated a newer target head\noutside the lease. Repeat the full semantic verification against that refreshed\ntree, then run either `review-fail` or `finalize` again. Any other nonzero script\nexit fails the run loudly. The script persists the one allowed v2 outcome;\nnever call `task_output` for this step or write a report file.",
+  );
+
+export const restorePreOptionalReviewPrompt = (prompt: string): string => restorePreFrozenRegressionPrompt(prompt)
   .replaceAll("review-findings", "sol-findings")
   .replaceAll("the code review report", "the Sol report")
   // Every registered generation predates the salvage-resume rollover, so the

--- a/packages/db/src/canonical-published-generations.ts
+++ b/packages/db/src/canonical-published-generations.ts
@@ -61,12 +61,14 @@ export const PUBLISHED_PROMPT_GENERATIONS = {
     { digest: "a1a15921c9a4592c05db1e0d6d42f95ab2aa8c0011102bd20bf4d3b67b1bd0a1", retiredByShape: "pre-model-neutral-review-output" },
     { digest: "04d473928d65443202bd68b6d865df61f26983fc35870cf43e5032279e1ed107" },
     { digest: "79921b8f06e1abbfdcd3db7132e48816edb68deda47082b9c2508b1b74067ca1" },
+    { digest: "667f0aadce31cc62aa7043d6c46a1ee89d08ce4f8690bd5a5fe50a5fd5662abd" },
   ],
   "compound-engineer-workflow": [
     { digest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9", retiredByShape: "model-neutral-review-step-names" },
     { digest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9" },
     { digest: "be4428549ef4c428fd82ea9e6315bee040bd7874561f2fcc362a49216497bb66", retiredByShape: "pre-model-neutral-review-output" },
     { digest: "6d0e84947f79d3c1307727d4d0cdfae7827828e488dc6a05c2a9366480791142" },
+    { digest: "2a3634bc7c7f74a066ab8fce78c4e0f02f2f9ac65acdcf37e07c993c445bed2c" },
   ],
   [PR_TEMPLATE_NAME]: [
     { digest: "1c1169bf0586f6bb71f4ed34b3eb6b166828802a9b24c6b07844b2f526b5f8a8", retiredByShape: "model-neutral-review-step-names" },

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -329,6 +329,20 @@ const legacyTemplateGenerations = {
         { name: "Merge execution", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
       ],
     },
+    {
+      marker: "pre-frozen-regression-baseline",
+      promptDigest: "79921b8f06e1abbfdcd3db7132e48816edb68deda47082b9c2508b1b74067ca1",
+      shape: [
+        { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Code review", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "review-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
+        { name: "Blind code review", assigneeType: AssigneeType.AGENT, approvalGate: false, optional: true, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
+        { name: "Apply review fixes", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Regression verification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Merge authorization", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
+        { name: "Merge execution", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+      ],
+    },
   ],
   "compound-engineer-workflow": [
     {
@@ -574,6 +588,24 @@ const legacyTemplateGenerations = {
         { name: "Merge execution", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
       ],
     },
+    {
+      marker: "pre-frozen-regression-baseline",
+      promptDigest: "6d0e84947f79d3c1307727d4d0cdfae7827828e488dc6a05c2a9366480791142",
+      shape: [
+        { name: "Write a spec", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "spec", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: false, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Plan review", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "plan-review", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 3, spawnPolicy: null },
+        { name: "Revise plan", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revised-plan", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Implementation", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: true, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Code review", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "review-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null, provisionDependencies: false },
+        { name: "Blind code review", assigneeType: AssigneeType.AGENT, approvalGate: false, optional: true, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 5, layer: 6, spawnPolicy: null, provisionDependencies: false },
+        { name: "Apply review fixes", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+        { name: "Librarian", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "documentation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 8, spawnPolicy: null },
+        { name: "Regression verification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 9, spawnPolicy: null },
+        { name: "Merge authorization", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 10, spawnPolicy: null },
+        { name: "Merge execution", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 11, spawnPolicy: null },
+      ],
+    },
   ],
   [PR_TEMPLATE_NAME]: [
     {
@@ -683,8 +715,8 @@ export const LEGACY_TEMPLATE_GENERATIONS: Readonly<
  * `agents/templates/` and fails on a mismatch.
  */
 export const CANONICAL_SOURCE_PROMPT_GENERATIONS = {
-  [DIRECT_TEMPLATE_NAME]: "79921b8f06e1abbfdcd3db7132e48816edb68deda47082b9c2508b1b74067ca1",
-  "compound-engineer-workflow": "6d0e84947f79d3c1307727d4d0cdfae7827828e488dc6a05c2a9366480791142",
+  [DIRECT_TEMPLATE_NAME]: "667f0aadce31cc62aa7043d6c46a1ee89d08ce4f8690bd5a5fe50a5fd5662abd",
+  "compound-engineer-workflow": "2a3634bc7c7f74a066ab8fce78c4e0f02f2f9ac65acdcf37e07c993c445bed2c",
   [PR_TEMPLATE_NAME]: "93a909a5d88b6aa158f9f86155853d7aed7762b61bd56dc9a1b17b6e7051281f",
 } as const satisfies Readonly<Record<CanonicalTemplateRegistryName, string>>;
 

--- a/packages/db/src/template-sources.test.ts
+++ b/packages/db/src/template-sources.test.ts
@@ -156,8 +156,10 @@ test("canonical sources expose the exact layered Direct and Full graphs", async 
     assert.match(regression.prompt, /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" prepare/u);
     assert.match(regression.prompt, /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" review-fail/u);
     assert.match(regression.prompt, /\$\{AGENTOS_TOOLS:\?AGENTOS_TOOLS is required\}\/regression-verification\.sh" finalize/u);
-    assert.match(regression.prompt, /finalize exit 77[\s\S]*Repeat the full semantic verification/u);
-    assert.match(regression.prompt, /finalize exit 0[\s\S]*`pass`, `gate-fail`,\s+or `refresh-conflict`/u);
+    assert.match(regression.prompt, /head[\s\S]*and baseline frozen by prepare/u);
+    assert.match(regression.prompt, /focused regressions[\s\S]*Merge gate owns full workspace and repository suites/u);
+    assert.doesNotMatch(regression.prompt, /semantic-stale|exit 77/u);
+    assert.match(regression.prompt, /finalize exit 0[\s\S]*`pass` or `gate-fail`/u);
     assert.match(regression.prompt, /script persists the one allowed v2 outcome/u);
     assert.doesNotMatch(regression.prompt, /merge-lease\.sh|gate-dispatch\.sh|\{"schemaVersion":2/u);
     assert.ok(regression.prompt.split("\n").length < 30, "the semantic prompt stays materially shorter than the retired 62-line procedure");
@@ -739,12 +741,13 @@ test("bare revalidation only selects v1 for complete historical Direct identitie
   assert.equal(canonicalOutputGeneration({ outputKind: "revalidation-v2", taskTemplateName }), "v2");
 });
 
-test("registered pre-route Direct generations retain the v1 output protocol", () => {
+test("registered Direct generations retain their historical revalidation protocol", () => {
   for (const generation of LEGACY_TEMPLATE_GENERATIONS[DIRECT_TEMPLATE_NAME]) {
     if (!generation.shape.some(({ outputKind }) => outputKind === "revalidation")) continue;
+    const expected = generation.marker === "pre-frozen-regression-baseline" ? "v2" : "v1";
     const taskTemplateName = templateRolloverName(DIRECT_TEMPLATE_NAME, generation.marker, "row");
-    assert.equal(canonicalOutputGeneration({ outputKind: "revalidation", taskTemplateName }), "v1");
-    assert.equal(canonicalOutputGeneration({ outputKind: "revalidation", taskTemplate: { name: taskTemplateName } }), "v1");
+    assert.equal(canonicalOutputGeneration({ outputKind: "revalidation", taskTemplateName }), expected);
+    assert.equal(canonicalOutputGeneration({ outputKind: "revalidation", taskTemplate: { name: taskTemplateName } }), expected);
     assert.equal(canonicalOutputGeneration({ outputKind: "revalidation-v2", taskTemplateName }), "v2");
   }
 });

--- a/packages/github-client/package.json
+++ b/packages/github-client/package.json
@@ -16,7 +16,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/github-client -- tsc -p tsconfig.json",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/github-client -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/github-client -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/github-client -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts"
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/github-client -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts"
   },
   "devDependencies": {
     "@types/node": "^24.10.1",

--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -7,7 +7,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/inbox -- tsc -p tsconfig.json",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/inbox -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/inbox -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/inbox -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/inbox -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js"
   },

--- a/packages/merge-executor/package.json
+++ b/packages/merge-executor/package.json
@@ -7,7 +7,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/merge-executor -- tsc -p tsconfig.json",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/merge-executor -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/merge-executor -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/merge-executor -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/merge-executor -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts",
     "start": "node dist/index.js",
     "schema-gate": "MERGE_EXECUTOR_SCHEMA_GATE_REQUIRED=1 node --conditions=development --import tsx --test src/schema-gate.test.ts"
   },

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -29,7 +29,7 @@
     "build": "bash ../../scripts/host-proof-slot.sh build @anneal/runner -- /bin/sh -c 'tsc -p tsconfig.json && node scripts/build-runtime-tools.mjs && node ../build-info/stamp.mjs dist'",
     "typecheck": "bash ../../scripts/host-proof-slot.sh typecheck @anneal/runner -- tsc -p tsconfig.json --noEmit",
     "lint": "bash ../../scripts/host-proof-slot.sh lint @anneal/runner -- /bin/sh -c 'biome lint . && eslint .'",
-    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/runner -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts src/adapters/*.test.ts scripts/*.test.mjs",
+    "test": "bash ../../scripts/host-proof-slot.sh test @anneal/runner -- node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts src/adapters/*.test.ts scripts/*.test.mjs",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js"
   },

--- a/packages/runner/runtime-tools/regression-verification.sh
+++ b/packages/runner/runtime-tools/regression-verification.sh
@@ -12,7 +12,6 @@
 set -u
 set -o pipefail
 
-EXIT_SEMANTIC_STALE=77
 OUTPUT_KIND="regression-verification-v2"
 SHA_RE='^[0-9a-f]{40}$'
 
@@ -44,6 +43,9 @@ cleanup() {
   [ -z "$GATE_LOG" ] || rm -f -- "$GATE_LOG"
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 valid_sha() { [[ "$1" =~ $SHA_RE ]]; }
 
@@ -54,24 +56,21 @@ head_sha() {
   printf '%s' "$head"
 }
 
-FETCH_ATTEMPTS=6
+FETCH_ATTEMPTS=3
 
-# Kept in parity with db's transport vocabulary by transport-vocabulary.test.ts.
-FETCH_TRANSIENT_RE='fetch failed|SSL_ERROR_SYSCALL|SSL_connect|unexpected EOF|early EOF|(^|[^A-Za-z0-9_])Post[[:space:]]+"[^"]+"[[:space:]]*:[[:space:]]*EOF([^A-Za-z0-9_]|$)|our servers are currently overloaded|(^|[^A-Za-z0-9_])model[[:space:]]+is[[:space:]]+(currently[[:space:]]+)?at capacity([^A-Za-z0-9_]|$)|connection (reset|closed|timed out|lost|aborted|refused)|RPC failed|Operation timed out|Failed to connect|Could not resolve host|Recv failure|socket hang ?up|HTTP( response)?[[:space:]]*(408|425|429|5[0-9][0-9])|status( code)?[[:space:]]*(408|425|429|5[0-9][0-9])|502 Bad Gateway|503 Service Unavailable|504 Gateway Timeout|ECONNABORTED|ECONNRESET|EHOSTUNREACH|ENETDOWN|ENETRESET|ENETUNREACH|EPIPE|ETIMEDOUT|EAI_AGAIN|ETIMEOUT'
-FETCH_ACCESS_REFUSAL_RE='authentication failed|could not read Username|permission denied|forbidden|HTTP( response)?[[:space:]]*(401|403)|status( code)?[[:space:]]*(401|403)|bad credentials|authorization failed|(^|[^A-Za-z0-9_])unauthorized([^A-Za-z0-9_]|$)|invalid credentials|requested URL returned error:[[:space:]]*(401|403)([^A-Za-z0-9_]|$)|resource not accessible'
+# Fetch is a read-only, replay-safe operation. Retry unknown failures within an
+# attempt budget; the Run deadline still bounds a hanging fetch. Error text
+# only vetoes actionable deterministic failures. Transport implementations
+# need no shared symptom vocabulary here.
+FETCH_REFUSAL_RE='authentication failed|could not read Username|permission denied|forbidden|HTTP( response)?[[:space:]]*(401|403|404|429)|status( code)?[[:space:]]*(401|403|404|429)|requested URL returned error:[[:space:]]*(401|403|404|429)|bad credentials|authorization failed|(^|[^A-Za-z0-9_])unauthorized([^A-Za-z0-9_]|$)|invalid credentials|resource not accessible|too many requests|rate limit|captcha|human verification|does not appear to be a git repository|not a git repository|repository .*not found|couldn.t find remote ref|invalid refspec|not a valid (object|ref|branch)|bad config|invalid config|unable to read config|URL rejected|bad/illegal format|unsupported protocol|protocol .*not supported|no space left|disk quota|read-only file system|unable to create|cannot create|could not lock|cannot lock ref|insufficient permission|unable to write|certificate.*(verif|expired|invalid)|SSL certificate problem|server certificate verification failed|unable to get local issuer certificate|host key verification failed'
 
-fetch_is_transient() (
+fetch_is_retryable() (
   shopt -s nocasematch
-  [[ ! "$1" =~ $FETCH_ACCESS_REFUSAL_RE && "$1" =~ $FETCH_TRANSIENT_RE ]]
+  [[ ! "$1" =~ $FETCH_REFUSAL_RE ]]
 )
 
-# Exponential backoff with full jitter, capped per attempt, matching the clone
-# profile in network-retry.ts. This host reaches GitHub through a proxy whose
-# 443 exit drops for seconds at a time; on 2026-09-02 the previous budget
-# (3 attempts, 1s apart) was exhausted inside one such drop twice in a row and
-# burned both Runs of a regression step before any verification began. Waiting
-# up to 1s,2s,4s,8s,8s (~23s worst case) rides out a second-scale drop while
-# staying far inside the step's stall timeout.
+# Full jitter gives brief transport interruptions time to clear, with at most
+# two waits (one and two seconds) inside the three-attempt operation budget.
 fetch_backoff() {
   local ceiling=$(( 1 << (($1 < 4 ? $1 : 4) - 1) ))
   sleep "$(awk -v ceiling="$ceiling" 'BEGIN { srand(); printf "%.2f", rand() * ceiling }')"
@@ -133,7 +132,12 @@ fetch_base() {
       printf '%s' "$fetched"
       return 0
     fi
-    if ! fetch_is_transient "$error"; then
+    # A terminated child is cancellation, never another transport attempt.
+    if [ "$status" -gt 128 ] && [ "$status" -lt 193 ]; then
+      printf 'regression-verification: target fetch interrupted (exit %s): %s\n' "$status" "$error" >&2
+      return "$status"
+    fi
+    if ! fetch_is_retryable "$error"; then
       persist_target_fetch_block "$error"
       printf 'regression-verification: target fetch failed (exit %s): %s\n' "$status" "$error" >&2
       return 1
@@ -141,7 +145,7 @@ fetch_base() {
     [ "$attempt" -lt "$FETCH_ATTEMPTS" ] || break
     printf 'regression-verification: target fetch failed; retrying attempt=%s/%s\n' \
       "$((attempt + 1))" "$FETCH_ATTEMPTS" >&2
-    fetch_backoff "$attempt"
+    fetch_backoff "$attempt" || return "$?"
   done
   persist_target_fetch_block "$error"
   printf 'regression-verification: target fetch failed after %s attempts: %s\n' \
@@ -580,7 +584,7 @@ prepare() {
   [ ! -L "$output_dir" ] || die "refusing symlinked regression output directory"
   rm -f -- "$OUTPUT_FILE" || die "cannot clear stale regression output handoff"
   incoming_head="$(head_sha)" || die "cannot resolve incoming workspace HEAD"
-  base_head="$(fetch_base)" || die "cannot refresh target head"
+  base_head="$(fetch_base)" || die "cannot refresh target head" "$?"
   refresh_onto_target "$base_head"
   result=$?
   [ "$result" -eq 0 ] || return 0
@@ -593,21 +597,6 @@ prepare() {
     write_state "$prepared_head" "$base_head"
     printf 'REGRESSION PREPARE: ready %s %s\n' "$prepared_head" "$base_head"
   fi
-}
-
-semantic_stale() {
-  local target_head="$1" result refreshed_head
-  # A base move invalidates the prepare-time semantic reuse authorization even
-  # when refreshing the workspace later reports a conflict. Do not leave a
-  # skipped-review marker available to a subsequent finalize invocation.
-  [ "${SEMANTIC_VERDICT:-}" = "reused" ] && clear_reuse_state
-  refresh_onto_target "$target_head"
-  result=$?
-  [ "$result" -eq 0 ] || return 0
-  refreshed_head="$(head_sha)" || die "cannot resolve refreshed workspace HEAD"
-  write_state "$refreshed_head" "$target_head"
-  printf 'REGRESSION FINALIZE: semantic-stale %s %s\n' "$refreshed_head" "$target_head"
-  return "$EXIT_SEMANTIC_STALE"
 }
 
 review_fail() {
@@ -626,7 +615,7 @@ review_fail() {
 }
 
 finalize() {
-  local current latest gate_log gate_status gate_proof gate_failure_summary gate_failure_excerpt attempt verdict
+  local current gate_log gate_status gate_proof gate_failure_summary gate_failure_excerpt attempt verdict
   read_state
   current="$(head_sha)" || die "cannot resolve finalize workspace HEAD"
   if [ "$current" != "$VERIFIED_HEAD_SHA" ]; then
@@ -634,14 +623,9 @@ finalize() {
     die "workspace HEAD changed after semantic verification"
   fi
 
-  # Most drift is discovered and integrated before acquire, so no other chain
-  # queues behind a tree that still needs another model pass.
-  latest="$(fetch_base)" || die "cannot refresh target head"
-  if [ "$latest" != "$BASE_HEAD_SHA" ]; then
-    semantic_stale "$latest"
-    return $?
-  fi
-
+  # Prove the pair frozen by prepare. Live target reads belong to Merge
+  # readiness under its Lease; a later network failure or base move must not
+  # discard completed semantic work or the gate verdict for this pair.
   current="$(head_sha)" || die "cannot resolve gated workspace HEAD"
   gate_log="$(mktemp "${TMPDIR:-/tmp}/regression-gate.XXXXXX")" \
     || die "cannot create gate output file"
@@ -661,14 +645,6 @@ finalize() {
     esac
   done
   gate_proof="$(gate_verdict_read "$gate_log")" || gate_proof=""
-
-  # Gate execution may be long. Do not publish evidence against a base that
-  # moved while it ran; readiness performs the final check again under Lease.
-  latest="$(fetch_base)" || die "cannot refresh target head after gate"
-  if [ "$latest" != "$BASE_HEAD_SHA" ]; then
-    semantic_stale "$latest"
-    return $?
-  fi
 
   case "$gate_proof" in
     "MERGE GATE: PASS $current")

--- a/packages/runner/src/adapters.test.ts
+++ b/packages/runner/src/adapters.test.ts
@@ -229,6 +229,8 @@ test("a recovery Regression claim carries the pinned context and skip instructio
   assert.match(prompt, /Platform-pinned base-drift recovery instruction:/u);
   assert.match(prompt, /semantic-reused[\s\S]*skip the semantic model recheck[\s\S]*finalize immediately/u);
   assert.match(prompt, /finalize always runs the Merge gate/u);
+  assert.match(prompt, /head and baseline frozen by prepare/u);
+  assert.doesNotMatch(prompt, /semantic-stale|exit 77/u);
 
   const config = {
     path: "/bin",

--- a/packages/runner/src/adapters.ts
+++ b/packages/runner/src/adapters.ts
@@ -63,7 +63,7 @@ const recoveryPromptSection = (claim: ClaimedTask): string[] => {
     "Platform-pinned base-drift recovery instruction:",
     `- Recovery Run ${context.recoveryRunId} is queued for base ${context.currentBaseSha} and authorized head ${context.authorizedHeadSha}.`,
     "- Run regression-verification.sh prepare first. If it reports `REGRESSION PREPARE: semantic-reused`, the persisted prior Run is an exact-head semantic PASS: skip the semantic model recheck and invoke regression-verification.sh finalize immediately.",
-    "- finalize always runs the Merge gate. If prepare reports `ready`, or finalize reports semantic-stale with exit 77, perform the full semantic recheck required by the Regression task before finalizing.",
+    "- finalize always runs the Merge gate. If prepare reports `ready`, perform the full semantic recheck with focused regressions required by the Regression task before finalizing. The gate proves the head and baseline frozen by prepare; Merge readiness checks the latest target under its Lease.",
   ];
 };
 

--- a/packages/runner/src/regression-verification-script.test.ts
+++ b/packages/runner/src/regression-verification-script.test.ts
@@ -78,13 +78,13 @@ const fixture = (): Fixture => {
   // reaches real git. `git fetch` is the only reachable transient network call
   // in this script, and it is what the retry budget exists for.
   executable(join(bin, "git"), `#!/bin/sh
-if [ "$1" = "fetch" ] && [ "${"$"}{REGRESSION_FIXTURE_FETCH_FAILURES:-0}" -gt 0 ]; then
+if [ "$1" = "fetch" ]; then
   attempt="$(wc -l < "$REGRESSION_FIXTURE_FETCH_LOG" | tr -d ' ')"
   attempt=$((attempt + 1))
   printf '%s\\n' "$attempt" >> "$REGRESSION_FIXTURE_FETCH_LOG"
-  if [ "$attempt" -le "$REGRESSION_FIXTURE_FETCH_FAILURES" ]; then
-    printf 'fatal: unable to access: LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443\\n' >&2
-    exit 128
+  if [ "$attempt" -le "${"$"}{REGRESSION_FIXTURE_FETCH_FAILURES:-0}" ]; then
+    printf '%s\\n' "${"$"}{REGRESSION_FIXTURE_FETCH_ERROR:-fatal: unable to access: LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443}" >&2
+    exit "${"$"}{REGRESSION_FIXTURE_FETCH_EXIT:-128}"
   fi
 fi
 if [ "$1" = "rev-parse" ] && [ "$2" = "FETCH_HEAD" ]; then
@@ -446,16 +446,6 @@ test("prepare fails loudly when the refreshed Prisma client cannot be regenerate
   assert.equal(existsSync(seeded.output), false, "a broken workspace publishes no verdict");
 });
 
-test("a semantic-stale refresh regenerates the Prisma client for the newer target", () => {
-  const seeded = fixture();
-  assert.equal(run(seeded, "prepare").status, 0);
-  advanceBase(seeded, "packages/db/prisma/schema.prisma", "// later schema\n");
-  const finalized = run(seeded, "finalize");
-  assert.equal(finalized.status, 77, finalized.stderr);
-  assert.match(finalized.stdout, /^REGRESSION FINALIZE: semantic-stale /u);
-  assert.equal(readFileSync(seeded.npmLog, "utf8"), "run db:generate\n");
-});
-
 test("finalize publishes the dispatch PASS handoff before readiness acquires the lease", () => {
   const seeded = fixture();
   assert.equal(run(seeded, "prepare").status, 0);
@@ -499,7 +489,7 @@ test("the mechanical handoff requires no session or fencing credentials", () => 
   assert.equal(seeded.env.AGENTOS_FENCING_TOKEN, undefined);
 });
 
-test("an unreachable target fails prepare and finalize with a block record", () => {
+test("an unreachable target blocks prepare but cannot erase a prepared verdict", () => {
   const prepareFixture = fixture();
   git(prepareFixture.work, "remote", "set-url", "origin", join(prepareFixture.root, "missing.git"));
   const prepared = run(prepareFixture, "prepare");
@@ -513,28 +503,57 @@ test("an unreachable target fails prepare and finalize with a block record", () 
   assert.equal(run(finalizeFixture, "prepare").status, 0);
   git(finalizeFixture.work, "remote", "set-url", "origin", join(finalizeFixture.root, "missing.git"));
   const finalized = run(finalizeFixture, "finalize");
-  assert.notEqual(finalized.status, 0);
-  assert.match(finalized.stderr, /target fetch failed \(exit \d+\): .*does not appear to be a git repository/su);
-  assert.doesNotMatch(finalized.stdout, /refresh-conflict/u);
-  assert.equal(existsSync(finalizeFixture.output), true);
+  assert.equal(finalized.status, 0, finalized.stderr);
+  assert.equal(JSON.parse(handoff(finalizeFixture).body).outcome, "pass");
+  assert.equal(readFileSync(finalizeFixture.fetchLog, "utf8").trim(), "1");
 });
 
 test("a transient target fetch failure is retried instead of failing the Run", () => {
   const seeded = fixture();
-  seeded.env.REGRESSION_FIXTURE_FETCH_FAILURES = "3";
+  seeded.env.REGRESSION_FIXTURE_FETCH_FAILURES = "2";
   const prepared = run(seeded, "prepare");
   assert.equal(prepared.status, 0);
   assert.match(prepared.stdout, /REGRESSION PREPARE: ready/u);
-  assert.match(prepared.stderr, /retrying attempt=4\/6/u);
-  assert.equal(readFileSync(seeded.fetchLog, "utf8").trim().split("\n").length, 4);
+  assert.match(prepared.stderr, /retrying attempt=3\/3/u);
+  assert.equal(readFileSync(seeded.fetchLog, "utf8").trim().split("\n").length, 3);
+});
+
+test("unknown fetch failures use the bounded read-only operation retry", () => {
+  for (const error of ["gnutls_handshake() failed: The TLS connection was non-properly terminated", "unrecognized upstream failure", "notunauthorized ECONNRESET"]) {
+    const seeded = fixture();
+    seeded.env.REGRESSION_FIXTURE_FETCH_FAILURES = "2";
+    seeded.env.REGRESSION_FIXTURE_FETCH_ERROR = error;
+    const prepared = run(seeded, "prepare");
+    assert.equal(prepared.status, 0, prepared.stderr);
+    assert.equal(readFileSync(seeded.fetchLog, "utf8").trim().split("\n").length, 3);
+  }
+});
+
+test("fetch refusals and child interruption never retry", () => {
+  for (const [error, status] of [
+    ["authentication failed", 128], ["HTTP 429 Too Many Requests", 128],
+    ["SSL certificate problem: certificate has expired", 128],
+    ["fatal: unable to create temporary file: No space left on device", 128],
+    ["fatal: bad config line 1", 128], ["fatal: couldn't find remote ref missing", 128],
+    ["interrupted", 130], ["terminated", 143],
+  ] as const) {
+    const seeded = fixture();
+    seeded.env.REGRESSION_FIXTURE_FETCH_FAILURES = "3";
+    seeded.env.REGRESSION_FIXTURE_FETCH_ERROR = error;
+    seeded.env.REGRESSION_FIXTURE_FETCH_EXIT = String(status);
+    const prepared = run(seeded, "prepare");
+    assert.equal(prepared.status, status > 128 ? status : 1, prepared.stderr);
+    assert.equal(readFileSync(seeded.fetchLog, "utf8").trim(), "1");
+    assert.doesNotMatch(prepared.stderr, /retrying attempt/u);
+  }
 });
 
 test("a target fetch failure leaves a machine-readable block record", () => {
   const seeded = fixture();
-  seeded.env.REGRESSION_FIXTURE_FETCH_FAILURES = "6";
+  seeded.env.REGRESSION_FIXTURE_FETCH_FAILURES = "3";
   const prepared = run(seeded, "prepare");
   assert.notEqual(prepared.status, 0);
-  assert.match(prepared.stderr, /target fetch failed after 6 attempts: .*SSL_ERROR_SYSCALL/u);
+  assert.match(prepared.stderr, /target fetch failed after 3 attempts: .*SSL_ERROR_SYSCALL/u);
   assert.equal(existsSync(seeded.output), true);
   const block = JSON.parse(readFileSync(seeded.output, "utf8")) as Record<string, unknown>;
   assert.equal(block.schemaVersion, 1);
@@ -582,50 +601,52 @@ test("a successful target fetch leaves no block record", () => {
   assert.equal(existsSync(seeded.output), false);
 });
 
-test("finalize refreshes drift outside the lease and requires semantic recheck", () => {
-  const seeded = fixture();
-  assert.equal(run(seeded, "prepare").status, 0);
-  const main = join(seeded.root, "main");
-  git(seeded.root, "clone", "--branch", "main", seeded.origin, main);
-  writeFileSync(join(main, "drift.txt"), "drift\n");
-  git(main, "add", "drift.txt");
-  git(main, "commit", "-m", "drift");
-  git(main, "push", "origin", "main");
-
-  const finalized = run(seeded, "finalize");
-  assert.equal(finalized.status, 77, finalized.stderr);
-  assert.match(finalized.stdout, /^REGRESSION FINALIZE: semantic-stale /u);
-  assert.equal(readFileSync(seeded.leaseLog, "utf8"), "", "drift was detected before acquire");
-  assert.equal(readFileSync(seeded.gateLog, "utf8"), "");
-  assert.equal(existsSync(seeded.output), false);
-  assert.equal(readFileSync(join(seeded.work, "drift.txt"), "utf8"), "drift\n");
+test("finalize refuses changed workspace HEAD and clears skipped-review provenance", () => {
+  for (const reused of [false, true]) {
+    const seeded = fixture();
+    if (reused) seeded.env.AGENTOS_REGRESSION_RECOVERY_CONTEXT = recoveryContext(seeded);
+    assert.equal(run(seeded, "prepare").status, 0);
+    writeFileSync(join(seeded.work, "changed.txt"), "changed\n");
+    git(seeded.work, "add", "changed.txt");
+    git(seeded.work, "commit", "-m", "changed after review");
+    const finalized = run(seeded, "finalize");
+    assert.notEqual(finalized.status, 0);
+    assert.match(finalized.stderr, /workspace HEAD changed after semantic verification/u);
+    assert.equal(readFileSync(seeded.gateLog, "utf8"), "");
+    assert.equal(existsSync(seeded.output), false);
+    assert.doesNotMatch(readFileSync(join(seeded.work, ".git", "agentos-regression-state"), "utf8"), /semanticVerdict|semanticSourceRunId/u);
+  }
 });
 
-test("a reused verdict is cleared when base drift refreshes the prepared head", () => {
+test("finalize preserves the prepared pair when the target advances before the gate", () => {
+  const seeded = fixture();
+  assert.equal(run(seeded, "prepare").status, 0);
+  advanceBase(seeded, "packages/db/prisma/schema.prisma", "// newer schema\n");
+  const finalized = run(seeded, "finalize");
+  assert.equal(finalized.status, 0, finalized.stderr);
+  const verdict = JSON.parse(handoff(seeded).body);
+  assert.equal(verdict.headSha, seeded.branchSha);
+  assert.equal(verdict.baseHeadSha, seeded.baseSha);
+  assert.equal(verdict.outcome, "pass");
+  assert.equal(readFileSync(seeded.npmLog, "utf8"), "");
+  assert.equal(readFileSync(seeded.fetchLog, "utf8").trim(), "1");
+});
+
+test("finalize preserves reuse provenance for the frozen pair despite target drift", () => {
   const seeded = fixture();
   seeded.env.AGENTOS_REGRESSION_RECOVERY_CONTEXT = recoveryContext(seeded);
   assert.equal(run(seeded, "prepare").status, 0);
-  assert.match(readFileSync(join(seeded.work, ".git", "agentos-regression-state"), "utf8"), /semanticVerdict=reused/u);
-
   advanceBase(seeded, "drift.txt", "drift\n");
-  const stale = run(seeded, "finalize");
-  assert.equal(stale.status, 77, stale.stderr);
-  assert.match(stale.stdout, /^REGRESSION FINALIZE: semantic-stale /u);
-  assert.doesNotMatch(readFileSync(join(seeded.work, ".git", "agentos-regression-state"), "utf8"), /semanticVerdict|semanticSourceRunId/u);
-  assert.equal(existsSync(seeded.output), false);
-
-  // The model would recheck the newly refreshed head before this second
-  // finalize. Calling finalize directly proves the stale head cannot inherit
-  // the skipped-review provenance from the first prepare.
   const finalized = run(seeded, "finalize");
   assert.equal(finalized.status, 0, finalized.stderr);
-  const verdict = JSON.parse(handoff(seeded).body) as Record<string, unknown>;
-  assert.equal(verdict.outcome, "pass");
-  assert.equal(verdict.semanticVerdict, undefined);
-  assert.equal(verdict.semanticSourceRunId, undefined);
+  const verdict = JSON.parse(handoff(seeded).body);
+  assert.equal(verdict.headSha, seeded.branchSha);
+  assert.equal(verdict.baseHeadSha, seeded.baseSha);
+  assert.equal(verdict.semanticVerdict, "reused");
+  assert.equal(verdict.semanticSourceRunId, "prior-regression-run");
 });
 
-test("finalize refuses a PASS when the target moves during the gate", () => {
+test("finalize persists frozen evidence when the target moves during the gate", () => {
   const seeded = fixture();
   assert.equal(run(seeded, "prepare").status, 0);
   const main = join(seeded.root, "main-during-gate");
@@ -641,11 +662,14 @@ printf 'MERGE GATE: PASS %s\n' "$1"
   seeded.env.REGRESSION_GATE_DISPATCH = driftGate;
 
   const finalized = run(seeded, "finalize");
-  assert.equal(finalized.status, 77, finalized.stderr);
-  assert.match(finalized.stdout, /^REGRESSION FINALIZE: semantic-stale /u);
-  assert.equal(existsSync(seeded.output), false);
+  assert.equal(finalized.status, 0, finalized.stderr);
+  const verdict = JSON.parse(handoff(seeded).body);
+  assert.equal(verdict.outcome, "pass");
+  assert.equal(verdict.headSha, seeded.branchSha);
+  assert.equal(verdict.baseHeadSha, seeded.baseSha);
   assert.equal(readFileSync(seeded.leaseLog, "utf8"), "");
-  assert.equal(readFileSync(join(seeded.work, "during-gate.txt"), "utf8"), "drift during gate\n");
+  assert.equal(existsSync(join(seeded.work, "during-gate.txt")), false);
+  assert.equal(readFileSync(seeded.fetchLog, "utf8").trim(), "1");
 });
 
 test("review-fail is emitted mechanically without acquiring or dispatching", () => {

--- a/packages/runner/src/transport-vocabulary.test.ts
+++ b/packages/runner/src/transport-vocabulary.test.ts
@@ -1,6 +1,4 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -90,19 +88,6 @@ const nonTransportMessages = [
   "Post \"https://example.com\": EOFx"
 ];
 
-const shell = readFileSync(new URL("../runtime-tools/regression-verification.sh", import.meta.url), "utf8");
-const transientSource = shell.match(/^FETCH_TRANSIENT_RE='([^']+)'$/m)?.[1];
-const refusalSource = shell.match(/^FETCH_ACCESS_REFUSAL_RE='([^']+)'$/m)?.[1];
-const predicate = shell.match(/^fetch_is_transient\(\) \(\n[\s\S]*?^\)/m)?.[0];
-assert.ok(transientSource);
-assert.ok(refusalSource);
-assert.ok(predicate);
-
-// POSIX space classes are the only ERE syntax needing translation for JS.
-const asJs = (source: string): RegExp => new RegExp(source.replaceAll("[[:space:]]", "\\s"), "i");
-const transientRegex = asJs(transientSource);
-const refusalRegex = asJs(refusalSource);
-
 const messages = [
   ...transientMessages,
   ...transientMessages.map((text) => text.toUpperCase()),
@@ -112,12 +97,10 @@ const messages = [
   ...refusals.map((text) => `Selected model is at capacity; ${text}`),
 ];
 
-test("shell fetch and TypeScript agree across the vocabulary, including veto precedence", () => {
+test("shared transport vocabulary covers its categories and access veto precedence", () => {
   for (const message of messages) {
-    assert.equal(
-      !refusalRegex.test(message) && transientRegex.test(message),
-      isTransientTransportFailure(message), message,
-    );
+    const expected = transientMessages.some((candidate) => candidate.toLowerCase() === message.toLowerCase());
+    assert.equal(isTransientTransportFailure(message), expected, message);
   }
   for (const pattern of TRANSIENT_TRANSPORT_PATTERNS) {
     assert.ok(transientMessages.some((text) => pattern.test(text)), String(pattern));
@@ -125,22 +108,4 @@ test("shell fetch and TypeScript agree across the vocabulary, including veto pre
   for (const pattern of DETERMINISTIC_ACCESS_PATTERNS) {
     assert.ok(refusals.some((text) => pattern.test(text)), String(pattern));
   }
-  for (const alternative of transientSource.split("|")) {
-    // Complete alternatives only: grouped branches are covered by TS fixtures.
-    if (alternative.includes("(") || alternative.includes(")")) continue;
-    assert.ok(transientMessages.some((text) => asJs(alternative).test(text)), alternative);
-  }
-});
-
-test("the actual Bash fetch predicate agrees without invoking regression tooling", () => {
-  const result = execFileSync("bash", ["-c", `
-FETCH_TRANSIENT_RE=$1
-FETCH_ACCESS_REFUSAL_RE=$2
-shift 2
-${predicate}
-for message in "$@"; do
-  if fetch_is_transient "$message"; then printf 'true\\n'; else printf 'false\\n'; fi
-done
-`, "transport-parity", transientSource, refusalSource, ...messages], { encoding: "utf8" });
-  assert.deepEqual(result.trim().split("\n"), messages.map((message) => String(isTransientTransportFailure(message))));
 });

--- a/scripts/host-proof-slot.test.mjs
+++ b/scripts/host-proof-slot.test.mjs
@@ -686,6 +686,7 @@ test("a killed holder releases its descriptor, while a live holder is never recl
 });
 
 const RUN_TEST_CONCURRENCY_CAP = "${AGENTOS_RUN_ID:+--test-concurrency=2}";
+const GATE_TEST_CONCURRENCY_CAP = "${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}}";
 
 test("the Run-only test concurrency cap expands under a Run and vanishes on the host fast path", async () => {
   const command = ["/bin/sh", "-c", `printf '%s\\n' --test ${RUN_TEST_CONCURRENCY_CAP} src/*.test.ts`];
@@ -707,6 +708,33 @@ test("the Run-only test concurrency cap expands under a Run and vanishes on the 
   assert.equal(stdout, "--test\nsrc/*.test.ts\n");
 });
 
+test("the gate-only test concurrency cap expands on the host fast path", async () => {
+  const command = ["/bin/sh", "-c", `printf '%s\\n' --test ${GATE_TEST_CONCURRENCY_CAP} src/*.test.ts`];
+  const capped = spawn("bash", [wrapper, "test", "@anneal/test", "--", ...command], {
+    cwd: repositoryRoot,
+    env: cleanEnvironment({ AGENTOS_GATE_UNIT_TEST_CONCURRENCY: "7" }),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let cappedStdout = "";
+  capped.stdout.setEncoding("utf8");
+  capped.stdout.on("data", (chunk) => { cappedStdout += chunk; });
+  const cappedStatus = await new Promise((resolve) => capped.once("close", resolve));
+  assert.equal(cappedStatus, 0);
+  assert.equal(cappedStdout, "--test\n--test-concurrency=7\nsrc/*.test.ts\n");
+
+  const uncapped = spawn("bash", [wrapper, "test", "@anneal/test", "--", ...command], {
+    cwd: repositoryRoot,
+    env: cleanEnvironment({}),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let uncappedStdout = "";
+  uncapped.stdout.setEncoding("utf8");
+  uncapped.stdout.on("data", (chunk) => { uncappedStdout += chunk; });
+  const uncappedStatus = await new Promise((resolve) => uncapped.once("close", resolve));
+  assert.equal(uncappedStatus, 0);
+  assert.equal(uncappedStdout, "--test\nsrc/*.test.ts\n");
+});
+
 test("all workspace proof manifests are wrapped exactly once without changing commands or lifecycle hooks", () => {
   const expected = {
     "apps/web/package.json": {
@@ -715,7 +743,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "/bin/sh -c 'tsc -b && vite build'",
         typecheck: "tsc -b --pretty false",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "/bin/sh -c 'TSX_TSCONFIG_PATH=tsconfig.app.json node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} \"src/**/*.test.ts\" \"src/**/*.test.tsx\"'",
+        test: "/bin/sh -c 'TSX_TSCONFIG_PATH=tsconfig.app.json node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} \"src/**/*.test.ts\" \"src/**/*.test.tsx\"'",
       },
       hooks: {},
     },
@@ -725,7 +753,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "/bin/sh -c 'tsc -p tsconfig.json && node ../build-info/stamp.mjs dist'",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts src/routes/*.test.ts src/files/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts src/routes/*.test.ts src/files/*.test.ts",
         "test:db": "node --conditions=development --import tsx scripts/dbtest.mjs",
       },
       hooks: {},
@@ -734,7 +762,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
       name: "@anneal/build-info",
       scripts: {
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --test ${AGENTOS_RUN_ID:+--test-concurrency=2} *.test.mjs",
+        test: "node --conditions=development --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} *.test.mjs",
       },
       hooks: {},
     },
@@ -744,7 +772,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "tsc -p tsconfig.json",
         typecheck: "/bin/sh -c 'tsc -p tsconfig.json --noEmit && npm run typecheck:cli'",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} prisma/*.test.ts src/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} prisma/*.test.ts src/*.test.ts",
         "test:db": "node --conditions=development --import tsx --test --test-concurrency=1 src/*.dbtest.ts",
       },
       hooks: {},
@@ -755,7 +783,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "tsc -p tsconfig.json",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts",
       },
       hooks: {},
     },
@@ -765,7 +793,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "tsc -p tsconfig.json",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts",
       },
       hooks: {},
     },
@@ -775,7 +803,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "tsc -p tsconfig.json",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts",
       },
       hooks: {},
     },
@@ -785,7 +813,7 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         build: "/bin/sh -c 'tsc -p tsconfig.json && node scripts/build-runtime-tools.mjs && node ../build-info/stamp.mjs dist'",
         typecheck: "tsc -p tsconfig.json --noEmit",
         lint: "/bin/sh -c 'biome lint . && eslint .'",
-        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} src/*.test.ts src/adapters/*.test.ts scripts/*.test.mjs",
+        test: "node --conditions=development --import tsx --test ${AGENTOS_RUN_ID:+--test-concurrency=2} ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} src/*.test.ts src/adapters/*.test.ts scripts/*.test.mjs",
       },
       hooks: {},
     },
@@ -817,6 +845,11 @@ test("all workspace proof manifests are wrapped exactly once without changing co
         manifest.scripts[scriptName].split(RUN_TEST_CONCURRENCY_CAP).length - 1,
         scriptName === "test" ? 1 : 0,
         `${contract.name} ${scriptName} must carry the Run-only test concurrency cap exactly when it is the unit test script`,
+      );
+      assert.equal(
+        manifest.scripts[scriptName].split(GATE_TEST_CONCURRENCY_CAP).length - 1,
+        scriptName === "test" ? 1 : 0,
+        `${contract.name} ${scriptName} must carry the gate-only test concurrency cap exactly when it is the unit test script`,
       );
       wrappedCount += 1;
     }

--- a/scripts/merge-gate-parallel.test.mjs
+++ b/scripts/merge-gate-parallel.test.mjs
@@ -268,6 +268,59 @@ test("on the 16-vCPU worker a host share of two gives each gate half the machine
   assert.equal(sizing(whole).GATE_CPUS, 16);
 });
 
+test("UNIT-SHAPE serializes workspaces while passing the full gate lane budget to Node", () => {
+  assert.match(gateSource, /export AGENTOS_GATE_UNIT_TEST_CONCURRENCY="\$\{GATE_UNIT_LANES\}"/u);
+  assert.match(gateSource, /run_workspace_script_parallel test 1 1/u);
+});
+
+test("UNIT-BOUND the gate cap limits real Node test-file processes", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "merge-gate-unit-bound."));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const events = join(root, "events.log");
+  writeFileSync(events, "");
+  const packageScript = "node --test ${AGENTOS_GATE_UNIT_TEST_CONCURRENCY:+--test-concurrency=${AGENTOS_GATE_UNIT_TEST_CONCURRENCY}} *.test.mjs";
+  writeFileSync(join(root, "package.json"), JSON.stringify({ private: true, scripts: { test: packageScript } }));
+  // Wait for a second worker instead of guessing a sleep. The 60s hang bound
+  // follows CONTRIBUTING.md's loaded-host test timing rule and costs no time
+  // when both workers are admitted promptly.
+  const fixture = [
+    'import test from "node:test";',
+    'import { appendFileSync, readFileSync } from "node:fs";',
+    'const events = process.env.UNIT_BOUND_EVENTS;',
+    'test("holds a file worker", async () => {',
+    '  appendFileSync(events, `start ${process.pid}\\n`);',
+    '  const deadline = Date.now() + 60_000;',
+    '  while (readFileSync(events, "utf8").split("\\n").filter((line) => line.startsWith("start ")).length < 2) {',
+    '    if (Date.now() > deadline) throw new Error("second file worker did not start within the bound");',
+    '    await new Promise((resolve) => setTimeout(resolve, 10));',
+    '  }',
+    '  appendFileSync(events, `end ${process.pid}\\n`);',
+    '});',
+  ].join("\n");
+  for (let index = 1; index <= 6; index += 1) {
+    writeFileSync(join(root, `case-${index}.test.mjs`), fixture);
+  }
+  const environment = { ...process.env, AGENTOS_GATE_UNIT_TEST_CONCURRENCY: "2", UNIT_BOUND_EVENTS: events };
+  // This is a fresh test runner, not a worker of the enclosing node:test process.
+  delete environment.NODE_TEST_CONTEXT;
+  const result = spawnSync("npm", ["run", "test", "--silent"], {
+    cwd: root,
+    encoding: "utf8",
+    env: environment,
+  });
+  assert.equal(result.status, 0, `${root}\n${packageScript}\n${fixture}\n${result.stdout}\n${result.stderr}`);
+  const active = new Set();
+  let maximum = 0;
+  for (const line of readFileSync(events, "utf8").trim().split("\n")) {
+    const [kind, name] = line.split(" ");
+    if (kind === "start") active.add(name);
+    else active.delete(name);
+    maximum = Math.max(maximum, active.size);
+  }
+  assert.equal(active.size, 0, "every test-file process should have finished");
+  assert.equal(maximum, 2, `Node should run two files concurrently under the gate cap, saw ${maximum}: ${root}: ${readFileSync(events, "utf8")}`);
+});
+
 // Enough of the gate for the engine to run: the two output helpers it owes the
 // engine, the temp root it writes member logs into, and the working directory
 // it runs members in. Nothing here stands in for the behaviour being tested.

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -735,7 +735,15 @@ parallel_unit_tests() {
   # every run, then suppress only those redundant lifecycle hooks. If any hook
   # gains another responsibility, this check fails instead of skipping it.
   verify_build_only_lifecycle_hooks pretest || return 1
-  run_workspace_script_parallel test 1 "${GATE_UNIT_LANES}"
+  # Each workspace's node --test command can fan out its matched files too.
+  # Keep only one workspace command in flight and give that command the whole
+  # unit budget, so the nested fan-out is bounded by GATE_UNIT_LANES rather than
+  # multiplying it. The package scripts consume this gate-only variable before
+  # their file globs; it is unset on ordinary host and Run invocations.
+  (
+    export AGENTOS_GATE_UNIT_TEST_CONCURRENCY="${GATE_UNIT_LANES}"
+    run_workspace_script_parallel test 1 1
+  )
 }
 
 verify_build_only_lifecycle_hooks() {


### PR DESCRIPTION
Regression could finish semantic checks and its Merge gate, then lose the result when a final target fetch failed. Prepare now freezes the candidate and baseline; finalize persists that pair's gate verdict without another target fetch. Merge readiness retains the latest-base/head checks under the Merge Lease. Read-only preparation fetches make at most three attempts for unknown failures, while deterministic refusals and cancellation stop immediately.

The Gate previously limited concurrent workspaces while each workspace independently used Node's full-host test concurrency. Unit workspaces now run one at a time, each passing the Gate's unit-lane budget to Node before its file globs. Ordinary host and Run defaults remain unchanged. This is a test-worker budget, not a hard CPU quota for subprocesses launched by tests.

Regression still checks the complete fix and every finding disposition, using focused regressions while the Gate owns full suites. Canonical prompt generations and executable contracts are updated together. Base drift can still requeue Regression through readiness; semantic reuse has not been broadened.

Validation: full Merge gate PASS for `30800b149c8c644bfbe468d23296f3ed6af43880` against `afd6029a745cf44b18ed60596b941c71135e3787`. All unit and database suites, build, lint, typechecks, and gate contracts passed. Focused recovery/canonical, gate/proof-slot, template, and historical-generation fixture tests also passed, along with Compose binding verification. Historical prompt fixture reconstruction and the Regression instantiation snapshot were updated without changing retired generation digests.

The final cold-build Gate took approximately 356 seconds (DB 277 seconds, unit 194 seconds) with one worker slot and host-share 2. The earlier baseline sample took approximately 350 seconds with host-share 1; these are observational samples, not a controlled throughput or runner-latency benchmark.
