### PR TITLE
perf(gate): reduce repeated work and database wave tail

### DIFF
--- a/docs/runbooks/gate-worker.md
+++ b/docs/runbooks/gate-worker.md
@@ -78,6 +78,21 @@ is a guess about a ratio nothing maintains, and on the four-core fallback worker
 the guess starved the small wave to a single lane and 201 seconds. One pool
 balances itself and migrates the template once.
 
+The pool schedules files by the previous successful wave's measured duration,
+longest first, with unmeasured files first. This prevents a late-starting slow
+file from holding the worker after its other lanes drain. The programmatic
+Node test runner preserves that queue order; the CLI sorts explicit filenames.
+Each file still owns a separate process, cloned database, and host roots, and
+the lane budget is unchanged. Provisioning, test processes, and database
+cleanup have separate timings in the log.
+
+Scheduling history lives at `dbtest-timings.jsonl` under the gate cache root.
+It contains package-relative filenames and durations, never test results or
+proof. Missing or unreadable history is reported and cannot omit a file; only
+a complete passing database wave with successful cleanup replaces it, using
+an atomic rename. History may span commits because it changes execution order
+only. Every full gate still executes every check against its exact candidate.
+
 `provision.sh` is in `scripts/gate-worker/`; the other five ship from
 `packages/runner/runtime-tools/gate-worker/`:
 

--- a/packages/api/scripts/dbtest-process.mjs
+++ b/packages/api/scripts/dbtest-process.mjs
@@ -1,0 +1,21 @@
+// The CLI sorts explicit filenames alphabetically. The programmatic runner
+// preserves the measured queue order while retaining one process per file.
+import { run } from "node:test";
+import { spec } from "node:test/reporters";
+
+const [concurrency, ...files] = process.argv.slice(2);
+if (process.env.AGENTOS_DBTEST_PLAN) {
+  // Node 20's run() has no execArgv option; it inherits process.execArgv.
+  // Only file children load the preamble: this coordinator has no assignment.
+  process.execArgv.push("--import", new URL("dbtest-preamble.mjs", import.meta.url).href);
+}
+const controller = new AbortController();
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    process.exitCode = signal === "SIGINT" ? 130 : 143;
+    controller.abort();
+  });
+}
+const stream = run({ files, concurrency: Number(concurrency), signal: controller.signal });
+stream.on("test:fail", () => { process.exitCode ||= 1; });
+stream.compose(spec).pipe(process.stdout);

--- a/packages/api/scripts/dbtest.mjs
+++ b/packages/api/scripts/dbtest.mjs
@@ -28,11 +28,10 @@ import { spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { availableParallelism, constants } from "node:os";
 import { join, resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import {
   derivedMaintenanceUrl,
-  planEnvironmentVariable,
   provisioningAvailable,
   provisioningRequested,
 } from "../src/dbtest-plan.ts";
@@ -41,7 +40,7 @@ import { dbtestInvocationDecision } from "../src/dbtest-scope.ts";
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url));
 const sourceDirectory = join(packageRoot, "src");
-const preamble = pathToFileURL(join(packageRoot, "scripts", "dbtest-preamble.mjs")).href;
+const testProcess = join(packageRoot, "scripts", "dbtest-process.mjs");
 
 const say = (message) => process.stdout.write(`dbtest: ${message}\n`);
 
@@ -63,9 +62,13 @@ const testFiles = () => {
  */
 const runNodeTest = ({ files, concurrency, environment, signal }) => new Promise((resolveRun) => {
   const args = ["--conditions=development", "--import", "tsx"];
-  if (environment[planEnvironmentVariable]) args.push("--import", preamble);
-  args.push("--test", `--test-concurrency=${concurrency}`, ...files);
-  const child = spawn(process.execPath, args, { cwd: packageRoot, stdio: "inherit", env: environment });
+  args.push(testProcess, String(concurrency), ...files);
+  const child = spawn(process.execPath, args, {
+    cwd: packageRoot, stdio: "inherit",
+    // A DB harness can itself be exercised by a node:test file. The coordinator
+    // is a new runner, not a recursive call in that test's child process.
+    env: { ...environment, NODE_TEST_CONTEXT: undefined },
+  });
   const forward = () => child.kill("SIGTERM");
   signal?.addEventListener("abort", forward, { once: true });
   const done = (code) => {

--- a/packages/api/src/dbtest-runner.test.ts
+++ b/packages/api/src/dbtest-runner.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,9 +10,54 @@ import test from "node:test";
 import { planEnvironmentVariable } from "./dbtest-plan.js";
 import { runDbtest, type RunTestsOptions, type ScratchManagerLike } from "./dbtest-runner.js";
 import { fixtureDatabaseUrl } from "./dbtest-url-fixture.js";
+import { formatTimingLine, timingHistoryEnvironmentVariable, timingsEnvironmentVariable } from "./dbtest-timings.js";
 
 const dbtestScript = fileURLToPath(new URL("../scripts/dbtest.mjs", import.meta.url));
 const apiRoot = fileURLToPath(new URL("..", import.meta.url));
+const testProcess = fileURLToPath(new URL("../scripts/dbtest-process.mjs", import.meta.url));
+
+test("DBTEST-PROCESS preserves queue order, isolates files, and propagates failures", (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "agentos-dbtest-order-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const first = join(directory, "z-first.mjs");
+  const second = join(directory, "a-second.mjs");
+  writeFileSync(first, 'import test from "node:test"; globalThis.leaked = true; test("first", () => console.log("ORDER=first"));');
+  writeFileSync(second, 'import test from "node:test"; import assert from "node:assert/strict"; test("second", () => { console.log("ORDER=second"); assert.equal(globalThis.leaked, undefined); });');
+  const environment = { ...process.env, NODE_TEST_CONTEXT: undefined, AGENTOS_DBTEST_PLAN: undefined, NODE_OPTIONS: undefined };
+  const invoke = (files: string[]) => spawnSync(process.execPath, [testProcess, "1", ...files], {
+    encoding: "utf8", env: environment,
+  });
+  const passed = invoke([first, second]);
+  assert.equal(passed.status, 0, passed.stdout + passed.stderr);
+  assert.deepEqual(passed.stdout.match(/ORDER=\w+/gu), ["ORDER=first", "ORDER=second"]);
+  writeFileSync(second, 'import test from "node:test"; test("fails", () => { throw new Error("intentional-fixture-failure"); });');
+  const failed = invoke([first, second]);
+  assert.equal(failed.status, 1, failed.stdout + failed.stderr);
+  assert.match(failed.stdout, /intentional-fixture-failure/u);
+  assert.equal(invoke([join(directory, "missing.mjs")]).status, 1);
+});
+
+test("DBTEST-PROCESS aborts its live file child before returning a signal status", async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "agentos-dbtest-signal-"));
+  const ready = join(directory, "ready");
+  const entry = join(directory, "pending.mjs");
+  writeFileSync(entry, `import { writeFileSync } from "node:fs"; import test from "node:test";
+    test("pending", async () => { writeFileSync(${JSON.stringify(ready)}, String(process.pid));
+      await new Promise(() => { setInterval(() => {}, 1000); }); });`);
+  const child = spawn(process.execPath, [testProcess, "1", entry], {
+    stdio: "ignore", env: { ...process.env, NODE_TEST_CONTEXT: undefined, AGENTOS_DBTEST_PLAN: undefined },
+  });
+  const closed = new Promise<number | null>((resolve) => child.once("close", resolve));
+  t.after(() => { child.kill("SIGKILL"); rmSync(directory, { recursive: true, force: true }); });
+  // A loaded worker can delay child startup; wait for its actual ready signal.
+  const deadline = Date.now() + 30_000;
+  while (!existsSync(ready) && Date.now() < deadline) await delay(20);
+  assert.ok(existsSync(ready), "file child never became ready");
+  const filePid = Number(readFileSync(ready, "utf8"));
+  child.kill("SIGTERM");
+  assert.equal(await closed, 143);
+  assert.throws(() => process.kill(filePid, 0), /ESRCH/u, "coordinator left its file child alive");
+});
 
 /**
  * The manager's own contract, in memory: a database exists from the moment
@@ -206,6 +252,26 @@ test("DBTEST-RUN-ISOLATION gives every file its own database and its own three r
       assert.ok(existsSync(assignment[field] as string), `${field} was planned but not created`);
     }
   }
+});
+
+test("DBTEST-HISTORY is advisory, withheld from children, and saved only after a clean wave", async (t) => {
+  const h = harness(t);
+  const directory = mkdtempSync(join(tmpdir(), "agentos-dbtest-history-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const history = join(directory, "history.jsonl");
+  const previous = h.files.map((file, index) => formatTimingLine({ file, ms: index + 1 })).join("");
+  writeFileSync(history, previous);
+  h.environment[timingHistoryEnvironmentVariable] = history;
+  const invoke = (status: number) => run(h, async ({ files, environment }) => {
+    assert.deepEqual(files, [...h.files].reverse());
+    assert.equal(environment[timingHistoryEnvironmentVariable], undefined);
+    writeFileSync(environment[timingsEnvironmentVariable]!, files.map((file) => formatTimingLine({ file, ms: 5 })).join(""));
+    return status;
+  });
+  assert.equal(await invoke(1), 1);
+  assert.equal(readFileSync(history, "utf8"), previous);
+  assert.equal(await invoke(0), 0);
+  assert.notEqual(readFileSync(history, "utf8"), previous);
 });
 
 test("DBTEST-RUN-CLEANUP drops every database it made, and takes the plan with it", async (t) => {

--- a/packages/api/src/dbtest-runner.test.ts
+++ b/packages/api/src/dbtest-runner.test.ts
@@ -37,7 +37,7 @@ test("DBTEST-PROCESS preserves queue order, isolates files, and propagates failu
   assert.equal(invoke([join(directory, "missing.mjs")]).status, 1);
 });
 
-test("DBTEST-PROCESS aborts its live file child before returning a signal status", async (t) => {
+test("DBTEST-PROCESS aborts its live file child before returning a signal status", { timeout: 45_000 }, async (t) => {
   const directory = mkdtempSync(join(tmpdir(), "agentos-dbtest-signal-"));
   const ready = join(directory, "ready");
   const entry = join(directory, "pending.mjs");

--- a/packages/api/src/dbtest-runner.ts
+++ b/packages/api/src/dbtest-runner.ts
@@ -8,9 +8,9 @@
 // than when it is finished with, and the run's result is not green unless the
 // cleanup was.
 
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import {
   connectionLimit,
@@ -22,7 +22,11 @@ import {
   type DbtestAssignment,
   type DbtestPlan,
 } from "./dbtest-plan.js";
-import { formatTimingReport, parseTimings, timingsEnvironmentVariable } from "./dbtest-timings.js";
+import {
+  formatTimingLine, formatTimingReport, orderByTimings, parseTimings,
+  timingDisplayName, timingHistoryEnvironmentVariable, timingsEnvironmentVariable,
+  type DbtestFileTiming,
+} from "./dbtest-timings.js";
 
 /** Just enough of ScratchDatabaseManager to run against, and to fake. */
 export interface ScratchManagerLike {
@@ -123,8 +127,23 @@ export const runDbtest = async ({
   const planDirectory = mkdtempSync(join(tmpdir(), "agentos-dbtest-plan-"));
   const timingsPath = join(planDirectory, "timings.jsonl");
   const abandoned = (): number => signalExitCode(signalled ?? "SIGTERM");
+  const historyPath = environment[timingHistoryEnvironmentVariable];
+  let orderedFiles = files;
+  if (historyPath) {
+    try {
+      const history = parseTimings(readFileSync(historyPath, "utf8"));
+      if (history.unreadable > 0) log(`timing history: ignored ${history.unreadable} unreadable record(s)`);
+      orderedFiles = orderByTimings(files, history.timings);
+      const known = new Set(history.timings.map(({ file }) => timingDisplayName(file)));
+      log(`timing history: longest first, ${files.filter((file) => known.has(timingDisplayName(file))).length}/${files.length} measured files`);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      log(`timing history unavailable (${code ?? String(error)}); using discovery order`);
+    }
+  }
 
   const provisionAndRun = async (): Promise<number> => {
+    const provisioningStarted = performance.now();
     const { reclaimed } = await manager.reclaimOrphans();
     if (reclaimed.length > 0) {
       log(`reclaimed ${reclaimed.length} database(s) from a run that never got to clean up`);
@@ -165,26 +184,33 @@ export const runDbtest = async ({
     const planPath = join(planDirectory, "plan.json");
     writeFileSync(planPath, JSON.stringify(plan));
     log(`template ${template.name} cloned ${files.length} times, ${limit} connections each of ${maxConnections}`);
+    log(`provisioning: ${((performance.now() - provisioningStarted) / 1000).toFixed(1)}s`);
 
     // Created empty rather than left to the first writer: an appending process
     // should not have to decide whether the file exists, and an empty file is
     // also the honest report for a run that was signalled before a file ended.
     writeFileSync(timingsPath, "");
 
-    return await runTests({
-      files,
+    const testsStarted = performance.now();
+    const status = await runTests({
+      files: orderedFiles,
       concurrency,
       environment: {
         ...environment,
         [planEnvironmentVariable]: planPath,
         [timingsEnvironmentVariable]: timingsPath,
+        // Nested harness fixtures must never publish over the real wave's history.
+        [timingHistoryEnvironmentVariable]: undefined,
       },
       signal: controller.signal,
     });
+    log(`test processes: ${((performance.now() - testsStarted) / 1000).toFixed(1)}s`);
+    return status;
   };
 
   let exitCode: number | null = null;
   let failure: unknown = null;
+  let measured: DbtestFileTiming[] = [];
   try {
     exitCode = await provisionAndRun();
   } catch (error) {
@@ -196,14 +222,35 @@ export const runDbtest = async ({
   // failed: a red wave is exactly when someone wants to know which file it was.
   try {
     const { timings, unreadable } = parseTimings(readFileSync(timingsPath, "utf8"));
+    if (unreadable === 0) measured = timings;
     for (const line of formatTimingReport(timings, { unreadable })) log(line);
   } catch {
     // No timings file means the run never got as far as starting the tests.
   }
   rmSync(planDirectory, { recursive: true, force: true });
+  const cleanupStarted = performance.now();
   const leaked = await manager.dropAll();
   for (const { name, error } of leaked) log(`could not drop ${name}: ${error.message}`);
   await manager.disconnect();
+  log(`database cleanup: ${((performance.now() - cleanupStarted) / 1000).toFixed(1)}s`);
+
+  // Atomically replace advisory scheduling data only after a complete clean
+  // wave. A cache failure is reported, never promoted into verification proof.
+  if (historyPath && failure === null && exitCode === 0 && leaked.length === 0
+    && measured.length === files.length
+    && files.every((file) => measured.some((entry) => resolve(entry.file) === resolve(file)))) {
+    const temporary = `${historyPath}.${process.pid}.tmp`;
+    try {
+      mkdirSync(dirname(historyPath), { recursive: true });
+      writeFileSync(temporary, measured.map(({ file, ms }) => formatTimingLine({ file: timingDisplayName(file), ms })).join(""));
+      renameSync(temporary, historyPath);
+    } catch (error) {
+      log(`could not save timing history: ${String(error)}`);
+    } finally {
+      try { rmSync(temporary, { force: true }); }
+      catch (error) { log(`could not remove temporary timing history: ${String(error)}`); }
+    }
+  }
 
   // The cleanup runs before this rethrow so that a failure while provisioning
   // still takes its databases with it; the failure itself is what the caller

--- a/packages/api/src/dbtest-timings.test.ts
+++ b/packages/api/src/dbtest-timings.test.ts
@@ -7,7 +7,17 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { formatTimingLine, formatTimingReport, parseTimings, timingDisplayName } from "./dbtest-timings.js";
+import { formatTimingLine, formatTimingReport, orderByTimings, parseTimings, timingDisplayName } from "./dbtest-timings.js";
+
+it("history orders long files first across checkouts without selecting or dropping files", () => {
+  const files = ["/new/packages/api/src/a.ts", "/new/packages/db/src/a.ts", "/new/packages/api/src/new.ts"];
+  const history = [
+    { file: "api/a.ts", ms: 10 }, { file: "/old/packages/db/src/a.ts", ms: 90 },
+    { file: "api/deleted.ts", ms: 999 },
+  ];
+  assert.deepEqual(orderByTimings(files, history), [files[2], files[1], files[0]]);
+  assert.deepEqual(files, ["/new/packages/api/src/a.ts", "/new/packages/db/src/a.ts", "/new/packages/api/src/new.ts"]);
+});
 
 describe("formatTimingLine", () => {
   it("writes one complete line per file, which is what keeps concurrent writers apart", () => {

--- a/packages/api/src/dbtest-timings.ts
+++ b/packages/api/src/dbtest-timings.ts
@@ -20,6 +20,7 @@
 
 /** Names the file every test process appends its own line to. */
 export const timingsEnvironmentVariable = "AGENTOS_DBTEST_TIMINGS";
+export const timingHistoryEnvironmentVariable = "AGENTOS_DBTEST_TIMING_HISTORY";
 
 /**
  * How a file is named in the report.
@@ -44,6 +45,20 @@ export interface DbtestFileTiming {
   ms: number;
 }
 
+/** History controls order only. Unknown files run first so new slow tests do
+ * not become an unmeasured tail. Every requested file is retained exactly once
+ * per occurrence, regardless of stale or foreign history entries. */
+export const orderByTimings = (files: string[], timings: DbtestFileTiming[]): string[] => {
+  const known = new Map(timings.map(({ file, ms }) => [timingDisplayName(file), ms]));
+  return [...files].sort((left, right) => {
+    const a = known.get(timingDisplayName(left));
+    const b = known.get(timingDisplayName(right));
+    if (a === undefined && b !== undefined) return -1;
+    if (b === undefined && a !== undefined) return 1;
+    return (b ?? 0) - (a ?? 0) || left.localeCompare(right);
+  });
+};
+
 export const formatTimingLine = (timing: DbtestFileTiming): string => `${JSON.stringify(timing)}\n`;
 
 /**
@@ -62,7 +77,7 @@ export const parseTimings = (contents: string): { timings: DbtestFileTiming[]; u
     try {
       const parsed: unknown = JSON.parse(line);
       const record = parsed as Partial<DbtestFileTiming>;
-      if (typeof record.file !== "string" || typeof record.ms !== "number" || !Number.isFinite(record.ms)) {
+      if (typeof record.file !== "string" || typeof record.ms !== "number" || !Number.isFinite(record.ms) || record.ms < 0) {
         unreadable += 1;
         continue;
       }

--- a/packages/db/src/canonical-prompt-sync-multi-project.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync-multi-project.dbtest.ts
@@ -57,7 +57,10 @@ const databaseUrl = (() => {
 })();
 
 const command = (args: string[]) => {
-  const result = spawnSync("npx", args, {
+  const isTsxScript = args[0] === "tsx";
+  const result = spawnSync(isTsxScript ? process.execPath : "npx", isTsxScript
+    ? ["--import", "tsx", ...args.slice(1)]
+    : args, {
     cwd: packageRoot,
     encoding: "utf8",
     env: { ...process.env, DATABASE_URL: databaseUrl },

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -50,7 +50,10 @@ const databaseUrl = (() => {
   return url.href;
 })();
 const command = (args: string[]) => {
-  const result = spawnSync("npx", args, {
+  const isTsxScript = args[0] === "tsx";
+  const result = spawnSync(isTsxScript ? process.execPath : "npx", isTsxScript
+    ? ["--import", "tsx", ...args.slice(1)]
+    : args, {
     cwd: packageRoot,
     encoding: "utf8",
     env: { ...process.env, DATABASE_URL: databaseUrl },

--- a/packages/db/src/preflight-goal-execution.dbtest.ts
+++ b/packages/db/src/preflight-goal-execution.dbtest.ts
@@ -67,7 +67,7 @@ const urlFor = (schema: string): string => {
 interface Outcome { status: number | null; output: string }
 
 const runPreflight = (schema: string, extra: Record<string, string> = {}): Outcome => {
-  const result = spawnSync("npx", ["tsx", "prisma/preflight-goal-execution.ts"], {
+  const result = spawnSync(process.execPath, ["--import", "tsx", "prisma/preflight-goal-execution.ts"], {
     cwd: packageRoot,
     encoding: "utf8",
     env: {

--- a/packages/db/src/seed-canonical-drift.dbtest.ts
+++ b/packages/db/src/seed-canonical-drift.dbtest.ts
@@ -41,7 +41,10 @@ const databaseUrl = (() => {
   return url.href;
 })();
 const command = (args: string[]) => {
-  const result = spawnSync("npx", args, {
+  const isTsxScript = args[0] === "tsx";
+  const result = spawnSync(isTsxScript ? process.execPath : "npx", isTsxScript
+    ? ["--import", "tsx", ...args.slice(1)]
+    : args, {
     cwd: packageRoot,
     encoding: "utf8",
     env: { ...process.env, DATABASE_URL: databaseUrl },

--- a/packages/db/src/verify-agent-template.dbtest.ts
+++ b/packages/db/src/verify-agent-template.dbtest.ts
@@ -50,7 +50,10 @@ const databaseUrl = (() => {
 type CommandResult = { status: number | null; output: string };
 
 const command = (args: string[]): CommandResult => {
-  const result = spawnSync("npx", args, {
+  const isTsxScript = args[0] === "tsx";
+  const result = spawnSync(isTsxScript ? process.execPath : "npx", isTsxScript
+    ? ["--import", "tsx", ...args.slice(1)]
+    : args, {
     cwd: packageRoot,
     encoding: "utf8",
     env: { ...process.env, DATABASE_URL: databaseUrl },

--- a/packages/runner/src/delivery.test.ts
+++ b/packages/runner/src/delivery.test.ts
@@ -1435,7 +1435,10 @@ test("the ref that was actually pushed is recorded on every path that pushed", a
     if (executable === "gh" && args[1] === "create") throw new Error("gh: API rate limit exceeded");
     return "";
   };
-  const failed = await deliverWorkspace(config, claim, workspace, { command: prFails });
+  // These command doubles test publication evidence, not backoff wall time.
+  // Keep the real retry policy/attempts; advance through its waits immediately.
+  const retryOptions = { wait: async () => undefined };
+  const failed = await deliverWorkspace(config, claim, workspace, { command: prFails, retryOptions });
   assert.equal(failed.pushStatus, "FAILED");
   assert.equal(failed.pushedBranch, "feature/test");
 
@@ -1443,7 +1446,7 @@ test("the ref that was actually pushed is recorded on every path that pushed", a
     if (executable === "git" && args[0] === "push") throw new Error("remote rejected");
     return "";
   };
-  assert.equal((await deliverWorkspace(config, claim, workspace, { command: pushFails })).pushedBranch, undefined);
+  assert.equal((await deliverWorkspace(config, claim, workspace, { command: pushFails, retryOptions })).pushedBranch, undefined);
 
   const salvage: CommandRunner = async (executable, args) => {
     if (executable === "git" && args[0] === "status") return "M tracked.ts";

--- a/packages/runner/src/repo-mirror.test.ts
+++ b/packages/runner/src/repo-mirror.test.ts
@@ -372,7 +372,7 @@ test("a held lock is waited for, and one left behind by a dead holder is stolen"
   }
 });
 
-test("a live heartbeating holder can cross the creation ceiling before releasing the lock", async () => {
+test("a live heartbeating holder can cross the creation ceiling before releasing the lock", { timeout: 30_000 }, async () => {
   const { root, remote, config, mirror } = await fixture("lock-live");
   const holderReady = deferred<void>();
   const holderRelease = deferred<void>();
@@ -390,6 +390,7 @@ test("a live heartbeating holder can cross the creation ceiling before releasing
 
   let clock = 0;
   let released = false;
+  const waitClocks: number[] = [];
   const progress: RepoMirrorProgress[] = [];
   try {
     await holderReady.promise;
@@ -403,16 +404,20 @@ test("a live heartbeating holder can cross the creation ceiling before releasing
         lockPollMs: 1,
         now: () => clock,
         sleep: async () => {
-          clock += 1_000;
-          // Keep the lock held through the first acquisition attempt after the
-          // creation ceiling. The waiter's explicit slack then gives the live
-          // holder time to finish its in-lock setup and teardown.
-          if (clock > CLONE_CREATION_TIMEOUT_MS && released === false) {
-            if (clock > CLONE_CREATION_TIMEOUT_MS + 1_000) {
-              released = true;
-              holderRelease.resolve();
-            }
+          // Keep the lock held at the ceiling and through the first acquisition
+          // attempt beyond it, then let the holder finish its release. The
+          // clock stops there so the fake wait cannot overshoot the default
+          // lock wait while the real holder's cleanup gets a chance to run.
+          if (waitClocks.length === 0) {
+            clock = CLONE_CREATION_TIMEOUT_MS;
+          } else if (waitClocks.length === 1) {
+            clock = CLONE_CREATION_TIMEOUT_MS + 1_000;
+          } else if (released === false) {
+            released = true;
+            holderRelease.resolve();
+            await holder;
           }
+          waitClocks.push(clock);
           await new Promise<void>((resolve) => { setImmediate(resolve); });
         },
         report: (event) => progress.push(event),
@@ -421,7 +426,12 @@ test("a live heartbeating holder can cross the creation ceiling before releasing
     );
 
     assert.equal(result, mirror);
-    assert.ok(clock > CLONE_CREATION_TIMEOUT_MS, "the waiter must outlive the full creation ceiling");
+    assert.deepEqual(
+      waitClocks,
+      [CLONE_CREATION_TIMEOUT_MS, CLONE_CREATION_TIMEOUT_MS + 1_000, CLONE_CREATION_TIMEOUT_MS + 1_000],
+      "the waiter must cover the ceiling and first poll beyond it before releasing the live holder",
+    );
+    assert.equal(clock, CLONE_CREATION_TIMEOUT_MS + 1_000, "the synthetic clock must stay inside the default lock wait");
     assert.equal(progress.some(({ event }) => event === "lock-steal"), false, "a live holder must not be stolen");
   } finally {
     holderRelease.resolve();

--- a/public-snapshot.json
+++ b/public-snapshot.json
@@ -84,6 +84,7 @@
     { "glob": "packages/api/binding.gyp", "purpose": "API native addon build definition" },
     { "glob": "packages/api/native/control_plane_directory.c", "purpose": "API control-plane directory native implementation" },
     { "glob": "packages/api/scripts/dbtest-preamble.mjs", "purpose": "database-test preamble: hands each test file the database and roots the run planned for it, and refuses a file that plan does not name" },
+    { "glob": "packages/api/scripts/dbtest-process.mjs", "purpose": "database-test process runner preserving measured file order and per-file process isolation" },
     { "glob": "packages/api/scripts/dbtest.mjs", "purpose": "database-test runner: the process behind npm run test:db, which migrates one template, gives every test file a copy of it, and drops what it made" },
     { "glob": "packages/api/src/**/*.ts", "purpose": "API TypeScript source and tests" },
     { "glob": "packages/api/tsconfig.json", "purpose": "API TypeScript configuration" },

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -1227,7 +1227,6 @@ parallel_steps "dependencies and the install-free suites" \
   "frozen-record checker fixtures" node --test scripts/check-frozen-docs.test.mjs :: \
   "operator API handbook coverage" node --test scripts/operator-api-docs.test.mjs :: \
   "host proof slot fixtures" node --test scripts/host-proof-slot.test.mjs :: \
-  "delivery concurrency and gate worker fixtures" node --test scripts/gate-worker/gate-env.test.mjs scripts/gate-worker/gate-worker.test.mjs scripts/gate-worker/gate-dispatch.test.mjs scripts/merge-lease.test.mjs scripts/merge-train.test.mjs :: \
   "parallel-group fixtures" node --test scripts/merge-gate-parallel.test.mjs :: \
   "build layer fixtures" node --test scripts/build-layers.test.mjs
 
@@ -1252,7 +1251,12 @@ step "throwaway PostgreSQL is accepting connections" await_postgres
 # The migration needs the server and dependencies, not the build, so it belongs
 # in this group too. prisma resolves its schema from the working directory,
 # which is why it runs inside packages/db rather than at the repository root.
+# The delivery fixtures spend about thirty seconds exercising bounded waits.
+# They use isolated fixture repositories and need no dist output, so let those
+# waits overlap compilation instead of holding a finished npm ci at the first
+# barrier. Every fixture still runs once and must pass before the proof waves.
 parallel_steps "static analysis, build, and the suites that need no build output" \
+  "delivery concurrency and gate worker fixtures" node --test scripts/gate-worker/gate-env.test.mjs scripts/gate-worker/gate-worker.test.mjs scripts/gate-worker/gate-dispatch.test.mjs scripts/merge-lease.test.mjs scripts/merge-train.test.mjs :: \
   "build (all workspaces)" build_all :: \
   "lint (biome + type-aware no-floating-promises)" parallel_lint :: \
   "quiet-window auto-deploy harness" npm run test:auto-deploy :: \

--- a/scripts/merge-gate.sh
+++ b/scripts/merge-gate.sh
@@ -787,6 +787,7 @@ run_database_tests() {
   local suite_root="${GATE_TMP}/dbtest-roots"
   mkdir -p "${suite_root}/workspaces" "${suite_root}/state" "${suite_root}/files" || return 1
   AGENTOS_DBTEST_CONCURRENCY="${GATE_DB_LANES}" \
+  AGENTOS_DBTEST_TIMING_HISTORY="${CACHE_ROOT}/dbtest-timings.jsonl" \
   RUNNER_WORKSPACE_ROOT="${suite_root}/workspaces" \
   CONTROL_PLANE_STATE_DIR="${suite_root}/state" \
   FILES_ROOT="${suite_root}/files" \


### PR DESCRIPTION
The full Merge gate took about six minutes on the shared worker. Start database files in measured longest-first order, remove redundant npx launch layers in CLI database tests, bound synthetic clock/backoff work in two runner fixtures, and overlap unchanged delivery fixture waits with compilation. Preserve every required check, the existing lane budget, per-file processes and cloned databases, and exact-head proof.

Scheduling history is advisory, contains only durations, and cannot select tests or supply proof. Only a complete passing DB wave with successful cleanup replaces it atomically. Missing history remains explicit and runs all files.

On the same 14-vCPU shared worker (capacity 1, host-share 2), baseline cache-hit gates took 355.6s and 350.4s (353.0s mean). Final head passed in 294.6s with a cold build and 287.7s with a build-cache hit: 18.5% faster for the comparable cache-hit measurement, short of the 180s target. The final DB waves both took 233s; unit took 184s and 183s. The earlier implementation also passed a 310.9s cold gate. Host CPU work remained approximately flat while runnable peaks increased; these observations do not establish runner task latency under sixteen busy Runs. Services were not restarted or reconfigured.

Validation: full exact-head Merge gate passed twice at 088f0d5971a1692134aaa3db0230cc541b014c07 against 30800b149c8c644bfbe468d23296f3ed6af43880. All 1,209 DB tests pass; unit coverage increases from 3,820 to 3,824 tests with the same eight conditional skips. Focused scheduling/isolation/failure/cancellation/history checks pass on Node 20.19 and Node 26, gate shell/group fixtures pass, affected lint/typecheck and Compose binding pass, and independent review found no actionable findings.
