### PR TITLE
fix(deploy): pin deploy subprocesses to the C locale

### DIFF
--- a/docs/runbooks/quiet-window-auto-deploy.md
+++ b/docs/runbooks/quiet-window-auto-deploy.md
@@ -745,7 +745,14 @@ the builder's terminal `DeployFailure: release-artifact-source-unavailable:
 exit-128` header and a matching final `fatal:` diagnostic before that exception
 (allowing Node's throw-site display). This identifies the source clone or
 checkout's promisor fetch; earlier recovered transport errors, terminal
-compile/dependency failures, and ambiguous output do not qualify. The allowlist is explicit
+compile/dependency failures, and ambiguous output do not qualify.
+
+Every deploy subprocess runs with `LC_ALL=C`, because this allowlist and the
+remote-main reader's transport and authentication patterns all match English
+diagnostics. Do not remove the pin to inherit the host's locale: macOS resolves
+an unset `LANG` through `AppleLanguages`, so a launchd job on a non-English
+desktop gets translated `git` output, every pattern here stops matching, and a
+transient clone failure latches for an operator instead of retrying itself. The allowlist is explicit
 and fail-closed: compile, test, missing-dependency, unknown, and every other
 build detail remains commit-scoped when the marker names a full target commit.
 Environment, authentication, malformed remote state, artifact, verification,

--- a/scripts/deploy/quiet-window-command.mjs
+++ b/scripts/deploy/quiet-window-command.mjs
@@ -5,6 +5,17 @@ import { DeployFailure } from "./quiet-window-lib.mjs";
 
 export const COMMAND_KILL_GRACE_MS = 2_000;
 
+/** Every reader of a deploy subprocess's output parses English: the remote-main
+ * reader's transport and auth patterns, the escalation classifier's `fatal: `
+ * source-transport allowlist, and the builder's own clone retry. A host whose
+ * git is translated — macOS resolves an unset `LANG` through `AppleLanguages`,
+ * so a launchd job on a non-English desktop is translated by default — answers
+ * every one of those with a silent no, and a transient clone failure latches
+ * the pipeline for an operator instead of retrying itself. Pin the child to the
+ * locale those patterns are written against. `C` is deliberate rather than
+ * `LC_MESSAGES=C`: gettext ignores `LANGUAGE` only when `LC_ALL` is `C`. */
+export const deployChildEnvironment = (env = process.env) => ({ ...env, LC_ALL: "C" });
+
 const timeoutFailure = (program, timeoutMs, reason) => new DeployFailure(
   reason,
   `program-${basename(program)}-timeout-${timeoutMs}ms`,
@@ -38,7 +49,7 @@ export const runDeployCommand = (program, args, {
   return new Promise((accept, reject) => {
     const child = spawn(program, args, {
       cwd,
-      env,
+      env: deployChildEnvironment(env),
       shell: false,
       detached: true,
       stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",

--- a/scripts/deploy/quiet-window-command.test.mjs
+++ b/scripts/deploy/quiet-window-command.test.mjs
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { performance } from "node:perf_hooks";
 import test from "node:test";
 
-import { runDeployCommand } from "./quiet-window-command.mjs";
+import { deployChildEnvironment, runDeployCommand } from "./quiet-window-command.mjs";
 import { DeployFailure } from "./quiet-window-lib.mjs";
 
 const env = { PATH: process.env.PATH ?? "/usr/bin:/bin" };
@@ -42,6 +42,29 @@ test("deploy command returns captured output before its step deadline", async ()
     timeoutReason: "fixture-timeout",
   });
   assert.deepEqual(result, { code: 0, signal: null, stdout: "ok", stderr: "warning" });
+});
+
+test("deploy command pins its child to the locale the classifiers read", async () => {
+  // The host's own translated locale reaches the child otherwise, and every
+  // downstream reader of `fatal: ` diagnostics stops recognising them.
+  const result = await runDeployCommand("/bin/sh", ["-c", "printf %s \"$LC_ALL\""], {
+    cwd: process.cwd(),
+    env: { ...env, LC_ALL: "zh_CN.UTF-8", LANG: "zh_CN.UTF-8", LANGUAGE: "zh_CN" },
+    capture: true,
+    timeoutMs: 30_000,
+    timeoutReason: "fixture-timeout",
+  });
+  assert.equal(result.stdout, "C");
+});
+
+test("the pinned child environment overrides a translated host and keeps the rest", () => {
+  assert.deepEqual(
+    deployChildEnvironment({ PATH: "/usr/bin", LC_ALL: "zh_CN.UTF-8" }),
+    { PATH: "/usr/bin", LC_ALL: "C" },
+  );
+  // An explicit `C` is what gettext needs to ignore `LANGUAGE` as well, so the
+  // pin is not weakened to `LC_MESSAGES`.
+  assert.equal(deployChildEnvironment({ LANGUAGE: "zh_CN" }).LC_ALL, "C");
 });
 
 test("deploy command requires an explicit step budget and timeout reason", () => {

--- a/scripts/deploy/release-artifact.mjs
+++ b/scripts/deploy/release-artifact.mjs
@@ -11,6 +11,7 @@ import {
   workspaceDependencyPaths,
 } from "./release-artifacts.mjs";
 import { assembleReleaseDirectory, verifyReleaseDirectory } from "./release-directory.mjs";
+import { deployChildEnvironment } from "./quiet-window-command.mjs";
 import { DeployFailure } from "./quiet-window-lib.mjs";
 
 const SHA = /^[0-9a-f]{40}$/u;
@@ -278,12 +279,19 @@ const run = (program, args, options = {}) => {
         stdio: ["inherit", "inherit", "pipe"],
         maxBuffer: 10 * 1024 * 1024,
         ...spawnOptions,
+        // After the spread: the clone retry below and the escalation classifier
+        // both read this stderr, and both read English.
+        env: deployChildEnvironment(spawnOptions.env),
       });
       if (result.error || result.status !== 0) throw result;
       if (result.stderr) process.stderr.write(result.stderr);
       return result.stdout;
     }
-    return execFileSync(program, args, { stdio: "inherit", ...spawnOptions });
+    return execFileSync(program, args, {
+      stdio: "inherit",
+      ...spawnOptions,
+      env: deployChildEnvironment(spawnOptions.env),
+    });
   } catch (error) {
     // Captured stderr still belongs in the operator's log; classification is a
     // second reader of it, not its owner.


### PR DESCRIPTION
## What broke

The Mac runner-only host's auto-deploy latched on 2026-09-08T08:05Z and stayed latched for 17.7 hours and 213 ticks after the network recovered, needing a manual `--clear-escalation`.

The clone failed on a transient GitHub transport blip, which the escalation classifier is already built to retry unattended. It did not retry, because the diagnostic it classifies was translated:

```
致命错误：无法访问 'https://github.com/mosonlab/anneal.git/'：LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to github.com:443
致命错误：无法从承诺者远程获取 f72e9faa…
```

`artifactSourceTransportFailure` requires the terminal diagnostic to match `/^fatal: /` and one of its transport patterns. Neither matched, so the marker was classified `commit-scoped` — operator-latched — instead of `retryable-transient`.

macOS resolves an unset `LANG` through `AppleLanguages`; `launchctl getenv LANG` is empty for this job, and the desktop is `zh-Hans-CN`, so `git` is translated by default. Reproduced directly:

```
$ env -u LANG -u LC_ALL -u LC_MESSAGES git clone https://github.com/mosonlab/does-not-exist.git /tmp/x
致命错误：仓库 '…' 未找到
```

The same exposure exists in `remote-main-read.mjs` (`AUTH_FAILURE` and `TRANSIENT_FAILURE`) and in the builder's own `TRANSIENT_CLONE_STDERR` retry. All three are English-only patterns reading child output.

## The fix

Pin every deploy child to `LC_ALL=C` at the two spawn seams those classifiers read from: `runDeployCommand` and `release-artifact.mjs`'s `run`. `C` rather than `LC_MESSAGES=C`, because gettext ignores `LANGUAGE` only when `LC_ALL` is `C`.

Feeding the real marker through `escalationScope` before and after:

| detail | class |
| --- | --- |
| as the Mac wrote it | `commit-scoped` |
| same failure in the C locale | `retryable-transient` |

No deploy code formats dates or numbers by locale, so the pin changes nothing else.

## Verification

- `npm run lint` — pass
- `npm run test:snapshot-scan` — pass
- `node --test` over `quiet-window-command`, `quiet-window-deadlines`, `quiet-window-escalation`, `release-artifact-import-graph` — 96 pass, 0 fail

Note for the reviewer: `quiet-window-deploy.test.mjs` has two failures on this macOS host (`forward proves the named release on linux/darwin`, `dispatch-drain-create-failed: TypeError`). They reproduce identically on a clean `main` checkout with no changes applied, so they are pre-existing here and not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwS3XbJrkYUb1EWurxTm5c