### PR TITLE
fix(deploy): scope auto-deploy Inbox notices by host

### DIFF
--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -664,15 +664,24 @@ export const openDispatchDrain = ({ insert, extend, remove, onWriteFailure, log:
 export const autoDeployNoticeDedupeKey = (body, dedupeScope = null) =>
   `auto-deploy:${createHash("sha256").update(dedupeScope === null ? body : `${dedupeScope}\n${body}`).digest("hex")}`;
 
-/** `dedupeScope` names what the notice is about when its text alone does not.
- * Deploy outcomes dedupe on their text; a per-attempt alert scopes its key to
- * the attempt, so a later attempt with the same revisions and the same timing
- * still reaches the operator instead of colliding with the earlier record. */
-const notify = async ({ outcome, reason, detail = "", from, to, dedupeScope = null }) => {
+/** The host that wrote a notice is part of what the notice is about. A
+ * control-plane host and the runner-only hosts following it deploy the same
+ * `from -> to`, so their notice bodies are identical: on one shared key the
+ * follower's outcome is dropped as a duplicate, and the Inbox keeps reporting
+ * whichever host wrote first. Scoping by host records each one. */
+export const autoDeployNoticeHostScope = (host, dedupeScope = null) =>
+  dedupeScope === null ? host : `${host}\n${dedupeScope}`;
+
+/** `dedupeScope` names what the notice is about when its text and its host
+ * alone do not. Deploy outcomes dedupe on their text; a per-attempt alert
+ * scopes its key to the attempt, so a later attempt with the same revisions
+ * and the same timing still reaches the operator instead of colliding with the
+ * earlier record. */
+const notify = async ({ outcome, reason, detail = "", from, to, dedupeScope = null, host = hostname() }) => {
   if (outcome === "success") throwIfInterrupted();
   const db = await database();
   const body = autoDeployNoticeBody({ outcome, reason, detail, from, to });
-  const dedupeKey = autoDeployNoticeDedupeKey(body, dedupeScope);
+  const dedupeKey = autoDeployNoticeDedupeKey(body, autoDeployNoticeHostScope(host, dedupeScope));
   try {
     const chatId = process.env.FEISHU_DEFAULT_CHAT_ID;
     if (!chatId) fail("environment-unreadable", "FEISHU_DEFAULT_CHAT_ID-missing");

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -56,6 +56,7 @@ import { buildReleaseArtifact, findReleaseArtifact, verifyReleaseArtifact } from
 import {
   autoDeployNoticeBody,
   autoDeployNoticeDedupeKey,
+  autoDeployNoticeHostScope,
   canonicalSyncNoticeRecord,
   canonicalSyncRefusedLines,
   createDeployHost,
@@ -2766,8 +2767,28 @@ test("an over-budget alert dedupes within its attempt and not across attempts", 
   // identical revisions and identical timing raises its own.
   assert.equal(keys[0], keys[1]);
   assert.notEqual(keys[0], keys[2]);
-  // An unscoped notice keys on its text alone, as every deploy outcome does.
+  // A notice carrying neither scope keys on its text alone.
   assert.notEqual(keys[0], autoDeployNoticeDedupeKey("[auto-deploy] failure: a -> b; reason=x"));
+});
+
+test("two hosts reporting the same deploy outcome each keep their own record", () => {
+  // A control plane and the runner-only host following it publish the same
+  // release, so both write this exact line.
+  const body = autoDeployNoticeBody({ outcome: "success", from: revisions.from, to: revisions.to, reason: "deployed" });
+  const controlPlane = autoDeployNoticeDedupeKey(body, autoDeployNoticeHostScope("control-plane-host"));
+  const follower = autoDeployNoticeDedupeKey(body, autoDeployNoticeHostScope("runner-host"));
+  // Sharing one key drops the second host's outcome as a duplicate, leaving the
+  // Inbox reporting the first host's — a stale failure outlives its repair.
+  assert.notEqual(controlPlane, follower);
+  // The same host reporting the same outcome twice is still one record.
+  assert.equal(controlPlane, autoDeployNoticeDedupeKey(body, autoDeployNoticeHostScope("control-plane-host")));
+  // A finer scope stays distinct within its host, and across hosts sharing it.
+  const attempt = autoDeployNoticeHostScope("control-plane-host", "attempt-one");
+  assert.notEqual(autoDeployNoticeDedupeKey(body, attempt), controlPlane);
+  assert.notEqual(
+    autoDeployNoticeDedupeKey(body, attempt),
+    autoDeployNoticeDedupeKey(body, autoDeployNoticeHostScope("runner-host", "attempt-one")),
+  );
 });
 
 test("an undelivered over-budget alert reports itself undelivered", async () => {


### PR DESCRIPTION
## What broke

The Inbox deploy strip kept reporting an 18-hour-old failure after the host that failed had been repaired and had redeployed successfully.

`notify` keys each record with `autoDeployNoticeDedupeKey(body)` — a hash of the notice text alone. The text is `[auto-deploy] <outcome>: <from> -> <to>; reason=<reason>`, which carries no host. A control-plane host and the runner-only hosts following it publish the same release, so their bodies are byte-identical and collide on one key. The upsert's `update: {}` then drops the second host's record silently.

Observed: the control plane wrote `success: 30800b14 -> 088f0d59` at 08:04:30Z. The Mac wrote the identical line at 01:57Z the next day after its own repair. No row was created, so the newest `[auto-deploy]` message in the table stayed the 08:05:24Z failure, and `latestDeploy` in `apps/web/src/lib/inbox.ts` — which reads the newest match regardless of status — kept rendering it.

## The fix

Key each notice by the host that wrote it, keeping the finer per-attempt scope the over-budget alert already relies on. `notify` is not reachable without a database, so the rule lives in the exported pure `autoDeployNoticeHostScope` and is tested there.

The notice body is unchanged, so `latestDeploy`'s parser and the operator-facing text are untouched.

## Verification

- `npm run lint` — pass
- `node --test scripts/deploy/quiet-window-deploy.test.mjs` — 174 pass

Note for the reviewer: the same run reports two failures on this macOS host (`forward proves the named release on linux/darwin`, `dispatch-drain-create-failed: TypeError`). They reproduce identically on a clean `main` checkout with no changes applied, so they are pre-existing here and not from this branch.

## Not in this change

The failure notice still does not say which host raised it, which is why the original triage started on the wrong machine. Adding that means changing the body and the web parser together; it is worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwS3XbJrkYUb1EWurxTm5c