### PR TITLE
feat(deploy): name the host in auto-deploy Inbox notices

### DIFF
--- a/apps/web/src/lib/inbox.ts
+++ b/apps/web/src/lib/inbox.ts
@@ -17,14 +17,19 @@ export type DeployNotice = {
    *  it resolved one. */
   revision: string;
   reason: string;
+  /** Which host wrote this. The control plane and the runner-only hosts
+   *  following it each deploy, so an unattributed failure sends the operator to
+   *  the wrong machine. `null` for a record written before hosts were named. */
+  host: string | null;
   at: string;
 };
 
 /* The body shape written by `scripts/deploy/quiet-window-deploy.mjs`:
- * `[auto-deploy] success: <from> -> <to>; reason=deployed`. A successful deploy
- * is archived on write and never notifies, so this line is the only place the
- * operator can see that production moved — and when. */
-const DEPLOY_BODY = /^\[auto-deploy\] (success|failure): \S+ -> (\S+); reason=([^;]+)/;
+ * `[auto-deploy] success: <from> -> <to>; reason=deployed; host=<name>`. A
+ * successful deploy is archived on write and never notifies, so this line is
+ * the only place the operator can see that production moved — and when. The
+ * host field is optional here because records already in the table predate it. */
+const DEPLOY_BODY = /^\[auto-deploy\] (success|failure): \S+ -> (\S+); reason=([^;]+)(?:; host=([^;]+))?/;
 
 export const latestDeploy = (messages: InboxMessage[]): DeployNotice | null => {
   /* `GET /inbox/messages` returns newest first, so the first match is current.
@@ -32,13 +37,15 @@ export const latestDeploy = (messages: InboxMessage[]): DeployNotice | null => {
   for (const message of messages) {
     const match = DEPLOY_BODY.exec(message.body);
     if (match === null) continue;
-    /* All three groups are mandatory in the pattern, so a match has them; the
-     * guard is what `noUncheckedIndexedAccess` needs to see. */
-    const [, outcome = "", revision = "", reason = ""] = match;
+    /* The first three groups are mandatory in the pattern, so a match has them;
+     * the guard is what `noUncheckedIndexedAccess` needs to see. The fourth is
+     * genuinely optional and stays `null` when the record omits it. */
+    const [, outcome = "", revision = "", reason = "", host] = match;
     return {
       outcome: outcome === "success" ? "success" : "failure",
       revision: revision.slice(0, 7),
       reason,
+      host: host ?? null,
       at: message.createdAt,
     };
   }

--- a/apps/web/src/pages/Inbox.tsx
+++ b/apps/web/src/pages/Inbox.tsx
@@ -80,9 +80,15 @@ const DeployStrip = ({ deploy }: { deploy: DeployNotice }): ReactNode => {
   const t = useT();
   return (
     <div className={cn(DEPLOY_STRIP, DEPLOY_TONE[deploy.outcome])}>
-      {deploy.outcome === "success"
-        ? t("inbox.deploy.success", { revision: deploy.revision, when: timeAgo(deploy.at) })
-        : t("inbox.deploy.failure", { revision: deploy.revision, when: timeAgo(deploy.at), reason: deploy.reason })}
+      {/* A hostname is a machine identifier, not prose: it stays out of the
+        * translated sentence and out of the message the operator reads aloud.
+        * Records written before hosts were named simply have none to show. */}
+      {deploy.host === null ? null : <span className="flex-none opacity-70">{deploy.host}</span>}
+      <span>
+        {deploy.outcome === "success"
+          ? t("inbox.deploy.success", { revision: deploy.revision, when: timeAgo(deploy.at) })
+          : t("inbox.deploy.failure", { revision: deploy.revision, when: timeAgo(deploy.at), reason: deploy.reason })}
+      </span>
     </div>
   );
 };

--- a/apps/web/src/tests/inbox-lanes.test.tsx
+++ b/apps/web/src/tests/inbox-lanes.test.tsx
@@ -98,6 +98,36 @@ test("a deploy that succeeded reports where production is, without occupying a l
   }
 });
 
+test("a deploy notice names the host that wrote it", async () => {
+  const failed = card({
+    id: "deploy-2", status: "CLOSED", answeredAt: now,
+    body: "[auto-deploy] failure: cd63e56186022274da18288bfd7ef36bd6b318ea -> cb46e4a003c3296fbd2f9ee49d6450ae7b7b3b3b;"
+      + " reason=release-artifact-build-failed; host=runner-host-1; detail=exit-1: fatal: unable to access",
+  });
+  const { container, page } = await renderInbox([failed]);
+  try {
+    const text = container.textContent ?? "";
+    // Without this the operator cannot tell which of the deploying hosts to go
+    // and look at, and the detail after it must not be mistaken for the host.
+    assert.match(text, /runner-host-1/);
+    assert.match(text, /release-artifact-build-failed/);
+    assert.doesNotMatch(text, /exit-1/);
+  } finally {
+    await page.dispose();
+  }
+});
+
+test("a deploy notice written before hosts were named still renders", async () => {
+  const { latestDeploy } = await import("../lib/inbox");
+  assert.deepEqual(latestDeploy([deployed])?.host, null);
+  const { container, page } = await renderInbox([deployed]);
+  try {
+    assert.match(container.textContent ?? "", /cb46e4a/);
+  } finally {
+    await page.dispose();
+  }
+});
+
 test("the sidebar badge counts the reply-owing cards only", async () => {
   const { needsReply } = await import("../lib/inbox");
   assert.deepEqual([gate, notice, deployed].filter(needsReply).map((message) => message.id), ["gate-1"]);

--- a/scripts/deploy/quiet-window-deploy.mjs
+++ b/scripts/deploy/quiet-window-deploy.mjs
@@ -278,10 +278,15 @@ export const canonicalSyncNoticeRecord = (record, refusedLines) => ({
     : {}),
 });
 
-export const autoDeployNoticeBody = ({ outcome, reason, detail = "", from, to }) =>
+/** `host` sits between the reason and the free-form detail: the reason is the
+ * last field a reader can bound by `;`, and a failure detail carries a whole
+ * builder transcript after it. A record written before hosts were named omits
+ * the field, and the Inbox reads it as optional. */
+export const autoDeployNoticeBody = ({ outcome, reason, detail = "", from, to, host = "" }) =>
   outcome === "info" && reason === QUIET_WINDOW_WAIT_EXCEEDED_REASON
     ? "自动部署等待超时，已开始排空派发"
-    : `[auto-deploy] ${outcome}: ${from} -> ${to}; reason=${reason}${detail ? `; detail=${detail}` : ""}`;
+    : `[auto-deploy] ${outcome}: ${from} -> ${to}; reason=${reason}`
+      + `${host ? `; host=${host}` : ""}${detail ? `; detail=${detail}` : ""}`;
 
 const parseJson = (contents, reason) => {
   try {
@@ -668,7 +673,11 @@ export const autoDeployNoticeDedupeKey = (body, dedupeScope = null) =>
  * control-plane host and the runner-only hosts following it deploy the same
  * `from -> to`, so their notice bodies are identical: on one shared key the
  * follower's outcome is dropped as a duplicate, and the Inbox keeps reporting
- * whichever host wrote first. Scoping by host records each one. */
+ * whichever host wrote first. Scoping by host records each one.
+ *
+ * The body names the host too, for the operator reading the notice. This key
+ * stays independent of it: dedupe should not rest on a human-readable string
+ * keeping a particular field. */
 export const autoDeployNoticeHostScope = (host, dedupeScope = null) =>
   dedupeScope === null ? host : `${host}\n${dedupeScope}`;
 
@@ -680,7 +689,7 @@ export const autoDeployNoticeHostScope = (host, dedupeScope = null) =>
 const notify = async ({ outcome, reason, detail = "", from, to, dedupeScope = null, host = hostname() }) => {
   if (outcome === "success") throwIfInterrupted();
   const db = await database();
-  const body = autoDeployNoticeBody({ outcome, reason, detail, from, to });
+  const body = autoDeployNoticeBody({ outcome, reason, detail, from, to, host });
   const dedupeKey = autoDeployNoticeDedupeKey(body, autoDeployNoticeHostScope(host, dedupeScope));
   try {
     const chatId = process.env.FEISHU_DEFAULT_CHAT_ID;

--- a/scripts/deploy/quiet-window-deploy.test.mjs
+++ b/scripts/deploy/quiet-window-deploy.test.mjs
@@ -3643,6 +3643,14 @@ test("wait exceeded sends informational Chinese text rather than a deploy failur
   assert.equal(notices[0].outcome, "info");
   assert.equal(autoDeployNoticeBody(notices[0]), "自动部署等待超时，已开始排空派发");
   assert.match(autoDeployNoticeBody({ outcome: "failure", reason: "build-failed", ...revisions }), /^\[auto-deploy\] failure:/u);
+  // The host is bounded by `;` before the detail, which carries a whole builder
+  // transcript and cannot be parsed past.
+  assert.match(
+    autoDeployNoticeBody({ outcome: "failure", reason: "build-failed", host: "runner-host-1", detail: "exit-1: fatal: x", ...revisions }),
+    /; reason=build-failed; host=runner-host-1; detail=exit-1: fatal: x$/u,
+  );
+  // A caller that names no host writes the shape every record before this one had.
+  assert.doesNotMatch(autoDeployNoticeBody({ outcome: "success", reason: "deployed", ...revisions }), /host=/u);
 });
 
 test("automatic cadence persists successful deployment time across ticks", async (t) => {


### PR DESCRIPTION
Follow-up to #618, which stopped two hosts' notices from colliding but left the notice itself unattributed.

## Why

An auto-deploy failure said only which revision it stopped at. Two hosts deploy — the control plane and the runner-only hosts following it — so the operator could not tell which machine to go and look at. In the incident that produced #617 and #618, triage started on the wrong one and spent a round of evidence there.

## What changed

The notice body now carries the writing host:

```
[auto-deploy] failure: <from> -> <to>; reason=<reason>; host=<name>[; detail=…]
```

The field sits between the reason and the detail. The reason is the last field a reader can bound by `;`, and a failure detail carries a whole builder transcript after it, so nothing parseable can follow the detail.

`latestDeploy` treats the field as optional, because every record already in the table predates it, and `DeployStrip` renders the hostname beside the sentence rather than inside it — a hostname is a machine identifier, not prose, so it needs no locale key and is not translated.

Dedupe keeps the separate host scope added in #618. That is deliberate rather than redundant: a dedupe guarantee should not rest on a human-readable string keeping a particular field, and the over-budget wait notice has a fixed body with no host in it at all.

## Verification

- `npm run lint` — pass
- `npm run typecheck -w @anneal/web` — pass
- `npm run test -w @anneal/web` — 797 pass, 0 fail
- `node --test scripts/deploy/quiet-window-deploy.test.mjs` — 174 pass

New coverage: the strip shows the host and does not leak the detail after it; a legacy body without the field still parses and renders; and the body builder omits the field entirely when no host is named.

Note for the reviewer: the deploy suite reports two failures on this macOS host (`forward proves the named release on linux/darwin`). They reproduce on a clean `main` with no changes applied and passed the gate on #617 and #618, so they are local to this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwS3XbJrkYUb1EWurxTm5c