### PR TITLE
chore(templates): default the hard tier to senior-dev-sol-high

### DIFF
--- a/agents/templates/direct-engineer-workflow/01-revalidate.md
+++ b/agents/templates/direct-engineer-workflow/01-revalidate.md
@@ -59,7 +59,7 @@ reason and check the listed not-a-reason cases before choosing a tier other than
   review or regression; for example, keeping an untested semantic intact
   across several providers' event handling. It is not a reason that the change
   is large, spans modules, or needs a lot of reading. The current Agent is
-  `senior-dev-astra-low`.
+  `senior-dev-sol-high`.
 - `hazard` — the failure the acceptance suite cannot witness: concurrency,
   transaction boundaries, lock or lease windows, cross-module contract
   migrations; or the change alters what the merge gate, merge automation, a

--- a/docs/BRIEF-TEMPLATE.md
+++ b/docs/BRIEF-TEMPLATE.md
@@ -103,7 +103,7 @@ for that tier. The tier criteria and their not-a-reason lists are:
   review or regression; for example, keeping an untested semantic intact
   across several providers' event handling. A large change, a change that
   spans modules, or a change that needs a lot of reading is not a reason to
-  choose it. Its canonical Agent today is `senior-dev-astra-low`.
+  choose it. Its canonical Agent today is `senior-dev-sol-high`.
 - **hazard** — the failure the acceptance suite cannot witness: concurrency,
   transaction boundaries, lock or lease windows, or cross-module contract
   migrations; or the change alters what the merge gate, merge automation, a

--- a/docs/governance/task-routing-v1.md
+++ b/docs/governance/task-routing-v1.md
@@ -96,7 +96,7 @@ operator configuration; an empty slot never falls through to another tier.
 | --- | --- | --- | --- |
 | `default` | Everything else. Acceptance that existing tests or grep can check stays here whatever it touches. | Crossing packages, touching web files, touching many files, landing in a sensitive directory, or an audit report once suggesting a stronger model. | `senior-dev-luna-max` |
 | `frontend` | The deliverable is a new page, a page redesign, or a new interaction or visual scheme. | Adding a field, wiring data, or changing copy on an existing component. | `frontend-dev-opus-medium` |
-| `hard` | A behavior that neither the brief nor an existing test pins down has to be defined by the implementer, and getting it wrong would not show in review or regression; for example, keeping an untested semantic intact across several providers' event handling. | The change is large, spans modules, or needs a lot of reading. | `senior-dev-astra-low` |
+| `hard` | A behavior that neither the brief nor an existing test pins down has to be defined by the implementer, and getting it wrong would not show in review or regression; for example, keeping an untested semantic intact across several providers' event handling. | The change is large, spans modules, or needs a lot of reading. | `senior-dev-sol-high` |
 | `hazard` | The failure the acceptance suite cannot witness: concurrency, transaction boundaries, lock or lease windows, or cross-module contract migrations; or the change alters what the merge gate, merge automation, a migration, or authorization does. | Merely touching those files without changing their behavior. | `senior-dev-astra-medium` |
 
 These tier criteria and not-a-reason lists are the text of record.

--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -1511,7 +1511,7 @@ curl -X DELETE "$BASE_URL/staffing-profiles/$PROFILE_ID" \
   `mergeTailRepairAgentId`; the active direct, PR, and compound canonical
   profiles set `tiers.default` to `senior-dev-luna-max`,
   `tiers.frontend` to `frontend-dev-opus-medium`, `tiers.hard` to
-  `senior-dev-astra-low`, and `tiers.hazard` to `senior-dev-astra-medium`, and
+  `senior-dev-sol-high`, and `tiers.hazard` to `senior-dev-astra-medium`, and
   set the repair slot to `senior-dev-luna-max`.
 - If the canonical repair Agent is missing or archived, reset restores the step
   entries, clears the repair slot, and returns a `merge_tail_repair_agent_unavailable`

--- a/packages/db/src/canonical-prompt-sync-fixtures.test.ts
+++ b/packages/db/src/canonical-prompt-sync-fixtures.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { restorePreFrozenRegressionPrompt, restorePreOptionalReviewPrompt, restorePreTierRevalidationPrompt } from "./canonical-prompt-sync-fixtures.js";
+import { restorePreFrozenRegressionPrompt, restorePreOptionalReviewPrompt, restorePreSolHighHardTierPrompt, restorePreTierRevalidationPrompt } from "./canonical-prompt-sync-fixtures.js";
 import { LEGACY_TEMPLATE_GENERATIONS, templatePromptGenerationDigest } from "./canonical-template-transition.js";
 import { loadAllTemplateStepSources } from "./template-sources.js";
 
@@ -31,4 +31,13 @@ test("sync fixtures reconstruct the registered pre-frozen-regression-baseline ge
     const steps = sources.get(name)!.map((step) => ({ ...step, prompt: restorePreFrozenRegressionPrompt(step.prompt) }));
     assert.equal(templatePromptGenerationDigest(steps), LEGACY_TEMPLATE_GENERATIONS[name].find((generation) => generation.marker === "pre-frozen-regression-baseline")!.promptDigest, name);
   }
+});
+
+test("sync fixtures reconstruct the registered pre-sol-high-hard-tier generation", async () => {
+  const sources = await loadAllTemplateStepSources();
+  const steps = sources.get("direct-engineer-workflow")!.map((step) => ({ ...step, prompt: restorePreSolHighHardTierPrompt(step.prompt) }));
+  assert.equal(
+    templatePromptGenerationDigest(steps),
+    LEGACY_TEMPLATE_GENERATIONS["direct-engineer-workflow"].find((generation) => generation.marker === "pre-sol-high-hard-tier")!.promptDigest,
+  );
 });

--- a/packages/db/src/canonical-prompt-sync-fixtures.ts
+++ b/packages/db/src/canonical-prompt-sync-fixtures.ts
@@ -1,9 +1,18 @@
 /**
+ * Restore the `hard` tier Agent name the revalidation prompt carried before the
+ * tier's canonical role moved to `senior-dev-sol-high` (2026-09-09). Every
+ * registered generation predates that rollover, so the older fixtures apply
+ * it first.
+ */
+export const restorePreSolHighHardTierPrompt = (prompt: string): string => prompt
+  .replace("The current Agent is\n  `senior-dev-sol-high`.", "The current Agent is\n  `senior-dev-astra-low`.");
+
+/**
  * Restore the Regression bytes retired by the frozen-baseline rollover before
  * applying older fixture transformations. Every historical generation digest
  * authenticates the whole template, including this mechanical handoff.
  */
-export const restorePreFrozenRegressionPrompt = (prompt: string): string => prompt
+export const restorePreFrozenRegressionPrompt = (prompt: string): string => restorePreSolHighHardTierPrompt(prompt)
   .replace(
     "The platform script owns prepare-time refresh/merge, gate dispatch and retries,\nverdict transcription, and the final `regression-verification-v2` task output.\nMerge readiness checks the latest target under the Merge Lease before authorizing\nthe exact merge.",
     "The platform script owns refresh/merge, merge-lease operations, gate dispatch\nand retries, verdict transcription, and the final `regression-verification-v2`\ntask output.",

--- a/packages/db/src/canonical-prompt-sync.dbtest.ts
+++ b/packages/db/src/canonical-prompt-sync.dbtest.ts
@@ -1318,6 +1318,15 @@ test(`sync recreates a missing ${specialName} Agent from senior-dev-astra-medium
     await prisma.repo.delete({ where: { id: repo.id } });
   });
 
+  // The canonical Default profiles may stake a tier slot on this role (the
+  // direct `hard` tier binds senior-dev-sol-high). Those rows restrict the
+  // delete, so lift them first and restake them on the recreated Agent below;
+  // sync never touches an existing profile's slots.
+  const stakedTiers = await prisma.staffingProfileTier.findMany({
+    where: { agentId: existingSol.id },
+    select: { profileId: true, tier: true },
+  });
+  await prisma.staffingProfileTier.deleteMany({ where: { agentId: existingSol.id } });
   await prisma.agent.delete({ where: { id: existingSol.id } });
 
   const synced = command(["tsx", "prisma/sync-canonical-prompts.ts"]);
@@ -1327,6 +1336,9 @@ test(`sync recreates a missing ${specialName} Agent from senior-dev-astra-medium
 
   const sol = await prisma.agent.findUniqueOrThrow({
     where: { projectId_name: { projectId: project.id, name: specialName } },
+  });
+  await prisma.staffingProfileTier.createMany({
+    data: stakedTiers.map((row) => ({ ...row, agentId: sol.id })),
   });
   assert.equal(sol.model, specialSource.model);
   assert.equal(sol.runnerPreference, specialSource.runnerPreference);

--- a/packages/db/src/canonical-published-generations.ts
+++ b/packages/db/src/canonical-published-generations.ts
@@ -62,6 +62,7 @@ export const PUBLISHED_PROMPT_GENERATIONS = {
     { digest: "04d473928d65443202bd68b6d865df61f26983fc35870cf43e5032279e1ed107" },
     { digest: "79921b8f06e1abbfdcd3db7132e48816edb68deda47082b9c2508b1b74067ca1" },
     { digest: "667f0aadce31cc62aa7043d6c46a1ee89d08ce4f8690bd5a5fe50a5fd5662abd" },
+    { digest: "cea709c7937fb307648ca7a5be2ed6de14aef3747ee96cff53e4d34270b03536" },
   ],
   "compound-engineer-workflow": [
     { digest: "e1e95c18a408a0c1847508ed16d4c60ae3978007dfccdbfe50cd793ee8a78fa9", retiredByShape: "model-neutral-review-step-names" },

--- a/packages/db/src/canonical-template-transition.ts
+++ b/packages/db/src/canonical-template-transition.ts
@@ -55,6 +55,10 @@ import type { PersistedTemplateStepStructure } from "./template-sources.js";
  * every reviewed-head mismatch, before a Run that starts on the `WIP salvage`
  * commit of its own prior failed attempt was told to continue from it.
  * Prompt-only in all three templates, on top of the renamed review steps.
+ * `pre-sol-high-hard-tier`: the direct graph whose revalidation prompt still
+ * named `senior-dev-astra-low` as the `hard` tier's Agent, before the tier's
+ * canonical role moved to `senior-dev-sol-high` (2026-09-09 ruling).
+ * Prompt-only in the direct template.
  */
 export type LegacyTemplateGeneration = Readonly<{
   marker: string;
@@ -332,6 +336,23 @@ const legacyTemplateGenerations = {
     {
       marker: "pre-frozen-regression-baseline",
       promptDigest: "79921b8f06e1abbfdcd3db7132e48816edb68deda47082b9c2508b1b74067ca1",
+      shape: [
+        { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
+        { name: "Implementation", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
+        { name: "Code review", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "review-findings", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
+        { name: "Blind code review", assigneeType: AssigneeType.AGENT, approvalGate: false, optional: true, outputKind: "blind-findings", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: 2, layer: 3, spawnPolicy: null, provisionDependencies: false },
+        { name: "Apply review fixes", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "fixed-implementation", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 4, spawnPolicy: null },
+        { name: "Regression verification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "regression-verification-v2", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 5, spawnPolicy: null },
+        { name: "Merge authorization", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-authorization", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 6, spawnPolicy: null },
+        { name: "Merge execution", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "merge-result", attachmentsFromPrevious: true, opensPullRequest: false, baseFromStepIndex: null, layer: 7, spawnPolicy: null },
+      ],
+    },
+    {
+      // Prompt-only rollover: the revalidation prompt names the hard tier's
+      // canonical Agent, which moved from senior-dev-astra-low to
+      // senior-dev-sol-high. The graph is unchanged.
+      marker: "pre-sol-high-hard-tier",
+      promptDigest: "667f0aadce31cc62aa7043d6c46a1ee89d08ce4f8690bd5a5fe50a5fd5662abd",
       shape: [
         { name: "Revalidate specification", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "revalidation", attachmentsFromPrevious: false, opensPullRequest: false, baseFromStepIndex: null, layer: 1, spawnPolicy: null },
         { name: "Implementation", assigneeType: AssigneeType.AGENT, approvalGate: false, outputKind: "implementation", attachmentsFromPrevious: false, requiresCommit: true, opensPullRequest: true, baseFromStepIndex: null, layer: 2, spawnPolicy: null },
@@ -715,7 +736,7 @@ export const LEGACY_TEMPLATE_GENERATIONS: Readonly<
  * `agents/templates/` and fails on a mismatch.
  */
 export const CANONICAL_SOURCE_PROMPT_GENERATIONS = {
-  [DIRECT_TEMPLATE_NAME]: "667f0aadce31cc62aa7043d6c46a1ee89d08ce4f8690bd5a5fe50a5fd5662abd",
+  [DIRECT_TEMPLATE_NAME]: "cea709c7937fb307648ca7a5be2ed6de14aef3747ee96cff53e4d34270b03536",
   "compound-engineer-workflow": "2a3634bc7c7f74a066ab8fce78c4e0f02f2f9ac65acdcf37e07c993c445bed2c",
   [PR_TEMPLATE_NAME]: "93a909a5d88b6aa158f9f86155853d7aed7762b61bd56dc9a1b17b6e7051281f",
 } as const satisfies Readonly<Record<CanonicalTemplateRegistryName, string>>;

--- a/packages/db/src/staffing-profile-canonical.ts
+++ b/packages/db/src/staffing-profile-canonical.ts
@@ -31,7 +31,7 @@ export type StaffingProfileTierKey = (typeof STAFFING_PROFILE_TIERS)[number];
 export const CANONICAL_STAFFING_TIER_ROLES: Readonly<Record<StaffingProfileTierKey, string>> = {
   default: "senior-dev-luna-max",
   frontend: "frontend-dev-opus-medium",
-  hard: "senior-dev-astra-low",
+  hard: "senior-dev-sol-high",
   hazard: "senior-dev-astra-medium",
 };
 

--- a/packages/db/src/template-sources.test.ts
+++ b/packages/db/src/template-sources.test.ts
@@ -744,7 +744,7 @@ test("bare revalidation only selects v1 for complete historical Direct identitie
 test("registered Direct generations retain their historical revalidation protocol", () => {
   for (const generation of LEGACY_TEMPLATE_GENERATIONS[DIRECT_TEMPLATE_NAME]) {
     if (!generation.shape.some(({ outputKind }) => outputKind === "revalidation")) continue;
-    const expected = generation.marker === "pre-frozen-regression-baseline" ? "v2" : "v1";
+    const expected = ["pre-frozen-regression-baseline", "pre-sol-high-hard-tier"].includes(generation.marker) ? "v2" : "v1";
     const taskTemplateName = templateRolloverName(DIRECT_TEMPLATE_NAME, generation.marker, "row");
     assert.equal(canonicalOutputGeneration({ outputKind: "revalidation", taskTemplateName }), expected);
     assert.equal(canonicalOutputGeneration({ outputKind: "revalidation", taskTemplate: { name: taskTemplateName } }), expected);


### PR DESCRIPTION
## Summary

- `CANONICAL_STAFFING_TIER_ROLES.hard` moves from `senior-dev-astra-low` to `senior-dev-sol-high`, matching the production Default staffing profile rebinding of 2026-09-09 so a profile reset no longer reverts it.
- The revalidation prompt, task routing contract, brief template, and operator API handbook name the new canonical `hard` Agent.
- Prompt-only rollover of the direct template: outgoing generation registered as `pre-sol-high-hard-tier`, source digest re-pinned, sync fixtures restore the old Agent name before reconstructing older generations.

The review-fix step stays bound to `senior-dev-astra-low`.

## Verification

- `npm run test -w @anneal/db` (676 pass), `npm run test -w @anneal/api` (1379 pass)
- `npm run lint`, `npm run test:snapshot-scan`, `npm run test:operator-api-docs`, `npm run test:frozen-docs`
- Merge gate dispatched on the exact head before publication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013gpBCreDG3uA8VqpPgDVFT
