### PR TITLE
docs(agents): scope decision reads and clarify workspace retention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,11 @@ this repository. Read "Everyone", then the section for your environment:
 ## Everyone
 
 - Before writing specs, plans, reviews, or documentation, read [the domain glossary](CONTEXT.md) and use its vocabulary.
-- Before proposing, specifying, or reviewing a design change, read [`docs/out-of-scope/`](docs/out-of-scope/) and the ADRs in [`docs/adr/`](docs/adr/); a proposal that contradicts an entry must cite it and argue its revisit condition.
+- Before proposing, specifying, or reviewing a design change, use the
+  [out-of-scope index](docs/out-of-scope/README.md) and
+  [ADR index](docs/adr/README.md) to find and read the relevant decisions,
+  following their current cross-references. A proposal that contradicts an
+  entry must cite it and argue its revisit condition.
 - Use the simplest design that meets current requirements. Add abstractions,
   configuration, or compatibility only for a current criterion or caller.
 - Run affected workspace checks (`npm run <script> -w <workspace>`) and relevant

--- a/agents/README.md
+++ b/agents/README.md
@@ -4,6 +4,10 @@ Source-of-truth files for canonical agent prompts and initial runtime defaults, 
 
 The chain prompts with an upstream counterpart in [mattpocock/skills](https://github.com/mattpocock/skills) do carry that text verbatim, wrapped in paragraphs written here for this platform's contracts; the notice is in [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md).
 
+Keep the Spec Writer and Plan guidance aligned with the upstream baseline
+recorded in that notice. Update their imported text through upstream
+synchronization, preserving Anneal's surrounding authority and output contracts.
+
 ## Canonical synchronization and verification
 
 The canonical synchronization, project-scoped installation and verification,

--- a/agents/README.md
+++ b/agents/README.md
@@ -4,9 +4,11 @@ Source-of-truth files for canonical agent prompts and initial runtime defaults, 
 
 The chain prompts with an upstream counterpart in [mattpocock/skills](https://github.com/mattpocock/skills) do carry that text verbatim, wrapped in paragraphs written here for this platform's contracts; the notice is in [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md).
 
-Keep the Spec Writer and Plan guidance aligned with the upstream baseline
-recorded in that notice. Update their imported text through upstream
-synchronization, preserving Anneal's surrounding authority and output contracts.
+Keep the [Spec Writer](roles/spec-opus-high.md) and
+[Plan](templates/compound-engineer-workflow/02-plan.md) guidance aligned with the
+upstream baseline recorded in that notice. Update their imported text only
+through upstream synchronization, preserving Anneal's surrounding authority and
+output contracts.
 
 ## Canonical synchronization and verification
 

--- a/agents/foundational.md
+++ b/agents/foundational.md
@@ -11,10 +11,10 @@ tools address Files Root instead and require a matching FilesystemGrant.
 Least privilege is a safety rule: stay inside the surfaces actually exposed
 to this session.
 
-Your working directory is a throwaway workspace that is destroyed when this
-session ends. Persist work by committing to a granted repo if you have
-git-write, or by writing files through the filesystem MCP. Nothing else
-survives.
+Your working directory is disposable. Failed workspaces may be retained for
+recovery, but retention is not a durable deliverable. Persist work through
+commits in a granted repo if you have git-write, granted filesystem MCP writes,
+or task outputs, as your role requires.
 
 Your job is the role prompt below. Do that job, then finish. Use the Anneal
 MCP to record notable progress and persist the deliverable as the task output.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,15 +1,21 @@
 # Architecture decision records
 
-- [0001 - Narrow the merge lease hold window](0001-merge-lease-hold-window.md) — Superseded by ADR-0003 (2026-08-28).
-- [0002 - Coordinate concurrent host deliveries with cumulative merge prefixes](0002-coordinate-main-delivery-with-merge-trains.md) — Accepted (2026-08-27).
-- [0003 - Acquire the merge lease in readiness](0003-acquire-merge-lease-in-readiness.md) — Accepted (2026-08-28).
-- [0004 - Publish ready Chains through a merge train](0004-publish-chains-through-a-merge-train.md) — Accepted (2026-09-07).
-- [0005 - Zero human gates by default](0005-zero-human-gates-by-default.md) — Accepted (2026-09-08).
-- [0006 - Merge lease is not a correctness boundary](0006-merge-lease-is-not-a-correctness-boundary.md) — Accepted (2026-09-08).
-- [0007 - One check instead of a mechanism](0007-one-check-instead-of-a-mechanism.md) — Accepted (2026-09-08).
-- [0008 - Templates are immutable once used](0008-templates-are-immutable-once-used.md) — Accepted (2026-09-08).
-- [0009 - Review and repair shape](0009-review-and-repair-shape.md) — Accepted (2026-09-08).
-- [0010 - Cross-family review before dispatch](0010-cross-family-review-before-dispatch.md) — Accepted (2026-09-08).
+Read the records whose scope overlaps the proposed change and the current
+decisions they reference. Superseded records explain history; use their named
+successors for current behavior.
+
+| When changing or investigating | Read | Status |
+| --- | --- | --- |
+| Historical Merge Lease hold windows | [0001 - Narrow the merge lease hold window](0001-merge-lease-hold-window.md) | Superseded by [ADR-0003](0003-acquire-merge-lease-in-readiness.md) (2026-08-28) |
+| Concurrent host delivery and cumulative merge prefixes | [0002 - Coordinate concurrent host deliveries with cumulative merge prefixes](0002-coordinate-main-delivery-with-merge-trains.md) | Accepted (2026-08-27) |
+| Merge readiness Lease acquisition and handoff | [0003 - Acquire the merge lease in readiness](0003-acquire-merge-lease-in-readiness.md) | Accepted (2026-08-28) |
+| Chain batch publication, base drift, or merge-train settlement | [0004 - Publish ready Chains through a merge train](0004-publish-chains-through-a-merge-train.md) | Accepted (2026-09-07) |
+| Approval gate defaults and human control points | [0005 - Zero human gates by default](0005-zero-human-gates-by-default.md) | Accepted (2026-09-08) |
+| Merge Lease correctness, post-gate base checks, or refund budgets | [0006 - Merge lease is not a correctness boundary](0006-merge-lease-is-not-a-correctness-boundary.md) | Accepted (2026-09-08) |
+| Recovery mechanisms, repair budgets, or missing pull requests | [0007 - One check instead of a mechanism](0007-one-check-instead-of-a-mechanism.md) | Accepted (2026-09-08) |
+| Canonical templates, prompt generations, or review base pinning | [0008 - Templates are immutable once used](0008-templates-are-immutable-once-used.md) | Accepted (2026-09-08) |
+| Review and fix responsibilities, mirror locks, or gate dependency installs | [0009 - Review and repair shape](0009-review-and-repair-shape.md) | Accepted (2026-09-08) |
+| Dispatch based on multi-agent audit conclusions | [0010 - Cross-family review before dispatch](0010-cross-family-review-before-dispatch.md) | Accepted (2026-09-08) |
 
 Entry uniqueness is checked against entry headings. A recursive full-text
 search also matches slugs in index links and cross-references; those link

--- a/docs/out-of-scope/README.md
+++ b/docs/out-of-scope/README.md
@@ -6,3 +6,16 @@ per refused design area. Each page holds entries with the headings `Decision`,
 
 An entry is a standing decision until a page or ADR supersedes it. A proposal
 that contradicts an entry must cite the entry and argue its revisit condition.
+
+Read the pages whose scope overlaps the proposed change, including any current
+decisions they reference. Each page carries the reasons and revisit conditions;
+this index routes to those decisions.
+
+| When changing or proposing | Read |
+| --- | --- |
+| Merge queuing, Lease waits, or Run ownership of the Merge Lease | [Merge tail](merge-tail.md) |
+| Merge gate coverage, scheduling, worker capacity, or database test provisioning | [Merge gate](merge-gate.md) |
+| Runner containment, workspace retention or reclaim, scope bypass, or execution abstractions | [Runner isolation](runner-isolation.md) |
+| Database shapes, query limits, event retention, canonical identity, or quotas | [Data model](data-model.md) |
+| Deployment safeguards, rollback, or source-build fallback removal | [Deployment](deployment.md) |
+| Supported operating systems or claim-rejection retry behavior | [Platform scope](platform-scope.md) |

--- a/docs/out-of-scope/README.md
+++ b/docs/out-of-scope/README.md
@@ -16,6 +16,6 @@ this index routes to those decisions.
 | Merge queuing, Lease waits, or Run ownership of the Merge Lease | [Merge tail](merge-tail.md) |
 | Merge gate coverage, scheduling, worker capacity, or database test provisioning | [Merge gate](merge-gate.md) |
 | Runner containment, workspace retention or reclaim, scope bypass, or execution abstractions | [Runner isolation](runner-isolation.md) |
-| Database shapes, query limits, event retention, canonical identity, or quotas | [Data model](data-model.md) |
+| Database shapes, query limits, event retention, canonical identity, quotas, or executor claim ranges, cancellation checks, and legacy constants | [Data model](data-model.md) |
 | Deployment safeguards, rollback, or source-build fallback removal | [Deployment](deployment.md) |
 | Supported operating systems or claim-rejection retry behavior | [Platform scope](platform-scope.md) |


### PR DESCRIPTION
Route design work through scoped ADR and out-of-scope indexes so agents read the relevant decisions while retaining their revisit obligations. Correct the foundational prompt to describe failed-workspace retention accurately, and record that imported Spec Writer and Plan guidance follows upstream synchronization.

Validation: 676 `@anneal/db` unit tests passed; `verify:compose-binding` passed; all 29 local Markdown links and decision-page index coverage checked. Independent review findings were addressed. All role and Step prompt files remain unchanged.

The full remote Merge gate passed for `2eaea1c7ab5fc4444beab703bf1fbab264ad3f58` against baseline `6e6a4b993c5e9227711406208d694b8477775b04`, including build, lint, unit tests, and database suites.
